### PR TITLE
Fix some label position

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/events/AddCustomEventPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/events/AddCustomEventPage.java
@@ -71,7 +71,7 @@ public class AddCustomEventPage extends AbstractWizardPage
         setControl(container);
         container.setLayout(new FormLayout());
 
-        Label labelSecurity = new Label(container, SWT.NONE);
+        Label labelSecurity = new Label(container, SWT.RIGHT);
         labelSecurity.setLayoutData(new FormData());
         labelSecurity.setText(Messages.ColumnSecurity);
 
@@ -114,7 +114,7 @@ public class AddCustomEventPage extends AbstractWizardPage
         // measuring the width requires that the font has been applied before
         stylingEngine.style(container);
 
-        int labelWidth = widest(labelSecurity, labelDate);
+        int labelWidth = widest(labelSecurity, labelDate, labelMessage);
 
         startingWith(comboSecurity.getControl(), labelSecurity) //
                         .thenBelow(boxDate.getControl()).label(labelDate) //

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/SelectSplitPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/SelectSplitPage.java
@@ -75,7 +75,7 @@ public class SelectSplitPage extends AbstractWizardPage
         setControl(container);
         container.setLayout(new FormLayout());
 
-        Label labelSecurity = new Label(container, SWT.NONE);
+        Label labelSecurity = new Label(container, SWT.RIGHT);
         labelSecurity.setText(Messages.ColumnSecurity);
 
         List<Security> securities = model.getClient().getActiveSecurities();


### PR DESCRIPTION
Hello PP team,
Very small proposition for a very small 'bug':
In the Custom Event Page, the location of label is not ideal in the case of a wide "EventLabel". This is unvisible in English or Deutsch language, but visible in Spanish and French language.

**Current:**
![Capture d'écran 2024-03-13 002145](https://github.com/portfolio-performance/portfolio/assets/160436107/4cbacc13-554f-463e-a837-10f25e64eafe)
![Capture d'écran 2024-03-13 002333](https://github.com/portfolio-performance/portfolio/assets/160436107/43572971-4c42-4fa0-b818-f8ca59cc8785)

**After Fix:**
![Capture d'écran 2024-03-13 002438](https://github.com/portfolio-performance/portfolio/assets/160436107/6ec2e5cb-eb58-4f5f-bad2-6a6756694ff4)

(Please note that I am unable to check the impact of the fix for other language than French, as when launched from Eclipse, the language setting is set by default on Automatic (this is a recent strange behaviour), so French for me. If I change the language, close and start again, I am stuck on automatic.. Only happening from Eclipse, the current official release does not have this issue)

I have also updated the Stock Split event in a similar way (once again, invisible in English & Deutsch setting):
**Before**
![Capture d'écran 2024-03-13 002604](https://github.com/portfolio-performance/portfolio/assets/160436107/50b0552f-c922-42a2-ac63-d54b42b14578)

**After**
![Capture d'écran 2024-03-13 004019](https://github.com/portfolio-performance/portfolio/assets/160436107/3bbf50aa-dac2-4745-b9a3-9ccc2313da03)
