### PR TITLE
Ignore inactive securities when searching for a matching identifier

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/SecurityCache.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/SecurityCache.java
@@ -32,18 +32,20 @@ public class SecurityCache
     {
         this.client = client;
 
-        this.localMaps.add(client.getSecurities().stream().filter(s -> s.getIsin() != null && !s.getIsin().isEmpty())
+        this.localMaps.add(client.getSecurities().stream()
+                        .filter(s -> s.getIsin() != null && !s.getIsin().isEmpty() && !s.isRetired())
                         .collect(Collectors.toMap(Security::getIsin, s -> s, (l, r) -> DUPLICATE_SECURITY_MARKER)));
 
         this.localMaps.add(client.getSecurities().stream()
-                        .filter(s -> s.getTickerSymbol() != null && !s.getTickerSymbol().isEmpty())
+                        .filter(s -> s.getTickerSymbol() != null && !s.getTickerSymbol().isEmpty() && !s.isRetired())
                         .collect(Collectors.toMap(Security::getTickerSymbolWithoutStockMarket, s -> s,
                                         (l, r) -> DUPLICATE_SECURITY_MARKER)));
 
-        this.localMaps.add(client.getSecurities().stream().filter(s -> s.getWkn() != null && !s.getWkn().isEmpty())
+        this.localMaps.add(client.getSecurities().stream()
+                        .filter(s -> s.getWkn() != null && !s.getWkn().isEmpty() && !s.isRetired())
                         .collect(Collectors.toMap(Security::getWkn, s -> s, (l, r) -> DUPLICATE_SECURITY_MARKER)));
-
-        this.localMaps.add(client.getSecurities().stream().filter(s -> s.getName() != null && !s.getName().isEmpty())
+        this.localMaps.add(client.getSecurities().stream()
+                        .filter(s -> s.getName() != null && !s.getName().isEmpty() && !s.isRetired())
                         .collect(Collectors.toMap(Security::getName, s -> s, (l, r) -> DUPLICATE_SECURITY_MARKER)));
 
     }


### PR DESCRIPTION
This is a small step towards improving support of "duplicate" securities (e.g. same ISIN), or rather, making it work again.

Currently, importing PDFs is basically impossible if the security ISIN/WKN exists twice. This has been acknowledged as a shortcoming in these forum threads:

https://forum.portfolio-performance.info/t/csv-import-of-portfolio-transaction-does-not-work-if-isin-is-not-unique/7386
https://forum.portfolio-performance.info/t/fehler-isin-existiert-mehrfach-in-wertpapierliste-beim-pdf-import/11087/25

To quote @buchen:

> Anyway: PP has a very simple logic. When importing data from CSV, I tries to match the information to the existing securities configured in the file. If the identifier (ISIN, WKN, ticker) points to two securities, then PP does not know which one to use and fails. **That might not be the most intelligent strategy** but it is then implemented. PP could allow the user to select the security in the dialog after parsing the CSV file. I never came around to implementing it, so if you want to give it a go, then I can point you to the place in the code

This change addresses the problem by at least allowing inactive securities and one active security to exist without blocking the PDF import. Inactive securities are ignored when searching for a security with matching identifier(s). Thus, the PDF import will match the single active security and allow importing again. This should solve most real-world scenarios for using multiple identical securities (as the "old" securities are likely already inactive or at least easily could be deactivated). It would also allow a workaround for users even in scenarios with identical active securities if they simply temporarily deactivate one of them for the PDF import and then activate it again.

Further improvements to the described problem could be:

1) During PDF import for a specific securities account, in the case of duplicates choose the security that is already an asset in this account, if exactly one matching asset exists in the account.

2) In any case where, even with the better matching described in 1) and in this change, more than one security matches, show a dialog allowing the user to choose the right security. This should be a rare scenario though because it could only happen if you trade two "identical" securities in the same account but somehow logically separated.