### PR TITLE
Fix tooltip of aggregation's menu in Perf Chart

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
@@ -228,6 +228,7 @@ public class PerformanceChartView extends AbstractHistoricView
                 public void run()
                 {
                     setLabel(Messages.LabelAggregationDaily);
+                    setToolTip(Messages.LabelAggregationDaily);
                     aggregationPeriod = null;
                     getPart().getPreferenceStore().setValue(KEY_AGGREGATION_PERIOD, ""); //$NON-NLS-1$
                     updateChart();
@@ -244,6 +245,7 @@ public class PerformanceChartView extends AbstractHistoricView
                     public void run()
                     {
                         setLabel(period.toString());
+                        setToolTip(period.toString());
                         aggregationPeriod = period;
                         getPart().getPreferenceStore().setValue(KEY_AGGREGATION_PERIOD, period.name());
                         updateChart();


### PR DESCRIPTION
In Performance Chart, the tooltip of aggregation's menu was not updated when changing the aggregation period.
![Capture d'écran 2024-04-22 125544](https://github.com/portfolio-performance/portfolio/assets/160436107/e88ddad6-72db-4484-9870-dbeaf8d45287)

(Note: this is similar but a different issue than https://github.com/portfolio-performance/portfolio/issues/3675, which is about legend's tooltip, I did not manage to fix it.)