### PR TITLE
fix wrong positioning of tooltip when PP is running on secondary screen, fixes #3622

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/AbstractChartToolTip.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/AbstractChartToolTip.java
@@ -193,8 +193,6 @@ public abstract class AbstractChartToolTip implements Listener
         Point pt = getPlotArea().toDisplay(x, event.y);
         // show above
         int y = pt.y - size.y - PADDING;
-        if (y < PADDING)
-            y = PADDING;
 
         return new Rectangle(pt.x, y, size.x, size.y);
     }


### PR DESCRIPTION
fixes #3622

Setting y to ``PADDING`` when y (``int y = pt.y - size.y - PADDING;``) was smaller results in tooltip beeing displayed on primary screen when PP was running on secondary screen (vertically arranged, primary bottom, secondary above). Because ``pt.y`` is negative when the mouse is on secondary screen, this condition always set y to ``PADDING`` and the tooltip is always on top of primary screen.