### PR TITLE
Update config for Launch Configuration DSL plug in

### DIFF
--- a/portfolio-app/eclipse/launches.lc
+++ b/portfolio-app/eclipse/launches.lc
@@ -28,13 +28,15 @@ eclipse configuration PortfolioPerformance {
 	ignore org.junit;
 	ignore org.hamcrest.core;
 	ignore org.hamcrest.library;
-	
-    memory min=512M max=1G;
     
     execution-environment 'JavaSE-17';
     
     argument "-consoleLog";
     
+    vm-argument "-Xms2G";
+    vm-argument "-Xmx6G";
+    vm-argument "-Xss320k";
+
     vm-argument "-XX:+IgnoreUnrecognizedVMOptions";
     vm-argument "--add-modules=ALL-SYSTEM";
     vm-argument "-XX:+UseG1GC";


### PR DESCRIPTION
Updating the memory usage when loading.

See PP-Forum:
https://forum.portfolio-performance.info/t/pp-wird-immer-langsamer/8819/9

I don't know whether it makes sense to set the configuration file to these default values for new installations.
Existing installations, i.e. updating the configuration file, will certainly be too time-consuming.