### PR TITLE
Adding support for the changed title in Consorsbank's dividend note PDFs

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
@@ -3616,6 +3616,38 @@ public class ConsorsbankPDFExtractorTest
     }
 
     @Test
+    public void testDividendeNeuabrechnung01()
+    {
+        ConsorsbankPDFExtractor extractor = new ConsorsbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "DividendeNeuabrechnung01.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("LU0292096186"), hasWkn("DBX1DG"), hasTicker(null), //
+                        hasName("Xtr.Stoxx Gbl Sel.Div.100 Swap Inhaber-Anteile 1D o.N."), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividende transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2024-03-07T00:00"), hasShares(100.4205), //
+                        hasSource("DividendeNeuabrechnung01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 45.68), hasGrossValue("EUR", 56.02), //
+                        hasTaxes("EUR", 9.8 + 0.54), hasFees("EUR", 0.00))));
+    }
+
+    @Test
     public void testStornoDividende01()
     {
         ConsorsbankPDFExtractor extractor = new ConsorsbankPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/DividendeNeuabrechnung01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/DividendeNeuabrechnung01.txt
@@ -1,0 +1,56 @@
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.67.2.qualifier
+-----------------------------------------
+Consorsbank  90318 Nürnberg
+Depotnummer: 1234567890
+1504753979/00
+Vermerk der Bank: 2000
+2
+Vorname Nachname
+Adrstraße. 123 Datum: 07.03.2024
+12345 Ort Seite: 1 von 2
+Ertragsgutschrift / Neuabrechnung
+Wertpapierbezeichnung WKN ISIN
+Xtr.Stoxx Gbl Sel.Div.100 Swap Inhaber-Anteile 1D o.N. DBX1DG LU0292096186
+Bestand
+100,4205 Stück
+Ertragsausschüttung je Anteil 0,5579 EUR Schlusstag 20.02.2024
+Brutto 56,02 EUR
+abzgl. Kapitalertragsteuer 25,00 % von 39,22 EUR 9,80 EUR
+abzgl. Solidaritätszuschlag 5,50 % von 9,80 EUR 0,54 EUR
+Netto zugunsten IBAN DE12 3456 7890 1234 5678 01 45,68 EUR
+Valuta 07.03.2024 BIC DABBDEMMXXX
+Bitte beachten Sie die weiteren Informationen auf Seite 2.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland (AG nach franz. Recht).
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil dAdministration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+1EE3F5A1-39F0-C59A-1189-45159B0B93B5
+Depotnummer: 1234567890
+1504753979/00
+Vermerk der Bank: 2000
+2
+Datum: 07.03.2024
+Seite: 2 von 2
+Details zur Abrechnung
+Informationen zum Investmentsteuergesetz
+Ausschüttung gem. §2 Abs. 11 InvStG 56,02 EUR
+abzgl. Teilfreistellung 30,00 % von 56,02 EUR 17,65 EUR
+Ertragsausschüttung mit Teilfreistellung 41,18 EUR
+Steuerpflichtiger Gesamtertrag 41,18 EUR
+Mit Verrechnungstopf "Allgemein" verrechnet 0,00 EUR
+Mit Sparerpauschbetrag verrechnet 0,00 EUR
+Mit Quellensteuer verrechnet 0,00 EUR
+somit verrechnete Quellensteuer 0,00 EUR
+Bemessungsgrundlage für Kapitalertragsteuer gesamt 41,18 EUR
+Details zu den Verrechnungstöpfen
+Verrechnungstopf "Allgemein" vor der Abrechnung 0,00 EUR
+Mit Verrechnungstopf "Allgemein" verrechnet 0,00 EUR
+Verrechnungstopf "Allgemein" nach der Abrechnung 0,00 EUR
+Sparerpauschbetrag vor der Abrechnung 0,00 EUR
+Mit Sparerpauschbetrag verrechnet 0,00 EUR
+Sparerpauschbetrag nach der Abrechnung 0,00 EUR
+Verrechnungstopf "Quellensteuer" vor der Abrechnung 0,00 EUR
+Änderung Verrechnungstopf "Quellensteuer" 0,00 EUR
+Verrechnungstopf "Quellensteuer" nach der Abrechnung 0,00 EUR

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -336,12 +336,15 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        DocumentType type = new DocumentType("(?i)(Dividendengutschrift|Ertragsgutschrift|ERTRAGSTHESAURIERUNG)", isJointAccount);
+        DocumentType type = new DocumentType(
+                        "(?i)(Dividendengutschrift|Ertragsgutschrift|ERTRAGSTHESAURIERUNG)(\\s*/\\s*Neuabrechnung)?",
+                        isJointAccount);
         this.addDocumentTyp(type);
 
         Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
 
-        Block firstRelevantLine = new Block("^(?i)(Dividendengutschrift|Ertragsgutschrift|ERTRAGSTHESAURIERUNG)([\\s]+)?$");
+        Block firstRelevantLine = new Block(
+                        "^(?i)(Dividendengutschrift|Ertragsgutschrift|ERTRAGSTHESAURIERUNG)(\\s*/\\s*Neuabrechnung)?([\\s]+)?$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 


### PR DESCRIPTION
As recently discussed in the [forum](https://forum.portfolio-performance.info/t/pdf-import-von-consorsbank/2697/264) Consorsbank seem to have changed the title in their PDFs for dividends, always containing the phrase "/ Neuabrechnung". This leads to the PDF importer to fail parsing them. The changes fixes this.