### PR TITLE
allow adding security with null or empty ticker symbol in SearchSecurityWizardDialog

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SearchSecurityWizardPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SearchSecurityWizardPage.java
@@ -136,7 +136,8 @@ public class SearchSecurityWizardPage extends WizardPage
 
         resultTable.addSelectionChangedListener(event -> {
             item = (ResultItem) ((IStructuredSelection) event.getSelection()).getFirstElement();
-            setPageComplete(item != null && !existingSymbols.contains(item.getSymbol()));
+            setPageComplete(item != null && (item.getSymbol() == null || item.getSymbol().isEmpty()
+                            || !existingSymbols.contains(item.getSymbol())));
         });
 
         setControl(container);


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/uebernehmen-ausgegraut-in-ergebnisliste-der-wertpapiersuche/9526/32