### PR TITLE
PerformanceView: show a disabled version of a security's logo if there are no holdings to prevent user confusion

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Images.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Images.java
@@ -12,6 +12,8 @@ import org.eclipse.swt.graphics.Image;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
+import name.abuchen.portfolio.model.ImageManager;
+
 @SuppressWarnings("restriction")
 public enum Images
 {
@@ -138,15 +140,24 @@ public enum Images
         this.file = file;
     }
 
-    public static Image resolve(String file)
+    public static Image resolve(String file, boolean disabled)
     {
-        Image image = imageRegistry.get(file);
-        if (image == null)
+        String key = file + ":" + disabled; //$NON-NLS-1$
+        Image image = imageRegistry.get(key);
+        if (image != null)
         {
-            descriptor(file); // lazy loading
-            image = imageRegistry.get(file);
+            return image; //
         }
+        ImageDescriptor desc = descriptor(file); // lazy loading
+        image = imageRegistry.get(file);
+        if (!disabled)
+        {
+            return image; //
+        }
+        image = ImageManager.getDisabledVersion(image);
+        imageRegistry.put(key, image); // $NON-NLS-1$
         return image;
+
     }
 
     private static ImageDescriptor descriptor(String file)
@@ -170,7 +181,12 @@ public enum Images
 
     public Image image()
     {
-        return resolve(file);
+        return image(false);
+    }
+
+    public Image image(boolean disabled)
+    {
+        return resolve(file, disabled);
     }
 
     public String getImageURI()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/parts/WelcomePart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/parts/WelcomePart.java
@@ -189,7 +189,7 @@ public class WelcomePart
         var qrcode = new ImageHyperlink(section, SWT.NONE);
         qrcode.setImage(Images.resolve(MessageFormat.format("qr/app_{0}_{1}.png", //$NON-NLS-1$
                         isGerman ? "de" : "en", //$NON-NLS-1$ //$NON-NLS-2$
-                        isDark ? "dark" : "light"))); //$NON-NLS-1$ //$NON-NLS-2$
+                        isDark ? "dark" : "light"), false)); //$NON-NLS-1$ //$NON-NLS-2$
 
         qrcode.addHyperlinkListener(
                         IHyperlinkListener.linkActivatedAdapter(e -> linkActivated(Messages.SiteAppLandingpage)));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/LogoManager.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/LogoManager.java
@@ -30,7 +30,12 @@ public final class LogoManager
 
     public Image getDefaultColumnImage(Object object, ClientSettings settings)
     {
-        Image logo = getLogoImage(object, settings);
+        return getDefaultColumnImage(object, settings, false);
+    }
+
+    public Image getDefaultColumnImage(Object object, ClientSettings settings, boolean disabled)
+    {
+        Image logo = getLogoImage(object, settings, disabled);
         return logo != null ? logo : getFallbackColumnImage(object);
     }
 
@@ -61,12 +66,12 @@ public final class LogoManager
         object.getAttributes().remove(logoAttr.get());
     }
 
-    private Image getLogoImage(Object object, ClientSettings settings)
+    private Image getLogoImage(Object object, ClientSettings settings, boolean disabled)
     {
         if (object instanceof Attributable target)
         {
             Optional<AttributeType> logoAttr = settings.getOptionalLogoAttributeType(target.getClass());
-            return logoAttr.isPresent() ? ImageManager.instance().getImage(target, logoAttr.get()) : null;
+            return logoAttr.isPresent() ? ImageManager.instance().getImage(target, logoAttr.get(), disabled) : null;
         }
         return null;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/LogoManager.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/LogoManager.java
@@ -36,7 +36,7 @@ public final class LogoManager
     public Image getDefaultColumnImage(Object object, ClientSettings settings, boolean disabled)
     {
         Image logo = getLogoImage(object, settings, disabled);
-        return logo != null ? logo : getFallbackColumnImage(object);
+        return logo != null ? logo : getFallbackColumnImage(object, disabled);
     }
 
     public boolean hasCustomLogo(Attributable object, ClientSettings settings)
@@ -76,18 +76,18 @@ public final class LogoManager
         return null;
     }
 
-    private Image getFallbackColumnImage(Object object)
+    private Image getFallbackColumnImage(Object object, boolean disabled)
     {
         if (object instanceof Account)
-            return Images.ACCOUNT.image();
+            return Images.ACCOUNT.image(disabled);
         else if (object instanceof Security security)
-            return security.isRetired() ? Images.SECURITY_RETIRED.image() : Images.SECURITY.image();
+            return security.isRetired() ? Images.SECURITY_RETIRED.image() : Images.SECURITY.image(disabled);
         else if (object instanceof Portfolio)
-            return Images.PORTFOLIO.image();
+            return Images.PORTFOLIO.image(disabled);
         else if (object instanceof InvestmentPlan)
-            return Images.INVESTMENTPLAN.image();
+            return Images.INVESTMENTPLAN.image(disabled);
         else if (object instanceof Classification)
-            return Images.CATEGORY.image();
+            return Images.CATEGORY.image(disabled);
         else
             return null;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
@@ -274,9 +274,8 @@ public class PerformanceView extends AbstractHistoricView
                         boolean hasHoldings = snapshot.getEndClientSnapshot().getPositionsByVehicle()
                                         .get(security) != null;
 
-                        if (hasHoldings)
-                            return LogoManager.instance().getDefaultColumnImage(security, getClient().getSettings());
-                        return Images.SECURITY_RETIRED.image();
+                        return LogoManager.instance().getDefaultColumnImage(security, getClient().getSettings(),
+                                        !hasHoldings);
                     }
                     else
                     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ImageManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ImageManager.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.model;
 
 import java.util.HashMap;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 
 import name.abuchen.portfolio.model.AttributeType.ImageConverter;
@@ -29,7 +30,18 @@ public final class ImageManager // NOSONAR
      */
     public Image getImage(Attributable target, AttributeType attr)
     {
-        return getImage(target, attr, 16, 16);
+        return getImage(target, attr, false);
+    }
+
+    /**
+     * Retrieves an image associated with the given Attributable and
+     * AttributeType. If not found, a default image is returned.
+     *
+     * @return The retrieved image or null if not found.
+     */
+    public Image getImage(Attributable target, AttributeType attr, boolean disabled)
+    {
+        return getImage(target, attr, 16, 16, disabled);
     }
 
     /**
@@ -40,6 +52,17 @@ public final class ImageManager // NOSONAR
      */
     public Image getImage(Attributable target, AttributeType attr, int width, int height)
     {
+        return getImage(target, attr, width, height, false);
+    }
+
+    /**
+     * Retrieves an image associated with the given Attributable, AttributeType,
+     * and additional parameters. If not found, a default image is returned.
+     *
+     * @return The retrieved image or null if not found.
+     */
+    public Image getImage(Attributable target, AttributeType attr, int width, int height, boolean disabled)
+    {
         if (target != null && target.getAttributes().exists(attr) && attr.getConverter() instanceof ImageConverter)
         {
             Object imgObject = target.getAttributes().get(attr);
@@ -47,7 +70,7 @@ public final class ImageManager // NOSONAR
                 return null;
 
             String imgString = String.valueOf(imgObject);
-            String imgKey = imgString + width + height;
+            String imgKey = imgString + width + height + disabled;
             synchronized (imageCache)
             {
                 Image img = imageCache.getOrDefault(imgKey, null);
@@ -55,11 +78,15 @@ public final class ImageManager // NOSONAR
                     return img;
 
                 img = ImageUtil.instance().toImage(imgString, width, height);
-                if (img != null)
+                if (img == null)
+                    return null;
+
+                if (disabled)
                 {
-                    imageCache.put(imgKey, img);
-                    return img;
+                    img = new Image(null, img, SWT.IMAGE_DISABLE);
                 }
+                imageCache.put(imgKey, img);
+                return img;
             }
         }
         return null;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ImageManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ImageManager.java
@@ -83,12 +83,17 @@ public final class ImageManager // NOSONAR
 
                 if (disabled)
                 {
-                    img = new Image(null, img, SWT.IMAGE_DISABLE);
+                    img = getDisabledVersion(img);
                 }
                 imageCache.put(imgKey, img);
                 return img;
             }
         }
         return null;
+    }
+
+    public static Image getDisabledVersion(Image img)
+    {
+        return new Image(null, img, SWT.IMAGE_DISABLE);
     }
 }


### PR DESCRIPTION
When going to the performance view (Performance->Calculation) entries of securities that have a quantity of zero are currently presented with the generic logo of an inactive entry even if there is a configured logo. That confuses me but I'm not [alone](https://forum.portfolio-performance.info/t/logo-fehlt-in-performanceberechnung-bei-bestand-0/10321).

I've extended the ImageManager to provide disabled versions of an image and use that in PerformanceView to keep the actual logo showing up while it still allows to distinguish between "has holdings" and "has no holdings".