### PR TITLE
Remove Benchmark from Turnover Ratio data selection

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
@@ -25,9 +25,9 @@ import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsByTaxonomyChar
 import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsChartWidget;
 import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsListWidget;
+import name.abuchen.portfolio.ui.views.dashboard.heatmap.CostHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dashboard.heatmap.InvestmentHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dashboard.heatmap.PerformanceHeatmapWidget;
-import name.abuchen.portfolio.ui.views.dashboard.heatmap.CostHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dashboard.heatmap.YearlyPerformanceHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeries;
 import name.abuchen.portfolio.ui.views.payments.PaymentsViewModel;
@@ -242,6 +242,7 @@ public enum WidgetFactory
                                         long sell = LongStream.of(index.getSells()).sum();
                                         return Long.min(buy, sell) / average.getAsDouble();
                                     }) //
+                                    .withBenchmarkDataSeries(false) //
                                     .withTooltip((ds, period) -> {
                                         PerformanceIndex index = data.calculate(ds, period);
                                         String currency = data.getCurrencyConverter().getTermCurrency();


### PR DESCRIPTION
The widget Portfolio Turnover Rate currently accepts to use "benchmark" data but doing so triggers an issue:
![Capture d'écran 2024-04-22 223854](https://github.com/portfolio-performance/portfolio/assets/160436107/da279d01-ced1-4e43-84a8-f081f52ea9d8)

indeed, computing "buys", "sells" and "average portfolio volume" of a benchmark does not seem to make sense.

-> the possibility to select benchmark data for this widget is removed.

