### PR TITLE
Fix small typo in AppStream metadata

### DIFF
--- a/portfolio-product/metainfo/info.portfolio_performance.PortfolioPerformance.metainfo.xml
+++ b/portfolio-product/metainfo/info.portfolio_performance.PortfolioPerformance.metainfo.xml
@@ -9,6 +9,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>EPL-1.0</project_license>
   <description>
+    <p>An open source tool to calculate the overall performance of an investment portfolio - across all accounts - using True-Time Weighted Return or Internal Rate of Return.</p>
     <ul>
       <li>Record the full history of your transactions: purchases, sales, taxes, fees, ...</li>
       <li>Calculate performance indicators such as the True-Time Weighted Rate of Return or the Internal Rate of Return (IRR) for your holdings.</li>
@@ -17,6 +18,7 @@
       <li>Rebalance your investment portfolio based on a freely defined Asset Allocation.</li>
       <li>Keep foreign currency accounts using the exchange rates published by the European Central Bank (ECB).</li>
     </ul>
+    <p xml:lang="de">Ein Open Source Programm zur Berechnung der Performance eines Gesamtportfolios - über verschiedene Depots und Konten hinweg - anhand von True-Time Weighted Rate of Return und internem Zinsfuß.</p>
     <ul xml:lang="de">
       <li>Die vollständige Historie aller Buchungen kann erfasst werden: Käufe, Verkäufe, Steuern, Gebühren, ...</li>
       <li>Performance-Kennzahlen wie der True-Time Weighted Rate of Return oder der interne Zinsfuß (Internal Rate of Return) werden errechnet.</li>
@@ -38,7 +40,7 @@
   </keywords>
   <releases>
 		<release version="0.65.0" date="2023-08-14">
-			<decription>
+			<description>
 				<ul>
 					<li>New: Suggestions of providers for historical prices for freshly imported securities from PDF or CSV files</li>
 					<li>New: Newly recognized securities can be assigned to existing securities during PDF import</li>
@@ -63,7 +65,7 @@
 					<li>Fix: Tooltip zur Berechnung der Kursgewinne auf 50 Zeilen limitiert</li>
 					<li>Fix: Filteroptionen werden nun ordnungsgemäß beim Öffnen der Liste aller Buchungen angewendet</li>
 				</ul>
-			</decription>
+			</description>
 		</release>
     <release version="0.64.5" date="2023-07-23">
       <description>


### PR DESCRIPTION
The "description" tag for the 0.65.0 release is misspelled "decription".

Also add an introductory paragraph to the app description to make appstream-util validate happy.