### PR TITLE
Show closing transactions for trades in the Payments view

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsViewModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsViewModel.java
@@ -318,6 +318,8 @@ public class PaymentsViewModel
 
                     sum.values[index] += value;
                     sum.sum += value;
+
+                    transactions.add(trade.getLastTransaction());
                 }
             }
         }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsViewModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsViewModel.java
@@ -6,6 +6,7 @@ import java.time.Month;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -280,11 +281,11 @@ public class PaymentsViewModel
         Interval interval = Interval.of(LocalDate.of(startYear - 1, Month.DECEMBER, 31), now);
         Predicate<Transaction> checkIsInInterval = t -> interval.contains(t.getDateTime());
 
+        Set<TransactionPair<?>> transactions = new HashSet<>();
         Map<InvestmentVehicle, Line> vehicle2line = new HashMap<>();
 
         this.sum = new Line(null, false, this.noOfmonths);
         this.sumRetired = new Line(null, useConsolidateRetired, this.noOfmonths);
-        this.transactions = new ArrayList<>();
 
         EnumSet<Mode> processGainTx = EnumSet.of(Mode.TRADES, Mode.ALL);
         if (processGainTx.contains(mode))
@@ -469,6 +470,8 @@ public class PaymentsViewModel
                 }
             }
         }
+        this.transactions = transactions.stream()
+                            .sorted(TransactionPair.BY_DATE).toList();
         this.lines = new ArrayList<>(vehicle2line.values());
     }
 


### PR DESCRIPTION
In the Payments view, there is a tab showing the individual transactions that are aggregated in the tables and graphs of the other tabs. However, in the mode that considers closed trades, this tab has been intentionally empty.

There are reasons for and against this behaviour: On the one hand, a single trade comprises multiple transactions (one or more opening and one closing), some of which may be outside the time period being considered, and the transactions (unlike for the other view such as fees, taxes) don’t immediately show the profit of the trade. On the other hand, users have been repeatedly confused ([A](https://forum.portfolio-performance.info/t/buchungen-in-trades-und-zahlungen-nicht-enthalten/20370), [B](https://forum.portfolio-performance.info/t/berichte-zahlungen-unter-geschlossene-trades-und-summe-fehlerhaft/25561/3), [C](https://forum.portfolio-performance.info/t/kaufe-verkaufe-unter-einnahmen-ausgaben-als-einlieferung-auslieferung-dargestellt/17252/4)) that there were no transactions listed for trades, and it makes verifying the aggregate results for trades hard.

Change this behaviour and from now on include (only) the closing transaction of each trade. The closing transaction always is within the observed time period; it gives the user a general idea of what has been included, and the date allows looking up the trade in the separate Trades view easily, for full details.