### PR TITLE
fix security heading label in SecurityDetailsViewer

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityDetailsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityDetailsViewer.java
@@ -85,7 +85,7 @@ public class SecurityDetailsViewer
         {
             Composite composite = new Composite(parent, SWT.NONE);
 
-            Label heading = createHeading(composite, Messages.ClientEditorLabelClientMasterData);
+            Label heading = createHeading(composite, Messages.ColumnSecurity);
 
             valueName = new Label(composite, SWT.NONE);
             valueISIN = new Label(composite, SWT.NONE);


### PR DESCRIPTION
Translators in Poeditor noticed that the label _ClientEditorLabelClientMasterData_ is used at two different locations for different meaning. 
![securitydetailslabel](https://github.com/portfolio-performance/portfolio/assets/160436107/8795bf8e-ef53-43f1-ab4b-0ca3d67e3921)
-> fixed for "Security". 

Translators were actually considering using "Security Master Data", in which case a new Messages label should be created, but I think "Security" is good and simple, and stay consistent with the other headings of `SecurityDetailsViewer` which are also using "Column" labels. and "Security Master Data" is already used with a slight different meaning the Security wizard.
But I can create a new Messages label if it is considered a better fix.