### PR TITLE
Fix and Modify Sunrise PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sunrise/Kauf02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sunrise/Kauf02.txt
@@ -1,0 +1,45 @@
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.67.1
+-----------------------------------------
+Depotführung: Ein Service von:
+Für Rückfragen wenden Sie sich bitte an:
+info@meetsunrise.com
+Herr
+Fondsabrechnung
+TOGSoj SozSi
+FcvmR ydOdxqCbtQB 7/0 Wien, 20.10.2022
+2908 vLwD Depotinhaber: frQDJw AedNd
+ukFulZrAOV Depotnummer: 5406992396
+Hiermit bestätigen wir Ihnen folgende Transaktion für Sie ausgeführt zu haben:
+Transaktion Fondsname Betrag Preis Anteile 
+WKN/ISIN Preisdatum Bestand neu
+Verwahrart/Lagerland
+Kauf Standortfonds Österreich 50.00 € 115.40 € 0.433
+AT0000A1QA38 18.10.2022 4.740
+Girosammelverwahrung/AT
+Abrechnungsbetrag: 50.00 €
+Ausgabeaufschlag/Provision: 0,00%
+Auftrags-Nummer: 747448052066562190749732135729
+KESt-Neubestand mit Anschaffungskosten nach dem gleitenden Durchschnittsverfahren § 27a Abs. 4 Zi 3 EStG: 
+0.433       Anteile.
+Steuerlicher Anschaffungswert: 49.97 €
+Verrechnung Kapitalertragssteuer*
+• Vor dieser Transaktion nicht ausgeglichene Gewinne:
+• Nach dieser Transaktion nicht ausgeglichene Gewinne:
+• Vor dieser Transaktion nicht ausgeglichene Verluste:
+• Nach dieser Transaktion nicht ausgeglichene Verluste:
+* Innerhalb eines Kalenderjahres werden realisierte Verluste mit realisierten Gewinnen ausgeglichen. Dabei werden alle
+von Ihnen bei uns gehaltenen Depots zusammen betrachtet. Es gibt zwei Fälle: Im ersten Fall haben Sie in der 
+Vergangenheit Gewinne realisiert, mit der aktuellen Transaktion machen Sie aber einen Verlust. In diesem Fall wird Ihre 
+bereits bezahlte Kapitalertragsteuer mit dieser Auszahlung rückerstattet. Im zweiten Fall haben Sie in der Vergangenheit 
+Verluste realisiert, machen aber mit dieser Auszahlung einen Gewinn. Dann wurde der Verlust aus der Vergangenheit bei 
+der Berechnung des Kapitalertragsteuerabzugs für diesen Verkauf berücksichtigt.
+Anlagen in Investmentfonds können erst nach Kenntnisnahme der gesetzlichen Verkaufsunterlagen (Prospekt, Kunden-
+informationsdokumente, Halb-/Jahresbericht) erfolgen. Diese Unterlagen haben Sie direkt über die Sunrise Kanäle 
+erhalten bzw. vor Auftragserteilung dort eingesehen. 
+Hinweis: Einwendungen gegen diese Fondsabrechnung wegen Unrichtigkeit oder Unvollständigkeit richten Sie bitte 
+schriftlich spätestens einen Monat nach Zugang an: info@meetsunrise.com
+Simpel S.A., 33, Boulevard Prince Henri, L-1724 Luxemburg; Sitz: Luxemburg; Umsatzsteuer-lD-Nr. LU32888126; Vorsitzender des Verwaltungsrats: 
+Thomas Niss; Conducting Officers: Martin Foussek, Christian McFadden
+Simpel Zweigniederlassung Österreich, 1040 Wien, Gußhausstraße 3/2a; Handelsgericht Wien, FN 562615a ; Niederlassungsleiter:
+Christian McFadden, Martin Foussek, Ständiger Vertreter: Thomas Niss

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sunrise/Kauf03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sunrise/Kauf03.txt
@@ -1,0 +1,33 @@
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.67.1
+-----------------------------------------
+Ein Service von:
+Für Rückfragen wenden Sie sich 
+bitte an: info@meetsunrise.com
+Herr
+bbMArl kpKGn Fondsabrechnung
+kyUDc IXQfXfvVuZi 6/0
+2952 Ytaj Datum: 29.12.2023
+TqZadDlMZh  Depotnummer: 6782756237
+Hiermit bestätigen wir Ihnen folgende Transaktion für Sie ausgeführt zu haben:
+Transaktion Fondsname Betrag Preis Anteile 
+ISIN Preisdatum Bestand neu
+Verwahrart/Lagerland
+Verwahrort
+Kauf Standortfonds Österreich 10.08 € 140.03 € 0.072
+AT0000A1QA38 28.12.2023 13.548
+Girosammelverwahrung/AT 
+Raiffeisen Bank International AG
+Abrechnungsbetrag: 10.08 €
+Ausgabeaufschlag/Provision: 0,00%
+Auftrags-Nummer: 751175802407452854275862438475
+Anlagen in Investmentfonds können erst nach Kenntnisnahme der gesetzlichen Verkaufsunterlagen 
+(Basisinformationsblatt) erfolgen. Diese Unterlagen haben Sie direkt über die Sunrise Kanäle erhalten bzw. vor 
+Auftragserteilung dort eingesehen.
+Wichtiger Hinweis: Einwendungen gegen diese Fondsabrechnung wegen Unrichtigkeit oder Unvollständigkeit 
+richten Sie bitte schriftlich spätestens einen Monat nach Zugang an: info@meetsunrise.com.
+Mit besten Grüßen
+Ihr Sunrise Team
+Sunrise Securities GmbH, Gußhausstraße 3/2, A-1040 Wien; UID-Nummer: ATU 68616777, Firmenbuchnummer: FN 410750w 
+Sunrise Securities GmbH nach österreichischem Recht Zweigniederlassung Deutschland, Rahel-Hirsch-Straße 10, D-10557 Berlin; Handelsregister: HRB 258310 B
+Version_2023_01_K

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sunrise/Kauf04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sunrise/Kauf04.txt
@@ -1,0 +1,33 @@
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.67.3
+-----------------------------------------
+Ein Service von:
+Für Rückfragen wenden Sie sich 
+bitte an: info@meetsunrise.com
+Herr
+gifSwG BNiVTeGR Fondsabrechnung
+zaeldasd-emd-MqKbfe 81
+39610 pTfvIfZgatMvWz Datum: 05.01.2024
+Deutschland  Depotnummer: 5190828770
+Hiermit bestätigen wir Ihnen folgende Transaktion für Sie ausgeführt zu haben:
+Transaktion Fondsname Betrag Preis Anteile 
+ISIN Preisdatum Bestand neu
+Verwahrart/Lagerland
+Verwahrort
+Kauf Standortfonds Deutschland 1003.84 € 133.81 € 7.502
+AT0000A1Z882 03.01.2024 275.444
+Girosammelverwahrung/AT 
+Raiffeisen Bank International AG
+Abrechnungsbetrag: 1003.84 €
+Ausgabeaufschlag/Provision: 0,00%
+Auftrags-Nummer: 413093083849495599565316731081
+Anlagen in Investmentfonds können erst nach Kenntnisnahme der gesetzlichen Verkaufsunterlagen 
+(Basisinformationsblatt) erfolgen. Diese Unterlagen haben Sie direkt über die Sunrise Kanäle erhalten bzw. vor 
+Auftragserteilung dort eingesehen.
+Wichtiger Hinweis: Einwendungen gegen diese Fondsabrechnung wegen Unrichtigkeit oder Unvollständigkeit 
+richten Sie bitte schriftlich spätestens einen Monat nach Zugang an: info@meetsunrise.com.
+Mit besten Grüßen
+Ihr Sunrise Team
+Sunrise Securities GmbH, Gußhausstraße 3/2, A-1040 Wien; UID-Nummer: ATU 68616777, Firmenbuchnummer: FN 410750w 
+Sunrise Securities GmbH nach österreichischem Recht Zweigniederlassung Deutschland, Rahel-Hirsch-Straße 10, D-10557 Berlin; Handelsregister: HRB 258310 B
+Version_2023_01_K

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sunrise/SunrisePDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sunrise/SunrisePDFExtractorTest.java
@@ -1,32 +1,41 @@
 package name.abuchen.portfolio.datatransfer.pdf.sunrise;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasIsin;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasName;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
-import static org.junit.Assert.assertNull;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
 
-import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
 import name.abuchen.portfolio.datatransfer.Extractor.Item;
-import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
-import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
 import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
 import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
 import name.abuchen.portfolio.datatransfer.pdf.SunrisePDFExtractor;
-import name.abuchen.portfolio.model.AccountTransaction;
-import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
-import name.abuchen.portfolio.model.PortfolioTransaction;
-import name.abuchen.portfolio.model.Security;
-import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.CurrencyUnit;
-import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.money.Values;
 
 @SuppressWarnings("nls")
 public class SunrisePDFExtractorTest
@@ -41,80 +50,156 @@ public class SunrisePDFExtractorTest
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf01.txt"), errors);
 
         assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("AT0000A1QA38"));
-        assertNull(security.getWkn());
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("Standortfonds Österreich"));
-        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(results, hasItem(security( //
+                        hasIsin("AT0000A1QA38"), hasWkn(null), hasTicker(null), //
+                        hasName("Standortfonds Österreich"), //
+                        hasCurrencyCode("EUR"))));
 
         // check buy sell transaction
-        BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2024-01-03T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.215)));
-        assertThat(entry.getSource(), is("Kauf01.txt"));
-        assertThat(entry.getNote(), is("Auftrags-Nummer: 345834056535324784670985082345"));
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(30.12))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(30.12))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2024-01-03T00:00"), hasShares(0.215), //
+                        hasSource("Kauf01.txt"), //
+                        hasNote("Auftrags-Nummer: 345834056535324784670985082345"), //
+                        hasAmount("EUR", 30.12), hasGrossValue("EUR", 30.12), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
-    public void testDividende01()
+    public void testWertpapierKauf02()
     {
-        Client client = new Client();
+        SunrisePDFExtractor extractor = new SunrisePDFExtractor(new Client());
 
-        SunrisePDFExtractor extractor = new SunrisePDFExtractor(client);
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("AT0000A1QA38"), hasWkn(null), hasTicker(null), //
+                        hasName("Standortfonds Österreich"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2022-10-18T00:00"), hasShares(0.433), //
+                        hasSource("Kauf02.txt"), //
+                        hasNote("Auftrags-Nummer: 747448052066562190749732135729"), //
+                        hasAmount("EUR", 50.00), hasGrossValue("EUR", 50.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testWertpapierKauf03()
+    {
+        SunrisePDFExtractor extractor = new SunrisePDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("AT0000A1QA38"), hasWkn(null), hasTicker(null), //
+                        hasName("Standortfonds Österreich"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2023-12-28T00:00"), hasShares(0.072), //
+                        hasSource("Kauf03.txt"), //
+                        hasNote("Auftrags-Nummer: 751175802407452854275862438475"), //
+                        hasAmount("EUR", 10.08), hasGrossValue("EUR", 10.08), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testWertpapierKauf04()
+    {
+        SunrisePDFExtractor extractor = new SunrisePDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf04.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("AT0000A1Z882"), hasWkn(null), hasTicker(null), //
+                        hasName("Standortfonds Deutschland"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2024-01-03T00:00"), hasShares(7.502), //
+                        hasSource("Kauf04.txt"), //
+                        hasNote("Auftrags-Nummer: 413093083849495599565316731081"), //
+                        hasAmount("EUR", 1003.84), hasGrossValue("EUR", 1003.84), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende22()
+    {
+        SunrisePDFExtractor extractor = new SunrisePDFExtractor(new Client());
 
         List<Exception> errors = new ArrayList<>();
 
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende01.txt"), errors);
 
         assertThat(errors, empty());
-        assertThat(results.size(), is(2));
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(2L));
+        assertThat(results.size(), is(3));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // check security
-        Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("AT0000A1QA38"));
-        assertNull(security.getWkn());
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("Standortfonds Österreich"));
-        assertThat(security.getCurrencyCode(), is(CurrencyUnit.EUR));
+        assertThat(results, hasItem(security( //
+                        hasIsin("AT0000A1QA38"), hasWkn(null), hasTicker(null), //
+                        hasName("Standortfonds Österreich"), //
+                        hasCurrencyCode("EUR"))));
 
         // check dividends transaction
-        AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2023-12-15T00:00"), hasShares(10.29 / 0.49), //
+                        hasSource("Dividende01.txt"), //
+                        hasNote("Turnus: jährlich"), //
+                        hasAmount("EUR", 10.29), hasGrossValue("EUR", 10.29), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2023-12-15T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(10.29 / 0.49)));
-        assertThat(transaction.getSource(), is("Dividende01.txt"));
-        assertThat(transaction.getNote(), is("Turnus: jährlich"));
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10.29))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10.29))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+        // check taxes transaction
+        assertThat(results, hasItem(taxes( //
+                        hasDate("2023-12-15T00:00"), hasShares(10.29 / 0.49), //
+                        hasSource("Dividende01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 10.29), hasGrossValue("EUR", 10.29), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SunrisePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SunrisePDFExtractor.java
@@ -14,21 +14,26 @@ import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.money.CurrencyUnit;
+import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
+
+/***
+ * @formatter:off
+ * @implNote The currency of Sunrise Securities GmbH is always EUR.
+ *
+ * @implSpec There is no information on the shares in the dividend transactions.
+ *           In this section we calculate the shares for the respective transaction.
+ * @formatter:on
+ */
 
 @SuppressWarnings("nls")
 public class SunrisePDFExtractor extends AbstractPDFExtractor
 {
-
-    /***
-     * Information: The currency of Sunrise Securities GmbH is always EUR.
-     */
-
     public SunrisePDFExtractor(Client client)
     {
         super(client);
 
-        addBankIdentifier("Sunrise Securities GmbH");
+        addBankIdentifier("info@meetsunrise.com");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -46,56 +51,57 @@ public class SunrisePDFExtractor extends AbstractPDFExtractor
         this.addDocumentTyp(type);
 
         Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
-        pdfTransaction.subject(() -> {
-            BuySellEntry entry = new BuySellEntry();
-            entry.setType(PortfolioTransaction.Type.BUY);
-            return entry;
-        });
 
-        Block firstRelevantLine = new Block("^([\\s]+)?(Kauf|Verkauf) .*$");
+        Block firstRelevantLine = new Block("^Kauf .* [\\.'\\d]+ \\p{Sc} [\\.'\\d]+ \\p{Sc} [\\.'\\d]+$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
-        pdfTransaction
-                        // Is type --> "Verkauf" change from BUY to SELL
-                        .section("type").optional().match("^([\\s]+)?(?<type>(Kauf|Verkauf)) .*$").assign((t, v) -> {
-                            if ("Verkauf".equals(v.get("type")))
-                            {
-                                t.setType(PortfolioTransaction.Type.SELL);
-                            }
+        pdfTransaction //
+
+                        .subject(() -> {
+                            BuySellEntry portfolioTransaction = new BuySellEntry();
+                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
+                            return portfolioTransaction;
                         })
 
+                        // @formatter:off
                         // Kauf Standortfonds Österreich 10.00 € 140.59 € 0.071
                         // AT0000A1QA38 10.01.2022 5.123
-                        .section("name", "isin")
-                        .match("^([\\s]+)?(Kauf|Verkauf) (?<name>.*) ['\\.\\d]+ \\p{Sc} ([\\s]+)?['\\.\\d]+ \\p{Sc} ([\\s]+)?[\\.\\d\\s]+$")
-                        .match("^(?<isin>[\\w]{12}) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ['\\.\\d]+$").assign((t, v) -> {
-                            v.put("currency", CurrencyUnit.EUR);
-                            t.setSecurity(getOrCreateSecurity(v));
-                        })
+                        // @formatter:on
+                        .section("name", "currency", "isin") //
+                        .match("^Kauf (?<name>.*) [\\.'\\d]+ \\p{Sc} [\\.'\\d]+ (?<currency>\\p{Sc}) [\\.'\\d]+$") //
+                        .match("^(?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} ['\\.\\d]+$") //
+                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
+                        // @formatter:off
                         // Kauf Standortfonds Österreich 10.00 € 140.59 € 0.071
-                        // Verkauf Standortfonds Deutschland 880.29 € 133.58 €
-                        // 6.590
-                        .section("shares")
-                        .match("^([\\s]+)?(Kauf|Verkauf) .* ['\\.\\d]+ \\p{Sc} ([\\s]+)?['\\.\\d]+ \\p{Sc} ([\\s]+)?(?<shares>[\\.\\d\\s]+)$")
+                        // @formatter:on
+                        .section("shares") //
+                        .match("^Kauf .* [\\.'\\d]+ \\p{Sc} [\\.'\\d]+ \\p{Sc} (?<shares>[\\.\\d\\s]+)$") //
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
+                        // @formatter:off
                         // AT0000A1QA38 10.01.2022 5.123
-                        .section("date").match("^[\\w]{12} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) ['\\.\\d]+$")
+                        // @formatter:on
+                        .section("date") //
+                        .match("^[A-Z]{2}[A-Z0-9]{9}[0-9] (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) [\\.'\\d]+$") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
+                        // @formatter:off
                         // Abrechnungsbetrag: 10.00 €
-                        // Auszahlungsbetrag: 848.68 €
-                        .section("amount")
-                        .match("^(Abrechnungsbetrag|Auszahlungsbetrag): ([\\s]+)?(?<amount>['\\.\\d]+) \\p{Sc}$")
+                        // @formatter:on
+                        .section("amount", "currency") //
+                        .match("^Abrechnungsbetrag: (?<amount>['\\.\\d]+) (?<currency>\\p{Sc})$") //
                         .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                         })
 
+                        // @formatter:off
                         // Auftrags-Nummer: 20220106123456789000000612345
-                        .section("note").optional().match("^(?<note>Auftrags-Nummer: [\\d]+)$")
+                        // @formatter:on
+                        .section("note").optional() //
+                        .match("^(?<note>Auftrags\\-Nummer: [\\d]+)$") //
                         .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
                         .wrap(BuySellEntryItem::new);
@@ -108,32 +114,37 @@ public class SunrisePDFExtractor extends AbstractPDFExtractor
         DocumentType type = new DocumentType("Aussch.ttungsanzeige");
         this.addDocumentTyp(type);
 
-        Block block = new Block("^.*Aussch.ttungsanzeige$");
-        type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
-            AccountTransaction entry = new AccountTransaction();
-            entry.setType(AccountTransaction.Type.DIVIDENDS);
-            return entry;
-        });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
 
-        pdfTransaction
+        Block firstRelevantLine = new Block("^.*Aussch.ttungsanzeige$");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
 
+        pdfTransaction //
+
+                        .subject(() -> {
+                            AccountTransaction accountTransaction = new AccountTransaction();
+                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
+                            return accountTransaction;
+                        })
+
+                        // @formatter:off
                         // Fondsname: Standortfonds Österreich
                         // WKN/ISIN: AT0000A1QA38 Datum des Ertrags: 15.12.2023
+                        // @formatter:on
                         .section("name", "isin") //
                         .match("^Fondsname: (?<name>.*)$") //
-                        .match("^WKN\\/ISIN: (?<isin>[\\w]{12}) Datum des.*$") //
+                        .match("^WKN\\/ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) Datum des.*$") //
                         .assign((t, v) -> {
                             v.put("currency", CurrencyUnit.EUR);
+
                             t.setSecurity(getOrCreateSecurity(v));
                         })
 
-                        // There is no information about the proportions in the
-                        // documents. In this section we calculate the shares
-                        // for the respective transaction.
-
+                        // @formatter:off
                         // Ausschüttung je Anteil: 2.71
                         // Ausschüttung gesamt: 17.58
+                        // @formatter:on
                         .section("amountPerShare", "gross") //
                         .match("^Aussch.ttung je Anteil: (?<amountPerShare>['\\.\\d]+)$") //
                         .match("^Aussch.ttung gesamt: (?<gross>['\\.\\d]+)$") //
@@ -142,49 +153,171 @@ public class SunrisePDFExtractor extends AbstractPDFExtractor
                             BigDecimal amountTotal = asExchangeRate(v.get("gross"));
 
                             int sharesPrecision = Values.Share.precision() * 2;
-                            BigDecimal shares = amountTotal.divide(amountPerShare, sharesPrecision,
-                                            RoundingMode.HALF_UP);
-
+                            BigDecimal shares = amountTotal.divide(amountPerShare, sharesPrecision, RoundingMode.HALF_UP);
                             t.setShares(asShares(shares.toPlainString()));
                         })
 
+                        // @formatter:off
                         // WKN/ISIN: AT0000A1QA38 Datum des Ertrags: 15.12.2023
+                        // @formatter:on
                         .section("date") //
                         .match("^WKN.*Datum des Ertrags: (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$") //
                         .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
-                        // Zur Auszahlung kommender Betrag: 0.00
-                        .section("amount") //
-                        .match("^ Zur Auszahlung kommender Betrag: (?<amount>['\\.\\d]+)$") //
+                        // @formatter:off
+                        // Ausschüttung gesamt: 10.29
+                        //  Zur Auszahlung kommender Betrag: 0.00
+                        // @formatter:on
+                        .section("gross", "amount") //
+                        .match("^Aussch.ttung gesamt: (?<gross>[\\.'\\d]+)$") //
+                        .match("^.*Zur Auszahlung kommender Betrag: (?<amount>[\\.'\\d]+)$") //
                         .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
+                            t.setCurrencyCode(CurrencyUnit.EUR);
+
+                            // @formatter:off
+                            // If the dividend amount correspond to the tax amount to be paid,
+                            // the taxes is recorded in a separate transaction.
+                            // @formatter:on
+                            if (t.getMonetaryAmount().isZero())
+                            {
+                                type.getCurrentContext().putBoolean("noTax", true);
+                                t.setAmount(asAmount(v.get("gross")));
+                            }
                         })
 
+                        // @formatter:off
                         // WKN / ISIN: AT0000A1Z882 Turnus: jährlich
+                        // @formatter:on
                         .section("note").optional() //
                         .match("^.* (?<note>Turnus: .*)$") //
                         .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
-                        .wrap(TransactionItem::new);
+                        .wrap((t, ctx) -> {
+                            type.getCurrentContext().remove("noTax");
+
+                            TransactionItem item = new TransactionItem(t);
+
+                            return item;
+                        });
 
         addTaxesSectionsTransaction(pdfTransaction, type);
+        addDividendeTaxBlock(type);
+    }
 
-        block.set(pdfTransaction);
+    private void addDividendeTaxBlock(DocumentType type)
+    {
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
+
+        Block firstRelevantLine = new Block("Aussch.ttungsanzeige");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
+
+        pdfTransaction //
+
+                        .subject(() -> {
+                            AccountTransaction accountTransaction = new AccountTransaction();
+                            accountTransaction.setType(AccountTransaction.Type.TAXES);
+                            return accountTransaction;
+                        })
+
+                        // @formatter:off
+                        // Fondsname: Standortfonds Österreich
+                        // WKN/ISIN: AT0000A1QA38 Datum des Ertrags: 15.12.2023
+                        // @formatter:on
+                        .section("name", "isin") //
+                        .match("^Fondsname: (?<name>.*)$") //
+                        .match("^WKN\\/ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) Datum des.*$") //
+                        .assign((t, v) -> {
+                            v.put("currency", CurrencyUnit.EUR);
+
+                            t.setSecurity(getOrCreateSecurity(v));
+                        })
+
+                        // @formatter:off
+                        // There is no information about the proportions in the
+                        // documents. In this section we calculate the shares
+                        // for the respective transaction.
+                        // @formatter:on
+
+                        // @formatter:off
+                        // Ausschüttung je Anteil: 2.71
+                        // Ausschüttung gesamt: 17.58
+                        // @formatter:on
+                        .section("amountPerShare", "gross") //
+                        .match("^Aussch.ttung je Anteil: (?<amountPerShare>['\\.\\d]+)$") //
+                        .match("^Aussch.ttung gesamt: (?<gross>['\\.\\d]+)$") //
+                        .assign((t, v) -> {
+                            BigDecimal amountPerShare = asExchangeRate(v.get("amountPerShare"));
+                            BigDecimal amountTotal = asExchangeRate(v.get("gross"));
+
+                            int sharesPrecision = Values.Share.precision() * 2;
+                            BigDecimal shares = amountTotal.divide(amountPerShare, sharesPrecision, RoundingMode.HALF_UP);
+                            t.setShares(asShares(shares.toPlainString()));
+                        })
+
+                        // @formatter:off
+                        // WKN/ISIN: AT0000A1QA38 Datum des Ertrags: 15.12.2023
+                        // @formatter:on
+                        .section("date") //
+                        .match("^WKN.*Datum des Ertrags: (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$") //
+                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
+
+                        // @formatter:off
+                        // Ausschüttung gesamt: 10.29
+                        // Kapitalertragsteuer (KESt) gesamt: 10.29
+                        // @formatter:on
+                        .section("tax", "amount") //
+                        .match("^Kapitalertragsteuer \\(KESt\\) gesamt: (?<tax>[\\.'\\d]+)$") //
+                        .match("^.*Zur Auszahlung kommender Betrag: (?<amount>[\\.'\\d]+)$") //
+                        .assign((t, v) -> {
+                            Money tax = Money.of(CurrencyUnit.EUR, asAmount(v.get("tax")));
+                            Money amount = Money.of(CurrencyUnit.EUR, asAmount(v.get("amount")));
+
+                            if (amount.isZero())
+                            {
+                                t.setMonetaryAmount(tax);
+                            }
+                            else
+                            {
+                                t.setAmount(0L);
+                                t.setCurrencyCode(CurrencyUnit.EUR);
+                            }
+                        })
+
+                        .wrap((t, ctx) -> {
+                            TransactionItem item = new TransactionItem(t);
+
+                            if (t.getCurrencyCode() != null && t.getAmount() == 0)
+                                return null;
+
+                            return item;
+                        });
     }
 
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
     {
-        transaction
+        transaction //
+
+                        // @formatter:off
                         // abgeführte Kapitalertragsteuer: 31.61 €
-                        .section("tax").optional() //
-                        .match("^abgef.hrte Kapitalertragsteuer: (?<tax>['\\.\\d]+) \\p{Sc}$") //
+                        // @formatter:on
+                        .section("tax", "currency").optional() //
+                        .match("^abgef.hrte Kapitalertragsteuer: (?<tax>[\\.'\\d]+) (?<currency>\\p{Sc})$") //
                         .assign((t, v) -> processTaxEntries(t, v, type))
 
+                        // @formatter:off
                         // Kapitalertragsteuer (KESt) gesamt: 4.28
+                        // @formatter:on
                         .section("tax").optional() //
-                        .match("^Kapitalertragsteuer \\(KESt\\) gesamt: (?<tax>['\\.\\d]+)$") //
-                        .assign((t, v) -> processTaxEntries(t, v, type));
+                        .match("^Kapitalertragsteuer \\(KESt\\) gesamt: (?<tax>[\\.'\\d]+)$") //
+                        .assign((t, v) -> {
+                            if (!type.getCurrentContext().getBoolean("noTax"))
+                            {
+                                v.put("currency", CurrencyUnit.EUR);
+                                processTaxEntries(t, v, type);
+                            }
+                        });
     }
 
     @Override


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/pdf-import-von-sunrise/26633 
https://forum.portfolio-performance.info/t/pdf-import-von-sunrise/26633/5

The Sunrise PDF importer was implemented in #3731 by @auchri 

If the dividends and the taxes neutralize each other, then negative dividends were previously posted (EUR 0.00 minus taxes). This is incorrect, as a negative dividend is then displayed under "Payments". The transactions are now recorded separately in this case.

A test case for the sale of securities does not exist. This has therefore been removed from the importer. (Validation)
The test cases have been updated.
Format source to standard eclipse format
Improve regulare expressions
Add missing currency detection
Remove obsolet source