### PR TITLE
Modify DKB PDF-Importer to support new transaction

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/Dividende01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/Dividende01.txt
@@ -1,4 +1,7 @@
-﻿10919 Berlin Seite 1
+﻿PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.66.2
+-----------------------------------------
+10919 Berlin Seite 1
 Depotnummer 500123451
 Kundennummer 51234561
 Max Mustermann

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/Dividende02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/Dividende02.txt
@@ -1,4 +1,7 @@
-﻿10919 Berlin
+﻿PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.66.2
+-----------------------------------------
+10919 Berlin
 Depotnummer 500123451
 Kundennummer 51234561
 Max Mustermann

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/Dividende11.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/Dividende11.txt
@@ -1,4 +1,7 @@
-﻿10919 Berlin Seite 1
+﻿PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.66.2
+-----------------------------------------
+10919 Berlin Seite 1
 Depotnummer 123456789
 Kundennummer 123456789
 Max Mustermann

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/Dividende17.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/Dividende17.txt
@@ -1,0 +1,63 @@
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.66.2
+-----------------------------------------
+10919 Berlin Seite 1
+Depotnummer 696332917
+Kundennummer 3096891285
+awtpqiC uGNNqJbwIwjCWN und YEAEV
+hwOYJkxVfssQRh
+Herrn u.Frau Abrechnungsnr. 85345940130
+cFboDhM zmpXIGVpEhjjcM Datum 19.12.2023
+und qftLP DVMoKPyDXFzGkA
+FvDhPht Vdo 16
+39654 FuUvur Qh gxL RcrSX
+Dividendengutschrift
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 497 MAIN STREET CAPITAL CORP. US56035L1044 (A0X8Y3)
+REGISTERED SHARES DL -,01
+Zahlbarkeitstag 15.12.2023 Dividende pro Stück 0,235 USD
+Bestandsstichtag 06.12.2023 Herkunftsland USA
+Ex-Tag 07.12.2023 Art der Dividende Monatliche Dividende
+Geschäftsjahr 01.01.2023 - 31.12.2023
+Devisenkurs EUR / USD 1,1002
+Devisenkursdatum 19.12.2023
+Dividendengutschrift 211,50 USD 192,24+ EUR
+Umrechnung in EUR 192,24 EUR
+Einbehaltene Quellensteuer 15 % auf 211,50 USD 28,84- EUR
+Anrechenbare Quellensteuer 15 % auf 192,24 EUR 28,84 EUR
+Kapitalertragsteuerpflichtige Dividende 192,24 EUR
+Verrechnete anrechenbare ausländische Quellensteuer
+(Verhältnis 100/25) auf 28,84 EUR 115,36 - EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 76,88 EUR
+Anteilige Berechnungsgrundlage für (50,00 %) entspricht 38,44 EUR
+Kapitalertragsteuer 24,45 % auf 38,44 EUR 9,40- EUR
+Solidaritätszuschlag 5,5 % auf 9,40 EUR 0,51- EUR
+Kirchensteuer 9 % auf 9,40 EUR 0,84- EUR
+Anteilige Berechnungsgrundlage für (50,00 %) entspricht 38,44 EUR
+Kapitalertragsteuer 24,45 % auf 38,44 EUR 9,40- EUR
+Solidaritätszuschlag 5,5 % auf 9,40 EUR 0,51- EUR
+Kirchensteuer 9 % auf 9,40 EUR 0,84- EUR
+Ausmachender Betrag 141,90+ EUR
+Bitte ggf. Rückseite beachten.
+0883.12200101.0012054ER01
+
+Seite 2
+Depotnummer 126072620
+Kundennummer 0210779768
+Abrechnungsnr. 21909666735
+Datum 19.12.2023
+Lagerstelle Clearstream Banking Lux (855719 / 28196)
+Den Betrag buchen wir mit Wertstellung 19.12.2023 zu Gunsten des Kontos 9365186941 (IBAN DE81 0209 9860 3621
+4110 01), BLZ 120 300 00 (BIC BYLADEM1001).
+Keine Steuerbescheinigung.
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verrechnungstöpfe 2023 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien und Sonstige
+Pauschbetrag Quellensteuer
+Vorher 0,00 0,00 0,00 0,00 1.174,52
+Ertrag 28,84
+0,00 0,00 0,00 28,84- 76,88
+Nachher 0,00 0,00 0,00 0,00 1.251,40
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+0883.12200101.0012055ER01

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -320,7 +320,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
         Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
 
-        Block firstRelevantLine = new Block("^Kundennummer.*$", "^Den Betrag buchen wir mit.*$");
+        Block firstRelevantLine = new Block("^10919 Berlin( Seite 1)?$", "^Den Betrag buchen wir mit.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/pdf-import-von-dkb/4449/102

Remove BOM in test files Dividende01.txt, Dividende02.txt and DIvidende11.txt

---
The character code 65279 represents the Unicode code for the Byte Order Mark, which often appears as an invisible character at the beginning of UTF-8 encoded files.

https://github.com/portfolio-performance/portfolio/blob/23a649217b18dc614f07e34d4dc416c49ebd1083/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java#L187

```
    String currentLine = lines[ii];
    int firstCharCode = (int) currentLine.charAt(0); // Charakter-Code des ersten Zeichens

    System.out.println("Character Code of first character in line [" + ii + "]: " + firstCharCode);

    Matcher matcher = startsWith.matcher(currentLine);
    System.out.println("Match gefunden => " + matcher.matches() + " [" + ii + "] -> " + currentLine);

    if (matcher.matches())
        blocks.add(ii);
```

Result:
```
Match gefunden => java.util.regex.Matcher[pattern=^10919 Berlin( Seite 1)?$ region=0,21 lastmatch=] -> ﻿10919 Berlin Seite 1
---------------
Character Code of first character in line [0]: 65279
```