### PR TITLE
Stretch text fields for ISIN, Ticker and WKN in SecurityMasterDataPage

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SecurityMasterDataPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SecurityMasterDataPage.java
@@ -108,7 +108,7 @@ public class SecurityMasterDataPage extends AbstractPage
 
         if (!isExchangeRate)
         {
-            isin = bindings.bindISINInput(container, Messages.ColumnISIN, "isin"); //$NON-NLS-1$
+            isin = bindings.bindStringInput(container, Messages.ColumnISIN, "isin"); //$NON-NLS-1$
             if (isSyncedOnline)
             {
                 isin.setEditable(false);
@@ -116,11 +116,11 @@ public class SecurityMasterDataPage extends AbstractPage
             }
         }
 
-        bindings.bindStringInput(container, Messages.ColumnTicker, "tickerSymbol", SWT.NONE, 12); //$NON-NLS-1$
+        bindings.bindStringInput(container, Messages.ColumnTicker, "tickerSymbol"); //$NON-NLS-1$
 
         if (!isExchangeRate)
         {
-            wkn = bindings.bindStringInput(container, Messages.ColumnWKN, "wkn", SWT.NONE, 12); //$NON-NLS-1$
+            wkn = bindings.bindStringInput(container, Messages.ColumnWKN, "wkn"); //$NON-NLS-1$
             if (isSyncedOnline)
             {
                 wkn.setEditable(false);


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/eingabefeld-symbol-in-der-eingabemaske-verlangern/24916

EDIT:
After initial commit I realized that with my change of the ISIN textinput I removed the validation of the ISIN value.
@buchen: If you generally would accept the stretching, then I will find a way to have both: stretch and validation. Just let me know.


