### PR TITLE
Add portfolio filter in Trades view

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
@@ -249,7 +249,8 @@ public class TradeDetailsView extends AbstractFinanceView
                 String[] properties = new String[] { security.getName(), //
                                 security.getIsin(), //
                                 security.getTickerSymbol(), //
-                                security.getWkn() //
+                                security.getWkn(), //
+                                trade.getPortfolio().getName()
                 };
 
                 for (String property : properties)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
@@ -136,7 +136,9 @@ public class TradeDetailsView extends AbstractFinanceView
 
     private MutableBoolean onlyProfitable = new MutableBoolean(false);
     private MutableBoolean onlyLossMaking = new MutableBoolean(false);
+
     private boolean isOn;
+
     private Pattern filterPattern;
     private ClientFilter clientFilter;
 
@@ -384,9 +386,6 @@ public class TradeDetailsView extends AbstractFinanceView
 
             clientFilterMenu.trackSelectedFilterConfigurationKey(TradeDetailsView.class.getSimpleName());
             clientFilter = clientFilterMenu.getSelectedFilter();
-
-            if (!isOn && !clientFilterMenu.hasActiveFilter())
-                setImage(Images.FILTER_OFF);
 
             if (isOn || clientFilterMenu.hasActiveFilter())
                 setImage(Images.FILTER_ON);


### PR DESCRIPTION
Closes https://github.com/portfolio-performance/portfolio/issues/1597 (except the Filter by date range (applied on the Close Date)..)
Issue: https://forum.portfolio-performance.info/t/weitere-filter-bei-trades-unter-dem-reiter-berichte-fur-einzelne-depots/21955
Issue: https://forum.portfolio-performance.info/t/trades-filtern/18171
Issue: https://forum.portfolio-performance.info/t/trades-nach-offen-vs-geschlossen-filtern/11208/5, fifth post

Hello this is a proposition to add to the Trades view a filter by account, in addition to the onlyOpen/onlyClose/onlyProfitable/onlyLoss already existing filtering options.

I have also added in the search box the possibility to search in the Portfolio column (second commit).

(I am thinking a little change to the `clientFilterMenu`, allowing to give the possibility to **only** fetch Portfolio account and custom filter account (instead of  fetching Portfolio account + (Portfolio +Deposit account) +custom filter account) may be good, .
I do not see the value of a (Portfolio + Deposit account) filter here for example, since, if I am not mistaken, it is the same filter as the Portfolio account only. Same for the `SecuritiesPerformanceView` (which is the reference for this commit's code). So the Portfolio +Deposit account takes a lot of place in the menu for nothing in those two views.
![tradefilter](https://github.com/portfolio-performance/portfolio/assets/160436107/e81fe1ac-c9a0-4d7a-8253-673c7f12948b)
)