### PR TITLE
disable finish button in search security wizard by default

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SearchSecurityWizardPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SearchSecurityWizardPage.java
@@ -54,6 +54,7 @@ public class SearchSecurityWizardPage extends WizardPage
         super(PAGE_ID);
         setTitle(Messages.SecurityMenuAddNewSecurity);
         setDescription(Messages.SecurityMenuAddNewSecurityDescription);
+        setPageComplete(false);
 
         this.client = client;
     }
@@ -161,6 +162,9 @@ public class SearchSecurityWizardPage extends WizardPage
     {
         try
         {
+            // after searching, selection required to enable finish button
+            setPageComplete(false);
+
             getContainer().run(true, false, progressMonitor -> {
                 List<SecuritySearchProvider> providers = Factory.getSearchProvider();
 


### PR DESCRIPTION
In current version, the finish button is active by default even if no item is selected. Also after searching for items, the button is enabled.
With thiw PR the button is only enabled when an item is selected.