### PR TITLE
Store time periods in xml file not in settings file, fixes #2952

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/EditReportingPeriodsDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/EditReportingPeriodsDialog.java
@@ -1,7 +1,10 @@
 package name.abuchen.portfolio.ui.dialogs;
 
+import static name.abuchen.portfolio.util.CollectorsUtil.toMutableList;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.dialogs.Dialog;
@@ -47,9 +50,9 @@ public class EditReportingPeriodsDialog extends Dialog
         super(parentShell);
     }
 
-    public void setReportingPeriods(List<ReportingPeriod> periods)
+    public void setReportingPeriods(Stream<ReportingPeriod> periods)
     {
-        this.periods = new ArrayList<>(periods);
+        this.periods = periods.collect(toMutableList());
     }
 
     public List<ReportingPeriod> getReportingPeriods()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientFilterMigration.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientFilterMigration.java
@@ -65,7 +65,7 @@ import name.abuchen.portfolio.ui.util.ClientFilterMenu.Item;
     {
         // migrate filter definitions
         ConfigurationSet set = client.getSettings()
-                        .getConfigurationSet(WellKnownConfigurationSets.CLIENT_FILTER_DEFINITIONS.getKey());
+                        .getConfigurationSet(WellKnownConfigurationSets.CLIENT_FILTER_DEFINITIONS);
         set.clear();
         newConfigurations.forEach(set::add);
     }
@@ -110,7 +110,7 @@ import name.abuchen.portfolio.ui.util.ClientFilterMenu.Item;
     private void migrateSelectedFiltersIntoClient(List<Configuration> newConfigurations)
     {
         ConfigurationSet set = client.getSettings()
-                        .getConfigurationSet(WellKnownConfigurationSets.CLIENT_FILTER_SELECTION.getKey());
+                        .getConfigurationSet(WellKnownConfigurationSets.CLIENT_FILTER_SELECTION);
         set.clear();
 
         loadSelectedFilters(newConfigurations).forEach(set::add);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/PortfolioPart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/PortfolioPart.java
@@ -3,7 +3,6 @@ package name.abuchen.portfolio.ui.editor;
 import java.io.File;
 import java.io.IOException;
 import java.text.MessageFormat;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -455,7 +454,7 @@ public class PortfolioPart implements ClientInputListener
         return clientInput.getEclipsePreferences();
     }
 
-    public List<ReportingPeriod> getReportingPeriods()
+    public ReportingPeriods getReportingPeriods()
     {
         return clientInput.getReportingPeriods();
     }
@@ -488,8 +487,8 @@ public class PortfolioPart implements ClientInputListener
 
         if (selectedPeriod == null)
         {
-            List<ReportingPeriod> periods = clientInput.getReportingPeriods();
-            selectedPeriod = periods.isEmpty() ? new ReportingPeriod.LastX(1, 0) : periods.get(0);
+            selectedPeriod = clientInput.getReportingPeriods().stream().findFirst()
+                            .orElseGet(() -> new ReportingPeriod.LastX(1, 0));
         }
 
         return selectedPeriod;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ReportingPeriods.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ReportingPeriods.java
@@ -1,0 +1,50 @@
+package name.abuchen.portfolio.ui.editor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import name.abuchen.portfolio.snapshot.ReportingPeriod;
+
+public class ReportingPeriods
+{
+    private final ArrayList<ReportingPeriod> periods;
+    private final ClientInput clientInput;
+
+    ReportingPeriods(ClientInput clientInput, ArrayList<ReportingPeriod> periods)
+    {
+        this.clientInput = clientInput;
+        this.periods = clientInput.loadReportingPeriods();
+    }
+
+    public Stream<ReportingPeriod> stream()
+    {
+        return periods.stream();
+    }
+
+    public void add(ReportingPeriod p)
+    {
+        if (periods.contains(p))
+            return;
+
+        periods.add(p);
+
+        clientInput.storeReportingPeriods(this.stream());
+        clientInput.touch();
+    }
+
+    public void replaceAll(List<ReportingPeriod> reportingPeriods)
+    {
+        periods.clear();
+        periods.addAll(reportingPeriods);
+
+        clientInput.storeReportingPeriods(this.stream());
+        clientInput.touch();
+    }
+
+    public boolean contains(ReportingPeriod p)
+    {
+        return periods.contains(p);
+    }
+
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
@@ -114,7 +114,7 @@ public final class ClientFilterMenu implements IMenuListener
         this.client = client;
         this.preferences = preferences;
         this.filterConfig = client.getSettings()
-                        .getConfigurationSet(WellKnownConfigurationSets.CLIENT_FILTER_DEFINITIONS.getKey());
+                        .getConfigurationSet(WellKnownConfigurationSets.CLIENT_FILTER_DEFINITIONS);
 
         selectedItem = new Item("", Messages.PerformanceChartLabelEntirePortfolio, "", //$NON-NLS-1$ //$NON-NLS-2$
                         ClientFilter.NO_FILTER);
@@ -367,7 +367,7 @@ public final class ClientFilterMenu implements IMenuListener
 
     public static void saveSelectedFilter(Client client, String key, String clientFilterId)
     {
-        var set = client.getSettings().getConfigurationSet(WellKnownConfigurationSets.CLIENT_FILTER_SELECTION.getKey());
+        var set = client.getSettings().getConfigurationSet(WellKnownConfigurationSets.CLIENT_FILTER_SELECTION);
 
         set.lookup(key).ifPresentOrElse(config -> config.setData(clientFilterId),
                         () -> set.add(new Configuration(key, "", clientFilterId))); //$NON-NLS-1$
@@ -377,7 +377,7 @@ public final class ClientFilterMenu implements IMenuListener
 
     public static Optional<String> getSelectedFilterId(Client client, String key)
     {
-        return client.getSettings().getConfigurationSet(WellKnownConfigurationSets.CLIENT_FILTER_SELECTION.getKey())
+        return client.getSettings().getConfigurationSet(WellKnownConfigurationSets.CLIENT_FILTER_SELECTION)
                         .lookup(key).map(Configuration::getData);
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ReportingPeriodDropDown.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ReportingPeriodDropDown.java
@@ -67,7 +67,10 @@ public final class ReportingPeriodDropDown extends DropDown implements IMenuList
                 doSelect(period);
 
                 if (!periods.contains(period))
+                {
                     periods.add(period);
+                    part.getClient().touch();
+                }
 
                 if (listener != null)
                     listener.reportingPeriodUpdated();
@@ -92,6 +95,8 @@ public final class ReportingPeriodDropDown extends DropDown implements IMenuList
                     doSelect(periods.get(0));
                     listener.reportingPeriodUpdated();
                 }
+
+                part.getClient().touch();
             }
         }));
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ReportingPeriodDropDown.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ReportingPeriodDropDown.java
@@ -1,7 +1,6 @@
 package name.abuchen.portfolio.ui.util;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.jface.action.Action;
@@ -17,6 +16,7 @@ import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.dialogs.EditReportingPeriodsDialog;
 import name.abuchen.portfolio.ui.dialogs.ReportingPeriodDialog;
 import name.abuchen.portfolio.ui.editor.PortfolioPart;
+import name.abuchen.portfolio.ui.editor.ReportingPeriods;
 
 public final class ReportingPeriodDropDown extends DropDown implements IMenuListener
 {
@@ -30,7 +30,7 @@ public final class ReportingPeriodDropDown extends DropDown implements IMenuList
     private final ReportingPeriodListener listener;
 
     private ReportingPeriod selected;
-    private List<ReportingPeriod> periods;
+    private ReportingPeriods periods;
 
     public ReportingPeriodDropDown(final PortfolioPart part, ReportingPeriodListener listener)
     {
@@ -49,12 +49,11 @@ public final class ReportingPeriodDropDown extends DropDown implements IMenuList
     @Override
     public void menuAboutToShow(IMenuManager manager)
     {
-        for (ReportingPeriod period : periods)
-        {
-            Action action = createActionFor(period);
-            action.setChecked(period.equals(selected));
+        periods.stream().forEach(p -> {
+            Action action = createActionFor(p);
+            action.setChecked(p.equals(selected));
             manager.add(action);
-        }
+        });
 
         manager.add(new Separator());
         manager.add(new SimpleAction(Messages.LabelReportingAddPeriod, a -> {
@@ -66,11 +65,7 @@ public final class ReportingPeriodDropDown extends DropDown implements IMenuList
 
                 doSelect(period);
 
-                if (!periods.contains(period))
-                {
-                    periods.add(period);
-                    part.getClient().touch();
-                }
+                periods.add(period);
 
                 if (listener != null)
                     listener.reportingPeriodUpdated();
@@ -79,20 +74,19 @@ public final class ReportingPeriodDropDown extends DropDown implements IMenuList
 
         manager.add(new SimpleAction(Messages.MenuReportingPeriodManage, a -> {
             EditReportingPeriodsDialog dialog = new EditReportingPeriodsDialog(Display.getDefault().getActiveShell());
-            dialog.setReportingPeriods(periods);
+            dialog.setReportingPeriods(periods.stream());
 
             if (dialog.open() == Window.OK)
             {
-                periods.clear();
-                periods.addAll(dialog.getReportingPeriods());
+                periods.replaceAll(dialog.getReportingPeriods());
 
                 // make sure at least one entry exists
-                if (periods.isEmpty())
+                if (periods.stream().findAny().isEmpty())
                     periods.add(selected);
 
                 if (!periods.contains(selected))
                 {
-                    doSelect(periods.get(0));
+                    doSelect(periods.stream().findFirst().get());
                     listener.reportingPeriodUpdated();
                 }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.ui.views;
 
+import static name.abuchen.portfolio.util.CollectorsUtil.toMutableList;
+
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.time.LocalDate;
@@ -207,7 +209,7 @@ public final class SecuritiesTable implements ModificationListener
         addQuoteDeltaColumn();
         support.addColumn(new DistanceFromMovingAverageColumn(LocalDate::now));
         support.addColumn(new DistanceFromAllTimeHighColumn(LocalDate::now,
-                        new ArrayList<>(view.getPart().getReportingPeriods())));
+                        view.getPart().getReportingPeriods().stream().collect(toMutableList())));
 
         for (Taxonomy taxonomy : getClient().getTaxonomies())
         {
@@ -556,7 +558,7 @@ public final class SecuritiesTable implements ModificationListener
     {
         // create a modifiable copy as all menus share the same list of
         // reporting periods
-        List<ReportingPeriod> options = new ArrayList<>(view.getPart().getReportingPeriods());
+        List<ReportingPeriod> options = view.getPart().getReportingPeriods().stream().collect(toMutableList());
 
         BiFunction<Object, ReportingPeriod, Double> valueProvider = (element, option) -> {
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.ui.views;
 
+import static name.abuchen.portfolio.util.CollectorsUtil.toMutableList;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -571,7 +573,7 @@ public class StatementOfAssetsViewer
 
         // create a modifiable copy as all menus share the same list of
         // reporting periods
-        List<ReportingPeriod> options = new ArrayList<>(owner.getPart().getReportingPeriods());
+        List<ReportingPeriod> options = owner.getPart().getReportingPeriods().stream().collect(toMutableList());
 
         addPerformanceColumns(options);
         addDividendColumns(options);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DashboardData.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DashboardData.java
@@ -1,9 +1,7 @@
 package name.abuchen.portfolio.ui.views.dashboard;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -19,6 +17,7 @@ import name.abuchen.portfolio.money.CurrencyConverterImpl;
 import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;
 import name.abuchen.portfolio.snapshot.ReportingPeriod;
+import name.abuchen.portfolio.ui.editor.ReportingPeriods;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeries;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeriesCache;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeriesSet;
@@ -35,7 +34,7 @@ public class DashboardData
 
     private final Map<Object, Object> cache = Collections.synchronizedMap(new HashMap<>());
 
-    private List<ReportingPeriod> defaultReportingPeriods = new ArrayList<>();
+    private ReportingPeriods defaultReportingPeriods;
     private ReportingPeriod defaultReportingPeriod;
 
     private CurrencyConverter converter;
@@ -84,12 +83,12 @@ public class DashboardData
         this.dashboard = dashboard;
     }
 
-    public void setDefaultReportingPeriods(List<ReportingPeriod> defaultReportingPeriods)
+    public void setDefaultReportingPeriods(ReportingPeriods periods)
     {
-        this.defaultReportingPeriods = defaultReportingPeriods;
+        this.defaultReportingPeriods = periods;
     }
 
-    public List<ReportingPeriod> getDefaultReportingPeriods()
+    public ReportingPeriods getDefaultReportingPeriods()
     {
         return defaultReportingPeriods;
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientSettings.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientSettings.java
@@ -14,6 +14,7 @@ import name.abuchen.portfolio.model.AttributeType.AmountPlainConverter;
 import name.abuchen.portfolio.model.AttributeType.ImageConverter;
 import name.abuchen.portfolio.model.AttributeType.PercentConverter;
 import name.abuchen.portfolio.model.AttributeType.StringConverter;
+import name.abuchen.portfolio.model.ConfigurationSet.WellKnownConfigurationSets;
 
 public class ClientSettings
 {
@@ -213,6 +214,11 @@ public class ClientSettings
     public ConfigurationSet getConfigurationSet(String key)
     {
         return configurationSets.computeIfAbsent(key, k -> new ConfigurationSet());
+    }
+
+    public ConfigurationSet getConfigurationSet(WellKnownConfigurationSets wellKnown)
+    {
+        return getConfigurationSet(wellKnown.getKey());
     }
 
     public Set<Map.Entry<String, ConfigurationSet>> getConfigurationSets()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ConfigurationSet.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ConfigurationSet.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -19,7 +20,8 @@ public class ConfigurationSet
          */
         CLIENT_FILTER_DEFINITIONS("client-filter-definitions"), //$NON-NLS-1$
         /** selected client filter in views; view name is key */
-        CLIENT_FILTER_SELECTION("client-filter-selection"); //$NON-NLS-1$
+        CLIENT_FILTER_SELECTION("client-filter-selection"), //$NON-NLS-1$
+        REPORTING_PERIODS("REPORTING_PERIODS"); //$NON-NLS-1$
 
         private WellKnownConfigurationSets(String key)
         {
@@ -122,6 +124,7 @@ public class ConfigurationSet
      */
     public void add(Configuration configuration)
     {
+        Objects.requireNonNull(configuration);
         configurations.add(configuration);
     }
 
@@ -130,6 +133,7 @@ public class ConfigurationSet
      */
     public void add(int index, Configuration configuration)
     {
+        Objects.requireNonNull(configuration);
         configurations.add(index, configuration);
     }
 


### PR DESCRIPTION
I am working on #2952.
Closes #2952



This is not the final state, therefore I set the PR to draft until I think it's ready for a full review. But I need a place to ask my questions and I don't want to use the issue for this.

I have following questions to continue my work:
* PP currently stores ``TIME_PERIODS`` in the settings file and ``SELECTED_TIME_PERIOD`` in the file ``copy.e4xmi`` in the workspace.
**Question: is the goal for this task to migrate both settings into the XML? Or only one of them?**
* For migrating the ``SELECTED_TIME_PERIOD`` we need the ``MPart`` in the migration logic. To get this I had to change the instance creation order of ``ClientInput`` and the ``MPart``. Here I don't know if this new order is allowed or if the old order (``MPart`` is created after the ``ClientInput``) is important.
* In general: how can I link this PR and the issue to see the PR as linked to the item in our project? Using ``fixes #2952`` in commit message did not make it. And linking it manually using the side menu is not possible. I cannot click on ``Development``. 