### PR TITLE
Fix IBKR import and value calculation of securities listed in other currencies

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/IBFlexStatementExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/IBFlexStatementExtractor.java
@@ -373,18 +373,11 @@ public class IBFlexStatementExtractor implements Extractor
                 }
             }
 
+            transaction.setSecurity(this.getOrCreateSecurity(element, true));
+            
             // transaction currency
             String currency = asCurrencyUnit(element.getAttribute("currency"));
-
-            // Set the Amount which is "netCash"
-            Double amount = Math.abs(Double.parseDouble(element.getAttribute("netCash")));
-            setAmount(element, transaction.getPortfolioTransaction(), amount, currency);
-            setAmount(element, transaction.getAccountTransaction(), amount, currency, false);
-
-            // Share Quantity
-            Double qty = Math.abs(Double.parseDouble(element.getAttribute("quantity")));
-            Double multiplier = Double.parseDouble(Optional.ofNullable(element.getAttribute("multiplier")).orElse("1"));
-            transaction.setShares(Math.round(qty.doubleValue() * Values.Share.factor() * multiplier.doubleValue()));
+            transaction.getPortfolioTransaction().setCurrencyCode(currency);
 
             // fees
             double fees = Math.abs(Double.parseDouble(element.getAttribute("ibCommission")));
@@ -397,7 +390,15 @@ public class IBFlexStatementExtractor implements Extractor
             Unit taxUnit = createUnit(element, Unit.Type.TAX, taxes, currency);
             transaction.getPortfolioTransaction().addUnit(taxUnit);
 
-            transaction.setSecurity(this.getOrCreateSecurity(element, true));
+            // Set the Amount which is "netCash"
+            Double amount = Math.abs(Double.parseDouble(element.getAttribute("netCash")));
+            setAmount(element, transaction.getPortfolioTransaction(), amount, currency);
+            setAmount(element, transaction.getAccountTransaction(), amount, currency, false);
+
+            // Share Quantity
+            Double qty = Math.abs(Double.parseDouble(element.getAttribute("quantity")));
+            Double multiplier = Double.parseDouble(Optional.ofNullable(element.getAttribute("multiplier")).orElse("1"));
+            transaction.setShares(Math.round(qty.doubleValue() * Values.Share.factor() * multiplier.doubleValue()));
 
             transaction.setNote(element.getAttribute("description"));
 
@@ -568,7 +569,7 @@ public class IBFlexStatementExtractor implements Extractor
 
                     // Gross value with conversion information for the security
                     // currency.
-                    Unit grossValue = new Unit(Unit.Type.GROSS_VALUE, transaction.getMonetaryAmount(),
+                    Unit grossValue = new Unit(Unit.Type.GROSS_VALUE, transaction.getGrossValue(),
                                     Money.of(transaction.getSecurity().getCurrencyCode(),
                                                     Math.round(securityCurrencyMoney.doubleValue())),
                                     inverseRate);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/IBFlexStatementExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/IBFlexStatementExtractor.java
@@ -163,7 +163,7 @@ public class IBFlexStatementExtractor implements Extractor
         private static final String ASSETKEY_STOCK = "STK";
         private static final String ASSETKEY_OPTION = "OPT";
         private static final String ASSETKEY_FUTURE_OPTION = "FOP";
-        
+
         private Document document;
         private List<Exception> errors = new ArrayList<>();
         private List<Item> results = new ArrayList<>();
@@ -374,7 +374,7 @@ public class IBFlexStatementExtractor implements Extractor
             }
 
             transaction.setSecurity(this.getOrCreateSecurity(element, true));
-            
+
             // transaction currency
             String currency = asCurrencyUnit(element.getAttribute("currency"));
             transaction.getPortfolioTransaction().setCurrencyCode(currency);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/SecurityPosition.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/SecurityPosition.java
@@ -101,7 +101,12 @@ public class SecurityPosition
                         .multiply(BigDecimal.valueOf(price.getValue()), Values.MC)
                         .movePointLeft(Values.Quote.precisionDeltaToMoney()) //
                         .setScale(0, RoundingMode.HALF_DOWN).longValue();
-        return Money.of(investment.getCurrencyCode(), marketValue);
+        String currencyForCalculation = investment.getCurrencyCode();
+        if (!transactions.isEmpty())
+        {
+            currencyForCalculation = transactions.get(0).getCurrencyCode();
+        }
+        return Money.of(currencyForCalculation, marketValue);
     }
 
     public static SecurityPosition split(SecurityPosition position, int weight)


### PR DESCRIPTION
I was facing an issue that prevented me from importing a security listed in other exchanges (hence in different currencies). I guess the issue occurs when you hold the security from various exchanges. 

My setup:
- EUR security account
- USD security account

The security is originally listed in USD but also on German exchanges in EUR. At first, you can have the originally listed security in USD but at some point, you may decide to buy the one listed in EUR. Then the issue occurs because the EUR listed security resolves to the same security listed in USD (I guess because it has the same isin). 

Therefore, the gross amount of the portfolio transaction must be set. Because of the order of operations in the code and the absence of currency code on the transation, gross value was not set. 
I spotted also an error in the calculation of value because there is an assumption that the value of the investment is in the currency of the security.

Caution: I am not an expert in Portfolio Performance.