### PR TITLE
clean some save chart behavior

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
@@ -252,6 +252,7 @@ import name.abuchen.portfolio.util.TextUtil;
                             chart.suspendUpdate(true);
                             chart.getTitle().setVisible(isChartTitleVisible);
                             chart.getLegend().setVisible(isChartLegendVisible);
+                            chart.redraw();
                             chart.suspendUpdate(false);
                         }
                     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountBalanceChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountBalanceChart.java
@@ -39,6 +39,7 @@ public class AccountBalanceChart extends TimelineChart // NOSONAR
 
             if (account == null)
                 return;
+            getTitle().setText(account.getName());
 
             List<AccountTransaction> tx = account.getTransactions();
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractStackedChartViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractStackedChartViewer.java
@@ -124,6 +124,7 @@ public abstract class AbstractStackedChartViewer extends AbstractChartPage imple
 
         chart = new StackedTimelineChart(composite, getDates());
         chart.getTitle().setVisible(false);
+        chart.getTitle().setText(getModel().getTaxonomy().getName());
 
         chart.getLegend().setPosition(SWT.BOTTOM);
         chart.getLegend().setVisible(true);


### PR DESCRIPTION
First commit : add missing title to chart 

Even if charts titles are hidden, they appear when saving the charts.
For Deposit account balance chart and Taxonomy stacked charts, no title was provided. 
So, when exporting those charts, a default "Chart Title" was used as title and default filename, while for all other charts, a correct title is provided.


Second commit : 

Closes https://github.com/portfolio-performance/portfolio/issues/3972 
Fix the chart appearance just after saving it. fix looks ok on my Windows.

(should this have been two separate PR ?)
