### PR TITLE
AllTransactionsView: Fixes missing item when cross owner should match the filter

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AllTransactionsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AllTransactionsView.java
@@ -438,9 +438,11 @@ public class AllTransactionsView extends AbstractFinanceView
                 if (clientFilter == null)
                     return true;
                 TransactionPair<?> tx = (TransactionPair<?>) element;
+                // check owner and cross owner
                 return clientFilter.hasElement(tx.getOwner())
-                                || (tx.getTransaction().getCrossEntry() != null && clientFilter.hasElement(
-                                                tx.getTransaction().getCrossEntry().getOwner(tx.getTransaction())));
+                                || (tx.getTransaction().getCrossEntry() != null && clientFilter.hasElement(tx
+                                                .getTransaction().getCrossEntry() //
+                                                .getCrossOwner(tx.getTransaction())));
             }
         });
 


### PR DESCRIPTION
See https://forum.portfolio-performance.info/t/fehlende-umbuchungen-in-alle-buchungen-bei-filter/25062

## All transactions without Filter

![grafik](https://github.com/portfolio-performance/portfolio/assets/90478568/e8e1cb5e-607c-4209-a000-e72ba7f672c2)

## Before Fix (current PP version)

![grafik](https://github.com/portfolio-performance/portfolio/assets/90478568/552749e6-6ae0-418c-9c5f-68506f946b85)

## With Fix

![grafik](https://github.com/portfolio-performance/portfolio/assets/90478568/df71e217-431a-4577-9e1a-3b1e56487d8e)



