### PR TITLE
Add a Search box in Trades view

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.ui.views.trades;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -12,17 +13,22 @@ import jakarta.inject.Named;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.ActionContributionItem;
+import org.eclipse.jface.action.ControlContribution;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.action.ToolBarManager;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Text;
 
+import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyConverterImpl;
 import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
@@ -163,6 +169,8 @@ public class TradeDetailsView extends AbstractFinanceView
     private MutableBoolean onlyProfitable = new MutableBoolean(false);
     private MutableBoolean onlyLossMaking = new MutableBoolean(false);
 
+    private Pattern filterPattern;
+
     @Inject
     @Optional
     public void setTrades(@Named(UIConstants.Parameter.VIEW_PARAMETER) Input input)
@@ -196,6 +204,10 @@ public class TradeDetailsView extends AbstractFinanceView
     @Override
     protected void addButtons(ToolBarManager toolBarManager)
     {
+        addSearchButton(toolBarManager);
+
+        toolBarManager.add(new Separator());
+
         addFilterButton(toolBarManager);
 
         toolBarManager.add(new DropDown(Messages.MenuExportData, Images.EXPORT, SWT.NONE,
@@ -213,6 +225,43 @@ public class TradeDetailsView extends AbstractFinanceView
         boolean isOn = usePreselectedTrades.isTrue() || onlyOpen.isTrue() || onlyClosed.isTrue()
                         || onlyProfitable.isTrue() || onlyLossMaking.isTrue();
         dropDown.setImage(isOn ? Images.FILTER_ON : Images.FILTER_OFF);
+    }
+
+    private void addSearchButton(ToolBarManager toolBar)
+    {
+        toolBar.add(new ControlContribution("searchbox") //$NON-NLS-1$
+        {
+            @Override
+            protected Control createControl(Composite parent)
+            {
+                final Text search = new Text(parent, SWT.SEARCH | SWT.ICON_CANCEL);
+                search.setMessage(Messages.LabelSearch);
+                search.setSize(300, SWT.DEFAULT);
+
+                search.addModifyListener(e -> {
+                    String filterText = Pattern.quote(search.getText().trim());
+                    if (filterText.length() == 0)
+                    {
+                        filterPattern = null;
+                        table.getTableViewer().refresh(false);
+                    }
+                    else
+                    {
+                        filterPattern = Pattern.compile(".*" + filterText + ".*", //$NON-NLS-1$ //$NON-NLS-2$
+                                        Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+                        table.getTableViewer().refresh(false);
+                    }
+                });
+
+                return search;
+            }
+
+            @Override
+            protected int computeWidth(Control control)
+            {
+                return control.computeSize(100, SWT.DEFAULT, true).x;
+            }
+        });
     }
 
     private void addFilterButton(ToolBarManager manager)
@@ -290,6 +339,32 @@ public class TradeDetailsView extends AbstractFinanceView
 
         table.getTableViewer().addSelectionChangedListener(
                         e -> setInformationPaneInput(e.getStructuredSelection().getFirstElement()));
+
+        table.getTableViewer().addFilter(new ViewerFilter()
+        {
+            @Override
+            public boolean select(Viewer viewer, Object parentElement, Object element)
+            {
+                if (filterPattern == null)
+                    return true;
+                Trade trade = (Trade) element;
+                Security security = trade.getSecurity();
+
+                String[] properties = new String[] { security.getName(), //
+                                security.getIsin(), //
+                                security.getTickerSymbol(), //
+                                security.getWkn() //
+                };
+
+                for (String property : properties)
+                {
+                    if (property != null && filterPattern.matcher(property).matches())
+                        return true;
+                }
+
+                return false;
+            }
+        });
 
         update();
 


### PR DESCRIPTION
Issues : https://github.com/portfolio-performance/portfolio/issues/2075

This is a proposition to allow filtering the trades by a security name/ISIN/WKN. It is a copy paste of what is already existing in `SecurityListView`.

Well, I actually did not find a lot of request for it, but it seems relevant I guess ? Trades list can get quite long.

If relevant:

- is a search by security name/ISIN/WKN sufficient ? The search for AllTransaction is a bit different, covering all columns I think, but its code is a bit more complex to understand. So I went the easy way and mimicked `SecurityListView`..
- Do we want a Trades search to apply to more columns ? Securities Account ? Note ? numbered column (holding period, IRR..) ?

Side note :
It makes me notices that the SecurityList, TransactionList and Taxonomy search buttons do not search for the same items. Maybe an hovering label above each search button could add more information about the exact use of each search box ?

On the code itself, I was unsure if `table.getTableViewer().addFilter` should be before or after `update()` in `createBody`. Both worked on my side.