### PR TITLE
CSVAccountTransactionExtractor: Do not blindly ignore amount sign

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVAccountTransactionExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVAccountTransactionExtractor.java
@@ -236,6 +236,17 @@ import name.abuchen.portfolio.money.Money;
                 type = amount.isNegative() ? AccountTransaction.Type.REMOVAL : AccountTransaction.Type.DIVIDENDS;
             else
                 type = amount.isNegative() ? AccountTransaction.Type.REMOVAL : AccountTransaction.Type.DEPOSIT;
+        } else {
+            if (amount.isNegative()) {
+                if (type == AccountTransaction.Type.DEPOSIT)
+                    type = AccountTransaction.Type.REMOVAL;
+                else if (type == AccountTransaction.Type.REMOVAL)
+                    type = AccountTransaction.Type.DEPOSIT;
+                else if (type == AccountTransaction.Type.BUY)
+                    type = AccountTransaction.Type.SELL;
+                else if (type == AccountTransaction.Type.SELL)
+                    type = AccountTransaction.Type.BUY;
+            }
         }
         return type;
     }


### PR DESCRIPTION
CSV importer's existing mental model is that each transaction would be explicitly categorized (via a "type" column) as Buy or Sell. It then just ignores the sign of transaction amount (by calling Math.abs()).

This assumption is not realistic to cover all the cases. Another way is to have a generic "security transaction" type, and the sign of the amount signifies the actual operation, e.g. negative for Buy, positive for Sell.

This change allows to handle such CSV statements, by "inverting" the configured transaction type. For example, if given type column value is mapped to "BUY", but amount is negative, it is turned into "SELL".