### PR TITLE
simplifying InvestmentPlans

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/NewPlanDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/NewPlanDialog.java
@@ -26,7 +26,6 @@ public class NewPlanDialog extends AbstractDialog
         private long transactionCost;
         private Security security;
         private Date start = Dates.today();
-        private int period = 1;
         private boolean generateAccountTransactions = false;
 
         public Model(Client client)
@@ -47,8 +46,7 @@ public class NewPlanDialog extends AbstractDialog
             plan.setPortfolio(portfolio);
             plan.setSecurity(security);
             plan.setStart(start);
-            plan.setDayOfMonth(period);
-            plan.setGenerateAccountTransactions(generateAccountTransactions);
+            plan.setIsBuySellEntry(generateAccountTransactions);
             getClient().addPlan(plan);
         }
 
@@ -100,16 +98,6 @@ public class NewPlanDialog extends AbstractDialog
         public void setStart(Date start)
         {
             firePropertyChange("start", this.start, this.start = start);
-        }
-
-        public int getPeriod()
-        {
-            return period;
-        }
-
-        public void setPeriod(int period)
-        {
-            firePropertyChange("period", this.period, this.period = period);
         }
 
         public long getTransactionCost()
@@ -167,7 +155,6 @@ public class NewPlanDialog extends AbstractDialog
             }
         }, client.getSecurities().toArray());
         bindings().bindDatePicker(editArea, "Plan Start", "start");
-        bindings().bindSpinner(editArea, "Period", "period", 1, 30, 5, 1);
     }
 
     protected void configureShell(Shell shell)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ShowHideColumnHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ShowHideColumnHelper.java
@@ -372,7 +372,7 @@ public class ShowHideColumnHelper implements IMenuListener
 
     public void createColumns()
     {
-        createFromColumnConfig();
+        // createFromColumnConfig();
 
         if (viewer.getTable().getColumnCount() > 0)
         {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/InvestmentPlanListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/InvestmentPlanListView.java
@@ -174,24 +174,13 @@ public class InvestmentPlanListView extends AbstractListView
         });
         column.setMoveable(false);
         support.addColumn(column);
-        column = new Column("Day", SWT.None, 50);
-        column.setLabelProvider(new ColumnLabelProvider()
-        {
-            @Override
-            public String getText(Object e)
-            {
-                return String.format("%1d", ((InvestmentPlan) e).getDayOfMonth());
-            }
-        });
-        column.setMoveable(false);
-        support.addColumn(column);
         column = new Column("Account Transcations?", SWT.None, 50);
         column.setLabelProvider(new ColumnLabelProvider()
         {
             @Override
             public String getText(Object e)
             {
-                return "" + ((InvestmentPlan) e).isGenerateAccountTransactions();
+                return "" + ((InvestmentPlan) e).isBuySellEntry();
             }
         });
         column.setMoveable(false);
@@ -230,7 +219,7 @@ public class InvestmentPlanListView extends AbstractListView
         }).editable("name") //$NON-NLS-1$
                         .combobox("security", securities, true) //$NON-NLS-1$
                         .readonly("portfolio").amount("amount").amount("transactionCost").editable("start")
-                        .editable("dayOfMonth").combobox("generateAccountTransactions", booleans, false).apply();
+                        .combobox("isBuySellEntry", booleans, false).apply();
         hookContextMenu(plans.getTable(), new IMenuListener()
         {
             public void menuAboutToShow(IMenuManager manager)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/Dates.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/Dates.java
@@ -18,12 +18,11 @@ public class Dates
         return cal.getTime();
     }
 
-    public static Date progress(Date today, int period)
+    public static Date progress(Date today)
     {
         Calendar cal = Calendar.getInstance();
         cal.setTime(today);
         cal.add(Calendar.MONTH, 1);
-        cal.set(Calendar.DAY_OF_MONTH, period);
         return cal.getTime();
     }
 


### PR DESCRIPTION
no "period" property. The day of the month is taken from the start date.
renaming "generateAccountTransactions" to "isBuySellEntry".
simplifying generateTransactions by ignoring the Transactions already
present in the portfolio but not in the plan.
