### PR TITLE
Use getTextColor for the Limit Exceeded Widget and use black text color for Color.GREEN backgrounds

### DIFF
--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/utils/ColorsTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/utils/ColorsTest.java
@@ -1,0 +1,22 @@
+package name.abuchen.portfolio.ui.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.eclipse.swt.graphics.Color;
+import org.junit.Test;
+
+import name.abuchen.portfolio.ui.util.Colors;
+
+public class ColorsTest
+{
+    private final static Color SWT_BLACK = Colors.getColor(0, 0, 0);
+    private final static Color SWT_WHITE = Colors.getColor(255, 255, 255);
+
+    @Test
+    public void testGetTextColor()
+    {
+        assertThat(Colors.getTextColor(Colors.theme().greenBackground()), is(SWT_BLACK));
+        assertThat(Colors.getTextColor(Colors.theme().redBackground()), is(SWT_WHITE));
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientInput.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientInput.java
@@ -557,30 +557,31 @@ public class ClientInput
         if (preferences.getBoolean(UIConstants.Preferences.UPDATE_QUOTES_AFTER_FILE_OPEN, true))
         {
             Predicate<Security> onlyActive = s -> !s.isRetired();
+            Client c = getClient();
 
-            Job initialQuoteUpdate = new UpdateQuotesJob(client, onlyActive,
+            Job initialQuoteUpdate = new UpdateQuotesJob(c, onlyActive,
                             EnumSet.of(UpdateQuotesJob.Target.LATEST, UpdateQuotesJob.Target.HISTORIC));
             initialQuoteUpdate.schedule(1000);
 
-            CreateInvestmentPlanTxJob checkInvestmentPlans = new CreateInvestmentPlanTxJob(client,
+            CreateInvestmentPlanTxJob checkInvestmentPlans = new CreateInvestmentPlanTxJob(c,
                             exchangeRateProviderFacory);
             checkInvestmentPlans.startAfter(initialQuoteUpdate);
             checkInvestmentPlans.schedule(1100);
 
             int thirtyMinutes = 1000 * 60 * 30;
-            Job job = new UpdateQuotesJob(client, onlyActive, EnumSet.of(UpdateQuotesJob.Target.LATEST))
+            Job job = new UpdateQuotesJob(c, onlyActive, EnumSet.of(UpdateQuotesJob.Target.LATEST))
                             .repeatEvery(thirtyMinutes);
             job.schedule(thirtyMinutes);
             regularJobs.add(job);
 
             int sixHours = 1000 * 60 * 60 * 6;
-            job = new UpdateQuotesJob(client, onlyActive, EnumSet.of(UpdateQuotesJob.Target.HISTORIC))
+            job = new UpdateQuotesJob(c, onlyActive, EnumSet.of(UpdateQuotesJob.Target.HISTORIC))
                             .repeatEvery(sixHours);
             job.schedule(sixHours);
             regularJobs.add(job);
 
-            new SyncOnlineSecuritiesJob(client).schedule(5000);
-            new UpdateDividendsJob(getClient()).schedule(7000);
+            new SyncOnlineSecuritiesJob(c).schedule(5000);
+            new UpdateDividendsJob(c).schedule(7000);
         }
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/Colors.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/Colors.java
@@ -226,7 +226,6 @@ public final class Colors
         // http://stackoverflow.com/questions/596216/formula-to-determine-brightness-of-rgb-color
 
         double luminance = (0.299 * color.getRed() + 0.587 * color.getGreen() + 0.114 * color.getBlue()) / 255;
-        System.out.println(luminance);
         return luminance > 0.55 ? BLACK : WHITE;
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/Colors.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/Colors.java
@@ -21,8 +21,8 @@ public final class Colors
         private Color defaultForeground = Colors.BLACK;
         private Color defaultBackground = Colors.WHITE;
         private Color warningBackground = getColor(254, 223, 107); // FEDF6B
-        private Color redBackground = Colors.GREEN;
-        private Color greenBackground = Colors.RED;
+        private Color redBackground = Colors.RED;
+        private Color greenBackground = Colors.GREEN;
         private Color redForeground = Colors.DARK_RED;
         private Color greenForeground = Colors.DARK_GREEN;
         private Color grayForeground = getColor(112, 112, 112); // 707070
@@ -225,8 +225,9 @@ public final class Colors
     {
         // http://stackoverflow.com/questions/596216/formula-to-determine-brightness-of-rgb-color
 
-        double luminance = 1 - (0.299 * color.getRed() + 0.587 * color.getGreen() + 0.114 * color.getBlue()) / 255;
-        return luminance < 0.4 ? BLACK : WHITE;
+        double luminance = (0.299 * color.getRed() + 0.587 * color.getGreen() + 0.114 * color.getBlue()) / 255;
+        System.out.println(luminance);
+        return luminance > 0.55 ? BLACK : WHITE;
     }
 
     public static Color brighter(Color base)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/LimitExceededWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/LimitExceededWidget.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -103,10 +104,11 @@ public class LimitExceededWidget extends AbstractSecurityListWidget<LimitExceede
 
         // determine colors
         LimitPriceSettings settings = new LimitPriceSettings(item.attributeType.getProperties());
-        price.setBackdropColor(item.limit.getRelationalOperator().isGreater()
+        Color bgColor = item.limit.getRelationalOperator().isGreater()
                         ? settings.getLimitExceededPositivelyColor(Colors.theme().greenBackground())
-                        : settings.getLimitExceededNegativelyColor(Colors.theme().redBackground()));
-
+                        : settings.getLimitExceededNegativelyColor(Colors.theme().redBackground());
+        price.setBackdropColor(bgColor);
+        price.setForeground(Colors.getTextColor(bgColor));
         price.setText(Values.Quote.format(item.getSecurity().getCurrencyCode(), item.price.getValue()));
 
         Label limit = new Label(composite, SWT.NONE);


### PR DESCRIPTION
Hi,

I've started using limits and with the first entries exceeding them, I had a hard time reading the quotes:

![grafik](https://github.com/portfolio-performance/portfolio/assets/7911829/a72d2ca3-3858-4ae7-9512-7c4a1cf4bafe)

Pure green should have a black text color so I took the liberty to change the widget to actually set a forground color and use getTextColor for calulation. Because that had no effect due to the high threshold of 0.6 I've adjusted it to use 0.55 which "covers" pure green while keeping the threshold as close to the original one.

BTW:

        private Color redBackground = Colors.GREEN;
        private Color greenBackground = Colors.RED;

That looks wrong, so I've swapped the values.