### PR TITLE
Fixes wrong "benchmark" suffix for non-benchmark items

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeries.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeries.java
@@ -147,8 +147,7 @@ public final class DataSeries implements Adaptable
         }
 
         if (isBenchmark())
-            buf.append(" "); //$NON-NLS-1$
-            buf.append(Messages.ChartSeriesBenchmarkSuffix);
+            buf.append(" ").append(Messages.ChartSeriesBenchmarkSuffix); //$NON-NLS-1$
 
         return buf.toString();
     }


### PR DESCRIPTION
Fixes wrong "benchmark" suffix for non-benchmark items

see https://forum.portfolio-performance.info/t/auswahlmenue-der-datenreihen/2664/4?u=onkeldok