### PR TITLE
fix Fees in statement of assets chart

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/StatementOfAssetsSeriesBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/StatementOfAssetsSeriesBuilder.java
@@ -91,7 +91,7 @@ public class StatementOfAssetsSeriesBuilder extends AbstractChartSeriesBuilder
                                 Values.Amount.divider());
                 break;
             case FEES:
-                values = toDouble(add(clientIndex.getFees(), clientIndex.getInterest()), Values.Amount.divider());
+                values = toDouble(clientIndex.getFees(), Values.Amount.divider());
                 break;
             case FEES_ACCUMULATED:
                 values = accumulateAndToDouble(clientIndex.getFees(), Values.Amount.divider());


### PR DESCRIPTION
Unless I am missing something, the fee formula in statement of assert serie builder is wrong (included fee+_interest_), probably from a copy paste of the earnings formula just above.

The problem can be seen on the chart: "fee accumulated" is correct but inconsistent with "fees".
![Capture d'écran 2024-04-25 132229](https://github.com/portfolio-performance/portfolio/assets/160436107/4da7f77f-38f5-476d-900b-b855efb10c78)
