### PR TITLE
escape ampersands in label texts that would otherwise be interpreted as special character

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractSecurityListWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractSecurityListWidget.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views.dashboard;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -11,10 +12,12 @@ import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseListener;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
 
 import name.abuchen.portfolio.model.Dashboard.Widget;
 import name.abuchen.portfolio.model.Security;
@@ -165,6 +168,20 @@ public abstract class AbstractSecurityListWidget<T extends AbstractSecurityListW
     public Control getTitleControl()
     {
         return title;
+    }
+
+    protected Label createLabel(Composite composite, String text)
+    {
+        Label ret = new Label(composite, SWT.NONE);
+        ret.setText(Objects.toString(text).replace("&", "&&")); //$NON-NLS-1$ //$NON-NLS-2$
+        return ret;
+    }
+
+    protected Label createLabel(Composite composite, Image image)
+    {
+        Label ret = new Label(composite, SWT.NONE);
+        ret.setImage(image);
+        return ret;
     }
 
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractSecurityListWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractSecurityListWidget.java
@@ -173,7 +173,7 @@ public abstract class AbstractSecurityListWidget<T extends AbstractSecurityListW
     protected Label createLabel(Composite composite, String text)
     {
         Label ret = new Label(composite, SWT.NONE);
-        ret.setText(Objects.toString(text).replace("&", "&&")); //$NON-NLS-1$ //$NON-NLS-2$
+        ret.setText(TextUtil.tooltip(Objects.toString(text, ""))); //$NON-NLS-1$
         return ret;
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/FollowUpWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/FollowUpWidget.java
@@ -158,14 +158,12 @@ public class FollowUpWidget extends AbstractSecurityListWidget<FollowUpWidget.Fo
         Composite composite = new Composite(parent, SWT.NONE);
         composite.setLayout(new FormLayout());
 
-        Label logo = new Label(composite, SWT.NONE);
-        logo.setImage(LogoManager.instance().getDefaultColumnImage(item.getSecurity(), getClient().getSettings()));
+        Label logo = createLabel(composite,
+                        LogoManager.instance().getDefaultColumnImage(item.getSecurity(), getClient().getSettings()));
 
-        Label name = new Label(composite, SWT.NONE);
-        name.setText(item.getSecurity().getName());
+        Label name = createLabel(composite, item.getSecurity().getName());
 
-        Label date = new Label(composite, SWT.NONE);
-        date.setText(item.type.getName() + ": " + Values.Date.format(item.date)); //$NON-NLS-1$
+        Label date = createLabel(composite, item.type.getName() + ": " + Values.Date.format(item.date)); //$NON-NLS-1$
 
         composite.addMouseListener(mouseUpAdapter);
         name.addMouseListener(mouseUpAdapter);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/LimitExceededWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/LimitExceededWidget.java
@@ -94,11 +94,10 @@ public class LimitExceededWidget extends AbstractSecurityListWidget<LimitExceede
         Composite composite = new Composite(parent, SWT.NONE);
         composite.setLayout(new FormLayout());
 
-        Label logo = new Label(composite, SWT.NONE);
-        logo.setImage(LogoManager.instance().getDefaultColumnImage(item.getSecurity(), getClient().getSettings()));
+        Label logo = createLabel(composite,
+                        LogoManager.instance().getDefaultColumnImage(item.getSecurity(), getClient().getSettings()));
 
-        Label name = new Label(composite, SWT.NONE);
-        name.setText(item.getSecurity().getName());
+        Label name = createLabel(composite, item.getSecurity().getName());
 
         ColoredLabel price = new ColoredLabel(composite, SWT.RIGHT);
 
@@ -111,8 +110,7 @@ public class LimitExceededWidget extends AbstractSecurityListWidget<LimitExceede
         price.setForeground(Colors.getTextColor(bgColor));
         price.setText(Values.Quote.format(item.getSecurity().getCurrencyCode(), item.price.getValue()));
 
-        Label limit = new Label(composite, SWT.NONE);
-        limit.setText(settings.getFullLabel(item.limit, item.price));
+        Label limit = createLabel(composite, settings.getFullLabel(item.limit, item.price));
 
         composite.addMouseListener(mouseUpAdapter);
         name.addMouseListener(mouseUpAdapter);


### PR DESCRIPTION
Hi,

as shown in https://forum.portfolio-performance.info/t/widget-gesucht-bekannte-kunftige-dividendenzahlungen/28020/4 security names containing an ampersand show up in a wrong way if they are put into a label in a dashboard widget. This PR fixes that for exceeded limits and exceeded dates.

I've added two helper methods in AbstractSecurityListWidget that is also present in my other PR #3927.