### PR TITLE
Introduced protections against predictable RNG abuse

### DIFF
--- a/name.abuchen.portfolio.junit/src/name/abuchen/portfolio/junit/SecurityBuilder.java
+++ b/name.abuchen.portfolio.junit/src/name/abuchen/portfolio/junit/SecurityBuilder.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.junit;
 
+import java.security.SecureRandom;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.Random;
@@ -15,7 +16,7 @@ import name.abuchen.portfolio.money.CurrencyUnit;
 
 public class SecurityBuilder
 {
-	private static final Random RANDOM = new Random();
+	private static final Random RANDOM = new SecureRandom();
 
     private Security security;
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/DetectDuplicatesActionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/DetectDuplicatesActionTest.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.actions;
 
+import java.security.SecureRandom;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -116,7 +117,7 @@ public class DetectDuplicatesActionTest
 
     private static class PropertyChecker<T extends Transaction>
     {
-        private Random random = new Random();
+        private Random random = new SecureRandom();
 
         private Class<T> type;
         private List<PropertyDescriptor> properties = new ArrayList<>();

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.ibflex;
 
+import java.nio.file.Files;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -47,7 +48,7 @@ public class IBFlexStatementExtractorTest
 {
     private Extractor.InputFile createTempFile(InputStream input) throws IOException
     {
-        File tempFile = File.createTempFile("IBFlexStatementExtractorTest", null);
+        File tempFile = Files.createTempFile("IBFlexStatementExtractorTest", null).toFile();
         tempFile.deleteOnExit();
         FileOutputStream fos = new FileOutputStream(tempFile);
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SecurityTest.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.model;
 
+import java.security.SecureRandom;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -45,7 +46,7 @@ public class SecurityTest
             else if (p.getPropertyType() == boolean.class && p.getWriteMethod() != null)
                 p.getWriteMethod().invoke(source, true);
             else if (p.getPropertyType() == int.class && p.getWriteMethod() != null)
-                p.getWriteMethod().invoke(source, new Random().nextInt());
+                p.getWriteMethod().invoke(source, new SecureRandom().nextInt());
             else
                 skipped++;
         }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/CreateTextFromPDFHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/CreateTextFromPDFHandler.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.ui.handlers;
 
 import java.io.File;
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.Random;
 
 import jakarta.inject.Named;
@@ -95,7 +96,7 @@ public class CreateTextFromPDFHandler
 
     private static class PDFDebugMouseListener extends MouseAdapter
     {
-        private final Random random = new Random();
+        private final Random random = new SecureRandom();
         private final Text widget;
 
         public PDFDebugMouseListener(Text widget)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/update/UpdateHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/update/UpdateHelper.java
@@ -6,6 +6,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Locale;
@@ -367,7 +368,7 @@ public final class UpdateHelper
         File fileTest = null;
         try
         {
-            fileTest = File.createTempFile("writeableArea", ".dll", installDir); //$NON-NLS-1$ //$NON-NLS-2$
+            fileTest = Files.createTempFile(installDir.toPath(), "writeableArea", ".dll").toFile(); //$NON-NLS-1$ //$NON-NLS-2$
         }
         catch (IOException e)
         {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Classification.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Classification.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.model;
 
 import java.math.BigDecimal;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -115,7 +116,7 @@ public class Classification implements Named
     public static final String UNASSIGNED_ID = "$unassigned$"; //$NON-NLS-1$
     public static final String VIRTUAL_ROOT = "$virtualroot$"; //$NON-NLS-1$
 
-    private static final Random RANDOM = new Random();
+    private static final Random RANDOM = new SecureRandom();
 
     private String id;
     private String name;
@@ -150,7 +151,7 @@ public class Classification implements Named
 
         if (color == null)
         {
-            Random r = new Random();
+            Random r = new SecureRandom();
             this.color = '#' + Integer.toHexString(((r.nextInt(128) + 127) << 16) //
                             | ((r.nextInt(128) + 127) << 8) //
                             | (r.nextInt(128) + 127));


### PR DESCRIPTION
This change replaces all new instances of `java.util.Random` with the marginally slower, but much more secure `java.security.SecureRandom`.

We have to work pretty hard to get computers to generate genuinely unguessable random bits. The `java.util.Random` type uses a method of pseudo-random number generation that unfortunately emits fairly predictable numbers.

If the numbers it emits are predictable, then it's obviously not safe to use in cryptographic operations, file name creation, token construction, password generation, and anything else that's related to security. In fact, it may affect security even if it's not directly obvious.

Switching to a more secure version is simple and our changes all look something like this:

```diff
- Random r = new Random();
+ Random r = new java.security.SecureRandom();
```

<details>
  <summary>More reading</summary>

  * [https://owasp.org/www-community/vulnerabilities/Insecure_Randomness](https://owasp.org/www-community/vulnerabilities/Insecure_Randomness)
  * [https://metebalci.com/blog/everything-about-javas-securerandom/](https://metebalci.com/blog/everything-about-javas-securerandom/)
  * [https://cwe.mitre.org/data/definitions/330.html](https://cwe.mitre.org/data/definitions/330.html)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:java/secure-random](https://docs.pixee.ai/codemods/java/pixee_java_secure-random)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2Fpresto%7C4eae2eb3d045b68ebcf7464d4f49096e54beed75)

<!--{"type":"DRIP","codemod":"pixee:java/secure-random"}-->