### PR TITLE
Support transaction import for securities with different currencies

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/SecurityCacheTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/SecurityCacheTest.java
@@ -24,7 +24,31 @@ public class SecurityCacheTest
         security.setName("Security Name");
         security.setIsin("DE0007164600");
         security.setWkn("716460");
+        security.setCurrencyCode("EUR");
         client.addSecurity(security);
+
+        security = new Security();
+        security.setName("Security Name USD");
+        security.setIsin("DE0007164600");
+        security.setCurrencyCode("USD");
+        client.addSecurity(security);
+
+        for (int i = 0; i < 500; i++)
+        {
+            security = new Security();
+            security.setName("Security Name" + i);
+            security.setIsin("DE00071646" + i);
+            security.setCurrencyCode("USD");
+            client.addSecurity(security);
+        }
+        for (int i = 0; i < 500; i++)
+        {
+            security = new Security();
+            security.setName("Security Name USD" + i);
+            security.setIsin("DE00071646" + i);
+            security.setCurrencyCode("USD");
+            client.addSecurity(security);
+        }
     }
 
     @Test
@@ -49,5 +73,38 @@ public class SecurityCacheTest
         SecurityCache cache = new SecurityCache(client);
         Security lookup = cache.lookup(null, null, null, "Security Name", () -> new Security());
         assertThat(client.getSecurities().get(0), is(lookup));
+    }
+
+    @Test
+    public void testThatSecurityIsMatchedByISINUnique()
+    {
+        SecurityCache cache = new SecurityCache(client);
+        try
+        {
+            cache.lookup("DE0007164600", null, null, null, null, () -> new Security());
+            assertThat(true, is(false));
+        }
+        catch (IllegalArgumentException e)
+        {
+            assertThat(true, is(true));
+        }
+    }
+
+    @Test
+    public void testThatSecurityIsMatchedByISINandName()
+    {
+        SecurityCache cache = new SecurityCache(client);
+        Security lookup = cache.lookup("DE0007164600", null, null, "Security Name", () -> new Security());
+        assertThat(client.getSecurities().get(0), is(lookup));
+        assertThat(client.getSecurities().get(1), not(is(lookup)));
+    }
+
+    @Test
+    public void testThatSecurityIsMatchedByISINandCurrency()
+    {
+        SecurityCache cache = new SecurityCache(client);
+        Security lookup = cache.lookup("DE0007164600", null, null, null, "USD", () -> new Security());
+        assertThat(client.getSecurities().get(0), not(is(lookup)));
+        assertThat(client.getSecurities().get(1), is(lookup));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/SecurityCacheTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/SecurityCacheTest.java
@@ -32,23 +32,6 @@ public class SecurityCacheTest
         security.setIsin("DE0007164600");
         security.setCurrencyCode("USD");
         client.addSecurity(security);
-
-        for (int i = 0; i < 500; i++)
-        {
-            security = new Security();
-            security.setName("Security Name" + i);
-            security.setIsin("DE00071646" + i);
-            security.setCurrencyCode("USD");
-            client.addSecurity(security);
-        }
-        for (int i = 0; i < 500; i++)
-        {
-            security = new Security();
-            security.setName("Security Name USD" + i);
-            security.setIsin("DE00071646" + i);
-            security.setCurrencyCode("USD");
-            client.addSecurity(security);
-        }
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/SecurityCache.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/SecurityCache.java
@@ -82,12 +82,15 @@ public class SecurityCache
             return security;
 
         // third: check for isin and different currency
-        List<Security> securities = client.getSecurities().stream()
-                        .filter(s -> s.getIsin().equals(isin) && s.getCurrencyCode().equals(currency))
-                        .collect(Collectors.toList());
+        if (currency != null)
+        {
+            List<Security> securities = client.getSecurities().stream()
+                            .filter(s -> s.getIsin().equals(isin) && s.getCurrencyCode().equals(currency))
+                            .collect(Collectors.toList());
 
-        if (securities.size() == 1)
-            return securities.get(0);
+            if (securities.size() == 1)
+                return securities.get(0);
+        }
 
         // if we detect duplicate securities for one attribute, the error
         // message is only returned to the user if the other attributes also did
@@ -101,7 +104,10 @@ public class SecurityCache
         security.setWkn(wkn);
         security.setTickerSymbol(tickerSymbol);
         security.setName(name);
-        security.setCurrencyCode(currency);
+        if (currency != null)
+        {
+            security.setCurrencyCode(currency);
+        }
 
         for (int ii = 0; ii < localMaps.size(); ii++)
         {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/BaseCSVExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/BaseCSVExtractor.java
@@ -109,11 +109,12 @@ import name.abuchen.portfolio.util.TextUtil;
         String tickerSymbol = getText(Messages.CSVColumn_TickerSymbol, rawValues, field2column);
         String wkn = getText(Messages.CSVColumn_WKN, rawValues, field2column);
         String name = getText(Messages.CSVColumn_SecurityName, rawValues, field2column);
+        String currency = getText(Messages.CSVColumn_Currency, rawValues, field2column);
 
         if (isin != null || tickerSymbol != null || wkn != null || name != null)
         {
             name = constructName(isin, tickerSymbol, wkn, name);
-            security = securityCache.lookup(isin, tickerSymbol, wkn, name, () -> {
+            security = securityCache.lookup(isin, tickerSymbol, wkn, name, currency, () -> {
                 Security s = new Security();
                 s.setCurrencyCode(client.getBaseCurrency());
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -29,7 +29,8 @@ public abstract class AbstractPDFExtractor implements Extractor
 {
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("d.M.yyyy", Locale.GERMANY); //$NON-NLS-1$
     private static final DateTimeFormatter DATE_FORMAT_DASHES = DateTimeFormatter.ofPattern("yyyy-M-d", Locale.GERMANY); //$NON-NLS-1$
-    private static final DateTimeFormatter DATE_FORMAT_DASHES_REVERSE = DateTimeFormatter.ofPattern("d-M-yyyy", Locale.GERMANY); //$NON-NLS-1$
+    private static final DateTimeFormatter DATE_FORMAT_DASHES_REVERSE = DateTimeFormatter.ofPattern("d-M-yyyy", //$NON-NLS-1$
+                    Locale.GERMANY);
     private static final DateTimeFormatter DATE_TIME_SECONDS_FORMAT = DateTimeFormatter.ofPattern("d.M.yyyy HH:mm", //$NON-NLS-1$
                     Locale.GERMANY);
     private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("d.M.yyyy HH:mm:ss", //$NON-NLS-1$
@@ -113,7 +114,7 @@ public abstract class AbstractPDFExtractor implements Extractor
                 else
                     item.getSubject().setNote(item.getSubject().getNote().concat(" | ").concat(filename)); //$NON-NLS-1$
             }
-            
+
             return items;
         }
         catch (IllegalArgumentException e)
@@ -168,6 +169,10 @@ public abstract class AbstractPDFExtractor implements Extractor
         if (isin != null)
             isin = isin.trim();
 
+        String currency = values.get("currency"); //$NON-NLS-1$
+        if (currency != null)
+            currency = currency.trim();
+
         String tickerSymbol = values.get("tickerSymbol"); //$NON-NLS-1$
         if (tickerSymbol != null)
             tickerSymbol = tickerSymbol.trim();
@@ -184,9 +189,8 @@ public abstract class AbstractPDFExtractor implements Extractor
         if (nameRowTwo != null)
             name = name + " " + nameRowTwo.trim(); //$NON-NLS-1$
 
-        Security security = securityCache.lookup(isin, tickerSymbol, wkn, name, () -> {
+        Security security = securityCache.lookup(isin, tickerSymbol, wkn, name, asCurrencyCode(currency), () -> {
             Security s = new Security();
-            s.setCurrencyCode(asCurrencyCode(values.get("currency"))); //$NON-NLS-1$
             return s;
         });
 


### PR DESCRIPTION
Issue: https://forum.portfolio-performance.info/t/buchungen-importieren-fuer-doppelt-angelegtes-wertpapier-mit-unterschiedlichen-waehrungen/13301

Im Forum kam schon mehrfach die Frage auf, warum ein Import für Dokumente mit gleichen Wertpapieren aber unterschiedlichen Währungen nicht auch funktioniert. Hierzu diese Erweiterung als Vorschlag.

Und: Der hinzugefügte Test `testThatSecurityIsMatchedByISINandName` lief erst in einen Fehler, weil die Exception for der `lookupSecurityByName` geworfen wurde. Deswegen habe ich den Lookup nach vorne gezogen.