### PR TITLE
TradesTableViewer: Actually show cash account in trade breakdown tooltip

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
@@ -174,7 +174,7 @@ public class TradesTableViewer
                     row[5] = pair.getTransaction().getUnitSum(Unit.Type.FEE);
                     row[6] = pair.getTransaction().getUnitSum(Unit.Type.TAX);
                     row[7] = pair.getTransaction().getMonetaryAmount();
-                    row[8] = pair.getOwner();
+                    row[8] = pair.getTransaction().getCrossEntry().getCrossOwner(pair.getTransaction());
 
                     builder.addRow(row);
                 });


### PR DESCRIPTION
A tooltip with per-transaction breakdown of a trade, shown when hovering over a trade entry, has a column named "Cash Account". However, what's actually shown there is *portfolio* account. So, either column title is wrong, or value shown is wrong. Showing portfolio account wouldn't make much sense, as a trade always belongs to a single portfolio account, so value shown would be invariantly the same in each row. And user can see portfolio account in trade entry (if corresponding column is enabled), so duplicating it in the tooltip doesn't make much sense. Thus, it seems that the corresponding cash account was indeed intended to be shown, so let's make it so.