### PR TITLE
Set default colors in SecuritiesChart

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -345,18 +345,18 @@ public class SecuritiesChart
         }
     }
 
-    private Color colorQuote;
-    private Color colorQuoteAreaPositive;
-    private Color colorQuoteAreaNegative;
+    private Color colorQuote = Colors.getColor(77, 52, 235); // #4D34EB
+    private Color colorQuoteAreaPositive = Colors.getColor(90, 114, 226); // #5A72E2
+    private Color colorQuoteAreaNegative = Colors.getColor(226, 91, 90); // #E25B5A
 
-    private Color colorEventPurchase;
-    private Color colorEventSale;
-    private Color colorEventDividend;
+    private Color colorEventPurchase = Colors.getColor(26, 173, 33); // #1AAD21
+    private Color colorEventSale = Colors.getColor(255, 43, 48); // #FF2B30
+    private Color colorEventDividend = Colors.getColor(128, 99, 168); // #8063A8
 
-    private Color colorExtremeMarkerHigh;
-    private Color colorExtremeMarkerLow;
+    private Color colorExtremeMarkerHigh = Colors.getColor(0, 147, 15); // #00930F
+    private Color colorExtremeMarkerLow = Colors.getColor(168, 39, 42); // #A8272A
 
-    private Color colorNonTradingDay;
+    private Color colorNonTradingDay = Colors.getColor(255, 137, 89); // #FF8959
 
     private static final Color colorFifoPurchasePrice = Colors.getColor(226, 122, 121); // #E27A79
     private static final Color colorMovingAveragePurchasePrice = Colors.getColor(150, 82, 81); // #965251


### PR DESCRIPTION
One first fix to prevent the nullreference exception reported here: https://forum.portfolio-performance.info/t/fehlermeldung-java-lang-illegalargumentexception-argument-cannot-be-null-im-bereich-buchungen/25515
I used the old colors before introdution of CSS: https://github.com/portfolio-performance/portfolio/commit/9f44ee6a75ca7624d75615877d5d520da8ff8e52

But the main cause is not resolved with this: Why the colors from CSS are not set.

And additionally (optional) we can implement some check/fallback when [passing the marker color to the chart](https://github.com/portfolio-performance/portfolio/blob/master/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChart.java#L287): ``e.gc.setForeground(marker.color);``
We have following options when ``marker.color == null``:
* do not paint the line at all (cons: as long as nobody misses the line, the error remains hidden)
* use a fallback color (magenta, yellow, ...)
* no check - let the error occur: disadvantage is that the tool is not usable until the error is fixed

@buchen, what is your opinion?

