### PR TITLE
Modify ComDirect PDF-Importer to support new transaction

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
@@ -4346,39 +4346,6 @@ public class ComdirectPDFExtractorTest
     }
 
     @Test
-    public void testDividende27()
-    {
-        ComdirectPDFExtractor extractor = new ComdirectPDFExtractor(new Client());
-
-        List<Exception> errors = new ArrayList<>();
-
-        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende27.txt"), errors);
-
-        assertThat(errors, empty());
-        assertThat(countSecurities(results), is(1L));
-        assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(1L));
-        assertThat(results.size(), is(2));
-        new AssertImportActions().check(results, CurrencyUnit.EUR);
-
-        // check security
-        assertThat(results, hasItem(security( //
-                        hasIsin("DE0009848002"), hasWkn("984800"), hasTicker(null), //
-                        hasName("D WS In te rn e t - A k t i en T y p O I n ha b er - A nt e il e"), //
-                        hasCurrencyCode("EUR"))));
-
-        // check cancellation transaction
-        assertThat(results, hasItem(withFailureMessage( //
-                        Messages.MsgErrorTransactionTypeNotSupported, //
-                        dividend( //
-                                        hasDate("2006-10-02T00:00"), hasShares(67.000), //
-                                        hasSource("Dividende27.txt"), //
-                                        hasNote(null), //
-                                        hasAmount("EUR", 1.28), hasGrossValue("EUR", 1.34), //
-                                        hasTaxes("EUR", 0.06), hasFees("EUR", 0.00)))));
-    }
-
-    @Test
     public void testSteuerbehandlungVonDividende26()
     {
         ComdirectPDFExtractor extractor = new ComdirectPDFExtractor(new Client());
@@ -4410,6 +4377,39 @@ public class ComdirectPDFExtractorTest
                                         hasNote(null), //
                                         hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
                                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
+    }
+
+    @Test
+    public void testDividende27()
+    {
+        ComdirectPDFExtractor extractor = new ComdirectPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende27.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("DE0009848002"), hasWkn("984800"), hasTicker(null), //
+                        hasName("D WS In te rn e t - A k t i en T y p O I n ha b er - A nt e il e"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check cancellation transaction
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupported, //
+                        dividend( //
+                                        hasDate("2006-10-02T00:00"), hasShares(67.000), //
+                                        hasSource("Dividende27.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 1.28), hasGrossValue("EUR", 1.34), //
+                                        hasTaxes("EUR", 0.06), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -4511,8 +4511,7 @@ public class ComdirectPDFExtractorTest
                         hasDate("2023-11-03T00:00"), hasShares(0.516), //
                         hasSource("SteuerbehandlungVonDividende28.txt"), //
                         hasNote(null), //
-                        hasAmount("EUR", 0.03 + 0.04),
-                        hasGrossValue("EUR", 0.03 + 0.04), //
+                        hasAmount("EUR", 0.03 + 0.04), hasGrossValue("EUR", 0.03 + 0.04), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
@@ -4656,6 +4655,260 @@ public class ComdirectPDFExtractorTest
                         hasNote("Ref.-Nr.: 19IJYGE75X60021N | Quartalsdividende"), //
                         hasAmount("EUR", 0.21), hasGrossValue("EUR", 0.28), //
                         hasTaxes("EUR", 0.03 + 0.04), hasFees("EUR", 0.00), //
+                        check(tx -> {
+                            CheckCurrenciesAction c = new CheckCurrenciesAction();
+                            Account account = new Account();
+                            account.setCurrencyCode(CurrencyUnit.EUR);
+                            Status s = c.process((AccountTransaction) tx, account);
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
+    }
+
+    @Test
+    public void testDividende29()
+    {
+        ComdirectPDFExtractor extractor = new ComdirectPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende29.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US8825081040"), hasWkn("852654"), hasTicker(null), //
+                        hasName("T ex as I n s t ru m e nt s I n c. R e gi s t e re d S ha r e s DL 1"), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2023-11-16T00:00"), hasShares(10.512), //
+                        hasSource("Dividende29.txt"), //
+                        hasNote("Ref.-Nr.: 20IJZBCQ1A00002D | Quartalsdividende"), //
+                        hasAmount("EUR", 12.72), hasGrossValue("EUR", 12.72), //
+                        hasForexGrossValue("USD", 13.67), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende29WithSecurityInEUR()
+    {
+        Security security = new Security("T ex as I n s t ru m e nt s I n c. R e gi s t e re d S ha r e s DL 1", CurrencyUnit.EUR);
+        security.setIsin("US8825081040");
+        security.setWkn("852654");
+
+        Client client = new Client();
+        client.addSecurity(security);
+
+        ComdirectPDFExtractor extractor = new ComdirectPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende29.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2023-11-16T00:00"), hasShares(10.512), //
+                        hasSource("Dividende29.txt"), //
+                        hasNote("Ref.-Nr.: 20IJZBCQ1A00002D | Quartalsdividende"), //
+                        hasAmount("EUR", 12.72), hasGrossValue("EUR", 12.72), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        check(tx -> {
+                            CheckCurrenciesAction c = new CheckCurrenciesAction();
+                            Account account = new Account();
+                            account.setCurrencyCode(CurrencyUnit.EUR);
+                            Status s = c.process((AccountTransaction) tx, account);
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
+    }
+
+    @Test
+    public void testSteuerbehandlungVonDividende29()
+    {
+        ComdirectPDFExtractor extractor = new ComdirectPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor
+                        .extract(PDFInputFile.loadTestCase(getClass(), "SteuerbehandlungVonDividende29.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US8825081040"), hasWkn("852654"), hasTicker(null), //
+                        hasName("TEXAS INSTR. DL 1"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check cancellation transaction
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupported, //
+                        taxes( //
+                                        hasDate("2023-11-16T00:00"), hasShares(10.512), //
+                                        hasSource("SteuerbehandlungVonDividende29.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
+    }
+
+    @Test
+    public void testDividende29MitSteuerbehandlungVonDividende29()
+    {
+        ComdirectPDFExtractor extractor = new ComdirectPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(
+                        PDFInputFile.loadTestCase(getClass(), "Dividende29.txt", "SteuerbehandlungVonDividende29.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US8825081040"), hasWkn("852654"), hasTicker(null), //
+                        hasName("T ex as I n s t ru m e nt s I n c. R e gi s t e re d S ha r e s DL 1"), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2023-11-16T00:00"), hasShares(10.512), //
+                        hasSource("Dividende29.txt; SteuerbehandlungVonDividende29.txt"), //
+                        hasNote("Ref.-Nr.: 20IJZBCQ1A00002D | Quartalsdividende"), //
+                        hasAmount("EUR", 10.81), hasGrossValue("EUR", 12.72), //
+                        hasForexGrossValue("USD", 13.67), //
+                        hasTaxes("EUR", 1.91), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende29MitSteuerbehandlungVonDividende29WithSecurityInEUR()
+    {
+        Security security = new Security("T ex as I n s t ru m e nt s I n c. R e gi s t e re d S ha r e s DL 1", CurrencyUnit.EUR);
+        security.setIsin("US8825081040");
+        security.setWkn("852654");
+
+        Client client = new Client();
+        client.addSecurity(security);
+
+        ComdirectPDFExtractor extractor = new ComdirectPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(
+                        PDFInputFile.loadTestCase(getClass(), "Dividende29.txt", "SteuerbehandlungVonDividende29.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2023-11-16T00:00"), hasShares(10.512), //
+                        hasSource("Dividende29.txt; SteuerbehandlungVonDividende29.txt"), //
+                        hasNote("Ref.-Nr.: 20IJZBCQ1A00002D | Quartalsdividende"), //
+                        hasAmount("EUR", 10.81), hasGrossValue("EUR", 12.72), //
+                        hasTaxes("EUR", 1.91), hasFees("EUR", 0.00), //
+                        check(tx -> {
+                            CheckCurrenciesAction c = new CheckCurrenciesAction();
+                            Account account = new Account();
+                            account.setCurrencyCode(CurrencyUnit.EUR);
+                            Status s = c.process((AccountTransaction) tx, account);
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
+    }
+
+    @Test
+    public void testDividende29MitSteuerbehandlungVonDividende29_SourceFilesReversed()
+    {
+        ComdirectPDFExtractor extractor = new ComdirectPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(
+                        PDFInputFile.loadTestCase(getClass(), "SteuerbehandlungVonDividende29.txt", "Dividende29.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US8825081040"), hasWkn("852654"), hasTicker(null), //
+                        hasName("TEXAS INSTR. DL 1"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2023-11-16T00:00"), hasShares(10.512), //
+                        hasSource("Dividende29.txt; SteuerbehandlungVonDividende29.txt"), //
+                        hasNote("Ref.-Nr.: 20IJZBCQ1A00002D | Quartalsdividende"), //
+                        hasAmount("EUR", 10.81), hasGrossValue("EUR", 12.72), //
+                        hasTaxes("EUR", 1.91), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende29MitSteuerbehandlungVonDividende29WithSecurityInEUR_SourceFilesReversed()
+    {
+        Security security = new Security("TEXAS INSTR. DL 1", CurrencyUnit.EUR);
+        security.setIsin("US8825081040");
+        security.setWkn("852654");
+
+        Client client = new Client();
+        client.addSecurity(security);
+
+        ComdirectPDFExtractor extractor = new ComdirectPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(
+                        PDFInputFile.loadTestCase(getClass(), "SteuerbehandlungVonDividende29.txt", "Dividende29.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2023-11-16T00:00"), hasShares(10.512), //
+                        hasSource("Dividende29.txt; SteuerbehandlungVonDividende29.txt"), //
+                        hasNote("Ref.-Nr.: 20IJZBCQ1A00002D | Quartalsdividende"), //
+                        hasAmount("EUR", 10.81), hasGrossValue("EUR", 12.72), //
+                        hasTaxes("EUR", 1.91), hasFees("EUR", 0.00), //
                         check(tx -> {
                             CheckCurrenciesAction c = new CheckCurrenciesAction();
                             Account account = new Account();

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Dividende29.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Dividende29.txt
@@ -1,0 +1,50 @@
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.65.6
+-----------------------------------------
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+25449 Quickborn
+                                                                                                    
+                                                  
+                                                                      
+                                                                      
+                                                                      
+                   
+                        
+       
+                       
+Depotnr.:    286052747 
+10223 010 BLZ:        200 411 33      
+yDORg                              
+                             
+pHOZajXxh RuQEt              
+                             
+                             
+                                   
+RwpAxgtQFS 0                                                          
+                             
+35244 bIserqtQv                                                 
+14.11.2023
+USt-ID-Nr.:      DE812279461     
+Rechnungsnummer: 630156755624RHW2         
+G  u t s c h  ri f t fä  ll ig  e r W  e r t p a p i e r -E  r tr ä g e                                                                   
+Dividendengutschrift                                                               
+Depotbestand                          Wertpapier-Bezeichnung               WKN/ISIN
+ pe  r 2 7  . 10  . 20 2  3                        T  ex  as   I n s t ru m  e nt  s  I n c.                  8 5 2 6 5 4 
+ S T K              1 0  ,5 1 2                 R e gi s t e  re d  S  ha  r e s  DL  1            U  S 88  25  08 1  04  0
+                                      Emissionsland: VEREINIGTE STAATEN            
+USD 1,30       Dividende pro Stück für Geschäftsjahr        01.01.23 bis 31.12.23  
+zahlbar ab 14.11.2023                 Quartalsdividende                            
+                         Abrechnung Dividendengutschrift                           
+Bruttobetrag:                     USD              13,67                           
+15,000 % Quellensteuer            USD               2,05 -                         
+Ausmachender Betrag               USD              11,62                           
+    zum Devisenkurs: EUR/USD      1,075000                 EUR              10,81  
+Verrechnung über Konto (IBAN)           Valuta       Zu Ihren Gunsten vor Steuern  
+dR67 6492 3601 4544 6111 35   EUR       16.11.2023         EUR              10,81  
+Information zur steuerlichen Behandlung dieses Geschäftsvorganges und den auf      
+Ihrem Konto gebuchten Endbetrag finden Sie auf der separaten Steuermitteilung      
+(Referenz-Nr. 20IJZBCQ1A00002D).                                                   
+Ihre comdirect                                                                     
+                                                                                   
+*Diese Abrechnung wird von der Bank nicht unterschrieben                           
+DD762/11/09

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/SteuerbehandlungVonDividende29.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/SteuerbehandlungVonDividende29.txt
@@ -1,0 +1,116 @@
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.65.6
+-----------------------------------------
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+Kundennr. /BLZ Bezeichnung
+9610764  WTQTxQumi syJedAn  ikeBY                           
+                                                  
+            
+416 645 45 EMZRZvhYzd 2                                      78604 zlqRPwQCy MMGW                              
+abweichend wirtschaftlich Berechtigter
+                              
+                                              ----                    
+ c o  m   d  i r e  c  t                                    
+               
+ 2  5  4  5  1   Q  u  i c  k  b  o  r n                   
+0  1   0  1  0223
+                                                  
+ T  e  le  f o  n  :             0   4  1  0  6   -  7  0 8 25 00
+                              
+Herrn                          D  a  t u  m   :                       1   4  . 1  1  .2023         
+ F  l M  x P  N  d  e  r   k  s  L  q  l               
+ D  e  p  o  t  n  u  m   m  er:         7  5  4  1  6  0 5 00  
+E  F   TS c  h  L  A   c  E    9                            
+75624 jAuGVCrKg                R  e  f e  r e  n  z  - N   u mmer:    2  0  I J Z  B   C  Q   1 A00002D                               
+                                      
+Abstandnahme vom Steuerabzug gemäß                
+§ 44a Abs. 1 Nr. 2 und                            
+§ 44b Abs. 1 EStG                                 
+Steuerliche Behandlung: Ausländische Dividende vom 14.11.2023                                                                     
+Stk.              10,512 TEXAS INSTR.         DL 1 , WKN / ISIN: 852654  / US8825081040                                           
+Z u  Ih r e n G u n s t e n v o r S te u e r n :                                                                                                    E U R              10,8 1   
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+S  te u e rb e m  e ss u n g s g r u n d la g e                                                            E  U   R                                  0 , 0 0                          
+                                                                                                                                
+                                                                                                                                
+K  ap i ta le r tr a gs t e ue r                                                                        E  U   R                                  0 , 0 0                          
+S  ol id a ri tä t sz u s c hl a g                                                                      E  U   R                                  0 , 0 0                          
+ K irc h e n s te u e r                                                                              _E  _U   R_  _  _  _   _  _  _   _  _  _  _   _  _  _   _  0_ ,_ 0_ 0_                          
+ ab g e f ü h rt e S t e u er n                                                                                                                    _E U_ R_ _ _ _ _ _ _ _  _ __  __  __ _0_,0_ _0   
+                                                                                                                                
+ Zu  Ih r e n G u n s t e n n a c h S t e u er n :                                                                                                   E U R              10,8 1   
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+                                                                                                                                
+Die Gutschrift erfolgt mit Valuta 16.11.2023 auf Konto EUR mit der IBAN XZ25 8941 3549 5096 6334 03                                                   
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+KEINE STEUERBESCHEINIGUNG ...
+Bisher einbehaltene bzw. angerechnete Steuer in EUR (4)
+in 2023 einbehaltene einbehaltener einbehaltene angerechneteKapitalertragsteuer Solidaritätszuschlag Kirchensteuer ausländische Quellensteuer
+vor Ermittlung
+                0,00                 0,00
+                0,00                 0,00
+nach Ermittlung
+                0,00 0,00                 0,00                 0,00                
+Verrechnungssalden in EUR (4)
+in 2023 Gewinne / Verluste sonstige anrechenbare verfügbareraus Aktien Gewinne / Verluste ausländische Quellensteuer Freistellungsauftrag
+vor Ermittlung
+                0,47             4.073,06               -53,46                 0,00
+nach Ermittlung
+                0,47             4.085,78
+              -55,37                 0,00
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                                                                                    
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+Ihre comdirect                                                                                                                                        
+Diese Abrechnung ist maschinell erstellt und wird nicht unterschrieben.                                                                               
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+                                                                                                                                                      
+(4) Die ausgewiesenen EUR-Beträge spiegeln den Stand zum Abrechnungszeitpunkt wider.                                                                  
+KEINE STEUERBESCHEINIGUNG


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/pdf-import-von-comdirect/1647/319
Improve concat()

---

Hello  @buchen 
I have modified the concat() a bit because I want to remove this function from the PDF importer and move it to a more suitable location. The only question is where. [ExtractorUtils.java](https://github.com/portfolio-performance/portfolio/blob/a77ff90451fc9079a6a331e5efb1f734c2de626f/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java) or [TextUtil.java](https://github.com/portfolio-performance/portfolio/blob/a77ff90451fc9079a6a331e5efb1f734c2de626f/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TextUtil.java)

We could then use this function here
https://github.com/portfolio-performance/portfolio/blob/97e7c08635dcf8364c0c9f86a56defe14464a1dc/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java#L130

and here we could remove the "concat" and make the adjustments in postprocessing analogous to the Comdirect PDF importer.

https://github.com/portfolio-performance/portfolio/blob/97e7c08635dcf8364c0c9f86a56defe14464a1dc/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java
