### PR TITLE
modified the trade republic importer to take the booking date instead of document creation date

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -4848,7 +4848,7 @@ public class TradeRepublicPDFExtractorTest
 
         // check interest transaction
         assertThat(results, hasItem(interest( //
-                        hasDate("2023-01-31T00:00"), //
+                        hasDate("2023-02-01T00:00"), //
                         hasSource("Zinsabrechnung01.txt"), //
                         hasNote("2,00%"), //
                         hasAmount("EUR", 0.88), hasGrossValue("EUR", 0.88), //
@@ -4874,7 +4874,7 @@ public class TradeRepublicPDFExtractorTest
 
         // check interest transaction
         assertThat(results, hasItem(interest( //
-                        hasDate("2023-01-31T00:00"), //
+                        hasDate("2023-02-01T00:00"), //
                         hasSource("Zinsabrechnung02.txt"), //
                         hasNote("2,00%"), //
                         hasAmount("EUR", 2.58), hasGrossValue("EUR", 2.58), //
@@ -4900,7 +4900,7 @@ public class TradeRepublicPDFExtractorTest
 
         // check interest transaction
         assertThat(results, hasItem(interest( //
-                        hasDate("2023-10-31T00:00"), //
+                        hasDate("2023-11-01T00:00"), //
                         hasSource("Zinsabrechnung03.txt"), //
                         hasNote("01.10.2023 - 31.10.2023 (4,00%)"), //
                         hasAmount("EUR", 112.40), hasGrossValue("EUR", 152.67), //
@@ -4927,7 +4927,7 @@ public class TradeRepublicPDFExtractorTest
 
         // check interest transaction
         assertThat(results, hasItem(interest( //
-                        hasDate("2023-05-31"), //
+                        hasDate("2023-06-01"), //
                         hasSource("RescontoInteressiMaturati01.txt"), //
                         hasNote("2,00%"), //
                         hasAmount("EUR", 0.12), hasGrossValue("EUR", 0.12), //
@@ -4954,7 +4954,7 @@ public class TradeRepublicPDFExtractorTest
 
         // check interest transaction
         assertThat(results, hasItem(interest( //
-                        hasDate("2023-09-30"), //
+                        hasDate("2023-10-02"), //
                         hasSource("InterestInvoice01.txt"), //
                         hasNote("2,00%"), //
                         hasAmount("EUR", 1.47), hasGrossValue("EUR", 1.47), //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -1801,15 +1801,6 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                         })
 
                         // @formatter:off
-                        // zum 31.01.2023
-                        // alla data 31.05.2023
-                        // as of 30.09.2023
-                        // @formatter:on
-                        .section("date") //
-                        .match("^(zum|alla data|as of) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$") //
-                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
-
-                        // @formatter:off
                         // IBAN BUCHUNGSDATUM GUTSCHRIFT NACH STEUERN
                         // DE10123456789123456789 01.02.2023 0,88 EUR
                         //
@@ -1819,10 +1810,11 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                         // IBAN BOOKING DATE TOTAL
                         // DE27502109007011534672 02.10.2023 1,47 EUR
                         // @formatter:on
-                        .section("currency", "amount") //
+                        .section("date", "amount", "currency") //
                         .find("IBAN (BUCHUNGSDATUM|DATA EMISSIONE|BOOKING DATE) (GUTSCHRIFT NACH STEUERN|TOTALE|TOTAL)") //
-                        .match("^.* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
+                        .match("^.* (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
                         .assign((t, v) -> {
+                            t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                         })


### PR DESCRIPTION
Hi,
I had the effect, when importing account statements that the interest bookings shown up two times.
One caused from the interest statement and the other one from account statement.

My proposal would enable that the interest bookings from account statement will automatically be marked as already present and skipped.

Reference: #3981

BR Christian