### PR TITLE
Securities Account chart with Invested Capital, Delta

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioBalanceChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioBalanceChart.java
@@ -1,0 +1,90 @@
+package name.abuchen.portfolio.ui.views;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.swt.widgets.Composite;
+import org.swtchart.ISeries;
+
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.Portfolio;
+import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.Transaction;
+import name.abuchen.portfolio.money.CurrencyConverter;
+import name.abuchen.portfolio.money.CurrencyConverterImpl;
+import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.snapshot.PortfolioSnapshot;
+import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.chart.TimelineChart;
+
+public class PortfolioBalanceChart extends TimelineChart // NOSONAR
+{
+    private Client client;
+
+    public PortfolioBalanceChart(Composite parent, Client client)
+    {
+        super(parent);
+        this.client = client;
+        getTitle().setVisible(false);
+    }
+
+    public void updateChart(Portfolio portfolio, ExchangeRateProviderFactory exchangeRateProviderFactory)
+    {
+        try
+        {
+            suspendUpdate(true);
+
+            for (ISeries s : getSeriesSet().getSeries())
+                getSeriesSet().deleteSeries(s.getId());
+
+            if (portfolio == null)
+                return;
+
+            List<PortfolioTransaction> tx = portfolio.getTransactions();
+
+            if (tx.isEmpty())
+                return;
+
+            Collections.sort(tx, Transaction.BY_DATE);
+
+            LocalDate now = LocalDate.now();
+            LocalDate start = tx.get(0).getDateTime().toLocalDate();
+            LocalDate end = tx.get(tx.size() - 1).getDateTime().toLocalDate();
+
+            CurrencyConverter converter = new CurrencyConverterImpl(exchangeRateProviderFactory,
+                            client.getBaseCurrency());
+
+            if (now.isAfter(end))
+                end = now;
+            if (now.isBefore(start))
+                start = now;
+
+            int days = (int) ChronoUnit.DAYS.between(start, end) + 2;
+
+            LocalDate[] dates = new LocalDate[days];
+            double[] values = new double[days];
+
+            dates[0] = start.minusDays(1);
+            values[0] = 0d;
+
+            for (int ii = 1; ii < dates.length; ii++)
+            {
+                values[ii] = PortfolioSnapshot.create(portfolio, converter, start) //
+                                .getValue().getAmount() / Values.Amount.divider();
+                dates[ii] = start;
+                start = start.plusDays(1);
+            }
+
+            addDateSeries(portfolio.getUUID(), dates, values, Colors.CASH, portfolio.getName());
+        }
+        finally
+        {
+            adjustRange();
+            suspendUpdate(false);
+        }
+    }
+
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioBalanceChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioBalanceChart.java
@@ -2,10 +2,20 @@ package name.abuchen.portfolio.ui.views;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.action.ToolBarManager;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.swtchart.ILegend;
+import org.swtchart.ILineSeries;
 import org.swtchart.ISeries;
 
 import name.abuchen.portfolio.model.Client;
@@ -16,22 +26,71 @@ import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyConverterImpl;
 import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
 import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.snapshot.PerformanceIndex;
 import name.abuchen.portfolio.snapshot.PortfolioSnapshot;
+import name.abuchen.portfolio.snapshot.filter.ReadOnlyClient;
+import name.abuchen.portfolio.ui.Images;
+import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.DropDown;
+import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.chart.TimelineChart;
+import name.abuchen.portfolio.util.Interval;
 
 public class PortfolioBalanceChart extends TimelineChart // NOSONAR
 {
+    private static final String PREF_KEY = "portfolio-chart-details"; //$NON-NLS-1$
+
     private Client client;
+    private Portfolio portfolio;
+    private ExchangeRateProviderFactory exchangeRateProviderFactory;
+
+    private int swtAntialias = SWT.ON;
+    private EnumSet<ChartDetails> chartConfig = EnumSet.of(ChartDetails.ABSOLUTE_INVESTED_CAPITAL,
+                    ChartDetails.ABSOLUTE_DELTA);
+
+    private static final Color colorAbsoluteInvestedCapital = Display.getDefault().getSystemColor(SWT.COLOR_GRAY);
+    private static final Color colorAbsoluteDelta = Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY);
+    private static final Color colorTaxesAccumulated = Display.getDefault().getSystemColor(SWT.COLOR_RED);
+    private static final Color colorFeesAccumulated = Display.getDefault().getSystemColor(SWT.COLOR_GRAY);
 
     public PortfolioBalanceChart(Composite parent, Client client)
     {
         super(parent);
         this.client = client;
+
         getTitle().setVisible(false);
+
+        readChartConfig(client);
+
+        ILegend legend = getLegend();
+        legend.setPosition(SWT.BOTTOM);
+        legend.setVisible(true);
+        redraw();
+    }
+
+    private final void readChartConfig(Client client)
+    {
+        String pref = ReadOnlyClient.unwrap(client).getProperty(PREF_KEY);
+        if (pref == null)
+            return;
+
+        chartConfig.clear();
+        for (String key : pref.split(",")) //$NON-NLS-1$
+        {
+            chartConfig.add(ChartDetails.valueOf(key));
+        }
     }
 
     public void updateChart(Portfolio portfolio, ExchangeRateProviderFactory exchangeRateProviderFactory)
+    {
+        this.portfolio = portfolio;
+        this.exchangeRateProviderFactory = exchangeRateProviderFactory;
+        getTitle().setText(portfolio.getName());
+        updateChart();
+    }
+
+    public void updateChart()
     {
         try
         {
@@ -64,6 +123,10 @@ public class PortfolioBalanceChart extends TimelineChart // NOSONAR
 
             int days = (int) ChronoUnit.DAYS.between(start, end) + 2;
 
+            // Disable SWT antialias for more than 1000 records due to SWT
+            // performance issue in Drawing
+            swtAntialias = days > 1000 ? SWT.OFF : SWT.ON;
+
             LocalDate[] dates = new LocalDate[days];
             double[] values = new double[days];
 
@@ -78,8 +141,12 @@ public class PortfolioBalanceChart extends TimelineChart // NOSONAR
                 start = start.plusDays(1);
             }
 
-            addDateSeries(portfolio.getUUID(), dates, values, Colors.CASH, portfolio.getName());
+            ILineSeries lineSeries = addDateSeries(portfolio.getUUID(), dates, values, Colors.CASH,
+                            portfolio.getName());
+            lineSeries.setAntialias(swtAntialias);
+            addChartCommon(dates, converter);
         }
+
         finally
         {
             adjustRange();
@@ -87,4 +154,146 @@ public class PortfolioBalanceChart extends TimelineChart // NOSONAR
         }
     }
 
+    public void addButtons(ToolBarManager toolBar)
+    {
+        toolBar.add(new DropDown(Messages.MenuConfigureChart, Images.CONFIG, SWT.NONE, this::chartConfigAboutToShow));
+    }
+
+    public void chartConfigAboutToShow(IMenuManager manager)
+    {
+        manager.add(addMenuAction(ChartDetails.ABSOLUTE_INVESTED_CAPITAL));
+        manager.add(addMenuAction(ChartDetails.ABSOLUTE_DELTA));
+        manager.add(addMenuAction(ChartDetails.TAXES_ACCUMULATED));
+        manager.add(addMenuAction(ChartDetails.FEES_ACCUMULATED));
+    }
+
+    private Action addMenuAction(ChartDetails detail)
+    {
+        Action action = new SimpleAction(detail.toString(), a -> {
+            boolean isActive = chartConfig.contains(detail);
+
+            if (isActive)
+                chartConfig.remove(detail);
+            else
+                chartConfig.add(detail);
+
+            ReadOnlyClient.unwrap(client).setProperty(PREF_KEY, String.join(",", //$NON-NLS-1$
+                            chartConfig.stream().map(ChartDetails::name).toList()));
+
+            updateChart();
+
+        });
+
+        action.setChecked(chartConfig.contains(detail));
+        return action;
+    }
+
+    private void addChartCommon(LocalDate[] dates, CurrencyConverter converter)
+    {
+        if (chartConfig.contains(ChartDetails.ABSOLUTE_INVESTED_CAPITAL))
+            addAbsoluteInvestedCapital(dates, converter);
+
+        if (chartConfig.contains(ChartDetails.ABSOLUTE_DELTA))
+            addAbsoluteDeltaAllRecords(dates, converter);
+
+        if (chartConfig.contains(ChartDetails.TAXES_ACCUMULATED))
+            addTaxes(dates, converter);
+
+        if (chartConfig.contains(ChartDetails.FEES_ACCUMULATED))
+            addFees(dates, converter);
+    }
+
+    private void addAbsoluteInvestedCapital(LocalDate[] dates, CurrencyConverter converter)
+    {
+        List<Exception> warnings = new ArrayList<>();
+        PerformanceIndex index = PerformanceIndex.forPortfolio(client, converter, portfolio,
+                        Interval.of(dates[0], dates[dates.length - 1]), warnings);
+        double[] values;
+        values = toDouble(index.calculateAbsoluteInvestedCapital(), Values.Amount.divider());
+        String lineID = Messages.LabelAbsoluteInvestedCapital;
+
+        ILineSeries lineSeries = addDateSeries(lineID, dates, values, colorAbsoluteInvestedCapital, lineID); // $NON-NLS-1$
+        lineSeries.enableArea(true);
+        lineSeries.setAntialias(swtAntialias);
+    }
+
+    private void addAbsoluteDeltaAllRecords(LocalDate[] dates, CurrencyConverter converter)
+    {
+        List<Exception> warnings = new ArrayList<>();
+        PerformanceIndex index = PerformanceIndex.forPortfolio(client, converter, portfolio,
+                        Interval.of(dates[0], dates[dates.length - 1]), warnings);
+        double[] values;
+        values = toDouble(index.calculateAbsoluteDelta(), Values.Amount.divider());
+        String lineID = Messages.LabelAbsoluteDelta;
+
+        ILineSeries lineSeries = addDateSeries(lineID, dates, values, colorAbsoluteDelta, lineID); // $NON-NLS-1$
+        lineSeries.setAntialias(swtAntialias);
+    }
+
+    private void addTaxes(LocalDate[] dates, CurrencyConverter converter)
+    {
+        List<Exception> warnings = new ArrayList<>();
+        PerformanceIndex index = PerformanceIndex.forPortfolio(client, converter, portfolio,
+                        Interval.of(dates[0], dates[dates.length - 1]), warnings);
+        double[] values;
+        values = accumulateAndToDouble(index.getTaxes(), Values.Amount.divider());
+        String lineID = Messages.LabelAccumulatedTaxes;
+
+        ILineSeries lineSeries = addDateSeries(lineID, dates, values, colorTaxesAccumulated, lineID); // $NON-NLS-1$
+        lineSeries.setAntialias(swtAntialias);
+    }
+
+    private void addFees(LocalDate[] dates, CurrencyConverter converter)
+    {
+        List<Exception> warnings = new ArrayList<>();
+        PerformanceIndex index = PerformanceIndex.forPortfolio(client, converter, portfolio,
+                        Interval.of(dates[0], dates[dates.length - 1]), warnings);
+        double[] values;
+        values = accumulateAndToDouble(index.getFees(), Values.Amount.divider());
+        String lineID = Messages.LabelFeesAccumulated;
+
+        ILineSeries lineSeries = addDateSeries(lineID, dates, values, colorFeesAccumulated, lineID); // $NON-NLS-1$
+        lineSeries.setAntialias(swtAntialias);
+    }
+
+    private double[] toDouble(long[] input, double divider)
+    {
+        double[] answer = new double[input.length];
+        for (int ii = 0; ii < answer.length; ii++)
+            answer[ii] = input[ii] / divider;
+        return answer;
+    }
+
+    private double[] accumulateAndToDouble(long[] input, double divider)
+    {
+        double[] answer = new double[input.length];
+        long current = 0;
+        for (int ii = 0; ii < answer.length; ii++)
+        {
+            current += input[ii];
+            answer[ii] = current / divider;
+        }
+        return answer;
+    }
+
+    private enum ChartDetails
+    {
+        ABSOLUTE_INVESTED_CAPITAL(Messages.LabelAbsoluteInvestedCapital), //
+        ABSOLUTE_DELTA(Messages.LabelAbsoluteDelta), //
+        TAXES_ACCUMULATED(Messages.LabelAccumulatedTaxes), //
+        FEES_ACCUMULATED(Messages.LabelFeesAccumulated);
+
+        private final String label;
+
+        private ChartDetails(String label)
+        {
+            this.label = label;
+        }
+
+        @Override
+        public String toString()
+        {
+            return label;
+        }
+    }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioListView.java
@@ -53,6 +53,7 @@ import name.abuchen.portfolio.ui.views.columns.NameColumn;
 import name.abuchen.portfolio.ui.views.columns.NameColumn.NameColumnLabelProvider;
 import name.abuchen.portfolio.ui.views.columns.NoteColumn;
 import name.abuchen.portfolio.ui.views.panes.InformationPanePage;
+import name.abuchen.portfolio.ui.views.panes.PortfolioBalancePane;
 import name.abuchen.portfolio.ui.views.panes.StatementOfAssetsPane;
 import name.abuchen.portfolio.ui.views.panes.TransactionsPane;
 
@@ -348,5 +349,6 @@ public class PortfolioListView extends AbstractFinanceView implements Modificati
         super.addPanePages(pages);
         pages.add(make(StatementOfAssetsPane.class));
         pages.add(make(TransactionsPane.class));
+        pages.add(make(PortfolioBalancePane.class));
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/PortfolioBalancePane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/PortfolioBalancePane.java
@@ -6,6 +6,7 @@ import jakarta.inject.Named;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.ui.di.UIEventTopic;
 import org.eclipse.e4.ui.services.IStylingEngine;
+import org.eclipse.jface.action.ToolBarManager;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
@@ -75,4 +76,9 @@ public class PortfolioBalancePane implements InformationPanePage
             setInput(portfolio);
     }
 
+    @Override
+    public void addButtons(ToolBarManager toolBar)
+    {
+        chart.addButtons(toolBar);
+    }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/PortfolioBalancePane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/PortfolioBalancePane.java
@@ -1,0 +1,78 @@
+package name.abuchen.portfolio.ui.views.panes;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import org.eclipse.e4.core.di.annotations.Optional;
+import org.eclipse.e4.ui.di.UIEventTopic;
+import org.eclipse.e4.ui.services.IStylingEngine;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+
+import name.abuchen.portfolio.model.Adaptor;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.Portfolio;
+import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.UIConstants;
+import name.abuchen.portfolio.ui.util.format.AmountNumberFormat;
+import name.abuchen.portfolio.ui.util.format.ThousandsNumberFormat;
+import name.abuchen.portfolio.ui.views.PortfolioBalanceChart;
+
+public class PortfolioBalancePane implements InformationPanePage
+{
+
+    @Inject
+    @Named(UIConstants.Context.ACTIVE_CLIENT)
+    private Client client;
+
+    @Inject
+    private IStylingEngine stylingEngine;
+
+    @Inject
+    private ExchangeRateProviderFactory factory;
+
+    private Portfolio portfolio;
+    private PortfolioBalanceChart chart;
+
+    @Inject
+    @Optional
+    public void onDiscreedModeChanged(@UIEventTopic(UIConstants.Event.Global.DISCREET_MODE) Object obj)
+    {
+        if (chart != null)
+            chart.redraw();
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return Messages.TabAccountBalanceChart;
+    }
+
+    @Override
+    public Control createViewControl(Composite parent)
+    {
+        chart = new PortfolioBalanceChart(parent, client);
+        stylingEngine.style(chart);
+
+        chart.getAxisSet().getYAxis(0).getTick().setFormat(new ThousandsNumberFormat());
+        chart.getToolTip().setDefaultValueFormat(new AmountNumberFormat());
+
+        return chart;
+    }
+
+    @Override
+    public void setInput(Object input)
+    {
+        portfolio = Adaptor.adapt(Portfolio.class, input);
+        chart.updateChart(portfolio, factory);
+    }
+
+    @Override
+    public void onRecalculationNeeded()
+    {
+        if (portfolio != null)
+            setInput(portfolio);
+    }
+
+}


### PR DESCRIPTION
Hello,

**Proposition**:
In the same way than Deposit Accounts have a pane with an Account Balance Chart, this PR is proposing to add a Securities Account Balance Chart (first commit).
Actually, the real goal is also to associate to those Portfolio Charts the Invested Capital and Delta metrics (+accumulated Taxes and Fees and more if relevant) that a lot of users are looking for (second commit).

It is limited in scope compared to https://github.com/portfolio-performance/portfolio/pull/3754 which should be the general correct solution for those common metrics, but I think here the implementation is avoiding the "multiselection" and UI questions of https://github.com/portfolio-performance/portfolio/pull/3754. 
The metrics are here associated to a Portfolio only (no association to Taxonomy, Custom Filter Portfolio+Cash account etc) but I think this is nevertheless already providing some useful data.

**Implementation** : similar to the `AccountBalancePane`,  `AccountBalanceChart` and to the `SecuritiesChart`.
Caveat: by using a similar structure than `SecuritiesChart`, the plotted data series are **not** customisable (color, area vs line, linestyle etc). 
I mostly used the color defined in `DataSeriesSet` but "less gray" colors could be used.

**Results** : 
Example from kommer file:
![Capture d'écran 2024-04-30 002018](https://github.com/portfolio-performance/portfolio/assets/160436107/04f585af-7384-4202-8437-03d4b81115ac)
![Capture d'écran 2024-04-30 002116](https://github.com/portfolio-performance/portfolio/assets/160436107/f8fae12c-fa78-4cb8-a093-c1abbbba3a96)
custom account
![Capture d'écran 2024-04-30 011020](https://github.com/portfolio-performance/portfolio/assets/160436107/d5200d3e-d266-4767-a9f2-93a65f9a7c7d)

**Bug** : this PR is in Draft as there is at least one bug that I did not manage to fix. When the graph pane is selected from the Statement of Assets or Transactions panes of a Securities Account, the chart is somehow too big for the plotted data :
![Capture d'écran 2024-04-30 002145](https://github.com/portfolio-performance/portfolio/assets/160436107/0016363f-4b74-46db-b9ac-5e74719d0fc8)
It updates correctly when changing the metric in the chart menu or when switching between Securities Account.
If someones has an idea on this bug or a feedback, it is much welcome. 
 
(Other ideas in case of next steps:  in the same way, Earnings/Interests could be added to the `AccountBalanceChart`, Delta could be a bicolor positive/negative area as is in the `SecuritiesChart`, "account events" may be added in those charts.)