### PR TITLE
Fix für Delta-Anzeige in Wertpapierübersicht

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
@@ -234,7 +234,7 @@ public final class Security implements Attributable, InvestmentVehicle
             SecurityPrice last = prices.get(prices.size() - 1);
 
             // if 'last' younger than 'requested'
-            if (last.getTime().getTime() < time.getTime())
+            if (last.getTime().getTime() <= time.getTime())
             {
                 // if 'latest' older than 'last' -> 'latest' (else 'last')
                 if (latest.getTime().getTime() >= last.getTime().getTime())


### PR DESCRIPTION
Ich importiere Preise aus einer HTML-Tabelle, die aus historischen Werten und dem letzten Tick-Preis besteht. Dies führt dazu, daß bei mir `last.getTime() == time.getTime()`, wenn heute ein Handel getätigt wurde. In diesem Fall steigt der bisherige Code aus dem Block aus und gibt einen SecurityPrice anstelle des vorhandenen LatestSecurityPrice zurück. Dies wiederum führt dazu, daß mir in der Wertpapierübersicht oftmals kein Delta angezeigt wird.
