### PR TITLE
Improve legend consistency in payment charts builder

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerMonthChartBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerMonthChartBuilder.java
@@ -3,6 +3,8 @@ package name.abuchen.portfolio.ui.views.payments;
 import java.text.DateFormatSymbols;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.Consumer;
 
 import org.eclipse.swt.SWT;
@@ -144,25 +146,45 @@ public class PaymentsPerMonthChartBuilder implements PaymentsChartBuilder
                         new DividendPerMonthChartToolTip(chart, selectionListener));
     }
 
+    /**
+     * Creates bar series for each year in the provided chart, with bars
+     * representing monthly payment data. Uses a TreeMap to automatically sort
+     * the years in ascending order.
+     */
     @Override
     public void createSeries(Chart chart, PaymentsViewModel model)
     {
         chart.setData(PaymentsViewModel.class.getSimpleName(), model);
 
+        // Use a TreeMap to automatically sort the years
+        Map<Integer, IBarSeries> yearToSeries = new TreeMap<>();
+
+        // Iterate over the months in the model
         for (int index = 0; index < model.getNoOfMonths(); index += 12)
         {
             int year = model.getStartYear() + (index / 12);
 
-            IBarSeries barSeries = (IBarSeries) chart.getSeriesSet().createSeries(SeriesType.BAR, String.valueOf(year));
+            // Create or retrieve the data series for the current year
+            IBarSeries barSeries = yearToSeries.computeIfAbsent(year, //
+                            k -> {
+                                IBarSeries series = (IBarSeries) chart.getSeriesSet() //
+                                                .createSeries(SeriesType.BAR, String.valueOf(k));
+                                series.setBarColor(PaymentsColors.getColor(k));
+                                series.setBarPadding(25);
+                                return series;
+                            });
 
-            double[] series = new double[Math.min(12, model.getNoOfMonths() - index)];
-            for (int ii = 0; ii < series.length; ii++)
-                series[ii] = model.getSum().getValue(index + ii) / Values.Amount.divider();
+            int monthsToPopulate = Math.min(12, model.getNoOfMonths() - index);
+            double[] series = new double[monthsToPopulate];
+
+            // Populate the series with monthly payment values
+            for (int ii = 0; ii < monthsToPopulate; ii++)
+            {
+                int monthIndex = index + ii;
+                series[ii] = model.getSum().getValue(monthIndex) / Values.Amount.divider();
+            }
+
             barSeries.setYSeries(series);
-
-            barSeries.setBarColor(PaymentsColors.getColor(year));
-            barSeries.setBarPadding(25);
         }
-
     }
 }


### PR DESCRIPTION
#### Description:
Improvement of the three chart builder classes PaymentsPerMonthChartBuilder, PaymentsPerQuarterChartBuilder, and PaymentsPerYearChartBuilder.
The problem is that the legend for the diagram is not always displayed correctly. Sometimes ascending and sometimes descending.
https://forum.portfolio-performance.info/t/reihenfolge-der-legende-in-ertragsansicht/25705

#### PaymentsPerMonthChartBuilder and PaymentsPerQuarterChartBuilder:
- Introduced TreeMap<Integer, IBarSeries> (yearToSeries) for automatic sorting of yearly data. 
- Replaced the loop with a more expressive computeIfAbsent method. 
- Adjusted the iteration over the months to consider a variable (monthsToPopulate) for a clearer understanding of the loop's purpose.

#### PaymentsPerYearChartBuilder:
- Implemented TreeMap (yearToSeries) for automatic sorting of yearly data. 
- Replaced the loop with a more expressive computeIfAbsent method. 
- Adjusted variable names.
- Removed unnecessary logic for creating the bar series. 
- Removed the hasNegativeNumber logic as it is no longer needed.

---

Hello @buchen 
I'm not 100% sure, but why was the special function with negative values introduced in the annual bar series?
I have tried this on my system and so far everything is displayed correctly.
I have therefore removed it, otherwise we will have to add it again. But I don't really see the point.
Does anyone else still have the reason in mind? @OnkelDok @chirlu 

Regards
Alex