### PR TITLE
rework tooltips of assets diagram

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/HoldingsPieChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/HoldingsPieChartView.java
@@ -82,7 +82,7 @@ public class HoldingsPieChartView extends AbstractFinanceView
         private static final String ENTRY = "{\"label\":\"%s\"," //$NON-NLS-1$
                         + "\"value\":%s," //$NON-NLS-1$
                         + "\"color\":\"%s\"," //$NON-NLS-1$
-                        + "\"caption\":\"%s  %s  (%s)\"," //$NON-NLS-1$
+                        + "\"caption\":\"<b>%s</b> (%s)<br>%s x %s = %s\"," //$NON-NLS-1$
                         + "\"valueLabel\":\"%s\"" //$NON-NLS-1$
                         + "}"; //$NON-NLS-1$
 
@@ -113,8 +113,10 @@ public class HoldingsPieChartView extends AbstractFinanceView
                                     joiner.add(String.format(ENTRY, name, //
                                                     p.getValuation().getAmount(), //
                                                     colors.next(), //
-                                                    name, Values.Money.format(p.getValuation()), percentage, //
-                                                    percentage));
+                                                    name, percentage, Values.Share.format(p.getPosition().getShares()), //
+                                                    Values.Money.format(p.getValuation().divide(
+                                                                    (long) (p.getPosition().getShares() / Values.Share.divider()))), //
+                                                    Values.Money.format(p.getValuation()), percentage));
                                 });
 
                 return joiner.toString();


### PR DESCRIPTION
rework tooltips to show number of shares and current price per share, nicer formatting for security name.

Looks like that:
![portfolio_performance_2018-07-10_21-21-59](https://user-images.githubusercontent.com/670885/42532684-f995ec92-8487-11e8-8f4b-66bc80025015.png)
