### PR TITLE
nullcheck of taxonomy in EarningsByTaxonomyChartWidget

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/earnings/EarningsByTaxonomyChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/earnings/EarningsByTaxonomyChartWidget.java
@@ -90,7 +90,8 @@ public class EarningsByTaxonomyChartWidget extends CircularChartWidget<Map<Inves
 
             Label label = new Label(data, SWT.NONE);
             label.setData(UIConstants.CSS.CLASS_NAME, UIConstants.CSS.HEADING2);
-            label.setText(get(TaxonomyConfig.class).getTaxonomy().getName());
+            var taxonomy = get(TaxonomyConfig.class).getTaxonomy();
+            label.setText(taxonomy != null ? taxonomy.getName() : ""); //$NON-NLS-1$
 
             @SuppressWarnings("unchecked")
             List<Item> skipped = (List<Item>) getChart().getData();
@@ -184,6 +185,8 @@ public class EarningsByTaxonomyChartWidget extends CircularChartWidget<Map<Inves
     protected void createCircularSeries(Map<InvestmentVehicle, Item> vehicle2money)
     {
         Taxonomy taxonomy = get(TaxonomyConfig.class).getTaxonomy();
+        if (taxonomy == null)
+            return;
 
         // pie charts cannot have negative pie slides --> remember the removed
         // items in order to display them in the tool tip


### PR DESCRIPTION
Maybe reason for https://forum.portfolio-performance.info/t/fehlermeldung-java-lang-illegal-argumentexeption-bereich-ungultig/25118
But so far I could not reproduce the error exactly like it was reported in the initial post. But when I tried to create an new file (no taxonomies) and create a ``EarningsByTaxonomyChartWidget`` then I got NPE and this is fixed by this PR.