### PR TITLE
Reset error message in SearchSecurityWizardPage

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SearchSecurityWizardPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/SearchSecurityWizardPage.java
@@ -189,6 +189,8 @@ public class SearchSecurityWizardPage extends WizardPage
 
                     if (!errors.isEmpty())
                         setErrorMessage(String.join(", ", errors)); //$NON-NLS-1$
+                    else
+                        setErrorMessage(null);
                 });
 
             });


### PR DESCRIPTION
I've found another small thing in the ``SearchSecurityWizardPage``.
behaviour before the PR:

https://github.com/portfolio-performance/portfolio/assets/90478568/1fd273de-d134-4051-b15d-243fa8ffa9d1

with this PR:

https://github.com/portfolio-performance/portfolio/assets/90478568/25db3ea9-c077-4c3c-b242-ba378facf42d
