### PR TITLE
Fix Bigbank PDF Importer ignoring cent amounts

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/bigbank/BigbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/bigbank/BigbankPDFExtractorTest.java
@@ -46,15 +46,15 @@ public class BigbankPDFExtractorTest
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transaction
-        assertThat(results, hasItem(deposit(hasDate("2024-03-20"), hasAmount("EUR", 10.00), //
+        assertThat(results, hasItem(deposit(hasDate("2024-03-20"), hasAmount("EUR", 10.12), //
                         hasSource("Kontoauszug01.txt"), hasNote(null))));
 
         // assert transaction
-        assertThat(results, hasItem(deposit(hasDate("2024-03-21"), hasAmount("EUR", 1500.00), //
+        assertThat(results, hasItem(deposit(hasDate("2024-03-21"), hasAmount("EUR", 1500.34), //
                         hasSource("Kontoauszug01.txt"), hasNote(null))));
 
         // assert transaction
-        assertThat(results, hasItem(removal(hasDate("2024-03-25"), hasAmount("EUR", 10.00), //
+        assertThat(results, hasItem(removal(hasDate("2024-03-25"), hasAmount("EUR", 10.12), //
                         hasSource("Kontoauszug01.txt"), hasNote(null))));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/bigbank/Kontoauszug01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/bigbank/Kontoauszug01.txt
@@ -12,14 +12,14 @@ Kontoauszug von 01.03.2024 bis 25.03.2024
 IBAN: EE123456789101112131
 Anfangssaldo 01.03.2024 0,00
 Datum Gegenkonto Buchung Name  Betrag in EUR
-20.03.2024 AT123456789101112131 Einzahlung ffIpWotyu  dJMdyU +10,00
-21.03.2024 AT123456789101112131 Einzahlung oDkoRVZEb  TxDUxE +1 500,00
-25.03.2024 AT123456789101112131 Auszahlung sUBHAKqzf  vNNKxT -10,00
+20.03.2024 AT123456789101112131 Einzahlung ffIpWotyu  dJMdyU +10,12
+21.03.2024 AT123456789101112131 Einzahlung oDkoRVZEb  TxDUxE +1 500,34
+25.03.2024 AT123456789101112131 Auszahlung sUBHAKqzf  vNNKxT -10,12
 Endsaldo 25.03.2024 1 500,00
 Anfangssaldo 01.03.2024 0,00
-Summe Belastungen -10,00
-Summe Gutschriften +1 510,00
-Endsaldo 25.03.2024 1 500,00
+Summe Belastungen -10,12
+Summe Gutschriften +1 510,46
+Endsaldo 25.03.2024 1 500,34
 Dies ist ein automatisch generierter Kontoauszug.
 BIGBANK AS Telefon 0810 900 629
 Riia 2, Tartu E-mail kundenservice@bigbank.at

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BigbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BigbankPDFExtractor.java
@@ -92,6 +92,6 @@ public class BigbankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        return ExtractorUtils.convertToNumberLong(value, Values.Amount, "de", "CH");
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount, "et", "EE");
     }
 }


### PR DESCRIPTION
Bigbank uses the Estonian number format in their account statement transactions, namely a comma as decimal separator.

Before, numbers were parsed by the ExtractorUtils with the de_CH country code, which uses a dot as decimal separator. This has the effect that cent amount are ignored, but the test still passed since it did not include cent amounts.

This pull request:
* Modifies the test case to include cent amounts
* Adjust the ExtractorUtils' country code from de_CH to et_EE (see: https://www.localeplanet.com/icu/et-EE/index.html)