### PR TITLE
PDF import: Initial support for Directa SIM

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/directa/Buy01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/directa/Buy01.txt
@@ -1,0 +1,32 @@
+```
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.67.1.qualifier
+-----------------------------------------
+Signor
+oGRsHZwU UFRTNSbiqZNS
+bTf Wel hHsRutErw 18l
+08172 DbFjxX
+Italia
+Conto v2438
+Nota Informativa per l'ordine T1673620593440
+Vi Confermiamo il Vs. ordine sopra riportato del 5.01.2024
+per l'acquisto di: 29  VANGUARD FTSE ALL-WORLD UCITS ISIN IE00BK5BQT80
+Scadenza 00/00/0000
+eseguito per: 29
+tramite l'intermediario DIRECTA SIM.p.A.
+Tipo di Operazione: Acquisto     Mercato di esecuzione: Borsa - Euronext Milan
+Modalità di liquidazione:  Per consegna e pagamento in contanti
+                                                  Quantita'                 Euro               Prezzo      Valuta
+ 5.01.2024  14:02:36  Richiesta Immissione               29                                  106,1300
+ 5.01.2024  14:02:36  Inoltro
+ 5.01.2024  14:02:36  In negoziazione
+ 5.01.2024  14:02:36  Eseguito                           29             3.074,29             106,0100  09.01.2024
+                      Controvalore:                                     3.074,29             106,0100
+                      Commissioni:                                          5,00
+                      Ritenuta:
+                      Totale a Vs. Debito                               3.079,29
+Gli effetti fiscali saranno disponibili a data valuta nel menu Info -  2b.Capital Gain
+Torino, 5.01.2024
+       DIRECTA SIM
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/directa/DirectaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/directa/DirectaPDFExtractorTest.java
@@ -1,0 +1,34 @@
+package name.abuchen.portfolio.datatransfer.pdf.directa;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.datatransfer.Extractor.Item;
+import name.abuchen.portfolio.datatransfer.pdf.DirectaPDFExtractor;
+import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
+import name.abuchen.portfolio.model.Client;
+
+@SuppressWarnings("nls")
+public class DirectaPDFExtractorTest
+{
+    DirectaPDFExtractor extractor = new DirectaPDFExtractor(new Client());
+
+    @Test
+    public void testInfoReport01()
+    {
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Buy01.txt"), errors);
+
+        if (!errors.isEmpty())
+            errors.get(0).printStackTrace();
+
+        assertThat(errors, empty());
+        // 1 transaction
+    }
+}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/directa/DirectaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/directa/DirectaPDFExtractorTest.java
@@ -1,17 +1,31 @@
 package name.abuchen.portfolio.datatransfer.pdf.directa;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
 
+import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
 import name.abuchen.portfolio.datatransfer.Extractor.Item;
+import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
+import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
 import name.abuchen.portfolio.datatransfer.pdf.DirectaPDFExtractor;
 import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
+import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.Transaction;
+import name.abuchen.portfolio.model.Transaction.Unit;
+import name.abuchen.portfolio.money.CurrencyUnit;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.Values;
 
 @SuppressWarnings("nls")
 public class DirectaPDFExtractorTest
@@ -19,7 +33,7 @@ public class DirectaPDFExtractorTest
     DirectaPDFExtractor extractor = new DirectaPDFExtractor(new Client());
 
     @Test
-    public void testInfoReport01()
+    public void testBuy01Import()
     {
         List<Exception> errors = new ArrayList<>();
 
@@ -29,6 +43,36 @@ public class DirectaPDFExtractorTest
             errors.get(0).printStackTrace();
 
         assertThat(errors, empty());
-        // 1 transaction
+        assertThat(results.size(), is(2));
+
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSecurity();
+        assertThat(security.getIsin(), is("IE00BK5BQT80"));
+        assertThat(security.getName(), is("VANGUARD FTSE ALL-WORLD UCITS"));
+        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+
+        // check buy sell transaction
+        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
+                        .orElseThrow(IllegalArgumentException::new).getSubject();
+
+        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
+        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+
+        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2024-01-05T14:02:36")));
+        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(29)));
+        assertThat(entry.getSource(), is("Buy01.txt"));
+        assertThat(entry.getNote(), is("Ordine T1673620593440"));
+
+        Transaction transaction = entry.getPortfolioTransaction();
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3079.29))));
+        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3074.29))));
+        assertThat(transaction.getUnitSum(Unit.Type.TAX),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(transaction.getUnitSum(Unit.Type.FEE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.00))));
+
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DirectaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DirectaPDFExtractor.java
@@ -51,7 +51,7 @@ public class DirectaPDFExtractor extends AbstractPDFExtractor
                         // Nota Informativa per l'ordine T1673620593440
                         // @formatter:on
                         .section("orderNo").match("^Nota Informativa per l'ordine (?<orderNo>[A-Z0-9]+)$")
-                        .assign((t, v) -> t.setNote(v.get("orderNo")))
+                        .assign((t, v) -> t.setNote("Ordine " + v.get("orderNo")))
 
                         // @formatter:off
                         // per l'acquisto di: 29  VANGUARD FTSE ALL-WORLD UCITS ISIN IE00BK5BQT80

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DirectaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DirectaPDFExtractor.java
@@ -1,0 +1,73 @@
+package name.abuchen.portfolio.datatransfer.pdf;
+
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
+import name.abuchen.portfolio.model.BuySellEntry;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.money.CurrencyUnit;
+
+/**
+ * Importer for "Directa" purchases.
+ */
+@SuppressWarnings("nls")
+public class DirectaPDFExtractor extends AbstractPDFExtractor
+{
+    public DirectaPDFExtractor(Client client)
+    {
+        super(client);
+
+        addBankIdentifier("DIRECTA SIM");
+
+        addBuySellTransaction();
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return "Directa";
+    }
+
+    private void addBuySellTransaction()
+    {
+        DocumentType type = new DocumentType("acquisto di");
+        this.addDocumentTyp(type);
+
+        Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
+        pdfTransaction.subject(() -> {
+            BuySellEntry entry = new BuySellEntry();
+            entry.setType(PortfolioTransaction.Type.BUY);
+            return entry;
+        });
+
+        Block firstRelevantLine = new Block("^.*(acquisto di).*$");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
+
+        pdfTransaction
+                        //
+                        .section("shares", "name", "isin")
+                        .match("^.*:\s*(?<shares>\\d+)\s+(?<name>.*) ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$")
+                        .assign((t, v) -> { 
+                            t.setSecurity(getOrCreateSecurity(v));
+                            t.setShares(asShares(v.get("shares")));
+                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
+                        })
+
+                        .section("date", "amount")
+                        .match("^\\s(?<date>.*)(\\s{2}.*\\s{2}Eseguito\\s+([0-9]+))\\s+(?<amount>.\\S+)\\s+.*$")
+                        .assign((t, v) -> {
+                            t.setDate(asDate(v.get("date")));
+                            t.setAmount(asAmount(v.get("amount")));
+                        })
+
+                        // // Auftrags-Nummer: 20220106123456789000000612345
+                        // .section("note").optional().match("^(?<note>Auftrags-Nummer:
+                        // [\\d]+)$")
+                        // .assign((t, v) -> t.setNote(trim(v.get("note"))))
+
+                        .wrap(BuySellEntryItem::new);
+                        
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFImportAssistant.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFImportAssistant.java
@@ -50,6 +50,7 @@ public class PDFImportAssistant
         extractors.add(new DegiroPDFExtractor(client));
         extractors.add(new DekaBankPDFExtractor(client));
         extractors.add(new DeutscheBankPDFExtractor(client));
+        extractors.add(new DirectaPDFExtractor(client));
         extractors.add(new Direkt1822BankPDFExtractor(client));
         extractors.add(new DkbPDFExtractor(client));
         extractors.add(new DreiBankenEDVPDFExtractor(client));
@@ -216,3 +217,4 @@ public class PDFImportAssistant
     }
 
 }
+


### PR DESCRIPTION
Adds initial support for one of the bigger Italian brokers. Currently, only Buy transactions are supported. I would add support for additional types, if someone could send me debug txts.