### PR TITLE
do not gray out item when symbol is empty

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SearchSecurityWizardPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SearchSecurityWizardPage.java
@@ -248,7 +248,7 @@ public class SearchSecurityWizardPage extends WizardPage
         {
             ResultItem item = (ResultItem) element;
 
-            if (item.getSymbol() != null && symbols.contains(item.getSymbol()))
+            if (item.getSymbol() != null && !item.getSymbol().isEmpty() && symbols.contains(item.getSymbol()))
                 return Display.getCurrent().getSystemColor(SWT.COLOR_GRAY);
             else
                 return null;


### PR DESCRIPTION
In accordance with https://github.com/portfolio-performance/portfolio/commit/13fb3705db4a71fba4f490e35b8dca611bc709ce we should not gray out resulting items when the symbol is empty.