### PR TITLE
Fixes update issue in PaymentsView when filter is set

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsView.java
@@ -23,6 +23,7 @@ import org.eclipse.swt.widgets.Control;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.money.CurrencyConverterImpl;
 import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
+import name.abuchen.portfolio.snapshot.filter.ClientFilter;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.UIConstants;
@@ -75,23 +76,13 @@ public class PaymentsView extends AbstractFinanceView
 
         // setup filter
         clientFilterMenu = new ClientFilterMenu(client, preferences, filter -> {
-            Client filteredClient = filter.filter(client);
-            model.setFilteredClient(filteredClient);
-            setToContext(UIConstants.Context.FILTERED_CLIENT, filteredClient);
+            setFilteredClientToModel(filter);
+            viewInput.setClientFilterId(clientFilterMenu.getSelectedItem().getId());
             model.recalculate();
         });
 
-        viewInput.getClientFilterId().ifPresent(clientFilterId -> clientFilterMenu
-                        .selectItemFromClientFilterId(clientFilterId).ifPresent(item -> {
-                            Client filteredClient = item.getFilter().filter(client);
-                            model.setFilteredClient(filteredClient);
-                            setToContext(UIConstants.Context.FILTERED_CLIENT, filteredClient);
-
-                            // no recalculation needed as it is done as part
-                            // of the model#configure call
-                        }));
-
-        clientFilterMenu.addListener(filter -> viewInput.setClientFilterId(clientFilterMenu.getSelectedItem().getId()));
+        // set initial Filter
+        loadSavedFilterIdAndSetFilteredClientToModel();
 
         model.configure(viewInput.getYear(), viewInput.getMode(), viewInput.isUseGrossValue(),
                         viewInput.isUseConsolidateRetired());
@@ -104,9 +95,27 @@ public class PaymentsView extends AbstractFinanceView
         });
     }
 
+    private void setFilteredClientToModel(ClientFilter filter)
+    {
+        Client filteredClient = filter.filter(client);
+        model.setFilteredClient(filteredClient);
+        setToContext(UIConstants.Context.FILTERED_CLIENT, filteredClient);
+    }
+
+    private void loadSavedFilterIdAndSetFilteredClientToModel()
+    {
+        viewInput.getClientFilterId().ifPresent(clientFilterId -> clientFilterMenu
+                        .selectItemFromClientFilterId(clientFilterId).ifPresent(item -> {
+                            setFilteredClientToModel(item.getFilter());
+                        }));
+    }
+
     @Override
     public void notifyModelUpdated()
     {
+        // reload client filter, in case its data is outdated
+        loadSavedFilterIdAndSetFilteredClientToModel();
+
         model.recalculate();
     }
 


### PR DESCRIPTION
See issue report in forum: https://forum.portfolio-performance.info/t/zahlungen-ubersicht-aktualisiert-sich-nicht/24707

The error cause in current PP version is:
When a filter is set, the ``filteredClient`` in ``PaymentsViewModel`` is a readonly-instance which contains a state/snapshot of the account data from the moment in time when filter was set or view was initialized. Then, when the user modifies the account within this view (e.g. create new interest booking) then this new entry is added to the original client, but the ``ReadOnlyAccount`` used for the re-calculation is out-of-date: the new entry is missing in this instance.

So the current solution to fix this is to re-create and set the ``filteredClient`` before the recalculation when ``notifyModelUpdated`` is called.