### PR TITLE
SecurityListView: Use Pattern.DOTALL to properly search in multiline …

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
@@ -431,7 +431,7 @@ public class SecurityListView extends AbstractFinanceView
                     }
                     else
                     {
-                        filterPattern = Pattern.compile(".*" + filterText + ".*", Pattern.CASE_INSENSITIVE); //$NON-NLS-1$ //$NON-NLS-2$
+                        filterPattern = Pattern.compile(".*" + filterText + ".*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL); //$NON-NLS-1$ //$NON-NLS-2$
                         securities.refresh(false);
                     }
                 });


### PR DESCRIPTION
…notes

Security's notes field may easily contain newlines. Newlines are by default not matched by the regex "." operator, causing any notes containing newlines to not be matched by search filter.