### PR TITLE
pass empty string instead of null to prevent NPE

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ConfigurationStore.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ConfigurationStore.java
@@ -69,7 +69,7 @@ public class ConfigurationStore
         // make one active (and there always must be one active)
         this.active = configSet.lookup(preferences.getString(identifier + KEY_ACTIVE))
                         .orElseGet(() -> configSet.getConfigurations().findFirst().orElseGet(() -> {
-                            Configuration defaultConfig = new Configuration(Messages.ConfigurationStandard, null);
+                            Configuration defaultConfig = new Configuration(Messages.ConfigurationStandard, ""); //$NON-NLS-1$
                             configSet.add(defaultConfig);
                             return defaultConfig;
                         }));
@@ -202,7 +202,7 @@ public class ConfigurationStore
 
         listeners.forEach(ConfigurationStoreOwner::beforeConfigurationPicked);
         active = configSet.getConfigurations().findAny().orElseGet(() -> {
-            Configuration defaultConfig = new Configuration(Messages.ConfigurationStandard, null);
+            Configuration defaultConfig = new Configuration(Messages.ConfigurationStandard, ""); //$NON-NLS-1$
             configSet.add(defaultConfig);
             return defaultConfig;
         });

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ChartWidget.java
@@ -67,7 +67,7 @@ public class ChartWidget extends WidgetDelegate<Object>
             configSet = delegate.getClient().getSettings().getConfigurationSet(configName);
             String uuid = delegate.getWidget().getConfiguration().get(Dashboard.Config.CONFIG_UUID.name());
             config = configSet.lookup(uuid).orElseGet(() -> configSet.getConfigurations().findFirst()
-                            .orElseGet(() -> new ConfigurationSet.Configuration(Messages.LabelNoName, null)));
+                            .orElseGet(() -> new ConfigurationSet.Configuration(Messages.LabelNoName, ""))); //$NON-NLS-1$
 
             addConfig(new ChartShowYAxisConfig(delegate, false));
         }


### PR DESCRIPTION
Because some commits ago we introduced the null checks (https://github.com/portfolio-performance/portfolio/blob/f47258a2195760826a3df19cd806d7026b32f731/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ConfigurationSet.java#L64-L69) we now have to pass empty string instead of null.

In current version (with passing ``null``) this leads to errors when creating an empty new portfolio file. You cannot save the new file. The "Save" or "Save as" menu entries are disabled.