### PR TITLE
Sanitize header text in heat maps

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/AbstractHeatmapWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/AbstractHeatmapWidget.java
@@ -122,7 +122,7 @@ public abstract class AbstractHeatmapWidget<N extends Number> extends WidgetDele
 
         model.getHeader().forEach(header -> {
             CLabel l = new CLabel(table, SWT.CENTER);
-            l.setText(header.getLabel());
+            l.setText(TextUtil.tooltip(header.getLabel()));
             l.setBackground(table.getBackground());
 
             InfoToolTip.attach(l, header.getToolTip() != null ? header.getToolTip() : header.getLabel());


### PR DESCRIPTION
The header text for the heap maps is not sanitized to make sure ampersands are not interpreted as mnemonics. This PR fixes this.
