### PR TITLE
Light mode : set selected tab to white

### DIFF
--- a/name.abuchen.portfolio.ui/css/shared/light.css
+++ b/name.abuchen.portfolio.ui/css/shared/light.css
@@ -27,7 +27,7 @@ CTabFolder {
     swt-tab-outline: '#org-eclipse-ui-workbench-ACTIVE_TAB_OUTLINE_COLOR';
     swt-outer-keyline-color: '#org-eclipse-ui-workbench-ACTIVE_TAB_OUTER_KEYLINE_COLOR';
     swt-unselected-tabs-color: '#org-eclipse-ui-workbench-ACTIVE_UNSELECTED_TABS_COLOR_START' '#org-eclipse-ui-workbench-ACTIVE_UNSELECTED_TABS_COLOR_END' 100% 100%;
-    swt-selected-tab-fill: '#org-eclipse-ui-workbench-ACTIVE_TAB_BG_END';
+    swt-selected-tab-fill: white;
     swt-shadow-visible: false;
 }
 


### PR DESCRIPTION
Issue : https://forum.portfolio-performance.info/t/payment-tab-color-in-light-mode/27659

This change of color affects Performance/Calculation tabs + Performance/Payment tabs.

A very naive modification : is that ok to use a fixed color instead of some "#org-eclipse-ui-workbench-" colors here ? `white` is already used as the hover tab color. I cannot see the effect on Mac and Linux.

On my Windows this change from:
![Capture d'écran 2024-03-13 231843](https://github.com/portfolio-performance/portfolio/assets/160436107/399898b3-4cea-493d-941e-1806cc18dcbb)
to
![Capture d'écran 2024-03-13 231918](https://github.com/portfolio-performance/portfolio/assets/160436107/c773f6ca-8759-43cb-a3c5-b7d87a53be83)

(Another possible way would be to modify the unselected tab instead with **IN**ACTIVE_UNSELECTED instead of ACTIVE_UNSELECTED
`swt-unselected-tabs-color: '#org-eclipse-ui-workbench-INACTIVE_UNSELECTED_TABS_COLOR_START' '#org-eclipse-ui-workbench-INACTIVE_UNSELECTED_TABS_COLOR_END' 100% 100%;` which produces darker grey unselected tab:
![Capture d'écran 2024-03-13 231956](https://github.com/portfolio-performance/portfolio/assets/160436107/dc1f26f2-9e5f-4f39-8bf9-0ba0128bc308)

but it is still not super different from the selected in my view, but it allows to keep "#org-eclipse-ui-workbench-" colors for both the selected and unselected tab.)
Also possible to mix and use darker grey for unselected and white for selected.