### PR TITLE
add support for reporting period 'since first transaction'

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -671,6 +671,7 @@ public class Messages extends NLS
     public static String LabelReportingDialogMonths;
     public static String LabelReportingDialogQuarter;
     public static String LabelReportingDialogSince;
+    public static String LabelReportingDialogSinceFirstTransaction;
     public static String LabelReportingDialogTradingDays;
     public static String LabelReportingDialogUntil;
     public static String LabelReportingDialogWeek;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/ReportingPeriodDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/ReportingPeriodDialog.java
@@ -15,10 +15,12 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.DateTime;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Spinner;
 
+import name.abuchen.portfolio.model.FirstTransactionSupplier;
 import name.abuchen.portfolio.snapshot.ReportingPeriod;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.DatePicker;
@@ -48,6 +50,9 @@ public class ReportingPeriodDialog extends Dialog
     private Button radioSinceX;
     private DatePicker dateSince;
 
+    private Button radioSinceFirstTransaction;
+    private DateTime dateSinceFirstTransaction;
+    
     private Button radioYearX;
     private Spinner year;
 
@@ -62,10 +67,12 @@ public class ReportingPeriodDialog extends Dialog
     private Button radioPreviousYear;
 
     private List<Button> radioBtnList;
+    private FirstTransactionSupplier firstTransactionSupplier;
 
-    public ReportingPeriodDialog(Shell parentShell, ReportingPeriod template)
+    public ReportingPeriodDialog(Shell parentShell, ReportingPeriod template, FirstTransactionSupplier transactionSupplier)
     {
         super(parentShell);
+        this.firstTransactionSupplier = transactionSupplier;
         this.template = template != null ? template : new ReportingPeriod.LastX(1, 0);
     }
 
@@ -124,6 +131,14 @@ public class ReportingPeriodDialog extends Dialog
         radioSinceX = new Button(editArea, SWT.RADIO);
         radioSinceX.setText(Messages.LabelReportingDialogSince);
         dateSince = new DatePicker(editArea);
+        
+        radioSinceFirstTransaction = new Button(editArea, SWT.RADIO);
+        radioSinceFirstTransaction.setText(Messages.LabelReportingDialogSinceFirstTransaction);
+        LocalDate firstTransactionDate = getFirstTransactionDate();
+        LocalDate since = firstTransactionDate == null ? LocalDate.now() : firstTransactionDate;
+        dateSinceFirstTransaction = new DateTime(editArea, SWT.DATE | SWT.READ_ONLY | SWT.BORDER);
+        dateSinceFirstTransaction.setDate(since.getYear(), since.getMonthValue(), since.getDayOfMonth());
+        dateSinceFirstTransaction.setEnabled(false);
 
         radioYearX = new Button(editArea, SWT.RADIO);
         radioYearX.setText(Messages.LabelReportingDialogYear);
@@ -165,38 +180,44 @@ public class ReportingPeriodDialog extends Dialog
         // form layout
         //
 
-        FormDataFactory.startingWith(radioLast).top(new FormAttachment(0, 10)).thenRight(years).thenRight(lblYears)
-                        .thenRight(months).thenRight(lblMonths);
+        if (Platform.OS_MACOSX.equals(Platform.getOS()))
+        {
+            // under Mac OS X, the date input fields are not align with the text
+            // by default
+
+            FormDataFactory.startingWith(radioSinceFirstTransaction).top(new FormAttachment(0, 10))
+                            .thenRight(dateSinceFirstTransaction).top(new FormAttachment(radioSinceFirstTransaction, -1, SWT.TOP));
+            
+            FormDataFactory.startingWith(radioSinceX).top(new FormAttachment(radioSinceFirstTransaction, 20))
+                            .thenRight(dateSince.getControl()).top(new FormAttachment(radioSinceX, -1, SWT.TOP));
+            
+            FormDataFactory.startingWith(radioFromXtoY).top(new FormAttachment(radioSinceX, 20))
+                            .thenRight(dateFrom.getControl()).top(new FormAttachment(radioFromXtoY, -1, SWT.TOP))
+                            .thenRight(lblTo).top(new FormAttachment(radioFromXtoY, 2, SWT.TOP))
+                            .thenRight(dateTo.getControl()).top(new FormAttachment(radioFromXtoY, -1, SWT.TOP));
+        }
+        else
+        {
+            FormDataFactory.startingWith(radioSinceFirstTransaction).top(new FormAttachment(0, 10))
+                            .thenRight(dateSinceFirstTransaction);
+            
+            FormDataFactory.startingWith(radioSinceX).top(new FormAttachment(radioSinceFirstTransaction, 20))
+                            .thenRight(dateSince.getControl());
+            
+            FormDataFactory.startingWith(radioFromXtoY).top(new FormAttachment(radioSinceX, 20))
+                            .thenRight(dateFrom.getControl()).thenRight(lblTo).thenRight(dateTo.getControl());
+        }
+        
+        FormDataFactory.startingWith(radioLast).top(new FormAttachment(radioFromXtoY, 20))
+                        .thenRight(years).thenRight(lblYears).thenRight(months).thenRight(lblMonths);
 
         FormDataFactory.startingWith(radioLastDays).top(new FormAttachment(radioLast, 20)).thenRight(days)
                         .thenRight(lblDays);
 
         FormDataFactory.startingWith(radioLastTradingDays).top(new FormAttachment(radioLastDays, 20))
                         .thenRight(tradingDays).thenRight(lblTradingDays);
-
-        if (Platform.OS_MACOSX.equals(Platform.getOS()))
-        {
-            // under Mac OS X, the date input fields are not align with the text
-            // by default
-
-            FormDataFactory.startingWith(radioFromXtoY).top(new FormAttachment(radioLastTradingDays, 20))
-                            .thenRight(dateFrom.getControl()).top(new FormAttachment(radioFromXtoY, -1, SWT.TOP))
-                            .thenRight(lblTo).top(new FormAttachment(radioFromXtoY, 2, SWT.TOP))
-                            .thenRight(dateTo.getControl()).top(new FormAttachment(radioFromXtoY, -1, SWT.TOP));
-
-            FormDataFactory.startingWith(radioSinceX).top(new FormAttachment(radioFromXtoY, 20))
-                            .thenRight(dateSince.getControl()).top(new FormAttachment(radioSinceX, -1, SWT.TOP));
-        }
-        else
-        {
-            FormDataFactory.startingWith(radioFromXtoY).top(new FormAttachment(radioLastTradingDays, 20))
-                            .thenRight(dateFrom.getControl()).thenRight(lblTo).thenRight(dateTo.getControl());
-
-            FormDataFactory.startingWith(radioSinceX).top(new FormAttachment(radioFromXtoY, 20))
-                            .thenRight(dateSince.getControl());
-        }
-
-        FormDataFactory.startingWith(radioYearX).top(new FormAttachment(radioSinceX, 20)).thenRight(year);
+        
+        FormDataFactory.startingWith(radioYearX).top(new FormAttachment(radioLastTradingDays, 20)).thenRight(year);
 
         FormDataFactory.startingWith(lblCurrent).top(new FormAttachment(radioYearX, 20)).thenBelow(radioCurrentWeek)
                         .thenRight(radioCurrentMonth).thenRight(radioCurrentQuarter).thenRight(radioYTD);
@@ -213,7 +234,8 @@ public class ReportingPeriodDialog extends Dialog
 
         radioBtnList = Arrays.asList(radioLast, radioLastDays, radioLastTradingDays, radioFromXtoY, radioSinceX,
                         radioYearX, radioCurrentWeek, radioCurrentMonth, radioCurrentQuarter, radioYTD,
-                        radioPreviousWeek, radioPreviousMonth, radioPreviousQuarter, radioPreviousYear);
+                        radioPreviousWeek, radioPreviousMonth, radioPreviousQuarter, radioPreviousYear,
+                        radioSinceFirstTransaction);
         activateRadioOnChange(radioLast, years, months);
         activateRadioOnChange(radioLastDays, days);
         activateRadioOnChange(radioLastTradingDays, tradingDays);
@@ -254,7 +276,19 @@ public class ReportingPeriodDialog extends Dialog
         else if (template instanceof ReportingPeriod.FromXtoY)
             radioFromXtoY.setSelection(true);
         else if (template instanceof ReportingPeriod.SinceX)
-            radioSinceX.setSelection(true);
+        {
+            ReportingPeriod.SinceX sinceX = (ReportingPeriod.SinceX) template;
+            LocalDate sinceXDate = sinceX.getStartDate();
+            LocalDate firstTransactionDate = getFirstTransactionDate();
+            if (sinceXDate.equals(firstTransactionDate)) 
+            {
+                radioSinceFirstTransaction.setSelection(true);
+            }
+            else
+            {
+                radioSinceX.setSelection(true);
+            }
+        }
         else if (template instanceof ReportingPeriod.YearX)
             radioYearX.setSelection(true);
         else if (template instanceof ReportingPeriod.CurrentWeek)
@@ -325,6 +359,12 @@ public class ReportingPeriodDialog extends Dialog
 
             result = new ReportingPeriod.SinceX(dateSince.getSelection());
         }
+        else if (radioSinceFirstTransaction.getSelection())
+        {
+            LocalDate firstTransactionDate = getFirstTransactionDate();
+            LocalDate since = firstTransactionDate == null ? LocalDate.now() : firstTransactionDate;
+            result = new ReportingPeriod.SinceX(since);
+        }
         else if (radioYearX.getSelection())
         {
             result = new ReportingPeriod.YearX(year.getSelection());
@@ -374,4 +414,9 @@ public class ReportingPeriodDialog extends Dialog
         return result;
     }
 
+    private LocalDate getFirstTransactionDate()
+    {
+        return firstTransactionSupplier.get().map(t -> t.getDateTime().toLocalDate()).orElse(null);
+    }
+    
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1416,6 +1416,8 @@ LabelReportingDialogQuarter = Quarter
 
 LabelReportingDialogSince = Since
 
+LabelReportingDialogSinceFirstTransaction = From the first transaction
+
 LabelReportingDialogTradingDays = trading days
 
 LabelReportingDialogUntil = until

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_cs.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_cs.properties
@@ -1384,6 +1384,8 @@ LabelReportingDialogQuarter = \u010Ctvrtlet\u00ED
 
 LabelReportingDialogSince = Od
 
+LabelReportingDialogSinceFirstTransaction = Od prvn\u00ED transakce
+
 LabelReportingDialogTradingDays = obchodn\u00ED dny
 
 LabelReportingDialogUntil = do

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1407,6 +1407,8 @@ LabelReportingDialogQuarter = Quartal
 
 LabelReportingDialogSince = Seit
 
+LabelReportingDialogSinceFirstTransaction = Ab der ersten Transaktion
+
 LabelReportingDialogTradingDays = Handelstage
 
 LabelReportingDialogUntil = bis

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1399,6 +1399,8 @@ LabelReportingDialogQuarter = Trimestre
 
 LabelReportingDialogSince = Desde
 
+LabelReportingDialogSinceFirstTransaction = Desde la primera transacci\u00F3n
+
 LabelReportingDialogTradingDays = d\u00EDas de mercado
 
 LabelReportingDialogUntil = hasta

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -1400,6 +1400,8 @@ LabelReportingDialogQuarter = Trimestre
 
 LabelReportingDialogSince = Depuis
 
+LabelReportingDialogSinceFirstTransaction = D\u00E8s la premi\u00E8re transaction
+
 LabelReportingDialogTradingDays = jours de bourse
 
 LabelReportingDialogUntil = jusqu'\u00E0

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_it.properties
@@ -1409,6 +1409,8 @@ LabelReportingDialogQuarter = Trimestre
 
 LabelReportingDialogSince = Dal
 
+LabelReportingDialogSinceFirstTransaction = Dalla prima transazione
+
 LabelReportingDialogTradingDays = giorni negoziazione
 
 LabelReportingDialogUntil = fino al

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1399,6 +1399,8 @@ LabelReportingDialogQuarter = Kwartaal
 
 LabelReportingDialogSince = Sinds
 
+LabelReportingDialogSinceFirstTransaction = Vanaf de eerste transactie
+
 LabelReportingDialogTradingDays = handelsdagen
 
 LabelReportingDialogUntil = until

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1405,6 +1405,8 @@ LabelReportingDialogQuarter = Trimestre
 
 LabelReportingDialogSince = Desde
 
+LabelReportingDialogSinceFirstTransaction = Desde a primeira transa\u00E7\u00E3o
+
 LabelReportingDialogTradingDays = dias de negocia\u00E7\u00E3o
 
 LabelReportingDialogUntil = at\u00E9

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_ru.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_ru.properties
@@ -1409,6 +1409,8 @@ LabelReportingDialogQuarter = \u041A\u0432\u0430\u0440\u0442\u0430\u043B
 
 LabelReportingDialogSince = \u0421
 
+LabelReportingDialogSinceFirstTransaction = \u0421 \u043F\u0435\u0440\u0432\u043E\u0439 \u0442\u0440\u0430\u043D\u0437\u0430\u043A\u0446\u0438\u0438
+
 LabelReportingDialogTradingDays = \u0442\u043E\u0440\u0433\u043E\u0432\u044B\u0435 \u0434\u043D\u0438
 
 LabelReportingDialogUntil = \u0434\u043E

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ReportingPeriodDropDown.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ReportingPeriodDropDown.java
@@ -12,6 +12,7 @@ import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 
+import name.abuchen.portfolio.model.FirstTransactionSupplier;
 import name.abuchen.portfolio.snapshot.ReportingPeriod;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.dialogs.EditReportingPeriodsDialog;
@@ -56,9 +57,14 @@ public final class ReportingPeriodDropDown extends DropDown implements IMenuList
             manager.add(action);
         }
 
+        FirstTransactionSupplier firstTransactionSupplier = new FirstTransactionSupplier(part.getClient());
+        
         manager.add(new Separator());
         manager.add(new SimpleAction(Messages.LabelReportingAddPeriod, a -> {
-            ReportingPeriodDialog dialog = new ReportingPeriodDialog(Display.getDefault().getActiveShell(), selected);
+            ReportingPeriodDialog dialog = new ReportingPeriodDialog(
+                            Display.getDefault().getActiveShell(),
+                            selected,
+                            firstTransactionSupplier);
 
             if (dialog.open() == Window.OK)
             {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ReportingPeriodColumnOptions.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ReportingPeriodColumnOptions.java
@@ -7,6 +7,7 @@ import org.eclipse.swt.widgets.Shell;
 
 import com.ibm.icu.text.MessageFormat;
 
+import name.abuchen.portfolio.model.FirstTransactionSupplier;
 import name.abuchen.portfolio.snapshot.ReportingPeriod;
 import name.abuchen.portfolio.ui.dialogs.ReportingPeriodDialog;
 
@@ -14,9 +15,11 @@ public class ReportingPeriodColumnOptions implements Column.Options<ReportingPer
 {
     private String columnLabel;
     private List<ReportingPeriod> defaultOptions;
+    private FirstTransactionSupplier firstTransactionSupplier;
 
-    public ReportingPeriodColumnOptions(String columnLabel, List<ReportingPeriod> defaultOptions)
+    public ReportingPeriodColumnOptions(FirstTransactionSupplier firstTransactionSupplier, String columnLabel, List<ReportingPeriod> defaultOptions)
     {
+        this.firstTransactionSupplier = firstTransactionSupplier;
         this.columnLabel = columnLabel;
         this.defaultOptions = defaultOptions;
     }
@@ -73,7 +76,7 @@ public class ReportingPeriodColumnOptions implements Column.Options<ReportingPer
     @Override
     public ReportingPeriod createNewOption(Shell shell)
     {
-        ReportingPeriodDialog dialog = new ReportingPeriodDialog(shell, null);
+        ReportingPeriodDialog dialog = new ReportingPeriodDialog(shell, null, firstTransactionSupplier);
         if (dialog.open() == ReportingPeriodDialog.OK)
         {
             ReportingPeriod p = dialog.getReportingPeriod();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -47,6 +47,7 @@ import com.google.common.collect.Streams;
 
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.FirstTransactionSupplier;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.SecurityPrice;
@@ -592,8 +593,13 @@ public final class SecuritiesTable implements ModificationListener
             return Double.valueOf((latest.getValue() - previous.getValue()) / (double) previous.getValue());
         };
 
+        FirstTransactionSupplier firstTransactionSupplier = new FirstTransactionSupplier(getClient());
+        
         Column column = new Column("delta-w-period", Messages.ColumnQuoteChange, SWT.RIGHT, 80); //$NON-NLS-1$
-        column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnQuoteChange_Option, options));
+        column.setOptions(new ReportingPeriodColumnOptions(
+                        firstTransactionSupplier,
+                        Messages.ColumnQuoteChange_Option,
+                        options));
         column.setDescription(Messages.ColumnQuoteChange_Description);
         column.setLabelProvider(new QuoteReportingPeriodLabelProvider(valueProvider));
         column.setVisible(false);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -52,6 +52,7 @@ import name.abuchen.portfolio.model.Annotated;
 import name.abuchen.portfolio.model.Attributable;
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.FirstTransactionSupplier;
 import name.abuchen.portfolio.model.InvestmentVehicle;
 import name.abuchen.portfolio.model.Named;
 import name.abuchen.portfolio.model.Portfolio;
@@ -567,10 +568,15 @@ public class StatementOfAssetsViewer
     private void addPerformanceColumns(List<ReportingPeriod> options)
     {
         ReportingPeriodLabelProvider labelProvider;
+        
+        FirstTransactionSupplier firstTransactionSupplier = new FirstTransactionSupplier(client);
 
         Column column = new Column("ttwror", Messages.ColumnTTWROR, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(SecurityPerformanceRecord::getTrueTimeWeightedRateOfReturn);
-        column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnTTWROR_Option, options));
+        column.setOptions(new ReportingPeriodColumnOptions(
+                        firstTransactionSupplier, 
+                        Messages.ColumnTTWROR_Option, 
+                        options));
         column.setGroupLabel(Messages.GroupLabelPerformance);
         column.setDescription(Messages.LabelTTWROR);
         column.setLabelProvider(labelProvider);
@@ -581,7 +587,10 @@ public class StatementOfAssetsViewer
         column = new Column("ttwror_pa", Messages.ColumnTTWRORpa, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(
                         SecurityPerformanceRecord::getTrueTimeWeightedRateOfReturnAnnualized);
-        column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnTTWRORpa_Option, options));
+        column.setOptions(new ReportingPeriodColumnOptions(
+                        firstTransactionSupplier, 
+                        Messages.ColumnTTWRORpa_Option, 
+                        options));
         column.setGroupLabel(Messages.GroupLabelPerformance);
         column.setDescription(Messages.LabelTTWROR_Annualized);
         column.setLabelProvider(labelProvider);
@@ -591,7 +600,10 @@ public class StatementOfAssetsViewer
 
         column = new Column("irr", Messages.ColumnIRR, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(SecurityPerformanceRecord::getIrr);
-        column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnIRRPerformanceOption, options));
+        column.setOptions(new ReportingPeriodColumnOptions(
+                        firstTransactionSupplier, 
+                        Messages.ColumnIRRPerformanceOption, 
+                        options));
         column.setMenuLabel(Messages.ColumnIRR_MenuLabel);
         column.setGroupLabel(Messages.GroupLabelPerformance);
         column.setLabelProvider(labelProvider);
@@ -602,7 +614,10 @@ public class StatementOfAssetsViewer
         column = new Column("capitalgains", Messages.ColumnCapitalGains, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(SecurityPerformanceRecord::getCapitalGainsOnHoldings,
                         withSum(), true);
-        column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnCapitalGains_Option, options));
+        column.setOptions(new ReportingPeriodColumnOptions(
+                        firstTransactionSupplier,
+                        Messages.ColumnCapitalGains_Option, 
+                        options));
         column.setGroupLabel(Messages.GroupLabelPerformance);
         column.setDescription(Messages.ColumnCapitalGains_Description);
         column.setLabelProvider(labelProvider);
@@ -612,7 +627,10 @@ public class StatementOfAssetsViewer
 
         column = new Column("capitalgains%", Messages.ColumnCapitalGainsPercent, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(SecurityPerformanceRecord::getCapitalGainsOnHoldingsPercent);
-        column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnCapitalGainsPercent_Option, options));
+        column.setOptions(new ReportingPeriodColumnOptions(
+                        firstTransactionSupplier, 
+                        Messages.ColumnCapitalGainsPercent_Option, 
+                        options));
         column.setGroupLabel(Messages.GroupLabelPerformance);
         column.setDescription(Messages.ColumnCapitalGainsPercent_Description);
         column.setLabelProvider(labelProvider);
@@ -623,7 +641,10 @@ public class StatementOfAssetsViewer
         column = new Column("capitalgainsmvavg", Messages.ColumnCapitalGainsMovingAverage, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(
                         SecurityPerformanceRecord::getCapitalGainsOnHoldingsMovingAverage, withSum(), true);
-        column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnCapitalGainsMovingAverage_Option, options));
+        column.setOptions(new ReportingPeriodColumnOptions(
+                        firstTransactionSupplier, 
+                        Messages.ColumnCapitalGainsMovingAverage_Option, 
+                        options));
         column.setGroupLabel(Messages.GroupLabelPerformance);
         column.setDescription(Messages.ColumnCapitalGainsMovingAverage_Description);
         column.setLabelProvider(labelProvider);
@@ -634,7 +655,9 @@ public class StatementOfAssetsViewer
         column = new Column("capitalgainsmvavg%", Messages.ColumnCapitalGainsMovingAveragePercent, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(
                         SecurityPerformanceRecord::getCapitalGainsOnHoldingsMovingAveragePercent);
-        column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnCapitalGainsMovingAveragePercent_Option,
+        column.setOptions(new ReportingPeriodColumnOptions(
+                        firstTransactionSupplier,
+                        Messages.ColumnCapitalGainsMovingAveragePercent_Option,
                         options));
         column.setGroupLabel(Messages.GroupLabelPerformance);
         column.setDescription(Messages.ColumnCapitalGainsMovingAveragePercent_Description);
@@ -645,7 +668,10 @@ public class StatementOfAssetsViewer
 
         column = new Column("delta", Messages.ColumnAbsolutePerformance_MenuLabel, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(SecurityPerformanceRecord::getDelta, withSum(), true);
-        column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnAbsolutePerformance_Option, options));
+        column.setOptions(new ReportingPeriodColumnOptions(
+                        firstTransactionSupplier, 
+                        Messages.ColumnAbsolutePerformance_Option,
+                        options));
         column.setGroupLabel(Messages.GroupLabelPerformance);
         column.setDescription(Messages.ColumnAbsolutePerformance_Description);
         column.setLabelProvider(labelProvider);
@@ -655,7 +681,10 @@ public class StatementOfAssetsViewer
 
         column = new Column("delta%", Messages.ColumnAbsolutePerformancePercent_MenuLabel, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(SecurityPerformanceRecord::getDeltaPercent);
-        column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnAbsolutePerformancePercent_Option, options));
+        column.setOptions(new ReportingPeriodColumnOptions(
+                        firstTransactionSupplier, 
+                        Messages.ColumnAbsolutePerformancePercent_Option, 
+                        options));
         column.setGroupLabel(Messages.GroupLabelPerformance);
         column.setDescription(Messages.ColumnAbsolutePerformancePercent_Description);
         column.setLabelProvider(labelProvider);
@@ -667,12 +696,17 @@ public class StatementOfAssetsViewer
     private void addDividendColumns(List<ReportingPeriod> options)
     {
         ReportingPeriodLabelProvider labelProvider;
+        
+        FirstTransactionSupplier firstTransactionSupplier = new FirstTransactionSupplier(client);
 
         Column column = new Column("sumdiv", Messages.ColumnDividendSum, SWT.RIGHT, 80); //$NON-NLS-1$
 
         labelProvider = new ReportingPeriodLabelProvider(SecurityPerformanceRecord::getSumOfDividends, withSum(),
                         false);
-        column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnDividendSum + " {0}", options)); //$NON-NLS-1$
+        column.setOptions(new ReportingPeriodColumnOptions(
+                        firstTransactionSupplier, 
+                        Messages.ColumnDividendSum + " {0}",
+                        options)); //$NON-NLS-1$
         column.setGroupLabel(Messages.GroupLabelDividends);
         column.setMenuLabel(Messages.ColumnDividendSum_MenuLabel);
         column.setLabelProvider(labelProvider);
@@ -683,7 +717,10 @@ public class StatementOfAssetsViewer
         column = new Column("d%", Messages.ColumnDividendTotalRateOfReturn, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(SecurityPerformanceRecord::getTotalRateOfReturnDiv, null,
                         false);
-        column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnDividendTotalRateOfReturn + " {0}", options)); //$NON-NLS-1$
+        column.setOptions(new ReportingPeriodColumnOptions(
+                        firstTransactionSupplier, 
+                        Messages.ColumnDividendTotalRateOfReturn + " {0}", 
+                        options)); //$NON-NLS-1$
         column.setGroupLabel(Messages.GroupLabelDividends);
         column.setDescription(Messages.ColumnDividendTotalRateOfReturn_Description);
         column.setLabelProvider(labelProvider);
@@ -695,7 +732,9 @@ public class StatementOfAssetsViewer
         labelProvider = new ReportingPeriodLabelProvider(
                         SecurityPerformanceRecord::getTotalRateOfReturnDivMovingAverage, null, false);
         column.setOptions(new ReportingPeriodColumnOptions(
-                        Messages.ColumnDividendMovingAverageTotalRateOfReturn + " {0}", options)); //$NON-NLS-1$
+                        firstTransactionSupplier, 
+                        Messages.ColumnDividendMovingAverageTotalRateOfReturn + " {0}",
+                        options)); //$NON-NLS-1$
         column.setGroupLabel(Messages.GroupLabelDividends);
         column.setDescription(Messages.ColumnDividendMovingAverageTotalRateOfReturn_Description);
         column.setLabelProvider(labelProvider);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ReportingPeriodApplyToAll.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ReportingPeriodApplyToAll.java
@@ -6,6 +6,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 
+import name.abuchen.portfolio.model.FirstTransactionSupplier;
 import name.abuchen.portfolio.snapshot.ReportingPeriod;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.dialogs.ReportingPeriodDialog;
@@ -28,11 +29,15 @@ public class ReportingPeriodApplyToAll
 
         dashboardData.getDefaultReportingPeriods().stream()
                         .forEach(p -> subMenu.add(new SimpleAction(p.toString(), a -> apply(p, columnControl))));
-        subMenu.add(new Separator());
 
+        FirstTransactionSupplier firstTransactionSupplier = new FirstTransactionSupplier(dashboardData.getClient());
+        
+        subMenu.add(new Separator());
         subMenu.add(new SimpleAction(Messages.LabelReportingAddPeriod, a -> {
-            ReportingPeriodDialog dialog = new ReportingPeriodDialog(Display.getDefault().getActiveShell(),
-                            dashboardData.getDefaultReportingPeriod());
+            ReportingPeriodDialog dialog = new ReportingPeriodDialog(
+                            Display.getDefault().getActiveShell(),
+                            dashboardData.getDefaultReportingPeriod(),
+                            firstTransactionSupplier);
             if (dialog.open() == ReportingPeriodDialog.OK)
             {
                 ReportingPeriod reportingPeriod = dialog.getReportingPeriod();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ReportingPeriodConfig.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ReportingPeriodConfig.java
@@ -11,6 +11,7 @@ import org.eclipse.jface.action.Separator;
 import org.eclipse.swt.widgets.Display;
 
 import name.abuchen.portfolio.model.Dashboard;
+import name.abuchen.portfolio.model.FirstTransactionSupplier;
 import name.abuchen.portfolio.snapshot.ReportingPeriod;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.PortfolioPlugin;
@@ -77,11 +78,15 @@ public class ReportingPeriodConfig implements WidgetConfig
 
         delegate.getDashboardData().getDefaultReportingPeriods().stream()
                         .forEach(p -> subMenu.add(new SimpleAction(p.toString(), a -> setReportingPeriod(p))));
-        subMenu.add(new Separator());
+        
+        FirstTransactionSupplier firstTransactionSupplier = new FirstTransactionSupplier(delegate.getClient());
 
+        subMenu.add(new Separator());
         subMenu.add(new SimpleAction(Messages.LabelReportingAddPeriod, a -> {
-            ReportingPeriodDialog dialog = new ReportingPeriodDialog(Display.getDefault().getActiveShell(),
-                            getReportingPeriod());
+            ReportingPeriodDialog dialog = new ReportingPeriodDialog(
+                            Display.getDefault().getActiveShell(),
+                            getReportingPeriod(),
+                            firstTransactionSupplier);
             if (dialog.open() == ReportingPeriodDialog.OK)
             {
                 ReportingPeriod rp = dialog.getReportingPeriod();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/FirstTransactionSupplier.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/FirstTransactionSupplier.java
@@ -1,0 +1,28 @@
+package name.abuchen.portfolio.model;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import name.abuchen.portfolio.model.Transaction.ByDate;
+
+public final class FirstTransactionSupplier implements Supplier<Optional<PortfolioTransaction>>
+{
+
+    private final Client client;
+    private final ByDate byDateComparator;
+    
+    public FirstTransactionSupplier(Client client)
+    {
+        this.client = client;
+        this.byDateComparator = new ByDate();
+    }
+
+
+    @Override
+    public Optional<PortfolioTransaction> get()
+    {
+        if (client == null) return Optional.empty();
+        return client.getPortfolios().stream().flatMap(p -> p.getTransactions().stream()).min(byDateComparator);
+    }
+
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ReportingPeriod.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ReportingPeriod.java
@@ -385,6 +385,12 @@ public abstract class ReportingPeriod
         {
             this.startDate = startDate;
         }
+        
+        
+        public LocalDate getStartDate()
+        {
+            return startDate;
+        }
 
         @Override
         public Interval toInterval(LocalDate relativeTo)


### PR DESCRIPTION
This is an implementation of #2411.
This commit provides an option in the reporting period creation dialog to make a reporting period starting from the date of the first transaction.
This option is not introducing a new, specific reporting period implementation. Instead it is reusing the existing 'since-x' reporting period. The dialog merely uses a "macro" to bootstrap a 'since-x' reporting period with the date of the first transaction.
As such the option 'since first transaction' is not a pointer referencing the date of the first transaction in the ledger. It's not a dynamic functionality backed by the current state of a modifiable portfolio. It's based on a one-time, static snapshot of the portfolio state. When this option is selected in the reporting period dialog, it creates a 'since-x' reporting period based on the date of the first transaction at this point in time.
Due to the lack of dynamic transaction tracking this functionality obviously "breaks" when a new, first transaction is added in retrospect. Then a 'since-x' reporting period might have been created previously for the transaction that was considered the first one before. In this situation the user must update the 'since first transaction' reporting period manually. 
Despite of the need for a manual correction of the first transaction reporting period, there are no severe issues caused. The outdated state is handled rather graceful. When the user re-enters the reporting period dialog in such a situation, he'll notice that the 'since first transaction' option is no longer selected. Instead a 'since ${date of the previous first transaction}' is selected. An outdated 'since first transaction' deteriorates gracefully into a simple 'since-x' when a new first transaction is added in retrospect.
But despite of the described limitation, I think this is still a very useful feature. First transactions do not change (often).