### PR TITLE
Use crosshair cursor for chart tool

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartToolsManager.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartToolsManager.java
@@ -13,6 +13,7 @@ import org.eclipse.jface.action.ToolBarManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Event;
 
@@ -182,6 +183,8 @@ public class ChartToolsManager
                             updateButtonImages(this.activeTool);
 
                             chart.getToolTip().setActive(this.activeTool == ChartTools.NONE);
+                            chart.setCursor(this.activeTool == ChartTools.NONE ? null
+                                            : new Cursor(this.chart.getDisplay(), SWT.CURSOR_CROSS));
                             chart.redraw();
                         });
 


### PR DESCRIPTION
This little PR suggests to use the crosshair cursor for the new chart tools in order to better recognize that the chart tools are active and for easier positioning of the mouse cursor.