### PR TITLE
fix two-digits day dates

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/directasim/Buy03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/directasim/Buy03.txt
@@ -1,0 +1,32 @@
+```
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.68.3
+-----------------------------------------
+Signor
+jkStRODK SosCGeIjaaXA
+Xgc ScO zPRGXAAvt 13b
+94912 VEWrGy
+Italia
+Conto k7597
+Nota Informativa per l'ordine P9417565891845
+Vi Confermiamo il Vs. ordine sopra riportato del 12.04.2024 Data scadenza 10.04.2025
+per l'acquisto di: 7 VANGUARD FTSE ALL-WORLD UCITS ISIN IE00BK5BQT80
+Scadenza 00/00/0000
+eseguito per: 7
+tramite l'intermediario DIRECTA SIM.p.A.
+Tipo di Operazione: Acquisto     Mercato di esecuzione: Borsa - Euronext Milan
+Modalità di liquidazione:  Per consegna e pagamento in contanti
+                                                  Quantita'                 Euro               Prezzo      Valuta
+12.04.2024  09:03:49  Richiesta Immissione                7                                  118,5000
+12.04.2024  09:03:49  Inoltro
+12.04.2024  09:03:49  In negoziazione
+12.04.2024  09:04:21  Eseguito                            7               829,15             118,4500  16.04.2024
+                      Controvalore:                                       829,15             118,4500
+                      Commissioni:
+                      Ritenuta:
+                      Totale a Vs. Debito                                 829,15
+Gli effetti fiscali saranno disponibili a data valuta nel menu Info -  2b.Capital Gain
+Torino, 12.04.2024
+       DIRECTA SIM
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/directasim/DirectaSimPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/directasim/DirectaSimPDFExtractorTest.java
@@ -99,4 +99,36 @@ public class DirectaSimPDFExtractorTest
                         hasAmount("EUR", 1511.58), hasGrossValue("EUR", 1502.08), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 9.50))));
     }
+
+    @Test
+    public void testSecurityBuy03()
+    {
+        DirectaSimPDFExtractor extractor = new DirectaSimPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Buy03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00BK5BQT80"), hasWkn(null), hasTicker(null), //
+                        hasName("VANGUARD FTSE ALL-WORLD UCITS"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2024-04-12T09:04:21"), hasShares(7), //
+                        hasSource("Buy03.txt"), //
+                        hasNote("Ordine P9417565891845"), //
+                        hasAmount("EUR", 829.15), hasGrossValue("EUR", 829.15), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+    }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DirectaSimPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DirectaSimPDFExtractor.java
@@ -77,7 +77,7 @@ public class DirectaSimPDFExtractor extends AbstractPDFExtractor
                         //  5.01.2024  14:02:36  Eseguito                           29             3.074,29             106,0100  09.01.2024
                         // @formatter:on
                         .section("date", "time") //
-                        .match("^.*(?<date>[\\d]{1,2}\\.[\\d]{2}\\.[\\d]{4})[\\s]{1,}(?<time>[\\d]{2}\\:[\\d]{2}\\:[\\d]{2})[\\s]{1,}Eseguito.*$") //
+                        .match("^(\\s)*(?<date>[\\d]{1,2}\\.[\\d]{2}\\.[\\d]{4})[\\s]{1,}(?<time>[\\d]{2}\\:[\\d]{2}\\:[\\d]{2})[\\s]{1,}Eseguito.*$") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
 
                         // @formatter:off


### PR DESCRIPTION
The current version of the importer detected the date wrongly, if the day only contained a single digit.