### PR TITLE
added widget for the dashboard and columns for the information of dividends

### DIFF
--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/dashboard/DividendListWidgetTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/dashboard/DividendListWidgetTest.java
@@ -1,0 +1,251 @@
+package name.abuchen.portfolio.ui.views.dashboard;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.SecurityEvent;
+import name.abuchen.portfolio.model.SecurityEvent.DividendEvent;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.ui.views.dashboard.DividendListWidget.DateEndRange;
+import name.abuchen.portfolio.ui.views.dashboard.DividendListWidget.DateStartRange;
+import name.abuchen.portfolio.ui.views.dashboard.DividendListWidget.DateType;
+import name.abuchen.portfolio.ui.views.dashboard.DividendListWidget.DividendItem;
+
+public class DividendListWidgetTest
+{
+    private Locale defaultLocale;
+
+    private Security sec1;
+    private Security sec2;
+    private DividendEvent de1_1;
+    private DividendEvent de1_2;
+    private SecurityEvent de1_3;
+    private DividendEvent de1_4;
+    private DividendEvent de2_1;
+    private DividendEvent de2_2;
+    private SecurityEvent de2_3;
+    private DividendEvent de2_4;
+
+    @Before
+    public void setupLocale()
+    {
+        defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.GERMANY);
+    }
+
+    @After
+    public void resetLocale()
+    {
+        Locale.setDefault(defaultLocale);
+    }
+
+    @Before
+    public void setupTestData()
+    {
+        sec1 = new Security("Security 1", "EUR");
+        de1_1 = new DividendEvent(LocalDate.of(2024, 4, 9), LocalDate.of(2024, 4, 12), Money.of("EUR", 55), "source");
+        de1_2 = new DividendEvent(LocalDate.of(2024, 7, 14), LocalDate.of(2024, 8, 11), Money.of("EUR", 22), "source");
+        de1_3 = new SecurityEvent(LocalDate.of(2024, 2, 3), SecurityEvent.Type.NOTE, "some note");
+        de1_4 = new DividendEvent(LocalDate.of(2024, 2, 4), LocalDate.of(2024, 3, 5), Money.of("EUR", 33), "source");
+        sec1.addEvent(de1_1);
+        sec1.addEvent(de1_2);
+        sec1.addEvent(de1_3);
+        sec1.addEvent(de1_4);
+
+        sec2 = new Security("Security 2", "EUR");
+        de2_1 = new DividendEvent(LocalDate.of(2024, 4, 5), LocalDate.of(2024, 4, 9), Money.of("USD", 55), "source");
+        de2_2 = new DividendEvent(LocalDate.of(2024, 7, 14), LocalDate.of(2024, 7, 15), Money.of("USD", 122), "source");
+        de2_3 = new SecurityEvent(LocalDate.of(2024, 8, 25), SecurityEvent.Type.STOCK_SPLIT, "some stock split");
+        de2_4 = new DividendEvent(LocalDate.of(2024, 2, 5), LocalDate.of(2024, 3, 5), Money.of("USD", 1333), "source");
+        sec2.addEvent(de2_1);
+        sec2.addEvent(de2_2);
+        sec2.addEvent(de2_3);
+        sec2.addEvent(de2_4);
+
+    }
+
+    @Test
+    public void testDividendItemInstantiation()
+    {
+        DividendItem di;
+        
+        di = new DividendItem(DateType.EX_DIVIDEND_DATE, sec1, de1_1);
+        assertThat(di.getSecurity(), is(sec1));
+        assertThat(di.type, is(DateType.EX_DIVIDEND_DATE));
+        assertThat(di.div, is(de1_1));
+    }
+
+    @Test
+    public void testDateStartRange()
+    {
+        assertEquals("FROM_TODAY,FROM_ONE_WEEK,FROM_ONE_MONTH,FROM_YTD", //
+                        Arrays.stream(DateStartRange.values())
+                        .map(DateStartRange::name).collect(Collectors.joining(",")));
+
+        LocalDate now = LocalDate.of(2024, 4, 8);
+        assertThat(DateStartRange.FROM_TODAY.getDate(now), is(now));
+        assertThat(DateStartRange.FROM_ONE_WEEK.getDate(now), is(LocalDate.of(2024, 4, 1)));
+        assertThat(DateStartRange.FROM_ONE_MONTH.getDate(now), is(LocalDate.of(2024, 3, 8)));
+        assertThat(DateStartRange.FROM_YTD.getDate(now), is(LocalDate.of(2024, 1, 1)));
+    }
+
+    @Test
+    public void testDateEndRange()
+    {
+        assertEquals("UNTIL_EOY,UNTIL_ONE_MONTH,UNTIL_ONE_WEEK,UNTIL_TODAY", //
+                        Arrays.stream(DateEndRange.values()).map(DateEndRange::name).collect(Collectors.joining(",")));
+
+        LocalDate now = LocalDate.of(2024, 4, 8);
+        assertThat(DateEndRange.UNTIL_TODAY.getDate(now), is(now));
+        assertThat(DateEndRange.UNTIL_ONE_WEEK.getDate(now), is(LocalDate.of(2024, 4, 15)));
+        assertThat(DateEndRange.UNTIL_ONE_MONTH.getDate(now), is(LocalDate.of(2024, 5, 8)));
+        assertThat(DateEndRange.UNTIL_EOY.getDate(now), is(LocalDate.of(2024, 12, 31)));
+    }
+
+    @Test
+    public void testDateType()
+    {
+        assertEquals("ALL_DATES,EX_DIVIDEND_DATE,PAYMENT_DATE", //
+                        Arrays.stream(DateType.values()).map(DateType::name).collect(Collectors.joining(",")));
+
+        assertThat(DateType.ALL_DATES.getDate(de1_1), nullValue());
+        assertThat(DateType.EX_DIVIDEND_DATE.getDate(de1_1), is(de1_1.getDate()));
+        assertThat(DateType.PAYMENT_DATE.getDate(de1_1), is(de1_1.getPaymentDate()));
+    }
+
+    @Test
+    public void testGetUpdateTask() throws Exception
+    {
+        LocalDate testnow = LocalDate.now();
+        @SuppressWarnings("deprecation")
+        AbstractSecurityListWidget<DividendItem> widget = new DividendListWidget()
+        {
+            @Override
+            public Supplier<List<DividendItem>> getUpdateTask(LocalDate now)
+            {
+                assertThat(now, is(testnow));
+                return null;
+            }
+        };
+        assertThat(widget.getUpdateTask(), nullValue());
+    }
+
+    @Test
+    public void testGetUpdateTaskNow()
+    {
+        List<DividendItem> list;
+        AtomicReference<DateStartRange> dateStart = new AtomicReference<>(DateStartRange.FROM_TODAY);
+        AtomicReference<DateEndRange> dateEnd = new AtomicReference<>(DateEndRange.UNTIL_TODAY);
+        AtomicReference<DateType> dateType = new AtomicReference<>(DateType.ALL_DATES);
+
+        @SuppressWarnings("deprecation")
+        DividendListWidget widget = new DividendListWidget()
+        {
+            @Override
+            DateStartRange getStartRangeValue()
+            {
+                return dateStart.get();
+            }
+
+            @Override
+            DateEndRange getEndRangeValue()
+            {
+                return dateEnd.get();
+            }
+
+            @Override
+            DateType getDateTypeValue()
+            {
+                return dateType.get();
+            }
+
+            @Override
+            List<Security> getSecurities()
+            {
+                return Arrays.asList(sec1, sec2);
+            }
+        };
+
+        LocalDate now = LocalDate.of(2024, 4, 9);
+        list = widget.getUpdateTask(now).get();
+        assertEquals("2024-04-09 Security 1 EUR 0,55 Ex-Tag\r\n" //
+                        + "Security 2 USD 0,55 Zahltag", getListAsString(list));
+
+        now = LocalDate.of(2024, 4, 8);
+        list = widget.getUpdateTask(now).get();
+        assertEquals("", getListAsString(list));
+
+        dateStart.set(DateStartRange.FROM_YTD);
+        list = widget.getUpdateTask(now).get();
+        assertEquals("2024-02-04 Security 1 EUR 0,33 Ex-Tag\r\n" //
+                        + "2024-02-05 Security 2 USD 13,33 Ex-Tag\r\n" //
+                        + "2024-03-05 Security 1 EUR 0,33 Zahltag\r\n" //
+                        + "Security 2 USD 13,33 Zahltag\r\n" //
+                        + "2024-04-05 Security 2 USD 0,55 Ex-Tag", getListAsString(list));
+
+        dateEnd.set(DateEndRange.UNTIL_EOY);
+        list = widget.getUpdateTask(now).get();
+        assertEquals("2024-02-04 Security 1 EUR 0,33 Ex-Tag\r\n" //
+                        + "2024-02-05 Security 2 USD 13,33 Ex-Tag\r\n" //
+                        + "2024-03-05 Security 1 EUR 0,33 Zahltag\r\n" //
+                        + "Security 2 USD 13,33 Zahltag\r\n" //
+                        + "2024-04-05 Security 2 USD 0,55 Ex-Tag\r\n" //
+                        + "2024-04-09 Security 1 EUR 0,55 Ex-Tag\r\n" //
+                        + "Security 2 USD 0,55 Zahltag\r\n" //
+                        + "2024-04-12 Security 1 EUR 0,55 Zahltag\r\n" //
+                        + "2024-07-14 Security 1 EUR 0,22 Ex-Tag\r\n" //
+                        + "Security 2 USD 1,22 Ex-Tag\r\n" //
+                        + "2024-07-15 Security 2 USD 1,22 Zahltag\r\n" //
+                        + "2024-08-11 Security 1 EUR 0,22 Zahltag", getListAsString(list));
+        
+        dateType.set(DateType.EX_DIVIDEND_DATE);
+        list = widget.getUpdateTask(now).get();
+        assertEquals("2024-02-04 Security 1 EUR 0,33 Ex-Tag\r\n" //
+                        + "2024-02-05 Security 2 USD 13,33 Ex-Tag\r\n" //
+                        + "2024-04-05 Security 2 USD 0,55 Ex-Tag\r\n" //
+                        + "2024-04-09 Security 1 EUR 0,55 Ex-Tag\r\n" //
+                        + "2024-07-14 Security 1 EUR 0,22 Ex-Tag\r\n" //
+                        + "Security 2 USD 1,22 Ex-Tag", getListAsString(list));
+
+        dateType.set(DateType.PAYMENT_DATE);
+        list = widget.getUpdateTask(now).get();
+        assertEquals("2024-03-05 Security 1 EUR 0,33 Zahltag\r\n" //
+                        + "Security 2 USD 13,33 Zahltag\r\n" //
+                        + "2024-04-09 Security 2 USD 0,55 Zahltag\r\n" //
+                        + "2024-04-12 Security 1 EUR 0,55 Zahltag\r\n" //
+                        + "2024-07-15 Security 2 USD 1,22 Zahltag\r\n" //
+                        + "2024-08-11 Security 1 EUR 0,22 Zahltag", getListAsString(list));
+    }
+
+    private String getListAsString(List<DividendItem> list)
+    {
+        return list.stream() //
+                        .map(entry -> {
+                            StringBuilder sb = new StringBuilder();
+                            if (entry.hasNewDate)
+                            {
+                                sb.append(entry.type.getDate(entry.div).toString() + " ");
+                            }
+                            sb.append(entry.getSecurity().getName() + " ");
+                            sb.append(entry.div.getAmount() + " ");
+                            sb.append(entry.type);
+                            return sb.toString();
+                        }) //
+                        .collect(Collectors.joining("\r\n"));
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -1320,6 +1320,17 @@ public class Messages extends NLS
     public static String OptionDateIsInTheFuture;
     public static String OptionDateIsInThePast;
     public static String YearlyPerformanceHeatmapToolTip;
+
+    public static String LabelEarningsDividendList;
+    public static String LabelEarningsDividendPeriodFrom;
+    public static String LabelEarningsDividendPeriodUntil;
+    public static String LabelEarningsDividendDateType;
+    public static String ColumnDividendsNextExDate;
+    public static String ColumnDividendsNextExDate_MenuLabel;
+    public static String ColumnDividendsNextPaymentDate;
+    public static String ColumnDividendsNextPaymentDate_MenuLabel;
+    public static String ColumnDividendsNextPaymentAmount;
+    public static String ColumnDividendsNextPaymentAmount_MenuLabel;
     static
     {
         // initialize resource bundle

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -2631,3 +2631,23 @@ WatchlistRename = Rename Watchlist
 Website = Website
 
 YearlyPerformanceHeatmapToolTip = Yearly rate of return displayed as heatmap\n\nTo calculate the yearly rate of return, the true-time weighted rate of return (TTWROR) is used.\n\nThe rate of return is always calculated for the full year - even if the reporting interval ends or starts in the middle of a year.
+
+LabelEarningsDividendList = Upcoming dividends
+
+LabelEarningsDividendPeriodFrom = Period start
+
+LabelEarningsDividendPeriodUntil = Period end
+
+LabelEarningsDividendDateType = Type of date
+
+ColumnDividendsNextExDate = Next Ex-Date
+
+ColumnDividendsNextExDate_MenuLabel = Next Dividend Ex-Date
+
+ColumnDividendsNextPaymentDate = Next Paym. Date
+
+ColumnDividendsNextPaymentDate_MenuLabel = Next Dividend Payment Date
+
+ColumnDividendsNextPaymentAmount = Next Paym. Amt.
+
+ColumnDividendsNextPaymentAmount_MenuLabel = Next Divident Payment Amount

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -2624,3 +2624,23 @@ WatchlistRename = Watchliste umbenennen
 Website = Website
 
 YearlyPerformanceHeatmapToolTip = Jahresrenditen in einer Heatmap\n\nZur Berechnung der Jahresrendite wird der True-Time Weighted Rate of Return (TTWROR) herangezogen.\n\nDie Rendite bezieht sich immer auf das gesamte Jahr - selbst wenn der Berichtszeitraum in der Mitte des Jahres beginnt bzw. endet.
+
+LabelEarningsDividendList = \u00DCbersicht anstehender Dividenden
+
+LabelEarningsDividendPeriodFrom = Zeitraum ab
+
+LabelEarningsDividendPeriodUntil = Zeitraum bis
+
+LabelEarningsDividendDateType = Datumsart
+
+ColumnDividendsNextExDate = Div Ex. Tag
+
+ColumnDividendsNextExDate_MenuLabel = Nächster Ex-Dividendentag
+
+ColumnDividendsNextPaymentDate = Div. Zahltag
+
+ColumnDividendsNextPaymentDate_MenuLabel = Nächster Dividenden Zahltag
+
+ColumnDividendsNextPaymentAmount = Div. Betrag
+
+ColumnDividendsNextPaymentAmount_MenuLabel = Nächster Dividendenbetrag

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioListView.java
@@ -49,6 +49,7 @@ import name.abuchen.portfolio.ui.util.viewers.CopyPasteSupport;
 import name.abuchen.portfolio.ui.util.viewers.ListEditingSupport;
 import name.abuchen.portfolio.ui.util.viewers.ShowHideColumnHelper;
 import name.abuchen.portfolio.ui.views.columns.AttributeColumn;
+import name.abuchen.portfolio.ui.views.columns.DividendPaymentColumn;
 import name.abuchen.portfolio.ui.views.columns.NameColumn;
 import name.abuchen.portfolio.ui.views.columns.NameColumn.NameColumnLabelProvider;
 import name.abuchen.portfolio.ui.views.columns.NoteColumn;
@@ -259,6 +260,7 @@ public class PortfolioListView extends AbstractFinanceView implements Modificati
         portfolioColumns.addColumn(column);
 
         addAttributeColumns(portfolioColumns);
+        addDividendPaymentColumns(portfolioColumns);
 
         portfolioColumns.createColumns(true);
 
@@ -276,6 +278,14 @@ public class PortfolioListView extends AbstractFinanceView implements Modificati
         hookContextMenu(portfolios.getTable(), this::fillPortfolioContextMenu);
 
         return container;
+    }
+
+    private void addDividendPaymentColumns(ShowHideColumnHelper support)
+    {
+        DividendPaymentColumn.createFor() //
+                        .forEach(column -> {
+                            support.addColumn(column);
+                        });
     }
 
     private void addAttributeColumns(ShowHideColumnHelper support)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -98,6 +98,7 @@ import name.abuchen.portfolio.ui.util.viewers.StringEditingSupport;
 import name.abuchen.portfolio.ui.views.columns.AttributeColumn;
 import name.abuchen.portfolio.ui.views.columns.DistanceFromAllTimeHighColumn;
 import name.abuchen.portfolio.ui.views.columns.DistanceFromMovingAverageColumn;
+import name.abuchen.portfolio.ui.views.columns.DividendPaymentColumn;
 import name.abuchen.portfolio.ui.views.columns.IsinColumn;
 import name.abuchen.portfolio.ui.views.columns.NoteColumn;
 import name.abuchen.portfolio.ui.views.columns.SymbolColumn;
@@ -219,6 +220,7 @@ public final class SecuritiesTable implements ModificationListener
         }
 
         addAttributeColumns();
+        addDividendColumns();
         addQuoteFeedColumns();
         addDataQualityColumns();
 
@@ -238,6 +240,14 @@ public final class SecuritiesTable implements ModificationListener
         securities.refresh();
 
         hookContextMenu();
+    }
+
+    private void addDividendColumns()
+    {
+        DividendPaymentColumn.createFor() //
+                        .forEach(column -> {
+                            support.addColumn(column);
+                        });
     }
 
     private void addMasterDataColumns()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -108,6 +108,7 @@ import name.abuchen.portfolio.ui.util.viewers.StringEditingSupport;
 import name.abuchen.portfolio.ui.views.columns.AttributeColumn;
 import name.abuchen.portfolio.ui.views.columns.DistanceFromAllTimeHighColumn;
 import name.abuchen.portfolio.ui.views.columns.DistanceFromMovingAverageColumn;
+import name.abuchen.portfolio.ui.views.columns.DividendPaymentColumn;
 import name.abuchen.portfolio.ui.views.columns.IsinColumn;
 import name.abuchen.portfolio.ui.views.columns.NameColumn;
 import name.abuchen.portfolio.ui.views.columns.NameColumn.NameColumnLabelProvider;
@@ -749,6 +750,18 @@ public class StatementOfAssetsViewer
         column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
         column.setVisible(false);
         support.addColumn(column);
+
+        addDividendPaymentColumns();
+    }
+
+    private void addDividendPaymentColumns()
+    {
+        DividendPaymentColumn.createFor() //
+                        .forEach(column -> {
+                            if (column.getSorter() != null)
+                                column.getSorter().wrap(ElementComparator::new);
+                            support.addColumn(column);
+                        });
     }
 
     private void addAttributeColumns()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/DividendPaymentColumn.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/DividendPaymentColumn.java
@@ -1,0 +1,170 @@
+package name.abuchen.portfolio.ui.views.columns;
+
+import java.time.LocalDate;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+
+import name.abuchen.portfolio.model.Adaptor;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.SecurityEvent.DividendEvent;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.viewers.Column;
+import name.abuchen.portfolio.ui.util.viewers.ColumnViewerSorter;
+import name.abuchen.portfolio.ui.util.viewers.DateLabelProvider;
+
+public class DividendPaymentColumn
+{
+
+    static Column createNextDividendExDateColumn()
+    {
+        Column column = new Column("nexdd", Messages.ColumnDividendsNextExDate, SWT.LEFT, 80); //$NON-NLS-1$
+        column.setMenuLabel(Messages.ColumnDividendsNextExDate_MenuLabel);
+        column.setGroupLabel(Messages.GroupLabelDividends);
+        column.setVisible(false);
+
+        LocalDate now = LocalDate.now();
+
+        Function<Object, LocalDate> dataProvider = element -> {
+            Security sec = Adaptor.adapt(Security.class, element);
+            if (sec == null)
+            {
+                return null; //
+            }
+            return sec.getEvents().stream() //
+                            .filter(DividendEvent.class::isInstance) //
+                            .map(e -> ((DividendEvent) e).getDate()) //
+                            .sorted(Comparable::compareTo) //
+                            .filter(d -> d.isAfter(now)) //
+                            .findFirst().orElse(null);
+        };
+
+        column.setLabelProvider(new DateLabelProvider(dataProvider)
+        {
+            @Override
+            public Color getBackground(Object element)
+            {
+                LocalDate date = dataProvider.apply(element);
+                if (date == null)
+                {
+                    return null; //
+                }
+                if (!date.equals(LocalDate.now()))
+                {
+                    return null; //
+                }
+                return Colors.theme().greenBackground();
+            }
+        });
+        column.setSorter(ColumnViewerSorter.create(dataProvider::apply));
+        return column;
+    }
+
+    static Column createNextDividendPaymentDateColumn()
+    {
+        Column column = new Column("nexpdd", Messages.ColumnDividendsNextPaymentDate, SWT.LEFT, 80); //$NON-NLS-1$
+        column.setMenuLabel(Messages.ColumnDividendsNextPaymentDate_MenuLabel);
+        column.setGroupLabel(Messages.GroupLabelDividends);
+        column.setVisible(false);
+
+        LocalDate now = LocalDate.now();
+
+        Function<Object, LocalDate> dataProvider = element -> {
+            Security sec = Adaptor.adapt(Security.class, element);
+            if (sec == null)
+            {
+                return null; //
+            }
+            return sec.getEvents().stream() //
+                            .filter(DividendEvent.class::isInstance) //
+                            .map(e -> ((DividendEvent) e).getPaymentDate()) //
+                            .sorted(Comparable::compareTo) //
+                            .filter(d -> d.isAfter(now)) //
+                            .findFirst().orElse(null);
+        };
+
+        column.setLabelProvider(new DateLabelProvider(dataProvider)
+        {
+            @Override
+            public Color getBackground(Object element)
+            {
+                LocalDate date = dataProvider.apply(element);
+                if (date == null)
+                {
+                    return null; //
+                }
+                if (!date.equals(LocalDate.now()))
+                {
+                    return null; //
+                }
+                return Colors.theme().redBackground();
+            }
+        });
+        column.setSorter(ColumnViewerSorter.create(dataProvider::apply));
+        return column;
+    }
+
+    static Column createNextDividendPaymentAmount()
+    {
+        Column column = new Column("nexdpa", Messages.ColumnDividendsNextPaymentAmount, SWT.RIGHT, 60); //$NON-NLS-1$
+        column.setMenuLabel(Messages.ColumnDividendsNextPaymentAmount_MenuLabel);
+        column.setGroupLabel(Messages.GroupLabelDividends);
+        column.setVisible(false);
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object element)
+            {
+                Security sec = Adaptor.adapt(Security.class, element);
+                if (sec == null)
+                {
+                    return null; //
+                }
+                LocalDate now = LocalDate.now();
+                Money amount = getAmount(now, sec);
+
+                if (amount == null)
+                {
+                    return null; //
+                }
+                return Values.Money.format(amount);
+            }
+        });
+        column.setSorter(ColumnViewerSorter.create((o1, o2) -> {
+            Money m1 = getAmount(LocalDate.now(), (Security) o1);
+            Money m2 = getAmount(LocalDate.now(), (Security) o2);
+
+            if (m1 == null)
+                return m2 == null ? 0 : -1;
+            if (m2 == null)
+                return 1;
+
+            return m1.compareTo(m2);
+        }));
+        return column;
+    }
+
+    static Money getAmount(LocalDate now, Security sec)
+    {
+        return sec.getEvents().stream() //
+                        .filter(e -> e instanceof DividendEvent) //
+                        .map(e -> (DividendEvent) e) //
+                        .sorted((e1, e2) -> e1.getPaymentDate().compareTo(e2.getPaymentDate())) //
+                        .filter(d -> d.getPaymentDate().isAfter(now)) //
+                        .map(DividendEvent::getAmount).findFirst().orElse(null);
+    }
+
+    public static Stream<Column> createFor()
+    {
+        return Stream.of(createNextDividendExDateColumn(), //
+                        createNextDividendPaymentDateColumn(), //
+                        createNextDividendPaymentAmount());
+    }
+
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractSecurityListWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractSecurityListWidget.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views.dashboard;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -11,10 +12,12 @@ import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseListener;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
 
 import name.abuchen.portfolio.model.Dashboard.Widget;
 import name.abuchen.portfolio.model.Security;
@@ -62,6 +65,17 @@ public abstract class AbstractSecurityListWidget<T extends AbstractSecurityListW
 
         view.setInformationPaneInput(((Item) item).getSecurity());
     });
+
+    protected void addListener(MouseListener listener, Control... controls)
+    {
+        for (Control ctr : controls)
+        {
+            if (ctr != null)
+            {
+                ctr.addMouseListener(listener);
+            }
+        }
+    }
 
     public AbstractSecurityListWidget(Widget widget, DashboardData data)
     {
@@ -165,6 +179,20 @@ public abstract class AbstractSecurityListWidget<T extends AbstractSecurityListW
     public Control getTitleControl()
     {
         return title;
+    }
+
+    protected Label createLabel(Composite composite, String text)
+    {
+        Label ret = new Label(composite, SWT.NONE);
+        ret.setText(Objects.toString(text).replace("&", "&&")); //$NON-NLS-1$ //$NON-NLS-2$
+        return ret;
+    }
+
+    protected Label createLabel(Composite composite, Image image)
+    {
+        Label ret = new Label(composite, SWT.NONE);
+        ret.setImage(image);
+        return ret;
     }
 
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DividendListWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/DividendListWidget.java
@@ -1,0 +1,310 @@
+package name.abuchen.portfolio.ui.views.dashboard;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.FormAttachment;
+import org.eclipse.swt.layout.FormLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+
+import name.abuchen.portfolio.model.Dashboard;
+import name.abuchen.portfolio.model.Dashboard.Widget;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.SecurityEvent;
+import name.abuchen.portfolio.model.SecurityEvent.DividendEvent;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.util.FormDataFactory;
+import name.abuchen.portfolio.ui.util.LogoManager;
+
+public class DividendListWidget extends AbstractSecurityListWidget<DividendListWidget.DividendItem>
+{
+    public static class DividendItem extends AbstractSecurityListWidget.Item
+    {
+        boolean hasNewDate;
+        DateType type;
+        DividendEvent div;
+
+        public DividendItem(DateType type, Security security, DividendEvent div)
+        {
+            super(security);
+            this.div = div;
+            this.type = type;
+        }
+    }
+
+    public enum DateStartRange
+    {
+        FROM_TODAY(Messages.LabelToday, d -> d), //
+        FROM_ONE_WEEK(Messages.LabelReportingDialogWeek, d -> d.minus(1, ChronoUnit.WEEKS)), //
+        FROM_ONE_MONTH(Messages.LabelReportingDialogMonth, d -> d.minus(1, ChronoUnit.MONTHS)), //
+        FROM_YTD(Messages.LabelReportingDialogYearYTD, d -> LocalDate.of(d.getYear(), 1, 1)), //
+        ;
+
+        private DateStartRange(String label, UnaryOperator<LocalDate> dateStartProvider)
+        {
+            this.label = label;
+            this.dateStartProvider = dateStartProvider;
+        }
+
+        private String label;
+        private UnaryOperator<LocalDate> dateStartProvider;
+
+        LocalDate getDate(LocalDate now)
+        {
+            return dateStartProvider.apply(now);
+        }
+
+        @Override
+        public String toString()
+        {
+            return label;
+        }
+    }
+
+    static class DateStartRangeConfig extends EnumBasedConfig<DateStartRange>
+    {
+        public DateStartRangeConfig(WidgetDelegate<?> delegate)
+        {
+            super(delegate, Messages.LabelEarningsDividendPeriodFrom, DateStartRange.class,
+                            Dashboard.Config.START_YEAR, Policy.EXACTLY_ONE);
+        }
+    }
+
+    public enum DateEndRange
+    {
+        UNTIL_EOY(Messages.LabelReportingDialogYear, d -> LocalDate.of(d.getYear(), 12, 31)), //
+        UNTIL_ONE_MONTH(Messages.LabelReportingDialogMonth, d -> d.plus(1, ChronoUnit.MONTHS)), //
+        UNTIL_ONE_WEEK(Messages.LabelReportingDialogWeek, d -> d.plus(1, ChronoUnit.WEEKS)), //
+        UNTIL_TODAY(Messages.LabelToday, d -> d), //
+        ;
+
+        private DateEndRange(String label, UnaryOperator<LocalDate> dateStartProvider)
+        {
+            this.label = label;
+            this.dateEndProvider = dateStartProvider;
+        }
+
+        private String label;
+        private UnaryOperator<LocalDate> dateEndProvider;
+
+        LocalDate getDate(LocalDate now)
+        {
+            return dateEndProvider.apply(now);
+        }
+
+        @Override
+        public String toString()
+        {
+            return label;
+        }
+    }
+
+    static class DateEndRangeConfig extends EnumBasedConfig<DateEndRange>
+    {
+        public DateEndRangeConfig(WidgetDelegate<?> delegate)
+        {
+            super(delegate, Messages.LabelEarningsDividendPeriodUntil, DateEndRange.class,
+                            Dashboard.Config.REPORTING_PERIOD, Policy.EXACTLY_ONE);
+        }
+    }
+
+    public enum DateType
+    {
+        ALL_DATES(Messages.LabelAllAttributes, d -> null), //
+        EX_DIVIDEND_DATE(Messages.ColumnExDate, DividendEvent::getDate), //
+        PAYMENT_DATE(Messages.ColumnPaymentDate, DividendEvent::getPaymentDate), //
+        ;
+
+        private DateType(String label, Function<DividendEvent, LocalDate> dateProvider)
+        {
+            this.label = label;
+            this.dateProvider = dateProvider;
+        }
+
+        private String label;
+        private Function<DividendEvent, LocalDate> dateProvider;
+
+        public LocalDate getDate(DividendEvent evt)
+        {
+            return dateProvider.apply(evt);
+        }
+
+        @Override
+        public String toString()
+        {
+            return label;
+        }
+    }
+
+    static class DateTypeConfig extends EnumBasedConfig<DateType>
+    {
+        public DateTypeConfig(WidgetDelegate<?> delegate)
+        {
+            super(delegate, Messages.LabelEarningsDividendDateType, DateType.class, Dashboard.Config.EARNING_TYPE,
+                            Policy.EXACTLY_ONE);
+        }
+    }
+
+    /**
+     * @deprecated This constructor is only used for testing, don't use it for
+     *             anything else
+     */
+    @Deprecated
+    DividendListWidget() // needed for testing
+    {
+        super(null, null);
+    }
+
+    public DividendListWidget(Widget widget, DashboardData data)
+    {
+        super(widget, data);
+
+        addConfig(new DateTypeConfig(this));
+        addConfig(new DateStartRangeConfig(this));
+        addConfig(new DateEndRangeConfig(this));
+        addConfig(new ChartHeightConfig(this));
+    }
+
+    @Override
+    public Supplier<List<DividendItem>> getUpdateTask()
+    {
+        return getUpdateTask(LocalDate.now());
+    }
+
+    Supplier<List<DividendItem>> getUpdateTask(LocalDate now)
+    {
+        return () -> {
+
+            DateType dateType = getDateTypeValue();
+
+            List<DividendItem> items = new ArrayList<>();
+            LocalDate fromDate = getStartRangeValue().getDate(now);
+            LocalDate untilDate = getEndRangeValue().getDate(now);
+            for (Security security : getSecurities())
+            {
+                for (SecurityEvent se : security.getEvents())
+                {
+                    if (!(se instanceof DividendEvent de))
+                    {
+                        continue;
+                    }
+                    checkAndAdd(items, security, de, dateType, DateType.EX_DIVIDEND_DATE, fromDate, untilDate);
+                    checkAndAdd(items, security, de, dateType, DateType.PAYMENT_DATE, fromDate, untilDate);
+                }
+            }
+
+            Collections.sort(items, (di1, di2) -> di1.type.getDate(di1.div).compareTo(di2.type.getDate(di2.div)));
+            LocalDate prevDate = null;
+            for (DividendItem item : items)
+            {
+                LocalDate currDate = item.type.getDate(item.div);
+                if (prevDate == null || !currDate.isEqual(prevDate))
+                {
+                    item.hasNewDate = true;
+                    prevDate = currDate;
+                    continue;
+                }
+            }
+
+            return items;
+        };
+    }
+
+    DateStartRange getStartRangeValue()
+    {
+        return get(DateStartRangeConfig.class).getValue();
+    }
+
+    DateEndRange getEndRangeValue()
+    {
+        return get(DateEndRangeConfig.class).getValue();
+    }
+
+    DateType getDateTypeValue()
+    {
+        return get(DateTypeConfig.class).getValue();
+    }
+
+    List<Security> getSecurities()
+    {
+        return getClient().getSecurities();
+    }
+
+    DividendItem checkAndAdd(List<DividendItem> items, Security sec, DividendEvent de, DateType configuredType,
+                    DateType typeToAdd, LocalDate startRange, LocalDate endRange)
+    {
+        if (configuredType != typeToAdd && configuredType != DateType.ALL_DATES)
+        {
+            return null;
+        }
+
+        LocalDate checkDate = typeToAdd.getDate(de);
+        if (checkDate.isBefore(startRange))
+        {
+            return null; //
+        }
+
+        if (checkDate.isAfter(endRange))
+        {
+            return null; //
+        }
+
+        DividendItem ret = new DividendItem(typeToAdd, sec, de);
+        items.add(ret);
+        return ret;
+    }
+
+    @Override
+    protected Composite createItemControl(Composite parent, DividendItem item)
+    {
+        Security sec = item.getSecurity();
+        Composite composite = new Composite(parent, SWT.NONE);
+        composite.setLayout(new FormLayout());
+
+        Image image = LogoManager.instance().getDefaultColumnImage(sec, getClient().getSettings());
+        Label logo = createLabel(composite, image);
+        Label name = createLabel(composite, sec.getName());
+        Label amtAndType = createLabel(composite,
+                        "   " + Values.Money.format(item.div.getAmount()) + " " + item.type.label); //$NON-NLS-1$ //$NON-NLS-2$
+
+
+        Label date = null;
+
+        if (item.hasNewDate)
+        {
+            date = createLabel(composite, Values.Date.format(item.type.getDate(item.div)));
+        }
+
+        addListener(mouseUpAdapter, composite, name, date, amtAndType);
+
+        FormDataFactory start;
+        if (date != null)
+        {
+            start = FormDataFactory.startingWith(date).thenBelow(logo);
+        }
+        else
+        {
+            start = FormDataFactory.startingWith(logo);
+        }
+        start.thenRight(name).right(new FormAttachment(100)).thenBelow(amtAndType);
+
+        return composite;
+    }
+
+    @Override
+    protected void createEmptyControl(Composite parent)
+    {
+        // nothing to do
+    }
+
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
@@ -25,9 +25,9 @@ import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsByTaxonomyChar
 import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsChartWidget;
 import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsListWidget;
+import name.abuchen.portfolio.ui.views.dashboard.heatmap.CostHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dashboard.heatmap.InvestmentHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dashboard.heatmap.PerformanceHeatmapWidget;
-import name.abuchen.portfolio.ui.views.dashboard.heatmap.CostHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dashboard.heatmap.YearlyPerformanceHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeries;
 import name.abuchen.portfolio.ui.views.payments.PaymentsViewModel;
@@ -214,6 +214,8 @@ public enum WidgetFactory
     EARNINGS(Messages.LabelEarningsTransactionList, Messages.LabelEarnings, EarningsListWidget::new),
 
     HEATMAP_EARNINGS(Messages.LabelHeatmapEarnings, Messages.LabelEarnings, EarningsHeatmapWidget::new),
+
+    EARNINGS_DIVIDEND_LIST(Messages.LabelEarningsDividendList, Messages.LabelEarnings, DividendListWidget::new),
 
     EARNINGS_PER_YEAR_CHART(Messages.LabelEarningsPerYear, Messages.LabelEarnings, EarningsChartWidget::perYear),
 


### PR DESCRIPTION
Hi,

in #1669 and in the forum there seems to be demand for information widgets and columns showing informations about upcoming dividends. So here is my shot at it. This adds a widget for the dashboard, showing a list of upcoming dates (ex dividend, payment or both) of securities and the expected amounts. As well I've added columns for various tables (security view, etc.) that shows the date of the next ex/payment date for each security.

I've added new entries to be localized at the end of Messages and the properties-files for german and english to make it easier to spot them for the other languages. They can be resorted at the end of the process, of course.

Hope that helps and cheers, Lothar