### PR TITLE
fix csv export for custom filename

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/AbstractCSVExporter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/AbstractCSVExporter.java
@@ -22,6 +22,9 @@ public abstract class AbstractCSVExporter
 
     protected abstract Shell getShell();
 
+    private static final String[] FILTER_NAMES = { "CSV (*.csv)" }; //$NON-NLS-1$
+    private static final String[] FILTER_EXTS = { "*.csv" }; //$NON-NLS-1$
+
     protected abstract void writeToFile(File file) throws IOException;
 
     public void export(Object... labels)
@@ -48,6 +51,8 @@ public abstract class AbstractCSVExporter
     {
         FileDialog dialog = new FileDialog(getShell(), SWT.SAVE);
         dialog.setFileName(TextUtil.sanitizeFilename(fileName));
+        dialog.setFilterNames(FILTER_NAMES);
+        dialog.setFilterExtensions(FILTER_EXTS);
         dialog.setOverwrite(true);
         String name = dialog.open();
         if (name == null)


### PR DESCRIPTION
Issue: https://forum.portfolio-performance.info/t/csv-export-von-konto-oder-depotumsatzen-nicht-lesbar/24565

Hello,
in the above forum thread, one csv export issue is mentioned. One user replies that the .csv extension can be lost when the file is renamed. 
Indeed, if we rename the automatic file name before saving it, I am reproducing the issue (on Windows).

If this is not intended, then this small proposition consists in adding a '*.csv' filter extension when exporting csv instead of `*.*`. 
Note: with the filter extension added, maybe `fileName.append(".csv"); //$NON-NLS-1$` might become unnecessary and can be deleted ? I did not notice a difference with or without it when testing this commit. I am using Windows, I cannot see the behaviour for MacOS or Linux (and maybe the issue is not even present outside Windows? ).

Summary with pictures:
Currently the exported file type extension is not set. :
![Capture d'écran 2024-03-06 235730](https://github.com/portfolio-performance/portfolio/assets/160436107/5408a2f3-dc62-44b7-8a0c-f52f29576765)
If you rename the automatic filename, then the csv extension is lost.
With the filter extension, you can rename now the filename before saving it:
![Capture d'écran 2024-03-07 000341](https://github.com/portfolio-performance/portfolio/assets/160436107/a9325adc-2db0-4278-8cdb-46fb201d5567)

![Capture d'écran 2024-03-07 000240](https://github.com/portfolio-performance/portfolio/assets/160436107/9747c290-2fa2-47ff-a506-e6df83e0dcaa)

