### PR TITLE
Add PDF import support for 'Kreissparkasse'

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/Dividende14.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/Dividende14.txt
@@ -1,0 +1,59 @@
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.67.1
+-----------------------------------------
+Kreissparkasse Heidenheim · Postfach 1540 · 89505 Heidenheim  Seite 1
+Depotnummer
+ 1234567890
+ Kundennummer 11111111
+ Max MusterAbrechnungsnr. 84528768080
+Herrn Datum 11.12.2023
+Max Muster Ihr Berater Herr Florian Schermayer
+Musterstr 123 Telefon 07321 344-6850 
+88888 Hausen Telefax 07321 344-995799 
+ 
+   
+Dividendengutschrift
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 105 YUM! BRANDS, INC. US9884981013 (909190)
+REGISTERED SHARES O.N.
+Zahlbarkeitstag 08.12.2023 Dividende pro Stück 0,605 USD
+Bestandsstichtag 24.11.2023 Herkunftsland USA
+Ex-Tag 27.11.2023 Art der Dividende Quartalsdividende
+Geschäftsjahr 30.12.2022 - 29.12.2023
+Devisenkurs EUR / USD 1,0788
+Devisenkursdatum 11.12.2023
+Dividendengutschrift 63,53 USD 58,89+ EUR
+Umrechnung in EUR 58,89 EUR
+Einbehaltene Quellensteuer 15 % auf 63,53 USD 8,83- EUR
+Anrechenbare Quellensteuer 15 % auf 58,89 EUR 8,83 EUR
+Kapitalertragsteuerpflichtige Dividende 58,89 EUR
+Verrechnete anrechenbare ausländische Quellensteuer
+(Verhältnis 100/25) auf 8,83 EUR 35,32 - EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 23,57 EUR
+Kapitalertragsteuer 24,51 % auf 23,57 EUR 5,78- EUR
+Solidaritätszuschlag 5,5 % auf 5,78 EUR 0,31- EUR
+Kirchensteuer 8 % auf 5,78 EUR 0,46- EUR
+Ausmachender Betrag 43,51+ EUR
+Lagerstelle Clearstream Banking FFM (849000 / 40030000)
+Den Betrag buchen wir mit Wertstellung 12.12.2023 zu Gunsten des Kontos 12345678 (IBAN DE12 1234 1234 1234 1234
+12), BLZ 632 500 30 (BIC SOLADES1HDH). 
+Bitte ggf. Rückseite beachten.
+2332.12120100.0000157ER01
+
+Seite 2
+Depotnummer 1234567890
+Kundennummer 11111111
+Abrechnungsnr. 84528768080
+Datum 11.12.2023
+Keine Steuerbescheinigung. 
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verrechnungstöpfe 2023 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien und Sonstige
+Pauschbetrag Quellensteuer
+Vorher 0,00 0,00 0,00 0,00 759,80
+Ertrag 8,83
+0,00 0,00 0,00 8,83- 23,57
+Nachher 0,00 0,00 0,00 0,00 783,37
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+2332.12120100.0000158ER01

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/SBrokerPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/SBrokerPDFExtractorTest.java
@@ -1860,6 +1860,40 @@ public class SBrokerPDFExtractorTest
     }
 
     @Test
+    public void testDividende14()
+    {
+        SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende14.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US9884981013"), hasWkn("909190"), hasTicker(null), //
+                        hasName("YUM! BRANDS, INC. REGISTERED SHARES O.N."), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividende transaction
+        assertThat(results,
+                        hasItem(dividend(hasDate("2023-12-08T00:00"), hasShares(105.000), hasSource("Dividende14.txt"),
+                                        hasNote("Abrechnungsnr. 84528768080 | Quartalsdividende"),
+                                        hasGrossValue("EUR", 58.89),
+                                        hasAmount("EUR", 43.51),
+                                        hasForexGrossValue("USD", 63.53),
+                                        hasTaxes("EUR", 8.83 + 5.78 + 0.31 + 0.46),
+                                        hasFees("EUR", 0.00)
+        )));
+    }
+
+    @Test
     public void testDividendeStorno01()
     {
         SBrokerPDFExtractor extractor = new SBrokerPDFExtractor(new Client());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
@@ -31,6 +31,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         addBankIdentifier("S Broker AG & Co. KG");
         addBankIdentifier("Sparkasse");
         addBankIdentifier("Stadtsparkasse");
+        addBankIdentifier("Kreissparkasse");
 
         addBuySellTransaction();
         addDividendTransaction();


### PR DESCRIPTION
'SBrokerPDFExtractor' is perfectly capable of also handling banks with an identifier starting with 'Kreissparkasse'. This patch adds this identifier as an additional bank identifier.

Closes #3735
Issue: https://forum.portfolio-performance.info/t/pdf-import-von-s-broker-sparkasse/5195/91