### PR TITLE
fix start date of Portfolio chart

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioBalanceChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioBalanceChart.java
@@ -6,6 +6,7 @@ import static name.abuchen.portfolio.util.ArraysUtil.toDouble;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -29,6 +30,7 @@ import com.google.common.base.Objects;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyConverterImpl;
 import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
@@ -146,6 +148,8 @@ public class PortfolioBalanceChart extends TimelineChart // NOSONAR
 
         if (tx.isEmpty())
             return;
+
+        Collections.sort(tx, Transaction.BY_DATE);
 
         LocalDate now = LocalDate.now();
         LocalDate start = tx.get(0).getDateTime().toLocalDate();


### PR DESCRIPTION
as portfolio.getTransactions is not sorted by default Issue : https://github.com/portfolio-performance/portfolio/pull/3969

Hello, in the newly added Portfolio chart, if the transactions are not sorted we can have cases where the `start` date of the chart is incorrect. As mentionned in issue 3969 [comment](https://github.com/portfolio-performance/portfolio/pull/3969#issuecomment-2103552797), I have a case where a transfert of security is the first transaction returned (setting `start` date to this transfert date) while not being the oldest transaction of the Securities Account.