### PR TITLE
VIAC French import for PDF Extractor, basic tests

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/Dividende06_Francais.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/Dividende06_Francais.txt
@@ -1,0 +1,27 @@
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.65.5
+-----------------------------------------
+Fondation de prévoyance Terzo de la Banque WIR
+Auberg 1
+4002 Bâle
+Internet www.viac.ch
+Courrriel info@viac.ch
+Téléphone 0800 80 40 40
+Contrat 1.234.567.890 Monsieur
+Portefeuille 1.234.567.890.01 Max Mustermann
+Musterweg 12
+1234 Suisse
+Bâle, 06.11.2023
+Avis de dividende
+Nous avons versé le dividende suivant:
+Type de dividende: Dividende ordinaire
+0.027 CSIF Canada
+ISIN: CH0030849613
+Dividende distribué: CAD 1.16
+Montant CAD 0.03
+Taux de conversion CHF/CAD 0.749 CHF 0.02
+Montant crédité: Valeur 24.05.2022 CHF 0.02
+S. E. & O.
+Meilleures salutations
+Fondation de prévoyance Terzo
+Avis sans signature

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/Kauf11_Francais.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/Kauf11_Francais.txt
@@ -1,0 +1,27 @@
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.65.5
+-----------------------------------------
+Fondation de prévoyance Terzo de la Banque WIR
+Auberg 1
+4002 Bâle
+Internet www.viac.ch
+Courrriel info@viac.ch
+Téléphone 0800 80 40 40
+Contrat 1.234.567.890 Monsieur
+Portefeuille 1.234.567.890.01 Max Mustermann
+Musterweg 12
+1234 Suisse
+Bâle, 24.05.2022
+Opération de bourse - Achat CSIF Canada
+Nous avons exécuté l’ordre suivant:
+Ordre: Achat
+0.027 CSIF Canada
+ISIN: CH0030849613
+Cours: CAD 1'540.19
+Montant CAD 42.12
+Taux de conversion CHF/CAD 0.77983 CHF 32.84
+Montant comptabilisé: Valeur 19.05.2022 CHF 32.84
+S. E. & O.
+Meilleures salutations
+Fondation de prévoyance Terzo 
+Avis sans signature

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/WirBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/WirBankPDFExtractorTest.java
@@ -829,7 +829,7 @@ public class WirBankPDFExtractorTest
         assertNull(security.getWkn());
         assertNull(security.getTickerSymbol());
         assertThat(security.getName(), is("CSIF Canada"));
-        assertThat(security.getCurrencyCode(), is(CurrencyUnit.CAD));
+        assertThat(security.getCurrencyCode(), is("CAD"));
 
         // check buy sell transaction
         BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/WirBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/WirBankPDFExtractorTest.java
@@ -985,7 +985,7 @@ public class WirBankPDFExtractorTest
 
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-06-01T00:00")));
         assertThat(transaction.getSource(), is("Zins06_Francais.txt"));
-        assertThat(transaction.getNote(), is("Taux d\\'intérêt: 0.10% | Période d\\'intérêt: mai"));
+        assertThat(transaction.getNote(), is("Taux d'intérêt: 0.10% | Période d'intérêt: mai"));
 
         assertThat(transaction.getMonetaryAmount(),
                         is(Money.of("CHF", Values.Amount.factorize(0.04))));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/WirBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/WirBankPDFExtractorTest.java
@@ -854,7 +854,7 @@ public class WirBankPDFExtractorTest
 
         Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
                         .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(42.12))));
+        assertThat(grossValueUnit.getForex(), is(Money.of("CAD", Values.Amount.factorize(42.12))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/Zins04_Francais.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/Zins04_Francais.txt
@@ -1,0 +1,24 @@
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.65.5
+-----------------------------------------
+Fondation de prévoyance Terzo de la Banque WIR
+Auberg 1
+4002 Bâle
+Internet www.viac.ch
+Courrriel info@viac.ch
+Téléphone 0800 80 40 40
+Contrat 1.234.567.890 Monsieur
+Portefeuille 1.234.567.890.01 Max Mustermann
+Musterweg 12
+1234 Suisse
+Bâle, 01.06.2022
+Intérêts
+Nous avons crédité le 31.05.2022 les intérêts suivants:
+Taux d’intérêt: 0.10%
+Période d’intérêt: mai
+Intérêts créditeurs: CHF 0.04
+Montant crédité: CHF 0.04
+S. E. & O.
+Meilleures salutations
+Fondation de prévoyance Terzo
+Avis sans signature

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -198,7 +198,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("date", "amount", "currency") //
                         .find("(Zins|Interest|Int.r.ts)") //
-                        .match("^(Am|On|Nous avons crédité le) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (haben wir (Ihrem Konto|Ihnen) gutgeschrieben|we have credited your account|les intérêts suivants):$") //
+                        .match("^(Am|On|Nous avons cr.dit. le) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (haben wir (Ihrem Konto|Ihnen) gutgeschrieben|we have credited your account|les int.r.ts suivants):$") //
                         .match("^(Zinsgutschrift|Interest credit|Intérêts créditeurs): (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d]+)$") //
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -89,7 +89,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
 
         Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
 
-        Block firstRelevantLine = new Block("^(B.rsenabrechnung|Exchange Settlement|Opération de bourse) \\- (Kauf|Verkauf|Buy|Sell|Achat|Vente).*$");
+        Block firstRelevantLine = new Block("^(B.rsenabrechnung|Exchange Settlement|Op.ration de bourse) \\- (Kauf|Verkauf|Buy|Sell|Achat|Vente).*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -243,7 +243,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("date", "amount", "currency") //
                         .find("(Belastung|Commission)") //
-                        .match("^(Verrechneter Betrag: Valuta|Charged amount: Value date|Montant débité: Valuta) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<currency>[\\w]{3}) (\\-)?(?<amount>[\\.,'\\d]+)$")
+                        .match("^(Verrechneter Betrag: Valuta|Charged amount: Value date|Montant d.bit.: Valuta) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<currency>[\\w]{3}) (\\-)?(?<amount>[\\.,'\\d]+)$")
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -197,7 +197,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         // Zinsgutschrift: CHF 0.04
                         // @formatter:on
                         .section("date", "amount", "currency") //
-                        .find("(Zins|Interest|Intérêts)") //
+                        .find("(Zins|Interest|Int.r.ts)") //
                         .match("^(Am|On|Nous avons crédité le) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (haben wir (Ihrem Konto|Ihnen) gutgeschrieben|we have credited your account|les intérêts suivants):$") //
                         .match("^(Zinsgutschrift|Interest credit|Intérêts créditeurs): (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d]+)$") //
                         .assign((t, v) -> {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -285,7 +285,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         + "|Avis de dividende"
                         + "|R.ckerstattung Quellensteuer" //
                         + "|Refund withholding tax" //
-                        + "|Remboursement de l'impôt à la source)$");
+                        + "|Remboursement de l.imp.t . la source)$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -84,7 +84,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        DocumentType type = new DocumentType("(B.rsenabrechnung|Exchange Settlement|Opération de bourse) \\- (Kauf|Verkauf|Buy|Sell|Achat|Vente)");
+        DocumentType type = new DocumentType("(B.rsenabrechnung|Exchange Settlement|Op.ration de bourse) \\- (Kauf|Verkauf|Buy|Sell|Achat|Vente)");
         this.addDocumentTyp(type);
 
         Transaction<BuySellEntry> pdfTransaction = new Transaction<>();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -174,7 +174,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
 
     private void addInterestTransaction()
     {
-        DocumentType type = new DocumentType("(Zins|Interest|Intérêts)");
+        DocumentType type = new DocumentType("(Zins|Interest|Int.r.ts)");
         this.addDocumentTyp(type);
 
         Transaction<AccountTransaction> pdfTransaction = new Transaction<>();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -135,7 +135,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         // Verrechneter Betrag: Valuta 05.07.2018 CHF 360.43
                         // @formatter:on
                         .section("date") //
-                        .match("^(Verrechneter Betrag: Valuta|Charged amount: Value date|Montant comptabilisé: Valeur) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .*$") //
+                        .match("^(Verrechneter Betrag: Valuta|Charged amount: Value date|Montant comptabilis.: Valeur) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .*$") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -199,7 +199,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         .section("date", "amount", "currency") //
                         .find("(Zins|Interest|Int.r.ts)") //
                         .match("^(Am|On|Nous avons cr.dit. le) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (haben wir (Ihrem Konto|Ihnen) gutgeschrieben|we have credited your account|les int.r.ts suivants):$") //
-                        .match("^(Zinsgutschrift|Interest credit|Intérêts créditeurs): (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d]+)$") //
+                        .match("^(Zinsgutschrift|Interest credit|Int.r.ts créditeurs): (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d]+)$") //
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -211,8 +211,8 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         // Zinsperiode: März
                         // @formatter:on
                         .section("note1", "note2").optional() //
-                        .match("^(?<note1>(Zinssatz|Interest rate|Taux d'intérêt): [\\.,\\d]+%)$") //
-                        .match("^(?<note2>(Zinsperiode|Interest period|Période d'intérêt): .*)$") //
+                        .match("^(?<note1>(Zinssatz|Interest rate|Taux d.int.r.t): [\\.,\\d]+%)$") //
+                        .match("^(?<note2>(Zinsperiode|Interest period|P.riode d.int.r.t): .*)$") //
                         .assign((t, v) -> t.setNote(trim(v.get("note1")) + " | " + trim(v.get("note2"))))
 
                         .wrap(TransactionItem::new);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -128,7 +128,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("shares") //
                         .find("(Order|Ordre): (Kauf|Verkauf|Buy|Sell|Achat|Vente)") //
-                        .match("^(?<shares>[\\.,\\d]+) (Ant|Qty|Qté|Anteile|units|parts) (?<name>.*)$") //
+                        .match("^(?<shares>[\\.,\\d]+) (Ant|Qty|Qt.|Anteile|units|parts) (?<name>.*)$") //
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -142,7 +142,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         // Verrechneter Betrag: Valuta 05.07.2018 CHF 360.43
                         // @formatter:on
                         .section("amount", "currency") //
-                        .match("^(Verrechneter Betrag: Valuta|Charged amount: Value date|Montant comptabilisé: Valeur) .* (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d]+)$") //
+                        .match("^(Verrechneter Betrag: Valuta|Charged amount: Value date|Montant comptabilis.: Valeur) .* (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d]+)$") //
                         .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -103,7 +103,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
-                        .match("^(B.rsenabrechnung|Exchange Settlement|Opération de bourse) \\- (?<type>(Kauf|Verkauf|Buy|Sell|Achat|Vente)).*$") //
+                        .match("^(B.rsenabrechnung|Exchange Settlement|Op.ration de bourse) \\- (?<type>(Kauf|Verkauf|Buy|Sell|Achat|Vente)).*$") //
                         .assign((t, v) -> {
                             if ("Verkauf".equals(v.get("type")) || "Sell".equals(v.get("type")) || "Vente".equals(v.get("type")))
                                 t.setType(PortfolioTransaction.Type.SELL);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -179,7 +179,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
 
         Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
 
-        Block firstRelevantLine = new Block("^(Zins|Interest|Intérêts)$");
+        Block firstRelevantLine = new Block("^(Zins|Interest|Int.r.ts)$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -117,7 +117,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("isin", "name", "currency") //
                         .find("(Order|Ordre): (Kauf|Verkauf|Buy|Sell|Achat|Vente)") //
-                        .match("^[\\.,\\d]+ (Ant|Qty|Anteile|units|Qté|Quantité|parts|actions) (?<name>.*)$") //
+                        .match("^[\\.,\\d]+ (Ant|Qty|Anteile|units|Qt.|Quantit.|parts|actions) (?<name>.*)$") //
                         .match("^ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
                         .match("^(Kurs|Price|Cours): (?<currency>[\\w]{3}) .*$") //
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -65,7 +65,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("date", "amount", "currency") //
                         .find("(Einzahlung|Deposit|Versement) 3a") //
-                        .match("^(Gutschrift: Valuta|Credit: Value date|Montant crédité: Valeur) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d]+)$") //
+                        .match("^(Gutschrift: Valuta|Credit: Value date|Montant cr.dit.: Valeur) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<currency>[\\w]{3}) (?<amount>[\\.,'\\d]+)$") //
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -274,7 +274,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         + "|Avis de dividende"
                         + "|R.ckerstattung Quellensteuer" //
                         + "|Refund withholding tax" //
-                        + "|Remboursement de l'impôt à la source");
+                        + "|Remboursement de l.imp.t . la source");
         this.addDocumentTyp(type);
 
         Transaction<AccountTransaction> pdfTransaction = new Transaction<>();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -254,7 +254,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         // Effektive VIAC Verwaltungsgebühr: 0.123% p.a. CHF -1.11
                         // @formatter:on
                         .section("note").optional() //
-                        .match("^(Effektive|Effective|Commission de gestion effective) (?<note>(VIAC Verwaltungsgeb.hr|VIAC administration fee|VIAC p.a.): [\\.,\\d]+%) .*$") //
+                        .match("^(Effektive|Effective|Commission de gestion effective) (?<note>(VIAC Verwaltungsgeb.hr|VIAC administration fee|VIAC p\\.a\\.): [\\.,\\d]+%) .*$") //
                         .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
                         .wrap((t, ctx) -> {


### PR DESCRIPTION
Adding PDF Importer for WirBank documents (VIAC) in French (only English and German are supported in current release)