### PR TITLE
Fixes: LimitPrice value cannot be edited in SecuritiesPerformanceView

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -64,6 +64,7 @@ import name.abuchen.portfolio.ui.util.ReportingPeriodDropDown.ReportingPeriodLis
 import name.abuchen.portfolio.ui.util.TableViewerCSVExporter;
 import name.abuchen.portfolio.ui.util.viewers.Column;
 import name.abuchen.portfolio.ui.util.viewers.ColumnEditingSupport;
+import name.abuchen.portfolio.ui.util.viewers.ColumnEditingSupport.MarkDirtyClientListener;
 import name.abuchen.portfolio.ui.util.viewers.ColumnEditingSupport.TouchClientListener;
 import name.abuchen.portfolio.ui.util.viewers.ColumnViewerSorter;
 import name.abuchen.portfolio.ui.util.viewers.CopyPasteSupport;
@@ -965,7 +966,7 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
 
         AttributeColumn.createFor(getClient(), Security.class) //
                         .forEach(column -> {
-                            column.getEditingSupport().addListener(new TouchClientListener(getClient()));
+                            column.getEditingSupport().addListener(new MarkDirtyClientListener(getClient()));
                             recordColumns.addColumn(column);
                         });
     }


### PR DESCRIPTION
Hier gemeldet: https://forum.portfolio-performance.info/t/limit-preis-felder-in-ansicht-wertpapiere-editieren/18157

In der Ansicht Performance-Wertpapiere wurde der EditingSupport für Attribute bisher null gesetzt, wodurch Attribute aus dieser Ansicht nicht geändert werden konnten.