### PR TITLE
show the disabled logo instead of the retired one ("part 2")

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
@@ -29,7 +29,6 @@ import name.abuchen.portfolio.snapshot.ClientPerformanceSnapshot.Category;
 import name.abuchen.portfolio.snapshot.ClientPerformanceSnapshot.CategoryType;
 import name.abuchen.portfolio.snapshot.ClientPerformanceSnapshot.Position;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;
-import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.util.LogoManager;
@@ -151,10 +150,7 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
 
             boolean hasHoldings = snapshot.getEndClientSnapshot().getPositionsByVehicle().get(security) != null;
 
-            if (hasHoldings)
-                return LogoManager.instance().getDefaultColumnImage(security, client.getSettings());
-            else
-                return Images.SECURITY_RETIRED.image();
+            return LogoManager.instance().getDefaultColumnImage(security, client.getSettings(), !hasHoldings);
         }
 
         @Override


### PR DESCRIPTION
The tooltip of the performance calculation widget also shows the "retired"-logo if a there are no current holdings of a particular security, so I've applied the same logic here as I've done in #3977