### PR TITLE
allows benchmark selection in IRR widget

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
@@ -69,7 +69,6 @@ public enum WidgetFactory
                     (widget, data) -> IndicatorWidget.<Double>create(widget, data) //
                                     .with(Values.AnnualizedPercent2) //
                                     .with((ds, period) -> data.calculate(ds, period).getPerformanceIRR()) //
-                                    .withBenchmarkDataSeries(false) //
                                     .build()),
 
     ABSOLUTE_CHANGE(Messages.LabelAbsoluteChange, Messages.LabelStatementOfAssets, //


### PR DESCRIPTION
Issue : https://forum.portfolio-performance.info/t/irr-of-benchmark-is-always-calculated-as-0/28284/9

Proposition to allow the IRR widget to accept a benchmark selection. 
The IRR of a benchmark is relevant and defined, isn't it ? Benchmark's IRR are already available in the Return/Vol chart.