### PR TITLE
Add messages to non-descript Exceptions

### DIFF
--- a/name.abuchen.portfolio.bootstrap/src/name/abuchen/portfolio/bootstrap/CustomSaveHandler.java
+++ b/name.abuchen.portfolio.bootstrap/src/name/abuchen/portfolio/bootstrap/CustomSaveHandler.java
@@ -38,7 +38,7 @@ public class CustomSaveHandler extends PartServiceSaveHandler
     {
         Object clientInput = dirtyPart.getTransientData().get(ModelConstants.EDITOR_INPUT);
         if (clientInput == null)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("no client input found");
 
         EModelService modelService = dirtyPart.getContext().get(EModelService.class);
         MApplication app = dirtyPart.getContext().get(MApplication.class);

--- a/name.abuchen.portfolio.tests/src/fileversions/ReadingHistoricClientFilesTest.java
+++ b/name.abuchen.portfolio.tests/src/fileversions/ReadingHistoricClientFilesTest.java
@@ -107,6 +107,6 @@ public class ReadingHistoricClientFilesTest
                 return fullPath.get().toFile();
         }
 
-        throw new IllegalArgumentException();
+        throw new IllegalArgumentException("entry with name '" + name + "' not found");
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/AccountTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/AccountTest.java
@@ -1,6 +1,8 @@
 package name.abuchen.portfolio.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDate;
@@ -24,7 +26,7 @@ public class AccountTest
         account.setCurrencyCode(CurrencyUnit.EUR);
 
         this.transaction = new AccountTransaction();
-        transaction.setDateTime(LocalDate.now().atStartOfDay());
+        transaction.setDateTime(LocalDate.of(2024, 03, 12).atStartOfDay());
         transaction.setType(AccountTransaction.Type.DEPOSIT);
         transaction.setAmount(10000);
         transaction.setCurrencyCode(CurrencyUnit.EUR);
@@ -41,11 +43,29 @@ public class AccountTest
         assertTrue(account.getTransactions().contains(transaction));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAddTransactionIllegalCurrencyUnit()
     {
         transaction.setCurrencyCode(CurrencyUnit.USD);
 
-        account.addTransaction(transaction);
+        IllegalArgumentException iae = assertThrows(IllegalArgumentException.class,
+                        () -> account.addTransaction(transaction));
+        assertEquals("exception message mismatch",
+                        "Unable to add transaction '12.03.2024 DEPOSIT           USD    100,00 <no Security> <no XEntry>' to account 'Testaccount' (uuid "
+                                        + transaction.getUUID() + "): EUR <> USD",
+                        iae.getMessage());
+        assertNull("no cause expected", iae.getCause());
+
+        Security sec = new Security();
+        sec.setIsin("DEISIN");
+        sec.setName("Security Name Inc");
+        transaction.setSecurity(sec);
+
+        iae = assertThrows(IllegalArgumentException.class, () -> account.addTransaction(transaction));
+        assertEquals("exception message mismatch",
+                        "Unable to add transaction '12.03.2024 DEPOSIT           USD    100,00 Security Name Inc <no XEntry>' to account 'Testaccount' (uuid "
+                                        + transaction.getUUID() + "): EUR <> USD",
+                        iae.getMessage());
+        assertNull("no cause expected", iae.getCause());
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/AccountTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/AccountTest.java
@@ -50,12 +50,14 @@ public class AccountTest
         transaction.setCurrencyCode(CurrencyUnit.USD);
 
         String expectedDateText = Values.Date.format(LocalDate.of(2024, 03, 12));
+        String expectedAmount = Values.Amount.format(Long.valueOf(10000));
         
         IllegalArgumentException iae = assertThrows(IllegalArgumentException.class,
                         () -> account.addTransaction(transaction));
         assertEquals("exception message mismatch",
                         "Unable to add transaction '" + expectedDateText
-                                        + " DEPOSIT           USD    100,00 <no Security> <no XEntry>' to account 'Testaccount' (uuid "
+                                        + " DEPOSIT           USD    " + expectedAmount
+                                        + " <no Security> <no XEntry>' to account 'Testaccount' (uuid "
                                         + transaction.getUUID() + "): EUR <> USD",
                         iae.getMessage());
         assertNull("no cause expected", iae.getCause());
@@ -68,7 +70,8 @@ public class AccountTest
         iae = assertThrows(IllegalArgumentException.class, () -> account.addTransaction(transaction));
         assertEquals("exception message mismatch",
                         "Unable to add transaction '" + expectedDateText
-                                        + " DEPOSIT           USD    100,00 Security Name Inc <no XEntry>' to account 'Testaccount' (uuid "
+                                        + " DEPOSIT           USD    " + expectedAmount
+                                        + " Security Name Inc <no XEntry>' to account 'Testaccount' (uuid "
                                         + transaction.getUUID() + "): EUR <> USD",
                         iae.getMessage());
         assertNull("no cause expected", iae.getCause());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/AccountTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/AccountTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import name.abuchen.portfolio.money.CurrencyUnit;
+import name.abuchen.portfolio.money.Values;
 
 @SuppressWarnings("nls")
 public class AccountTest
@@ -48,10 +49,13 @@ public class AccountTest
     {
         transaction.setCurrencyCode(CurrencyUnit.USD);
 
+        String expectedDateText = Values.Date.format(LocalDate.of(2024, 03, 12));
+        
         IllegalArgumentException iae = assertThrows(IllegalArgumentException.class,
                         () -> account.addTransaction(transaction));
         assertEquals("exception message mismatch",
-                        "Unable to add transaction '12.03.2024 DEPOSIT           USD    100,00 <no Security> <no XEntry>' to account 'Testaccount' (uuid "
+                        "Unable to add transaction '" + expectedDateText
+                                        + " DEPOSIT           USD    100,00 <no Security> <no XEntry>' to account 'Testaccount' (uuid "
                                         + transaction.getUUID() + "): EUR <> USD",
                         iae.getMessage());
         assertNull("no cause expected", iae.getCause());
@@ -63,7 +67,8 @@ public class AccountTest
 
         iae = assertThrows(IllegalArgumentException.class, () -> account.addTransaction(transaction));
         assertEquals("exception message mismatch",
-                        "Unable to add transaction '12.03.2024 DEPOSIT           USD    100,00 Security Name Inc <no XEntry>' to account 'Testaccount' (uuid "
+                        "Unable to add transaction '" + expectedDateText
+                                        + " DEPOSIT           USD    100,00 Security Name Inc <no XEntry>' to account 'Testaccount' (uuid "
                                         + transaction.getUUID() + "): EUR <> USD",
                         iae.getMessage());
         assertNull("no cause expected", iae.getCause());

--- a/name.abuchen.portfolio.tests/src/scenarios/CurrencyTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/CurrencyTestCase.java
@@ -239,7 +239,7 @@ public class CurrencyTestCase
             if (account.equals(as.getAccount()))
                 return as;
 
-        throw new IllegalArgumentException();
+        throw new IllegalArgumentException("account " + account + " not found");
     }
 
     private AssetCategory getAssetCategoryByName(GroupByTaxonomy grouping, String label)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/ReportingPeriodDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/ReportingPeriodDialog.java
@@ -318,7 +318,7 @@ public class ReportingPeriodDialog extends Dialog
         else if (template instanceof ReportingPeriod.PreviousYear)
             radioPreviousYear.setSelection(true);
         else
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("no radio button available for template " + template); //$NON-NLS-1$
 
         Interval interval = template.toInterval(LocalDate.now());
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/BuySellModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/BuySellModel.java
@@ -22,7 +22,7 @@ import name.abuchen.portfolio.ui.Messages;
         super(client, type);
 
         if (!accepts(type))
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("type " + type + " not accepted for this model"); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/SecurityDeliveryModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/SecurityDeliveryModel.java
@@ -21,7 +21,7 @@ public class SecurityDeliveryModel extends AbstractSecurityTransactionModel
         super(client, type);
 
         if (!accepts(type))
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("type " + type + " not accepted for this model"); //$NON-NLS-1$ //$NON-NLS-2$
 
         this.transactionCurrency = CurrencyUnit.getInstance(client.getBaseCurrency());
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/SecurityTransactionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/SecurityTransactionDialog.java
@@ -3,8 +3,8 @@ package name.abuchen.portfolio.ui.dialogs.transactions;
 import static name.abuchen.portfolio.ui.util.FormDataFactory.startingWith;
 import static name.abuchen.portfolio.ui.util.SWTHelper.amountWidth;
 import static name.abuchen.portfolio.ui.util.SWTHelper.currencyWidth;
-import static name.abuchen.portfolio.ui.util.SWTHelper.widest;
 import static name.abuchen.portfolio.ui.util.SWTHelper.getAverageCharWidth;
+import static name.abuchen.portfolio.ui.util.SWTHelper.widest;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -31,6 +31,7 @@ import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.PortfolioTransaction.Type;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.TransactionPair;
 import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
@@ -341,29 +342,33 @@ public class SecurityTransactionDialog extends AbstractTransactionDialog // NOSO
 
     public void setBuySellEntry(BuySellEntry entry)
     {
-        if (!model().accepts(entry.getPortfolioTransaction().getType()))
-            throw new IllegalArgumentException();
+        Type type = entry.getPortfolioTransaction().getType();
+        if (!model().accepts(type))
+            throw new IllegalArgumentException("type " + type + " not accepted for this model"); //$NON-NLS-1$ //$NON-NLS-2$
         model().setSource(entry);
     }
 
     public void presetBuySellEntry(BuySellEntry entry)
     {
-        if (!model().accepts(entry.getPortfolioTransaction().getType()))
-            throw new IllegalArgumentException();
+        Type type = entry.getPortfolioTransaction().getType();
+        if (!model().accepts(type))
+            throw new IllegalArgumentException("type " + type + " not accepted for this model"); //$NON-NLS-1$ //$NON-NLS-2$
         model().presetFromSource(entry);
     }
 
     public void setDeliveryTransaction(TransactionPair<PortfolioTransaction> pair)
     {
-        if (!model().accepts(pair.getTransaction().getType()))
-            throw new IllegalArgumentException();
+        Type type = pair.getTransaction().getType();
+        if (!model().accepts(type))
+            throw new IllegalArgumentException("type " + type + " not accepted for this model"); //$NON-NLS-1$ //$NON-NLS-2$
         model().setSource(pair);
     }
 
     public void presetDeliveryTransaction(TransactionPair<PortfolioTransaction> pair)
     {
-        if (!model().accepts(pair.getTransaction().getType()))
-            throw new IllegalArgumentException();
+        Type type = pair.getTransaction().getType();
+        if (!model().accepts(type))
+            throw new IllegalArgumentException("type " + type + " not accepted for this model"); //$NON-NLS-1$ //$NON-NLS-2$
         model().presetFromSource(pair);
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientInput.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientInput.java
@@ -281,7 +281,7 @@ public class ClientInput
     public void doExportAs(Shell shell, String extension, Set<SaveFlag> flags)
     {
         if (flags.contains(SaveFlag.ENCRYPTED))
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("encrypted not supported"); //$NON-NLS-1$
 
         String fileNameProposal = clientFile != null ? clientFile.getName() : getLabel();
         if (!fileNameProposal.endsWith('.' + extension))
@@ -634,7 +634,7 @@ public class ClientInput
     /* package */ void setClient(Client client)
     {
         if (this.client != null)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("client is already set");
 
         this.client = client;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/PortfolioPart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/PortfolioPart.java
@@ -114,7 +114,7 @@ public class PortfolioPart implements ClientInputListener
         }
 
         if (clientInput == null)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("missing client info"); //$NON-NLS-1$
 
         if (clientInput.getFile() != null)
             part.getPersistedState().put(UIConstants.PersistedState.FILENAME, clientInput.getFile().getAbsolutePath());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ToolBarPlusChevronLayout.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ToolBarPlusChevronLayout.java
@@ -172,7 +172,7 @@ import name.abuchen.portfolio.ui.util.SimpleAction;
                 return toolBar;
         }
 
-        throw new IllegalArgumentException();
+        throw new IllegalArgumentException("no toolbar found in list of childs"); //$NON-NLS-1$
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/AbstractChartToolTip.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/AbstractChartToolTip.java
@@ -207,6 +207,6 @@ public abstract class AbstractChartToolTip implements Listener
         else if (chartV13 != null)
             return (Composite) chartV13.getPlotArea();
         else
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("no plot area found"); //$NON-NLS-1$
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/format/AmountNumberFormat.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/format/AmountNumberFormat.java
@@ -14,7 +14,7 @@ public class AmountNumberFormat extends Format
     public StringBuffer format(Object obj, StringBuffer toAppendTo, FieldPosition pos)
     {
         if (!(obj instanceof Number))
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("object must be a subclass of Number"); //$NON-NLS-1$
 
         return toAppendTo.append(Values.Amount.format(Values.Amount.factorize(((Number) obj).doubleValue())));
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/format/ThousandsNumberFormat.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/format/ThousandsNumberFormat.java
@@ -15,7 +15,7 @@ public class ThousandsNumberFormat extends Format
     public StringBuffer format(Object obj, StringBuffer toAppendTo, FieldPosition pos)
     {
         if (!(obj instanceof Number))
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("object must be a subclass of Number"); //$NON-NLS-1$
 
         if (DiscreetMode.isActive())
             toAppendTo.append(DiscreetMode.HIDDEN_AMOUNT);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/BooleanAttributeEditingSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/BooleanAttributeEditingSupport.java
@@ -15,8 +15,9 @@ public class BooleanAttributeEditingSupport extends AttributeEditingSupport
     {
         super(attribute);
 
-        if (attribute.getType() != Boolean.class)
-            throw new IllegalArgumentException();
+        Class<?> type = attribute.getType();
+        if (type != Boolean.class)
+            throw new IllegalArgumentException("attritbute is not of type Boolean but " + type); //$NON-NLS-1$
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ColumnViewerSorter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ColumnViewerSorter.java
@@ -160,7 +160,7 @@ public final class ColumnViewerSorter
                 catch (NoSuchMethodException e1)
                 {
                     PortfolioPlugin.log(Arrays.asList(e, e1));
-                    throw new IllegalArgumentException();
+                    throw new IllegalArgumentException("no read method found for " + camelCaseAttribute); //$NON-NLS-1$
                 }
             }
         }
@@ -314,7 +314,7 @@ public final class ColumnViewerSorter
             }
             else
             {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("unsupported viewerColumn type " + viewerColumn); //$NON-NLS-1$
             }
 
             if (columnIsCurrentlySorted)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ImageAttributeEditingSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ImageAttributeEditingSupport.java
@@ -13,6 +13,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
 
 import name.abuchen.portfolio.model.AttributeType;
+import name.abuchen.portfolio.model.AttributeType.Converter;
 import name.abuchen.portfolio.model.AttributeType.ImageConverter;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.util.ImageUtil;
@@ -23,8 +24,9 @@ public class ImageAttributeEditingSupport extends AttributeEditingSupport
     {
         super(attribute);
 
-        if (!(attribute.getConverter() instanceof ImageConverter))
-            throw new IllegalArgumentException();
+        Converter conv = attribute.getConverter();
+        if (!(conv instanceof ImageConverter))
+            throw new IllegalArgumentException("unsupported converter " + conv);
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ListEditingSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ListEditingSupport.java
@@ -24,7 +24,7 @@ public class ListEditingSupport extends PropertyEditingSupport
 
         for (Object option : options)
             if (option == null)
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("option must not be null"); //$NON-NLS-1$
 
         this.comboBoxItems = new ArrayList<>(options);
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/SharesLabelProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/SharesLabelProvider.java
@@ -88,7 +88,7 @@ public abstract class SharesLabelProvider extends OwnerDrawLabelProvider
         else if (widget instanceof TreeItem treeItem)
             return treeItem.getBounds(index);
         else
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("unsupported item type " + widget);
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/TransactionOwnerListEditingSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/TransactionOwnerListEditingSupport.java
@@ -122,7 +122,7 @@ public class TransactionOwnerListEditingSupport extends ColumnEditingSupport
                     skipTransfer = crossEntry.getOwner(transaction);
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    throw new IllegalArgumentException("unsupported edit mode " + editMode); //$NON-NLS-1$
             }
         }
         else
@@ -145,7 +145,7 @@ public class TransactionOwnerListEditingSupport extends ColumnEditingSupport
         }
         else
         {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("unsupported type " + ownerToEdit); //$NON-NLS-1$
         }
 
         String[] names = new String[comboBoxItems.size()];
@@ -162,10 +162,10 @@ public class TransactionOwnerListEditingSupport extends ColumnEditingSupport
     {
         Transaction transaction = getTransaction(element);
         if (transaction == null)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("no transaction found for " + element); //$NON-NLS-1$
         CrossEntry crossEntry = transaction.getCrossEntry();
         if (crossEntry == null)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("no cross entry found for transaction " + transaction); //$NON-NLS-1$
 
         TransactionOwner<?> owner = editMode.getOwner(crossEntry, transaction);
         return comboBoxItems.indexOf(owner);
@@ -180,10 +180,10 @@ public class TransactionOwnerListEditingSupport extends ColumnEditingSupport
 
         Transaction transaction = getTransaction(element);
         if (transaction == null)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("no transaction found for " + element); //$NON-NLS-1$
         CrossEntry crossEntry = transaction.getCrossEntry();
         if (crossEntry == null)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("no cross entry found for transaction " + transaction); //$NON-NLS-1$
 
         TransactionOwner<?> newValue = comboBoxItems.get(index);
         TransactionOwner<?> oldValue = editMode.getOwner(crossEntry, transaction);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/TransactionTypeEditingSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/TransactionTypeEditingSupport.java
@@ -151,7 +151,7 @@ public class TransactionTypeEditingSupport extends ColumnEditingSupport
         else if (t instanceof PortfolioTransaction pt)
             return pt.getType();
         else
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("unsupported transaction type " + t); //$NON-NLS-1$
     }
 
     @Override
@@ -238,6 +238,6 @@ public class TransactionTypeEditingSupport extends ColumnEditingSupport
                 return (Class<?>[]) TRANSITIONS[ii + 2];
         }
 
-        throw new IllegalArgumentException();
+        throw new IllegalArgumentException("transition from " + fromValue + " to " + toValue + " not found"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountListView.java
@@ -31,6 +31,7 @@ import org.eclipse.swt.widgets.Display;
 
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.AccountTransaction.Type;
 import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MutableMoney;
@@ -350,7 +351,8 @@ public class AccountListView extends AbstractFinanceView implements Modification
         MutableMoney balance = MutableMoney.of(account.getCurrencyCode());
         for (AccountTransaction t : tx)
         {
-            switch (t.getType())
+            Type type = t.getType();
+            switch (type)
             {
                 case DEPOSIT:
                 case INTEREST:
@@ -370,7 +372,7 @@ public class AccountListView extends AbstractFinanceView implements Modification
                     balance.subtract(t.getMonetaryAmount());
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    throw new IllegalArgumentException("unsupported type " + type + " for transaction " + tx); //$NON-NLS-1$ //$NON-NLS-2$
             }
 
             transaction2balance.put(t, balance.toMoney());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -238,7 +238,7 @@ public class SecuritiesChart
                                         prices.get(prices.size() - 1).getDate()));
 
                 default:
-                    throw new IllegalArgumentException();
+                    throw new IllegalArgumentException("unsupported chart type " + this); //$NON-NLS-1$
             }
         }
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TransactionsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TransactionsViewer.java
@@ -103,7 +103,7 @@ public final class TransactionsViewer implements ModificationListener
             else if (tx instanceof AccountTransaction t)
                 return t.getType().isDebit() ? Colors.theme().redForeground() : Colors.theme().greenForeground();
 
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("unsupported transaction type " + tx); //$NON-NLS-1$
         }
 
         @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/actions/ConvertBuySellToDeliveryAction.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/actions/ConvertBuySellToDeliveryAction.java
@@ -7,6 +7,7 @@ import org.eclipse.jface.action.Action;
 
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.PortfolioTransaction.Type;
 import name.abuchen.portfolio.model.TransactionPair;
 import name.abuchen.portfolio.ui.Messages;
 
@@ -31,12 +32,13 @@ public class ConvertBuySellToDeliveryAction extends Action
 
         for (TransactionPair<PortfolioTransaction> tx : transactionList)
         {
-            if (tx.getTransaction().getType() != PortfolioTransaction.Type.BUY
-                            && tx.getTransaction().getType() != PortfolioTransaction.Type.SELL)
-                throw new IllegalArgumentException();
+            Type type = tx.getTransaction().getType();
+            if (type != PortfolioTransaction.Type.BUY
+                            && type != PortfolioTransaction.Type.SELL)
+                throw new IllegalArgumentException("unsupported transaction type " + type); //$NON-NLS-1$
 
-            allBuy &= tx.getTransaction().getType() == PortfolioTransaction.Type.BUY;
-            allSell &= tx.getTransaction().getType() == PortfolioTransaction.Type.SELL;
+            allBuy &= type == PortfolioTransaction.Type.BUY;
+            allSell &= type == PortfolioTransaction.Type.SELL;
 
         }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/actions/ConvertDeliveryToBuySellAction.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/actions/ConvertDeliveryToBuySellAction.java
@@ -11,6 +11,7 @@ import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.PortfolioTransaction.Type;
 import name.abuchen.portfolio.model.TransactionPair;
 import name.abuchen.portfolio.ui.Messages;
 
@@ -35,12 +36,13 @@ public class ConvertDeliveryToBuySellAction extends Action
 
         for (TransactionPair<PortfolioTransaction> tx : transactionList)
         {
-            if (tx.getTransaction().getType() != PortfolioTransaction.Type.DELIVERY_INBOUND
-                            && tx.getTransaction().getType() != PortfolioTransaction.Type.DELIVERY_OUTBOUND)
-                throw new IllegalArgumentException();
+            Type type = tx.getTransaction().getType();
+            if (type != PortfolioTransaction.Type.DELIVERY_INBOUND
+                            && type != PortfolioTransaction.Type.DELIVERY_OUTBOUND)
+                throw new IllegalArgumentException("unsupported transaction type " + type + " for transaction " + tx); //$NON-NLS-1$ //$NON-NLS-2$
 
-            allInbound &= tx.getTransaction().getType() == PortfolioTransaction.Type.DELIVERY_INBOUND;
-            allOutbound &= tx.getTransaction().getType() == PortfolioTransaction.Type.DELIVERY_OUTBOUND;
+            allInbound &= type == PortfolioTransaction.Type.DELIVERY_INBOUND;
+            allOutbound &= type == PortfolioTransaction.Type.DELIVERY_OUTBOUND;
         }
 
         if (allInbound)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/actions/RevertInterestAction.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/actions/RevertInterestAction.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.ui.views.actions;
 import org.eclipse.jface.action.Action;
 
 import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.AccountTransaction.Type;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.TransactionPair;
 
@@ -16,22 +17,26 @@ public class RevertInterestAction extends Action
         this.client = client;
         this.transaction = transaction;
 
-        if (transaction.getTransaction().getType() != AccountTransaction.Type.INTEREST
-                        && transaction.getTransaction().getType() != AccountTransaction.Type.INTEREST_CHARGE)
-            throw new IllegalArgumentException();
+        AccountTransaction tx = transaction.getTransaction();
+        Type type = tx.getType();
+        if (type != AccountTransaction.Type.INTEREST
+                        && type != AccountTransaction.Type.INTEREST_CHARGE)
+            throw new IllegalArgumentException("unsupported transaction type " + type + " for transaction " + tx); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Override
     public void run()
     {
-        AccountTransaction accountTransaction = transaction.getTransaction();
+        AccountTransaction tx = transaction.getTransaction();
 
-        if (AccountTransaction.Type.INTEREST.equals(accountTransaction.getType()))
-            accountTransaction.setType(AccountTransaction.Type.INTEREST_CHARGE);
-        else if (AccountTransaction.Type.INTEREST_CHARGE.equals(accountTransaction.getType()))
-            accountTransaction.setType(AccountTransaction.Type.INTEREST);
+        Type type = tx.getType();
+        if (AccountTransaction.Type.INTEREST.equals(type))
+            tx.setType(AccountTransaction.Type.INTEREST_CHARGE);
+        else if (AccountTransaction.Type.INTEREST_CHARGE.equals(type))
+            tx.setType(AccountTransaction.Type.INTEREST);
         else
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException(
+                            "unsupported transaction type " + type + " for transaction " + tx); //$NON-NLS-1$ //$NON-NLS-2$
 
         client.markDirty();
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/actions/RevertTransferAction.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/actions/RevertTransferAction.java
@@ -6,9 +6,11 @@ import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.AccountTransferEntry;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CrossEntry;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.PortfolioTransferEntry;
+import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.model.TransactionPair;
 
 public class RevertTransferAction extends Action
@@ -21,30 +23,33 @@ public class RevertTransferAction extends Action
         this.client = client;
         this.transaction = transaction;
 
-        if (transaction.getTransaction() instanceof PortfolioTransaction)
+        Transaction tx = transaction.getTransaction();
+        if (tx instanceof PortfolioTransaction)
         {
             PortfolioTransaction.Type type = ((PortfolioTransaction) transaction.getTransaction()).getType();
 
             if (type != PortfolioTransaction.Type.TRANSFER_IN && type != PortfolioTransaction.Type.TRANSFER_OUT)
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("unsupported transaction type " + type + " for transaction " + tx); //$NON-NLS-1$ //$NON-NLS-2$
         }
-        else if (transaction.getTransaction() instanceof AccountTransaction)
+        else if (tx instanceof AccountTransaction)
         {
             AccountTransaction.Type type = ((AccountTransaction) transaction.getTransaction()).getType();
 
             if (type != AccountTransaction.Type.TRANSFER_IN && type != AccountTransaction.Type.TRANSFER_OUT)
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("unsupported transaction type " + type + " for transaction " + tx); //$NON-NLS-1$ //$NON-NLS-2$
         }
         else
         {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("unsupported transaction " + tx); //$NON-NLS-1$ //$NON-NLS-2$
         }
     }
 
     @Override
     public void run()
     {
-        if (transaction.getTransaction().getCrossEntry() instanceof PortfolioTransferEntry)
+        Transaction tx = transaction.getTransaction();
+        CrossEntry e = tx.getCrossEntry();
+        if (e instanceof PortfolioTransferEntry)
         {
             PortfolioTransferEntry entry = (PortfolioTransferEntry) transaction.getTransaction().getCrossEntry();
 
@@ -58,7 +63,7 @@ public class RevertTransferAction extends Action
             entry.setSourceTransaction(entry.getTargetTransaction());
             entry.setTargetTransaction(oldSourceTransaction);
         }
-        else if (transaction.getTransaction().getCrossEntry() instanceof AccountTransferEntry)
+        else if (e instanceof AccountTransferEntry)
         {
             AccountTransferEntry entry = (AccountTransferEntry) transaction.getTransaction().getCrossEntry();
 
@@ -74,7 +79,7 @@ public class RevertTransferAction extends Action
         }
         else
         {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("unsupported entry type " + e + " for transaction " + tx); //$NON-NLS-1$ //$NON-NLS-2$
         }
 
         client.markDirty();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ActivityWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ActivityWidget.java
@@ -435,7 +435,7 @@ public class ActivityWidget extends WidgetDelegate<List<TransactionPair<?>>>
                                         / Values.Amount.divider());
                         break;
                     default:
-                        throw new IllegalArgumentException();
+                        throw new IllegalArgumentException("unsupported chart type " + chartType); //$NON-NLS-1$
                 }
             }
         }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ChartWidget.java
@@ -314,7 +314,7 @@ public class ChartWidget extends WidgetDelegate<Object>
                 case RETURN_VOLATILITY:
                     throw new UnsupportedOperationException();
                 default:
-                    throw new IllegalArgumentException();
+                    throw new IllegalArgumentException("unsupported use case " + useCase); //$NON-NLS-1$
             }
 
             chart.adjustRange();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DashboardView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DashboardView.java
@@ -141,12 +141,12 @@ public class DashboardView extends AbstractHistoricView
 
             Dashboard.Widget droppedWidget = (Dashboard.Widget) droppedComposite.getData();
             if (droppedWidget == null)
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("dropped widget is null"); //$NON-NLS-1$
 
             Composite oldParent = droppedComposite.getParent();
             Dashboard.Column oldColumn = (Dashboard.Column) oldParent.getData();
             if (oldColumn == null)
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("old column is null"); //$NON-NLS-1$
 
             Composite newParent = dropTarget;
             while (!(newParent.getData() instanceof Dashboard.Column))
@@ -168,13 +168,14 @@ public class DashboardView extends AbstractHistoricView
         private void doDropCopy(Dashboard.Widget copiedWidget, Dashboard.Column newColumn, Composite newParent)
         {
             Composite elementToMoveAbove = null;
-            if (dropTarget.getData() instanceof Dashboard.Widget dropTargetWidget)
+            Object data = dropTarget.getData();
+            if (data instanceof Dashboard.Widget dropTargetWidget)
             {
                 // dropped on another widget, place above drop target
                 elementToMoveAbove = dropTarget;
                 newColumn.getWidgets().add(newColumn.getWidgets().indexOf(dropTargetWidget), copiedWidget);
             }
-            else if (dropTarget.getData() instanceof Dashboard.Column)
+            else if (data instanceof Dashboard.Column)
             {
                 // dropped on another column, place above filler
                 elementToMoveAbove = (Composite) newParent.getData(FILLER_KEY);
@@ -182,12 +183,13 @@ public class DashboardView extends AbstractHistoricView
             }
             else
             {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("unsupported data " + data); //$NON-NLS-1$
             }
 
-            WidgetFactory factory = WidgetFactory.valueOf(copiedWidget.getType());
+            String type = copiedWidget.getType();
+            WidgetFactory factory = WidgetFactory.valueOf(type);
             if (factory == null)
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("no widget factory for type " + type); //$NON-NLS-1$
 
             Pair<WidgetDelegate<?>, Composite> newDelegateWithComposite = dashboardView
                             .buildDelegateAndMoveAboveElement(newParent, factory, copiedWidget, elementToMoveAbove);
@@ -201,7 +203,8 @@ public class DashboardView extends AbstractHistoricView
         {
             droppedComposite.setParent(newParent);
 
-            if (dropTarget.getData() instanceof Dashboard.Widget dropTargetWidget)
+            Object data = dropTarget.getData();
+            if (data instanceof Dashboard.Widget dropTargetWidget)
             {
                 // dropped on another widget
                 droppedComposite.moveAbove(dropTarget);
@@ -209,7 +212,7 @@ public class DashboardView extends AbstractHistoricView
                 oldColumn.getWidgets().remove(droppedWidget);
                 newColumn.getWidgets().add(newColumn.getWidgets().indexOf(dropTargetWidget), droppedWidget);
             }
-            else if (dropTarget.getData() instanceof Dashboard.Column)
+            else if (data instanceof Dashboard.Column)
             {
                 // dropped on another column
                 Composite filler = (Composite) newParent.getData(FILLER_KEY);
@@ -220,7 +223,7 @@ public class DashboardView extends AbstractHistoricView
             }
             else
             {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("unsuppoerted data type " + data); //$NON-NLS-1$
             }
         }
 
@@ -644,13 +647,13 @@ public class DashboardView extends AbstractHistoricView
         manager.add(new SimpleAction(Messages.MenuDeleteWidget, a -> {
             Composite composite = findCompositeFor(delegate);
             if (composite == null)
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("composite is null"); //$NON-NLS-1$
 
             Composite parent = composite.getParent();
             Dashboard.Column column = (Dashboard.Column) parent.getData();
 
             if (!column.getWidgets().remove(delegate.getWidget()))
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("column doesn't contain widget"); //$NON-NLS-1$
 
             composite.dispose();
             parent.layout();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/EnumBasedConfig.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/EnumBasedConfig.java
@@ -110,7 +110,7 @@ public class EnumBasedConfig<E extends Enum<E>> implements WidgetConfig
                         this.values.add(value);
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    throw new IllegalArgumentException("unsupported policy " + policy); //$NON-NLS-1$
             }
 
             delegate.getWidget().getConfiguration().put(configurationKey.name(),
@@ -132,7 +132,7 @@ public class EnumBasedConfig<E extends Enum<E>> implements WidgetConfig
     public E getValue()
     {
         if (policy != Policy.EXACTLY_ONE)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("policy must be EXACTLY_ONE but is " + policy); //$NON-NLS-1$
         return values.iterator().next();
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/NewDashboardDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/NewDashboardDialog.java
@@ -102,7 +102,7 @@ public class NewDashboardDialog extends Dialog
                 buildEarningsDashboard(newDashboard);
                 break;
             default:
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("unsupported template " + selectedTemplate);
         }
 
         return newDashboard;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
@@ -224,7 +224,7 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
                 createTable(8);
                 break;
             default:
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("unsupported layout " + layout); //$NON-NLS-1$
         }
     }
 
@@ -314,7 +314,7 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
                 fillInOnlyRelevantValues(snapshot);
                 break;
             default:
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("unsupported layout " + layout); //$NON-NLS-1$
         }
 
         container.layout();
@@ -370,7 +370,8 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
 
         for (ClientPerformanceSnapshot.Category category : categories)
         {
-            switch (category.getSign())
+            String sign = category.getSign();
+            switch (sign)
             {
                 case "+": //$NON-NLS-1$
                     totalMoney.add(category.getValuation());
@@ -379,7 +380,7 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
                     totalMoney.subtract(category.getValuation());
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    throw new IllegalArgumentException("unsupported sign " + sign); //$NON-NLS-1$
             }
         }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/ColorSchema.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/ColorSchema.java
@@ -62,7 +62,7 @@ enum ColorSchema
                                     Colors.interpolate(Colors.theme().defaultBackground().getRGB(), color, (float) p));
                 };
             default:
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("unsupported color " + this); //$NON-NLS-1$
         }
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/StatementOfAssetsSeriesBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/StatementOfAssetsSeriesBuilder.java
@@ -117,7 +117,7 @@ public class StatementOfAssetsSeriesBuilder extends AbstractChartSeriesBuilder
     private long[] add(long[] a, long[] b)
     {
         if (a.length != b.length)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("length mismatch " + a.length + " != " + b.length); //$NON-NLS-1$ //$NON-NLS-2$
 
         long[] result = new long[a.length];
         for (int ii = 0; ii < result.length; ii++)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsViewModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsViewModel.java
@@ -275,7 +275,7 @@ public class PaymentsViewModel
         // determine the number of full months within period
         LocalDate now = LocalDate.now();
         if (startYear > now.getYear())
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("start year " + startYear + " is after " + now.getYear()); //$NON-NLS-1$ //$NON-NLS-2$
         this.noOfmonths = (now.getYear() - startYear) * 12 + now.getMonthValue();
 
         Interval interval = Interval.of(LocalDate.of(startYear - 1, Month.DECEMBER, 31), now);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/DeltaPercentageIndicatorLabelProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/DeltaPercentageIndicatorLabelProvider.java
@@ -115,7 +115,7 @@ public class DeltaPercentageIndicatorLabelProvider extends OwnerDrawLabelProvide
         else if (widget instanceof TreeItem treeItem)
             return treeItem.getBounds(index);
         else
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("unsupported widget type " + widget); //$NON-NLS-1$
     }
 
     @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/checks/impl/TransactionCurrencyCheck.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/checks/impl/TransactionCurrencyCheck.java
@@ -208,7 +208,8 @@ public class TransactionCurrencyCheck implements Check
             }
             else
             {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException(
+                                "unsupported transaction entry " + t.getClass() + ": " + t.toString()); //$NON-NLS-1$ //$NON-NLS-2$
             }
         }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/Extractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/Extractor.java
@@ -674,7 +674,7 @@ public interface Extractor
         }
         else
         {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("can't evaluate client for class " + this.getClass().getName());
         }
 
         SecurityCache securityCache = new SecurityCache(client);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVImporter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVImporter.java
@@ -178,7 +178,7 @@ public final class CSVImporter
         public Field(String code, String... names)
         {
             if (names.length < 1)
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("no names provided"); //$NON-NLS-1$
 
             this.code = code;
             this.names = names;
@@ -669,7 +669,7 @@ public final class CSVImporter
         {
             String s = enumMap.get(obj);
             if (s == null)
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("no enum found for object " + obj); //$NON-NLS-1$
 
             return toAppendTo.append(s);
         }
@@ -759,7 +759,7 @@ public final class CSVImporter
         {
             String s = (String) obj;
             if (s == null)
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("obj is null");
 
             return toAppendTo.append(s);
         }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractor.java
@@ -237,7 +237,8 @@ public class IBFlexStatementExtractor implements Extractor
                             asAmount(element.getAttribute("amount")));
 
             // Set transaction type based on the attribute "type"
-            switch (element.getAttribute("type"))
+            String type = element.getAttribute("type");
+            switch (type)
             {
                 case "Deposits":
                 case "Deposits & Withdrawals":
@@ -282,7 +283,7 @@ public class IBFlexStatementExtractor implements Extractor
                         accountTransaction.setType(AccountTransaction.Type.FEES_REFUND);
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    throw new IllegalArgumentException("unsupported type '" + type + "'");
             }
 
             // @formatter:off
@@ -375,13 +376,15 @@ public class IBFlexStatementExtractor implements Extractor
                 return null;
 
             // Check if the level of detail is supported
-            if (element.getAttribute("levelOfDetail").contains("ASSET_SUMMARY")
-                            || element.getAttribute("levelOfDetail").contains("SYMBOL_SUMMARY")
-                            || element.getAttribute("levelOfDetail").contains("ORDER"))
+            String lod = element.getAttribute("levelOfDetail");
+            if (lod.contains("ASSET_SUMMARY")
+                            || lod.contains("SYMBOL_SUMMARY")
+                            || lod.contains("ORDER"))
                 return null;
 
             // Set transaction type
-            switch (element.getAttribute("buySell"))
+            String tType = element.getAttribute("buySell");
+            switch (tType)
             {
                 case "BUY":
                     portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
@@ -398,7 +401,7 @@ public class IBFlexStatementExtractor implements Extractor
                     portfolioTransaction.setType(PortfolioTransaction.Type.SELL);
                     break;
                 default:
-                    throw new IllegalArgumentException();
+                    throw new IllegalArgumentException("unsupported transaction type '" + tType + "'");
             }
 
             // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -93,7 +93,8 @@ public abstract class AbstractPDFExtractor implements Extractor
         List<Item> results = new ArrayList<>();
 
         if (!(inputFile instanceof PDFInputFile))
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("input file doesn't seem to be a PDF-file but is of type "
+                            + inputFile.getClass().getName());
 
         String text = ((PDFInputFile) inputFile).getText();
         results.addAll(extract(inputFile.getFile().getName(), text, errors));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/json/JTransaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/json/JTransaction.java
@@ -216,7 +216,8 @@ public class JTransaction
     {
         jtx.account = tx.getOwner().toString();
 
-        switch (tx.getTransaction().getType())
+        name.abuchen.portfolio.model.AccountTransaction.Type tType = tx.getTransaction().getType();
+        switch (tType)
         {
             case DEPOSIT:
                 jtx.type = JTransaction.Type.DEPOSIT;
@@ -267,7 +268,8 @@ public class JTransaction
                                 jtx);
                 break;
             default:
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException(
+                                "unsupported transaction type '" + tType + "' for transaction " + jtx.toJson()); //$NON-NLS-1$ //$NON-NLS-2$
         }
     }
 
@@ -308,7 +310,8 @@ public class JTransaction
                 jtx.type = JTransaction.Type.OUTBOUND_DELIVERY;
                 break;
             default:
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException(
+                                "unsupported transaction type '" + type + "' for transaction " + transaction);
         }
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/math/Risk.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/math/Risk.java
@@ -19,10 +19,12 @@ public final class Risk
         public Drawdown(double[] values, LocalDate[] dates, int startAt)
         {
             if (values.length != dates.length)
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException(
+                                "values and dates mismatch: " + values.length + " != " + dates.length); //$NON-NLS-1$ //$NON-NLS-2$
 
             if (startAt >= values.length)
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("unable to start at " + startAt + ": values only conatins " //$NON-NLS-1$ //$NON-NLS-2$
+                                + values.length + " elements"); //$NON-NLS-1$
 
             double peak = values[startAt] + 1;
             double bottom = values[startAt] + 1;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Account.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Account.java
@@ -138,7 +138,11 @@ public class Account implements TransactionOwner<AccountTransaction>, Investment
     public void addTransaction(AccountTransaction transaction)
     {
         if (!currencyCode.equals(transaction.getCurrencyCode()))
-            throw new IllegalArgumentException();
+        {
+            throw new IllegalArgumentException("Unable to add transaction '" + transaction.toString() + "' to account '" //$NON-NLS-1$ //$NON-NLS-2$
+                            + getName() + "' (uuid " + transaction.getUUID() + "): " + currencyCode + " <> " //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                            + transaction.getCurrencyCode());
+        }
 
         this.transactions.add(transaction);
     }
@@ -173,7 +177,8 @@ public class Account implements TransactionOwner<AccountTransaction>, Investment
                                 case TRANSFER_OUT:
                                     return -t.getAmount();
                                 default:
-                                    throw new UnsupportedOperationException();
+                                    throw new UnsupportedOperationException("unsupported transaction type '" //$NON-NLS-1$
+                                                    + t.getType() + "' for transaction " + t); //$NON-NLS-1$
                             }
                         }).sum();
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AccountTransferEntry.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AccountTransferEntry.java
@@ -157,14 +157,14 @@ public class AccountTransferEntry implements CrossEntry, Annotated
     public void setOwner(Transaction t, TransactionOwner<? extends Transaction> owner)
     {
         if (!(owner instanceof Account))
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("owner isn't an account for transaction " + t);
 
         if (t.equals(transactionFrom) && !accountTo.equals(owner))
             accountFrom = (Account) owner;
         else if (t.equals(transactionTo) && !accountFrom.equals(owner))
             accountTo = (Account) owner;
         else
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("unable to set owner for transaction " + t);
     }
 
     @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/BuySellEntry.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/BuySellEntry.java
@@ -145,7 +145,7 @@ public class BuySellEntry implements CrossEntry, Annotated
         }
         else
         {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("transaction can't be used for update: " + t); //$NON-NLS-1$
         }
     }
 
@@ -157,7 +157,7 @@ public class BuySellEntry implements CrossEntry, Annotated
         else if (t.equals(accountTransaction))
             return account;
         else
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("unable to get owner for transcation " + t); //$NON-NLS-1$
 
     }
 
@@ -169,7 +169,7 @@ public class BuySellEntry implements CrossEntry, Annotated
         else if (t.equals(accountTransaction) && owner instanceof Account a)
             account = a;
         else
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("unable to set owner for transcation " + t);
     }
 
     @Override
@@ -180,7 +180,7 @@ public class BuySellEntry implements CrossEntry, Annotated
         else if (t.equals(accountTransaction))
             return portfolioTransaction;
         else
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("unable to get cross transaction for transcation " + t);
     }
 
     @Override
@@ -191,7 +191,7 @@ public class BuySellEntry implements CrossEntry, Annotated
         else if (t.equals(accountTransaction))
             return portfolio;
         else
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("unable to get cross owner for transcation " + t);
     }
 
     public PortfolioTransaction getPortfolioTransaction()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
@@ -270,7 +270,7 @@ public class ClientFactory
                 byte[] signature = new byte[SIGNATURE.length];
                 int read = input.read(signature);
                 if (read != SIGNATURE.length)
-                    throw new IOException();
+                    throw new IOException("tried to read " + SIGNATURE.length + " bytes but only got " + read); //$NON-NLS-1$ //$NON-NLS-2$
                 if (!Arrays.equals(signature, SIGNATURE))
                     throw new IOException(Messages.MsgNotAPortflioFile);
 
@@ -289,7 +289,7 @@ public class ClientFactory
                 byte[] iv = new byte[IV_LENGTH];
                 read = input.read(iv);
                 if (read != IV_LENGTH)
-                    throw new IOException();
+                    throw new IOException("tried to read " + IV_LENGTH + " bytes but only got " + read); //$NON-NLS-1$ //$NON-NLS-2$
 
                 Client client;
                 // build cipher and stream
@@ -301,12 +301,12 @@ public class ClientFactory
                     byte[] bytes = new byte[4];
                     read = decrypted.read(bytes); // content type
                     if (read != bytes.length)
-                        throw new IOException();
+                        throw new IOException("tried to read " + bytes.length + " bytes but only got " + read); //$NON-NLS-1$ //$NON-NLS-2$
 
                     int contentType = ByteBuffer.wrap(bytes).getInt();
                     read = decrypted.read(bytes); // version number
                     if (read != bytes.length)
-                        throw new IOException();
+                        throw new IOException("tried to read " + bytes.length + " bytes but only got " + read); //$NON-NLS-1$ //$NON-NLS-2$
 
                     int version = ByteBuffer.wrap(bytes).getInt();
 
@@ -465,7 +465,8 @@ public class ClientFactory
                 byte[] signature = new byte[Decryptor.SIGNATURE.length];
                 int read = input.read(signature);
                 if (read != Decryptor.SIGNATURE.length)
-                    throw new IOException();
+                    throw new IOException(
+                                    "tried to read " + Decryptor.SIGNATURE.length + " bytes but only got " + read); //$NON-NLS-1$ //$NON-NLS-2$
 
                 if (Arrays.equals(Decryptor.SIGNATURE, signature))
                 {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Dashboard.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Dashboard.java
@@ -28,7 +28,7 @@ public final class Dashboard
         public void setWeight(int weight)
         {
             if (weight <= 0)
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("invalid weight " + weight);
 
             this.weight = weight;
         }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/InvestmentPlan.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/InvestmentPlan.java
@@ -58,12 +58,18 @@ public class InvestmentPlan implements Named, Adaptable, Attributable
 
     public Type getPlanType()
     {
-        if (portfolio != null && security != null)
+        if (portfolio != null)
+        {
+            if (security == null)
+                throw new IllegalArgumentException("security is null with a set portfolio for" + name); //$NON-NLS-1$
             return Type.BUY_OR_DELIVERY;
-        else if (portfolio == null && account != null && security == null)
+        }
+        if (account == null)
+            throw new IllegalArgumentException("portfolio and account are not set for " + name); //$NON-NLS-1$
+        if (security == null)
             return (amount >= 0) ? Type.DEPOSIT : Type.REMOVAL;
         else
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("security is set with a set account for " + name); //$NON-NLS-1$
     }
 
     @Override
@@ -392,7 +398,7 @@ public class InvestmentPlan implements Named, Adaptable, Attributable
         else if (planType == Type.DEPOSIT || planType == Type.REMOVAL)
             return createAccountTx(converter, tDate);
         else
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("unsupported plan type " + planType.name()); //$NON-NLS-1$
     }
 
     private TransactionPair<?> createSecurityTx(CurrencyConverter converter, LocalDate tDate) throws IOException

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransferEntry.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransferEntry.java
@@ -145,7 +145,7 @@ public class PortfolioTransferEntry implements CrossEntry, Annotated
         else if (t.equals(transactionTo))
             copyAttributesOver(transactionTo, transactionFrom);
         else
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("unable to update from transaction " + t); //$NON-NLS-1$
     }
 
     private void copyAttributesOver(PortfolioTransaction source, PortfolioTransaction target)
@@ -164,21 +164,22 @@ public class PortfolioTransferEntry implements CrossEntry, Annotated
         else if (t.equals(transactionTo))
             return portfolioTo;
         else
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("unable to get owner of transaction " + t); //$NON-NLS-1$
     }
 
     @Override
     public void setOwner(Transaction t, TransactionOwner<? extends Transaction> owner)
     {
         if (!(owner instanceof Portfolio))
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException(
+                            "invalid owner type for owner " + owner + " when trying to set it to transaction " + t); //$NON-NLS-1$ //$NON-NLS-2$
 
         if (t.equals(transactionFrom) && !portfolioTo.equals(owner))
             portfolioFrom = (Portfolio) owner;
         else if (t.equals(transactionTo) && !portfolioFrom.equals(owner))
             portfolioTo = (Portfolio) owner;
         else
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("unable to set owner " + owner + " to transaction " + t); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Override
@@ -189,7 +190,7 @@ public class PortfolioTransferEntry implements CrossEntry, Annotated
         else if (t.equals(transactionTo))
             return transactionFrom;
         else
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("unable to get cross transction for transaction " + t); //$NON-NLS-1$
     }
 
     @Override
@@ -200,6 +201,6 @@ public class PortfolioTransferEntry implements CrossEntry, Annotated
         else if (t.equals(transactionTo))
             return portfolioFrom;
         else
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("unable to get cross owner for transaction " + t); //$NON-NLS-1$
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ProtobufWriter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ProtobufWriter.java
@@ -98,7 +98,7 @@ import name.abuchen.portfolio.money.Money;
         byte[] signature = new byte[SIGNATURE.length];
         int read = input.read(signature);
         if (read != SIGNATURE.length)
-            throw new IOException();
+            throw new IOException("tried to read " + SIGNATURE.length + " bytes but only got " + read); //$NON-NLS-1$ //$NON-NLS-2$
         if (!Arrays.equals(signature, SIGNATURE))
             throw new IOException(Messages.MsgNotAPortflioFile);
 
@@ -207,7 +207,8 @@ import name.abuchen.portfolio.money.Money;
                         ((DividendEvent) event).setSource(newEvent.getData(3).getString());
                         break;
                     default:
-                        throw new UnsupportedOperationException();
+                        throw new UnsupportedOperationException(
+                                        "unsupported type " + newEvent.getType() + "(" + newEvent.getTypeValue() + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
                 }
 
                 event.setDate(LocalDate.ofEpochDay(newEvent.getDate()));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/SecurityEvent.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/SecurityEvent.java
@@ -56,7 +56,7 @@ public class SecurityEvent
         public void setType(Type type)
         {
             if (type != Type.DIVIDEND_PAYMENT)
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("type must be DIVIDEND_PAYMENT but was " + type.name()); //$NON-NLS-1$
         }
 
         public LocalDate getPaymentDate()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/TaxonomyTemplate.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/TaxonomyTemplate.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.UUID;
@@ -110,7 +111,8 @@ public final class TaxonomyTemplate
         taxonomy.setRootNode(root);
         String labels = getString(bundle, "labels"); //$NON-NLS-1$
         if (labels == null)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException(
+                            "missing labels in resource bundle with id " + id + " with locale " + Locale.getDefault()); //$NON-NLS-1$ //$NON-NLS-2$
 
         // Arrays.asList is not serialized niceyl with XStream
         taxonomy.setDimensions(new ArrayList<>(Arrays.asList(labels.split(",")))); //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/AlphavantageQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/AlphavantageQuoteFeed.java
@@ -74,7 +74,7 @@ public class AlphavantageQuoteFeed implements QuoteFeed
     public void setCallFrequencyLimit(int limit)
     {
         if (limit <= 0)
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("illegal limit value " + limit); //$NON-NLS-1$
 
         rateLimiter.setRate((limit - .5) / 60d);
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioReportNet.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioReportNet.java
@@ -294,10 +294,10 @@ public class PortfolioReportNet
 
     public static boolean updateWith(Security security, ResultItem item)
     {
-        if (!(item instanceof OnlineItem))
-            throw new IllegalArgumentException();
+        if (!(item instanceof OnlineItem oItem))
+            throw new IllegalArgumentException("result item is null or of wrong type: " + item); //$NON-NLS-1$
 
-        return ((OnlineItem) item).update(security);
+        return oItem.update(security);
     }
 
     public static Security createFrom(ResultItem item, Client client)
@@ -308,7 +308,7 @@ public class PortfolioReportNet
         }
         else
         {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("result item is null or of wrong type: " + item); //$NON-NLS-1$
         }
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/Currency.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/Currency.java
@@ -8,7 +8,7 @@ public class Currency implements Macro
     public Currency(CharSequence input)
     {
         if (!"CURRENCY".equals(input)) //$NON-NLS-1$
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException(input.toString());
     }
 
     @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/ISIN.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/ISIN.java
@@ -8,7 +8,7 @@ public class ISIN implements Macro
     public ISIN(CharSequence input)
     {
         if (!"ISIN".equals(input)) //$NON-NLS-1$
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException(input.toString());
     }
 
     @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/PageNumber.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/PageNumber.java
@@ -9,7 +9,7 @@ public class PageNumber implements Macro
     public PageNumber(CharSequence input)
     {
         if (!"PAGE".equals(input)) //$NON-NLS-1$
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException(input.toString());
     }
 
     @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/TickerSymbol.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/TickerSymbol.java
@@ -8,7 +8,7 @@ public class TickerSymbol implements Macro
     public TickerSymbol(CharSequence input)
     {
         if (!"TICKER".equals(input)) //$NON-NLS-1$
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException(input.toString());
     }
 
     @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/Today.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/Today.java
@@ -25,7 +25,7 @@ public class Today implements Macro
         Matcher matcher = MACRO.matcher(input);
 
         if (!matcher.matches())
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException(input.toString());
 
         String p = matcher.group(2);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/WKN.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/variableurl/macros/WKN.java
@@ -8,7 +8,7 @@ public class WKN implements Macro
     public WKN(CharSequence input)
     {
         if (!"WKN".equals(input)) //$NON-NLS-1$
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException(input.toString());
     }
 
     @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientSecurityFilter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientSecurityFilter.java
@@ -11,6 +11,7 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.PortfolioTransaction.Type;
 import name.abuchen.portfolio.model.PortfolioTransferEntry;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Transaction.Unit;
@@ -78,7 +79,8 @@ public class ClientSecurityFilter implements ClientFilter
     private void addPortfolioTransaction(Function<Portfolio, ReadOnlyPortfolio> getPortfolio,
                     TransactionPair<PortfolioTransaction> pair)
     {
-        switch (pair.getTransaction().getType())
+        Type type = pair.getTransaction().getType();
+        switch (type)
         {
             case BUY:
             case DELIVERY_INBOUND:
@@ -96,7 +98,7 @@ public class ClientSecurityFilter implements ClientFilter
                 // handled via TRANSFER_IN
                 break;
             default:
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("unsupported type " + type); //$NON-NLS-1$
         }
     }
 
@@ -105,7 +107,8 @@ public class ClientSecurityFilter implements ClientFilter
     {
         AccountTransaction t = pair.getTransaction();
 
-        switch (pair.getTransaction().getType())
+        name.abuchen.portfolio.model.AccountTransaction.Type type = pair.getTransaction().getType();
+        switch (type)
         {
             case DIVIDENDS:
                 long taxes = t.getUnitSum(Unit.Type.TAX).getAmount();
@@ -146,7 +149,7 @@ public class ClientSecurityFilter implements ClientFilter
             case INTEREST:
             case INTEREST_CHARGE:
             default:
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("unsupported type " + type);
         }
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilter.java
@@ -60,7 +60,7 @@ public class PortfolioClientFilter implements ClientFilter
         else if (element instanceof Account account)
             accounts.add(account);
         else
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("element is null or of wrong type: " + element);
     }
     
     public boolean hasElement(Object element)
@@ -70,7 +70,7 @@ public class PortfolioClientFilter implements ClientFilter
         else if (element instanceof Account account)
             return accounts.contains(account);
         else
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("element is null or of wrong type: " + element);
     }
 
     public Object[] getAllElements()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DeltaCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DeltaCalculation.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.snapshot.security;
 
 import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.AccountTransaction.Type;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.Money;
@@ -42,7 +43,8 @@ import name.abuchen.portfolio.money.MutableMoney;
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.TransactionItem item, AccountTransaction t)
     {
-        switch (t.getType())
+        Type type = t.getType();
+        switch (type)
         {
             case TAXES:
             case FEES:
@@ -53,7 +55,7 @@ import name.abuchen.portfolio.money.MutableMoney;
                 delta.add(t.getMonetaryAmount().with(converter.at(t.getDateTime())));
                 break;
             default:
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException("unsupported type " + type); //$NON-NLS-1$
         }
 
     }
@@ -61,7 +63,8 @@ import name.abuchen.portfolio.money.MutableMoney;
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.TransactionItem item, PortfolioTransaction t)
     {
-        switch (t.getType())
+        name.abuchen.portfolio.model.PortfolioTransaction.Type type = t.getType();
+        switch (type)
         {
             case BUY:
             case DELIVERY_INBOUND:
@@ -78,7 +81,7 @@ import name.abuchen.portfolio.money.MutableMoney;
                 // transferals do not contribute to the delta
                 break;
             default:
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException("unsupported type " + type); //$NON-NLS-1$
         }
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeCollector.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeCollector.java
@@ -16,6 +16,7 @@ import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.PortfolioTransaction.Type;
 import name.abuchen.portfolio.model.PortfolioTransferEntry;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.TransactionPair;
@@ -92,7 +93,8 @@ public class TradeCollector
             Portfolio portfolio = (Portfolio) txp.getOwner();
             PortfolioTransaction t = (PortfolioTransaction) txp.getTransaction();
 
-            switch (t.getType())
+            Type type = t.getType();
+            switch (type)
             {
                 case BUY:
                 case DELIVERY_INBOUND:
@@ -113,7 +115,7 @@ public class TradeCollector
                     break;
 
                 default:
-                    throw new IllegalArgumentException();
+                    throw new IllegalArgumentException("unsupported type " + type); //$NON-NLS-1$
 
             }
         }


### PR DESCRIPTION
Hi,

in past discussions in the forum there often are failures to e.g. load a saved portfolio file where a non-descript InvalidArgumentException is thrown and you can only tell what happened but have no clue what actual data lead to this. So I've gone through the source to look for occurrences and added exception messages that contain parts of the data that lead to the problem with the hope that this might help with future occasions of this type.