### PR TITLE
[PDF] [Deutsche Bank] Fix detection of currency for account statement

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
@@ -2299,4 +2299,38 @@ public class DeutscheBankPDFExtractorTest
                         "Deutsche Bank Privat- und Geschäftskunden AG", "GiroKontoauszug05.txt");
         assertEquals(expectedErrorMessage, firstError.getMessage());
     }
+    
+    @Test
+    public void testGiroKontoauszug06()
+    {
+        DeutscheBankPDFExtractor extractor = new DeutscheBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "GiroKontoauszug06.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(3));
+
+        // check dividends transaction
+        assertThat(results, hasItem(removal( //
+                        hasDate("2023-08-14"), hasShares(0), //
+                        hasSource("GiroKontoauszug06.txt"), hasNote("Überweisung an 2023 2023 Max Mustermann"), //
+                        hasAmount("EUR", 1000), hasGrossValue("EUR", 1000), //
+                        hasTaxes("EUR", 0), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(deposit( //
+                        hasDate("2023-08-16"), hasShares(0), //
+                        hasSource("GiroKontoauszug06.txt"), hasNote(""), //
+                        hasAmount("EUR", 33.23), hasGrossValue("EUR", 33.23), //
+                        hasTaxes("EUR", 0), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(deposit( //
+                        hasDate("2023-08-31"), hasShares(0), //
+                        hasSource("GiroKontoauszug06.txt"), hasNote(""), //
+                        hasAmount("EUR", 74.49), hasGrossValue("EUR", 74.49), //
+                        hasTaxes("EUR", 0), hasFees("EUR", 0.00))));
+
+    }
+
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/GiroKontoauszug06.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/GiroKontoauszug06.txt
@@ -1,0 +1,50 @@
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.65.4.qualifier
+-----------------------------------------
+Deutsche Bank AG
+Filiale
+Mannheim-Neckarau
+Friedrichstraße 3-5
+Herrn 68199 Mannheim
+PkOgVXl uGpqfT Frau Nicole Schrempp
+FDBFxtwbEH. 12 Telefon (0621) 84228-14
+12929 FGSuxgpw
+24h-Kundenservice (069) 910-10000
+31. August 2023
+Kontoauszug vom 01.08.2023 bis 31.08.2023
+Kontoinhaber: BGAGHwc yrPqwr
+Auszug Seite von IBAN Alter Saldo per 31.07.2023
+8 1 2 DE03 0304 6283 7910 2573 16 EUR + 1.428,92
+Buchung Valuta Vorgang Soll Haben
+14.08. 14.08. SEPA Überweisung an - 1.000,00
+2023 2023 Max Mustermann
+IBAN DE70700100800927167806
+BIC PBNKDEFFXXX
+Verwendungszweck/ Kundenreferenz
+urlaub
+16.08. 16.08. Verwendungszweck/ Kundenreferenz + 33,23
+2023 2023 ZINSEN/DIVIDENDEN/ERTRAEGE FIL/DEPOT-NR:
+218/338781300IS.E.R.G.G.1.5-2.5Y U.ETF DE
+INH.ANT.E UR(D.)
+31.08. 31.08. Verwendungszweck/ Kundenreferenz + 74,49
+2023 2023 ZINSEN/DIVIDENDEN/ERTRAEGE FIL/DEPOT-NR:
+218/338781300ISHSII-CORE MSCI EUROPE U.ETF
+REG.SH.O .N.
+Filialnummer Kontonummer Neuer Saldo
+218 3387813 03
+EUR + 536,63
+BIC (SWIFT)
+DEUTDEDBXXX
+Wichtige Hinweise
+Bitte erheben Sie Einwendungen gegen einzelne Buchungen unverzüglich. Schecks, Wechsel und sonstige Lastschriften schreiben wir unter dem Vorbehalt
+des Eingangs gut. Der angegebene Kontostand berücksichtigt nicht die Wertstellung der Buchungen (siehe oben unter "Valuta").
+Somit können bei Verfügungen1) möglicherweise Zinsen für die Inanspruchnahme einer eingeräumten oder geduldeten Kontoüberziehung anfallen.
+Die abgerechneten Leistungen sind als Bank- oder Finanzdienstleistungen von der Umsatzsteuer befreit, sofern Umsatzsteuer nicht gesondert
+ausgewiesen ist. Umsatzsteuer ID Nr.: Deutsche Bank AG, 60262 Frankfurt DE114103379
+1) Der Begriff umfasst unter anderem die relevanten Zahlungskontendienste "Bargeldauszahlung" und "Überweisung".
+0000000003 / 06500900 / 20230902
+Auszug Seite von IBAN
+8 2 2 DE03 3807 0724 0248 4780 40
+Guthaben sind als Einlagen nach Maßgabe des Einlagensicherungsgesetzes entschädigungsfähig. Nähere Informationen können dem "Informationsbogen
+für den Einleger" entnommen werden.
+0000000003 / 06500900 / 20230902

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
@@ -335,14 +335,21 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
     private void addAccountStatementTransaction()
     {
         final DocumentType type = new DocumentType("Kontoauszug vom", (context, lines) -> {
-            Pattern pCurrency = Pattern.compile("[\\d]{3} [\\d]+ [\\d]{2} (?<currency>[\\w]{3}) [\\-|\\+] [\\.,\\d]+");
-            Pattern pYear = Pattern.compile("Kontoauszug vom [\\d]{2}\\.[\\d]{2}\\.(?<year>[\\d]{4}) bis [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}");
+            Pattern pCurrency = Pattern.compile(".* (?<currency>[\\w]{3}) [\\-|\\+] [\\.,\\d]+$");
+            Pattern pYear = Pattern.compile(
+                            "Kontoauszug vom [\\d]{2}\\.[\\d]{2}\\.(?<year>[\\d]{4}) bis [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}");
 
-            for (String line : lines)
+            for (int lineNo = 0; lineNo < lines.length; lineNo++)
             {
-                Matcher mCurrency = pCurrency.matcher(line);
-                if (mCurrency.matches())
-                    context.put("currency", mCurrency.group("currency"));
+                String line = lines[lineNo];
+
+                // check for currency
+                if (line.startsWith("Auszug Seite") && lineNo + 1 < lines.length)
+                {
+                    Matcher mCurrency = pCurrency.matcher(lines[lineNo + 1]);
+                    if (mCurrency.matches())
+                        context.put("currency", mCurrency.group("currency"));
+                }
 
                 Matcher mYear = pYear.matcher(line);
                 if (mYear.matches())


### PR DESCRIPTION
The latest account statements cannot be imported because the currency was not detected. Apparently the latest document (can) introduce a line break between account number and final balance.

With this change, the currency is retrieved from the header of the document. However, to enable this we need to check for two lines.