### PR TITLE
[PDF] [Deutsche Bank] Prevent transactions from statement if no currency is found

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
@@ -348,6 +348,12 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
                 if (mYear.matches())
                     context.put("year", mYear.group("year"));
             }
+
+            if (!context.containsKey("year"))
+                throw new IllegalArgumentException("No statement year found.");
+
+            if (!context.containsKey("currency"))
+                throw new IllegalArgumentException("No account currency found.");
         });
         this.addDocumentTyp(type);
 


### PR DESCRIPTION
The transaction year and transactions currency is parsed from the document header into the context. Until now, the information is not checked if it is actually found and leads to faulty transactions.

Closes #3549