### PR TITLE
Transaktionskosten in "Bezahlte Entgelte" einbeziehen

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshot.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshot.java
@@ -193,7 +193,7 @@ public class ClientPerformanceSnapshot
                         case TRANSFER_IN:
                         {
                             Long v = valuation.get(t.getSecurity());
-                            valuation.put(t.getSecurity(), v.longValue() - t.getAmount());
+                            valuation.put(t.getSecurity(), v.longValue() - t.getLumpSumPrice());
                             break;
                         }
                         case SELL:
@@ -201,7 +201,7 @@ public class ClientPerformanceSnapshot
                         case TRANSFER_OUT:
                         {
                             Long v = valuation.get(t.getSecurity());
-                            valuation.put(t.getSecurity(), v.longValue() + t.getAmount());
+                            valuation.put(t.getSecurity(), v.longValue() + t.getLumpSumPrice());
                             break;
                         }
                         default:


### PR DESCRIPTION
Bin mir nicht sicher, ob das gewollt ist, aber ich fänd's hilfreich die Transaktionskosten in der Performance-Berechnung bei den "Bezahlte Entgelte" einbezogen zu haben. HTH.
