### PR TITLE
Fix Bondora PDF-Importer

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -169,7 +169,7 @@ public abstract class AbstractPDFExtractor implements Extractor
     private void checkBankIdentifier(String filename, String text)
     {
         if (bankIdentifier.isEmpty())
-            bankIdentifier.add(getLabel());
+            return;
 
         for (String identifier : bankIdentifier)
             if (text.contains(identifier))

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
@@ -11,16 +11,16 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.money.CurrencyUnit;
 
+/**
+ * @implNote Bondora Capital does not have a specific bank identifier.
+ */
 @SuppressWarnings("nls")
 public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
 {
     public BondoraCapitalPDFExtractor(Client client)
     {
         super(client);
-
-        addBankIdentifier("Zusammenfassung");
-        addBankIdentifier("Summary");
-
+        
         addAccountStatementTransaction();
     }
 
@@ -32,7 +32,7 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
 
     private void addAccountStatementTransaction()
     {
-        final DocumentType type = new DocumentType("(Zusammenfassung|Summary)");
+        final DocumentType type = new DocumentType("^(Zusammenfassung|Summary)$");
         this.addDocumentTyp(type);
 
         Transaction<AccountTransaction> pdfTransaction = new Transaction<>();


### PR DESCRIPTION
Bondora Capital does not have a specific bank identifier.
To support the other error messages, we remove the requirement to have a bank identifier.