### PR TITLE
Improvement of the regular expression of the date in the PDF importers

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
@@ -30,6 +30,41 @@ import name.abuchen.portfolio.money.Values;
 
 public class ExtractorUtils
 {
+    /**
+     * @formatter:off
+     * Regex pattern to match month names in various languages, including English, German, Spanish, Italian, and French.
+     * The pattern covers month names in both full and abbreviated forms.
+     *
+     * Supported month names:
+     * - English: January (Jan), February (Feb), March (Mar), April (Apr), May (May), June (Jun), July (Jul), August (Aug), September (Sep), October (Oct), November (Nov), December (Dec)
+     * - German: Januar (Jan), Februar (Feb), März (Mär), April (Apr), Mai (Mai), Juni (Jun), Juli (Jul), August (Aug), September (Sep), Oktober (Okt), November (Nov), Dezember (Dez)
+     * - Spanish: Enero (Ene), Febrero (Feb), Marzo (Mar), Abril (Abr), Mayo (May), Junio (Jun), Julio (Jul), Agosto (Ago), Septiembre (Sep), Octubre (Oct), Noviembre (Nov), Diciembre (Dic)
+     * - Italian: Gennaio (Gen), Febbraio (Feb), Marzo (Mar), Aprile (Apr), Maggio (Mag), Giugno (Giu), Luglio (Lug), Agosto (Ago), Settembre (Set), Ottobre (Ott), Novembre (Nov), Dicembre (Dic)
+     * - French: Janvier (Jan), Février (Fév), Mars (Mar), Avril (Avr), Mai (Mai), Juin (Juin), Juillet (Juil), Août (Août), Septembre (Sept), Octobre (Oct), Novembre (Nov), Décembre (Déc)
+     *
+     * The regex also accounts for variations in month names, such as different spellings and abbreviations.
+     *
+     * DateTimeFormatter building patterns for month names:
+     * - For abbreviated month names: MMM (LLL) (e.g., Jan, Feb, Mar)
+     * - For full month names: MMMM (LLLL) (e.g., January, February, March)
+     *
+     * @formatter:on
+     */
+    @SuppressWarnings("nls")
+    public static final String REGEX_MONTHS = "(?i)" //
+                    + "(January|Januar|Enero|Gennaio|Janvier|Jan|Ene|Gen|Janv" //
+                    + "|February|Februar|Febrero|Febbraio|Février|Feb|Febb|Fév" //
+                    + "|March|März|Marzo|Mars|Mar|Marz|Mär|Mrz" //
+                    + "|April|Abril|Aprile|Avril|Apr|Abr|Avr" //
+                    + "|May|Mai|Mayo|Maggio|May|Mai|Mag" //
+                    + "|June|Juni|Junio|Giugno|Juin|Jun" //
+                    + "|July|Juli|Julio|Luglio|Juillet|Jul|Lug" //
+                    + "|August|Agosto|August|Agosto|Août|Aug|Ago" //
+                    + "|September|Septiembre|Settembre|Septembre|Sep|Set" //
+                    + "|October|Oktober|Octubre|Ottobre|Octobre|Oct|Okt|Ott" //
+                    + "|November|Noviembre|Novembre|Nov" //
+                    + "|December|Dezember|Diciembre|Dicembre|Dec|Dez|Dic)";
+
     // Helper method to create case-insensitive DateTimeFormatter instances
     private static DateTimeFormatter createFormatter(String pattern, Locale locale)
     {
@@ -316,6 +351,10 @@ public class ExtractorUtils
 
     public static LocalDateTime asDate(String value, Locale... hints)
     {
+        // JDK 7: Mrz 2014
+        // JDK 8: Mär 2014
+        value = value.replaceAll("(?i)\\bMrz\\b", "Mär");  //$NON-NLS-1$//$NON-NLS-2$
+
         Locale[] locales = hints.length > 0 ? hints
                         : new Locale[] { Locale.GERMANY, Locale.US, Locale.CANADA, Locale.CANADA_FRENCH, Locale.UK };
 
@@ -356,6 +395,10 @@ public class ExtractorUtils
 
     public static LocalDateTime asDate(String date, String time)
     {
+        // JDK 7: Mrz 2014
+        // JDK 8: Mär 2014
+        date = date.replaceAll("(?i)\\bMrz\\b", "Mär"); //$NON-NLS-1$ //$NON-NLS-2$
+
         String value = String.format("%s %s", date, time); //$NON-NLS-1$
 
         for (DateTimeFormatter formatter : DATE_TIME_FORMATTER)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AvivaPLCPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AvivaPLCPDFExtractor.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.REGEX_MONTHS;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
@@ -108,7 +109,7 @@ public class AvivaPLCPDFExtractor extends AbstractPDFExtractor
                         // Execution date: 07 Mar 2023 23:59:00.000
                         // @formatter:on
                         .section("date", "time") //
-                        .match("^Execution date(\\/time)?: (?<date>[\\d]{2} .* [\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$") //
+                        .match("^Execution date(\\/time)?: (?<date>[\\d]{2} " + REGEX_MONTHS + " [\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
 
                         .oneOf( //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComputersharePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComputersharePDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.REGEX_MONTHS;
+
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -118,7 +120,7 @@ public class ComputersharePDFExtractor extends AbstractPDFExtractor
 
                         section -> section.attributes("date", "amount", "shares", "fee") //
                                         .documentContext(TICKERSYMBOL, WKN) //
-                                        .match("^(?<date>[\\d]{2} [\\w]{3} [\\d]{4}) Purchase (?<amount>[\\.,\\d]+) (?<fee>[\\.,\\d]+) (?<netAmount>[\\.,\\d]+) (?<grantDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvGrant>[\\.,\\d]+) (?<purchaseDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvPurchase>[\\.,\\d]+) (?<sharePrice>[\\.,\\d]+) (?<shares>[\\.,\\d]+) (?<totalShares>[\\.,\\d]+).*") //
+                                        .match("^(?<date>[\\d]{2} " + REGEX_MONTHS + " [\\d]{4}) Purchase (?<amount>[\\.,\\d]+) (?<fee>[\\.,\\d]+) (?<netAmount>[\\.,\\d]+) (?<grantDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvGrant>[\\.,\\d]+) (?<purchaseDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvPurchase>[\\.,\\d]+) (?<sharePrice>[\\.,\\d]+) (?<shares>[\\.,\\d]+) (?<totalShares>[\\.,\\d]+).*") //
                                         .assign((t, v) -> {
                                             v.put("currency", "USD");
                                             t.setDate(asDate(v.get("date")));
@@ -131,7 +133,7 @@ public class ComputersharePDFExtractor extends AbstractPDFExtractor
 
                         section -> section.attributes("date", "amount", "shares") //
                                         .documentContext(TICKERSYMBOL, WKN) //
-                                        .match("^(?<date>[\\d]{2} [\\w]{3} [\\d]{4}) Purchase (?<amount>[\\.,\\d]+) (?<netAmount>[\\.,\\d]+) (?<grantDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvGrant>[\\.,\\d]+) (?<purchaseDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvPurchase>[\\.,\\d]+) (?<sharePrice>[\\.,\\d]+) (?<shares>[\\.,\\d]+) (?<totalShares>[\\.,\\d]+).*") //
+                                        .match("^(?<date>[\\d]{2} " + REGEX_MONTHS + " [\\d]{4}) Purchase (?<amount>[\\.,\\d]+) (?<netAmount>[\\.,\\d]+) (?<grantDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvGrant>[\\.,\\d]+) (?<purchaseDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvPurchase>[\\.,\\d]+) (?<sharePrice>[\\.,\\d]+) (?<shares>[\\.,\\d]+) (?<totalShares>[\\.,\\d]+).*") //
                                         .assign((t, v) -> {
                                             v.put("currency", "USD");
                                             t.setDate(asDate(v.get("date")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.REGEX_MONTHS;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetFee;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
 import static name.abuchen.portfolio.util.TextUtil.concatenate;
@@ -261,7 +262,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("^Ausf.hrungsdatum: (?<date>[\\d]{2}\\. .* [\\d]{4}).*$") //
+                                                        .match("^Ausf.hrungsdatum: (?<date>[\\d]{2}\\. " + REGEX_MONTHS + " [\\d]{4}).*$") //
                                                         .assign((t, v) -> {
                                                             if (type.getCurrentContext().get("time") != null)
                                                                 t.setDate(asDate(v.get("date"), type.getCurrentContext().get("time")));
@@ -710,7 +711,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("^Zahltag : (?<date>[\\d]{2}\\. .* [\\d]{4}).*$") //
+                                                        .match("^Zahltag : (?<date>[\\d]{2}\\. " + REGEX_MONTHS + " [\\d]{4}).*$") //
                                                         .assign((t, v) -> t.setDateTime(asDate(v.get("date")))),
                                         // @formatter:off
                                         // Valutatag : 23.05.2012
@@ -1049,7 +1050,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("^Ausf.hrungsdatum: (?<date>[\\d]{2}\\. .* [\\d]{4}).*$") //
+                                                        .match("^Ausf.hrungsdatum: (?<date>[\\d]{2}\\. " + REGEX_MONTHS + " [\\d]{4}).*$") //
                                                         .assign((t, v) -> {
                                                             if (type.getCurrentContext().get("time") != null)
                                                                 t.setDateTime(asDate(v.get("date"), type.getCurrentContext().get("time")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LGTBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LGTBankPDFExtractor.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.REGEX_MONTHS;
 import static name.abuchen.portfolio.util.TextUtil.concatenate;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
@@ -201,7 +202,7 @@ public class LGTBankPDFExtractor extends AbstractPDFExtractor
                         // Valuta 14. Mai 2020
                         // @formatter:on
                         .section("date") //
-                        .match("^Valuta (?<date>[\\d]{1,2}\\. .* [\\d]{4})$") //
+                        .match("^Valuta (?<date>[\\d]{1,2}\\. " + REGEX_MONTHS + " [\\d]{4})$") //
                         .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LiechtensteinischeLandesbankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LiechtensteinischeLandesbankAGPDFExtractor.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.REGEX_MONTHS;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
@@ -98,7 +99,7 @@ public class LiechtensteinischeLandesbankAGPDFExtractor extends AbstractPDFExtra
                         // Zu Ihren Lasten Valuta 22. November 2023 CHF 145.56
                         // @formatter:on
                         .section("date") //
-                        .match("^Zu Ihren (Lasten|Gunsten) Valuta (?<date>[\\d]{1,2}\\. .* [\\d]{4}) [\\w]{3} [\\.'\\d]+$") //
+                        .match("^Zu Ihren (Lasten|Gunsten) Valuta (?<date>[\\d]{1,2}\\. " + REGEX_MONTHS + " [\\d]{4}) [\\w]{3} [\\.'\\d]+$") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         // @formatter:off
@@ -106,7 +107,7 @@ public class LiechtensteinischeLandesbankAGPDFExtractor extends AbstractPDFExtra
                         // Zu Ihren Gunsten Valuta 7. November 2023 CHF 55.10
                         // @formatter:on
                         .section("currency", "amount") //
-                        .match("^Zu Ihren (Lasten|Gunsten) Valuta (?<date>[\\d]{1,2}\\. .* [\\d]{4}) (?<currency>[\\w]{3}) (?<amount>[\\.'\\d]+)$") //
+                        .match("^Zu Ihren (Lasten|Gunsten) Valuta [\\d]{1,2}\\. " + REGEX_MONTHS + " [\\d]{4} (?<currency>[\\w]{3}) (?<amount>[\\.'\\d]+)$") //
                         .assign((t, v) -> {
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -206,14 +207,14 @@ public class LiechtensteinischeLandesbankAGPDFExtractor extends AbstractPDFExtra
                         // Zu Ihren Gunsten Valuta 20. November 2023 CHF 5.65
                         // @formatter:on
                         .section("date") //
-                        .match("^Zu Ihren Gunsten Valuta (?<date>[\\d]{1,2}\\. .* [\\d]{4}) [\\w]{3} [\\.'\\d]+$") //
+                        .match("^Zu Ihren Gunsten Valuta (?<date>[\\d]{1,2}\\. " + REGEX_MONTHS + " [\\d]{4}) [\\w]{3} [\\.'\\d]+$") //
                         .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                         // @formatter:off
                         // Zu Ihren Gunsten Valuta 20. November 2023 CHF 5.65
                         // @formatter:on
                         .section("currency", "amount") //
-                        .match("^Zu Ihren Gunsten Valuta (?<date>[\\d]{1,2}\\. .* [\\d]{4}) (?<currency>[\\w]{3}) (?<amount>[\\.'\\d]+)$") //
+                        .match("^Zu Ihren Gunsten Valuta (?<date>[\\d]{1,2}\\. " + REGEX_MONTHS + " [\\d]{4}) (?<currency>[\\w]{3}) (?<amount>[\\.'\\d]+)$") //
                         .assign((t, v) -> {
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -309,7 +310,7 @@ public class LiechtensteinischeLandesbankAGPDFExtractor extends AbstractPDFExtra
 
                         .section("date", "note1", "note2", "amount") //
                         .documentContext("currency") //
-                        .match("^Per (?<date>[\\d]{1,2}\\. .* [\\d]{4})$") //
+                        .match("^Per (?<date>[\\d]{1,2}\\. " + REGEX_MONTHS + " [\\d]{4})$") //
                         .match("^Abrechnungsperiode (?<note1>[\\d]{1,2}\\.[\\d]{2}\\.[\\d]{4})\\-(?<note2>[\\d]{1,2}\\.[\\d]{2}\\.[\\d]{4})$") //
                         .match("^Habenzins (?<amount>[\\.'\\d]+)$") //
                         .assign((t, v) -> {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LimeTradingCorpPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LimeTradingCorpPDFExtractor.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.REGEX_MONTHS;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetTax;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
@@ -57,7 +58,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                         // AAAAA aAAAA STATEMENT PERIOD: March 1 - 31, 2022
                                         // @formatter:on
                                         .section("month", "day", "year") //
-                                        .match("^.* STATEMENT PERIOD: (?<month>.*) [\\d]{1,2} \\- (?<day>[\\d]{2}), (?<year>[\\d]{4})$") //
+                                        .match("^.* STATEMENT PERIOD: (?<month>" + REGEX_MONTHS + ") [\\d]{1,2} \\- (?<day>[\\d]{2}), (?<year>[\\d]{4})$") //
                                         .assign((ctx, v) -> {
                                             ctx.put("month", trim(v.get("month")));
                                             ctx.put("day", v.get("day"));
@@ -87,7 +88,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
 
                         .section("month", "day", "name", "wkn", "type", "shares", "amount", "nameContinued") //
                         .documentContext("year") //
-                        .match("^(?<month>[\\w]{3}) (?<day>[\\d]{1,2}) (?<name>.*) (?<wkn>[\\w]{9}) (?<type>(Buy|Sell)) (?<shares>[\\.,\\d]+) [\\.,\\d]+ (\\()?(?<amount>[\\.,\\d]+)(\\))?$") //
+                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{1,2}) (?<name>.*) (?<wkn>[\\w]{9}) (?<type>(Buy|Sell)) (?<shares>[\\.,\\d]+) [\\.,\\d]+ (\\()?(?<amount>[\\.,\\d]+)(\\))?$") //
                         .match("(?<nameContinued>.*)") //
                         .assign((t, v) -> {
                             // Is type --> "Sell" change from BUY to SELL
@@ -151,8 +152,8 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("month", "day", "name", "shares", "wkn", "amount","tax") //
                                                         .documentContext("year") //
-                                                        .match("^(?<month>[\\w]{3}) (?<day>[\\d]{1,2}) (?<name>.*) (?<shares>[\\.,\\d]+) (?<wkn>(?!Qualified).{9}) (Qualified )?Dividend (?<amount>[\\.,\\d]+)$") //
-                                                        .match("^[\\w]{3} [\\d]{2} .* [\\w]{9} (NRA Withhold|Foreign Withholding) \\((?<tax>[\\.,\\d]+)\\)$") //
+                                                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{1,2}) (?<name>.*) (?<shares>[\\.,\\d]+) (?<wkn>(?!Qualified).{9}) (Qualified )?Dividend (?<amount>[\\.,\\d]+)$") //
+                                                        .match("^" + REGEX_MONTHS + " [\\d]{2} .* [\\w]{9} (NRA Withhold|Foreign Withholding) \\((?<tax>[\\.,\\d]+)\\)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
                                                             v.put("currency", CurrencyUnit.USD);
@@ -174,8 +175,8 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("month", "day", "name", "shares", "wkn", "amount", "tax") //
                                                         .documentContext("year") //
-                                                        .match("^(?<month>[\\w]{3}) (?<day>[\\d]{1,2}) (?<name>.*) (?<shares>[\\.,\\d]+) (?<wkn>(?!(Qualified|Lmtd)).{9}) ((Qualified|Lmtd) )?(Dividend|Partner) (?<amount>[\\.,\\d]+)$") //
-                                                        .match("^[\\w]{3} [\\d]{2} .* [\\w]{9} (NRA Withhold|Foreign Withholding) \\((?<tax>[\\.,\\d]+)\\)$") //
+                                                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{1,2}) (?<name>.*) (?<shares>[\\.,\\d]+) (?<wkn>(?!(Qualified|Lmtd)).{9}) ((Qualified|Lmtd) )?(Dividend|Partner) (?<amount>[\\.,\\d]+)$") //
+                                                        .match("^" + REGEX_MONTHS + " [\\d]{2} .* [\\w]{9} (NRA Withhold|Foreign Withholding) \\((?<tax>[\\.,\\d]+)\\)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
                                                             v.put("currency", CurrencyUnit.USD);
@@ -198,7 +199,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("month", "day", "name", "shares", "wkn", "amount") //
                                                         .documentContext("year") //
-                                                        .match("^(?<month>.*) (?<day>[\\d]{1,2}) (?<name>.*) (?<shares>[\\.,\\d]+) (?<wkn>(?!Qualified).{9}) (Qualified )?Dividend (?<amount>[\\.,\\d]+)$") //
+                                                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{1,2}) (?<name>.*) (?<shares>[\\.,\\d]+) (?<wkn>(?!Qualified).{9}) (Qualified )?Dividend (?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
                                                             v.put("currency", CurrencyUnit.USD);
@@ -276,7 +277,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
         // Nov 15 Orion Office Reit Inc 68629Y103 Security Journal 2
         // Com
         // @formatter:on
-        Block blockDeliveryInBound = new Block("^[\\w]{3} [\\d]{2} .* [\\w]{9} Security Journal [\\.,\\d]+$");
+        Block blockDeliveryInBound = new Block("^" + REGEX_MONTHS + " [\\d]{2} .* [\\w]{9} Security Journal [\\.,\\d]+$");
         type.addBlock(blockDeliveryInBound);
         blockDeliveryInBound.set(new Transaction<PortfolioTransaction>()
 
@@ -288,7 +289,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
 
                         .section("month", "day", "name", "wkn", "shares", "nameContinued") //
                         .documentContext("year") //
-                        .match("^(?<month>[\\w]{3}) (?<day>[\\d]{1,2}) (?<name>.*) (?<wkn>[\\w]{9}) Security Journal (?<shares>[\\.,\\d]+)$") //
+                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{1,2}) (?<name>.*) (?<wkn>[\\w]{9}) Security Journal (?<shares>[\\.,\\d]+)$") //
                         .match("(?<nameContinued>.*)") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
@@ -334,7 +335,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
 
                         .section("month", "day", "name", "wkn", "amount") //
                         .documentContext("year") //
-                        .match("^(?<month>[\\w]{3}) (?<day>[\\d]{1,2}) Ca Fee_spinoff.* (?<name>.*) (?<wkn>.*) Journal \\((?<amount>[\\.,\\d]+)\\)$") //
+                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{1,2}) Ca Fee_spinoff.* (?<name>.*) (?<wkn>.*) Journal \\((?<amount>[\\.,\\d]+)\\)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
                             v.put("currency", CurrencyUnit.USD);
@@ -378,7 +379,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
 
                         .section("month", "day", "name", "wkn", "amount") //
                         .documentContext("year") //
-                        .match("^(?<month>[\\w]{3}) (?<day>[\\d]{1,2}) .* Allocation (?<wkn>[\\w]{9}) Journal (?<amount>[\\.,\\d]+)$") //
+                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{1,2}) .* Allocation (?<wkn>[\\w]{9}) Journal (?<amount>[\\.,\\d]+)$") //
                         .match("^(?<name>.*)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
@@ -423,7 +424,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
 
                         .section("month", "day", "amount") //
                         .documentContext("year") //
-                        .match("^(?<month>[\\w]{3}) (?<day>[\\d]{1,2}) Wire .* (?<amount>[\\.,\\d]+)$") //
+                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{1,2}) Wire .* (?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
                             v.put("currency", CurrencyUnit.USD);
@@ -453,7 +454,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
 
                         .section("month", "day", "amount") //
                         .documentContext("year") //
-                        .match("^(?<month>[\\w]{3}) (?<day>[\\d]{1,2}) .* Credit Interest (?<amount>[\\.,\\d]+)$") //
+                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{1,2}) .* Credit Interest (?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
                             v.put("currency", CurrencyUnit.USD);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RevolutLtdPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RevolutLtdPDFExtractor.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.REGEX_MONTHS;
+
 import java.util.Locale;
 
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
@@ -93,7 +95,7 @@ public class RevolutLtdPDFExtractor extends AbstractPDFExtractor
                         // TSLA Tesla US88160R1014 Sell 2.1451261 $1,166.12 03 Nov 2021
                         // @formatter:on
                         .section("date") //
-                        .match("^[A-Z0-9]{3,4} .* [A-Z]{2}[A-Z0-9]{9}[0-9] Sell [\\.,\\d]+ \\p{Sc}[\\.,\\d]+ (?<date>[\\d]{2} .* [\\d]{4})$") //
+                        .match("^[A-Z0-9]{3,4} .* [A-Z]{2}[A-Z0-9]{9}[0-9] Sell [\\.,\\d]+ \\p{Sc}[\\.,\\d]+ (?<date>[\\d]{2} " + REGEX_MONTHS + " [\\d]{4})$") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"), Locale.UK)))
 
                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScorePriorityIncPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScorePriorityIncPDFExtractor.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.REGEX_MONTHS;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetTax;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
@@ -83,7 +84,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
 
                         .section("month", "day", "name", "wkn", "type", "shares", "amount", "nameContinued") //
                         .documentContext("year") //
-                        .match("^(?<month>[\\w]{3}) (?<day>[\\d]{2}) (?<name>.*) (?<wkn>[\\w]{9}) (?<type>(Buy|Sell)) (?<shares>[\\.,\\d]+) [\\.,\\d]+ (\\()?(?<amount>[\\.,\\d]+)(\\))?$") //
+                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{2}) (?<name>.*) (?<wkn>[\\w]{9}) (?<type>(Buy|Sell)) (?<shares>[\\.,\\d]+) [\\.,\\d]+ (\\()?(?<amount>[\\.,\\d]+)(\\))?$") //
                         .match("(?<nameContinued>.*)") //
                         .assign((t, v) -> {
                             // Is type --> "Sell" change from BUY to SELL
@@ -132,8 +133,8 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("month", "day", "name", "shares", "wkn", "amount", "tax") //
                                                         .documentContext("year") //
-                                                        .match("^(?<month>[\\w]{3}) (?<day>[\\d]{2}) (?<name>.*) (?<shares>[\\.,\\d]+) (?<wkn>(?!Qualified).{9}) (Qualified )?Dividend (?<amount>[\\.,\\d]+)$") //
-                                                        .match("^[\\w]{3} [\\d]{2} .* [\\w]{9} (NRA Withhold|Foreign Withholding) \\((?<tax>[\\.,\\d]+)\\)$") //
+                                                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{2}) (?<name>.*) (?<shares>[\\.,\\d]+) (?<wkn>(?!Qualified).{9}) (Qualified )?Dividend (?<amount>[\\.,\\d]+)$") //
+                                                        .match("^" + REGEX_MONTHS + " [\\d]{2} .* [\\w]{9} (NRA Withhold|Foreign Withholding) \\((?<tax>[\\.,\\d]+)\\)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
                                                             v.put("currency", CurrencyUnit.USD);
@@ -151,7 +152,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("month", "day", "name", "shares", "wkn", "amount") //
                                                         .documentContext("year") //
-                                                        .match("^(?<month>.*) (?<day>[\\d]{2}) (?<name>.*) (?<shares>[\\.,\\d]+) (?<wkn>(?!Qualified).{9}) (Qualified )?Dividend (?<amount>[\\.,\\d]+)$") //
+                                                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{2}) (?<name>.*) (?<shares>[\\.,\\d]+) (?<wkn>(?!Qualified).{9}) (Qualified )?Dividend (?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
                                                             v.put("currency", CurrencyUnit.USD);
@@ -186,7 +187,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
 
                         .section("month", "day", "name", "wkn", "shares", "nameContinued") //
                         .documentContext("year") //
-                        .match("^(?<month>[\\w]{3}) (?<day>[\\d]{2}) (?<name>.*) (?<wkn>[\\w]{9}) Security Journal (?<shares>[\\.,\\d]+)$") //
+                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{2}) (?<name>.*) (?<wkn>[\\w]{9}) Security Journal (?<shares>[\\.,\\d]+)$") //
                         .match("(?<nameContinued>.*)") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
@@ -220,7 +221,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
 
                         .section("month", "day", "name", "wkn", "amount") //
                         .documentContext("year") //
-                        .match("^(?<month>[\\w]{3}) (?<day>[\\d]{2}) Ca Fee_spinoff.* (?<name>.*) (?<wkn>.*) Journal \\((?<amount>[\\.,\\d]+)\\)$") //
+                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{2}) Ca Fee_spinoff.* (?<name>.*) (?<wkn>.*) Journal \\((?<amount>[\\.,\\d]+)\\)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
                             v.put("currency", CurrencyUnit.USD);
@@ -264,7 +265,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
 
                         .section("month", "day", "name", "wkn", "amount") //
                         .documentContext("year") //
-                        .match("^(?<month>[\\w]{3}) (?<day>[\\d]{2}) .* Allocation (?<wkn>[\\w]{9}) Journal (?<amount>[\\.,\\d]+)$") //
+                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{2}) .* Allocation (?<wkn>[\\w]{9}) Journal (?<amount>[\\.,\\d]+)$") //
                         .match("^(?<name>.*)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
@@ -297,7 +298,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
 
                         .section("month", "day", "amount") //
                         .documentContext("year") //
-                        .match("^(?<month>[\\w]{3}) (?<day>[\\d]{2}) Incoming Wire .* (?<amount>[\\.,\\d]+)$") //
+                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{2}) Incoming Wire .* (?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
                             v.put("currency", CurrencyUnit.USD);
@@ -327,7 +328,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
 
                         .section("month", "day", "amount") //
                         .documentContext("year") //
-                        .match("^(?<month>[\\w]{3}) (?<day>[\\d]{2}) .* Credit Interest (?<amount>[\\.,\\d]+)$") //
+                        .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{2}) .* Credit Interest (?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
                             v.put("currency", CurrencyUnit.USD);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SelfWealthPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SelfWealthPDFExtractor.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.REGEX_MONTHS;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
@@ -83,7 +84,7 @@ public class SelfWealthPDFExtractor extends AbstractPDFExtractor
                         // 1 LONG ROAD Trade Date: 1 Jul 2021
                         // @formatter:on
                         .section("date") //
-                        .match("^.* Trade Date: (?<date>[\\d]+ .* [\\d]{4})$") //
+                        .match("^.* Trade Date: (?<date>[\\d]+ " + REGEX_MONTHS + " [\\d]{4})$") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SutorBankGmbHPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SutorBankGmbHPDFExtractor.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.REGEX_MONTHS;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetFee;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetTax;
 import static name.abuchen.portfolio.util.TextUtil.stripBlanks;
@@ -150,12 +151,12 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("^(Orderausf.hrung Datum\\/Zeit:|Schlusstag\\/\\-Zeit) (?<date>([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{1,2} .* [\\d]{4})).*$") //
+                                                        .match("^(Orderausf.hrung Datum\\/Zeit:|Schlusstag\\/\\-Zeit) (?<date>([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{1,2} " + REGEX_MONTHS + " [\\d]{4})).*$") //
                                                         .assign((t, v) -> {
                                                             if (type.getCurrentContext().get("time") != null)
-                                                                t.setDate(asDate(v.get("date").replace("Mrz", "Mär"), type.getCurrentContext().get("time")));
+                                                                t.setDate(asDate(v.get("date"), type.getCurrentContext().get("time")));
                                                             else
-                                                                t.setDate(asDate(v.get("date").replace("Mrz", "Mär")));
+                                                                t.setDate(asDate(v.get("date")));
                                                         }),
                                         // @formatter:off
                                         // Orderausführung Datum/Zeit: 13. 06. 2023 11:10:52
@@ -174,8 +175,8 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("^Valutadatum (?<date>[\\d]{1,2}\\. .* [\\d]{4})$") //
-                                                        .assign((t, v) -> t.setDate(asDate(v.get("date").replace("Mrz", "Mär")))))
+                                                        .match("^Valutadatum (?<date>[\\d]{1,2}\\. " + REGEX_MONTHS + " [\\d]{4})$") //
+                                                        .assign((t, v) -> t.setDate(asDate(v.get("date")))))
 
                         .oneOf( //
                                         // @formatter:off
@@ -278,12 +279,12 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                         // Orderausführung Datum / Zeit: 13. Februar 2021 04:21:59
                         // @formatter:on
                         .section("date") //
-                        .match("^Orderausf.hrung Datum \\/ Zeit: (?<date>[\\d]{1,2}\\. .* [\\d]{4}).*$") //
+                        .match("^Orderausf.hrung Datum \\/ Zeit: (?<date>[\\d]{1,2}\\. " + REGEX_MONTHS + " [\\d]{4}).*$") //
                         .assign((t, v) -> {
                             if (type.getCurrentContext().get("time") != null)
-                                t.setDate(asDate(v.get("date").replace("Mrz", "Mär"), type.getCurrentContext().get("time")));
+                                t.setDate(asDate(v.get("date"), type.getCurrentContext().get("time")));
                             else
-                                t.setDate(asDate(v.get("date").replace("Mrz", "Mär")));
+                                t.setDate(asDate(v.get("date")));
                         })
 
                         // @formatter:off
@@ -353,8 +354,8 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                         // Valutadatum 15. März 2021
                         // @formatter:on
                         .section("date") //
-                        .match("^Valutadatum (?<date>[\\d]{1,2}\\. .* [\\d]{4})$") //
-                        .assign((t, v) -> t.setDateTime(asDate(v.get("date").replace("Mrz", "Mär"))))
+                        .match("^Valutadatum (?<date>[\\d]{1,2}\\. " + REGEX_MONTHS + " [\\d]{4})$") //
+                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                         // @formatter:off
                         // Ausmachender Betrag EUR 12,15
@@ -421,8 +422,8 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                         // Tag des Zuflusses 02 Januar 2024
                         // @formatter:on
                         .section("date") //
-                        .match("^Tag des Zuflusses (?<date>[\\d]{1,2} .* [\\d]{4}).*$") //
-                        .assign((t, v) -> t.setDateTime(asDate(v.get("date").replace("Mrz", "Mär"))))
+                        .match("^Tag des Zuflusses (?<date>[\\d]{1,2} " + REGEX_MONTHS + " [\\d]{4}).*$") //
+                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                         // @formatter:off
                         // Aufgrund nachstehender Abrechnung buchen wir zu Ihren Lasten €34,25
@@ -1056,8 +1057,8 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                         // Ex Datum - Tag 25. Mai 2023
                         // @formatter:on
                         .section("date") //
-                        .match("^Ex Datum \\- Tag (?<date>[\\d]{1,2}\\. .* [\\d]{4})$") //
-                        .assign((t, v) -> t.setDateTime(asDate(v.get("date").replace("Mrz", "Mär"))))
+                        .match("^Ex Datum \\- Tag (?<date>[\\d]{1,2}\\. " + REGEX_MONTHS + " [\\d]{4})$") //
+                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                         // @formatter:off
                         // Verhältnis Neu/ Alt 1 : 3,00

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -1,4 +1,5 @@
 package name.abuchen.portfolio.datatransfer.pdf;
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.REGEX_MONTHS;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
 import static name.abuchen.portfolio.util.TextUtil.concatenate;
 import static name.abuchen.portfolio.util.TextUtil.trim;
@@ -1437,7 +1438,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         });
         this.addDocumentTyp(type);
 
-        Block depositRemovalBlock_Format01 = new Block("^[\\d]{2} [\\wä]{3,4}([\\.]{1})?( [\\d]{4})? .berweisung .*$");
+        Block depositRemovalBlock_Format01 = new Block("^[\\d]{2} " + REGEX_MONTHS + "([\\.]{1})?( [\\d]{4})? .berweisung .*$");
         type.addBlock(depositRemovalBlock_Format01);
         depositRemovalBlock_Format01.setMaxSize(1);
         depositRemovalBlock_Format01.set(new Transaction<AccountTransaction>()
@@ -1454,7 +1455,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date", "year", "amount", "currency") //
-                                                        .match("^(?<date>[\\d]{2} [\\wä]{3,4}([\\.]{1})?) .berweisung Einzahlung .* auf (?<year>[\\d]{4}) .* (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
+                                                        .match("^(?<date>[\\d]{2} " + REGEX_MONTHS + "([\\.]{1})?) .berweisung Einzahlung .* auf (?<year>[\\d]{4}) .* (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date") + " " + v.get("year")));
                                                             t.setAmount(asAmount(v.get("amount")));
@@ -1465,7 +1466,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date", "amount", "currency") //
-                                                        .match("^(?<date>[\\d]{2} [\\wä]{3,4}([\\.]{1})? [\\d]{4}) .berweisung PayOut .* (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
+                                                        .match("^(?<date>[\\d]{2} " + REGEX_MONTHS + "([\\.]{1})? [\\d]{4}) .berweisung PayOut .* (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
                                                         .assign((t, v) -> {
                                                             t.setType(AccountTransaction.Type.REMOVAL);
 
@@ -1476,7 +1477,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
                         .wrap(TransactionItem::new));
 
-        Block depositRemovalBlock_Format02 = new Block("^[\\d]{2} [\\wä]{3,4}([\\.]{1})?[\\s]$");
+        Block depositRemovalBlock_Format02 = new Block("^[\\d]{2} " + REGEX_MONTHS + "([\\.]{1})?[\\s]$");
         type.addBlock(depositRemovalBlock_Format02);
         depositRemovalBlock_Format02.setMaxSize(4);
         depositRemovalBlock_Format02.set(new Transaction<AccountTransaction>()
@@ -1497,7 +1498,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date", "year", "note", "amount", "currency", "amountAfter", "currencyAfter") //
-                                                        .match("^(?<date>[\\d]{2} [\\wä]{3,4}([\\.]{1})?)[\\s]$") //
+                                                        .match("^(?<date>[\\d]{2} " + REGEX_MONTHS + "([\\.]{1})?)[\\s]$") //
                                                         .match("^(?<year>[\\d]{4}) Kartentransaktion (?<note>.*) (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) (?<amountAfter>[\\.,\\d]+) (?<currencyAfter>\\p{Sc})$") //
                                                         .assign((t, v) -> {
                                                             DocumentContext context = type.getCurrentContext();
@@ -1527,7 +1528,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date", "year", "amount", "currency") //
-                                                        .match("^(?<date>[\\d]{2} [\\wä]{3,4}([\\.]{1})?)[\\s]$") //
+                                                        .match("^(?<date>[\\d]{2} " + REGEX_MONTHS + "([\\.]{1})?)[\\s]$") //
                                                         .match("^(?<year>[\\d]{4}) .berweisung$") //
                                                         .match("^Einzahlung akzeptiert: .*$") //
                                                         .match("^.* (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
@@ -1545,11 +1546,12 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date", "year", "amount", "currency") //
-                                                        .match("^(?<date>[\\d]{2} [\\wä]{3,4}([\\.]{1})?)[\\s]$") //
+                                                        .match("^(?<date>[\\d]{2} " + REGEX_MONTHS + "([\\.]{1})?)[\\s]$") //
                                                         .match("^(?<year>[\\d]{4}) " //
                                                                         + "(.berweisung Einzahlung akzeptiert:"
                                                                         + "|Pr.mie Your Saveback)" //
-                                                                        + ".* (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
+                                                                        + ".* (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) "
+                                                                        + "[\\.,\\d]+ \\p{Sc}$") //
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date") + " " + v.get("year")));
                                                             t.setAmount(asAmount(v.get("amount")));
@@ -1582,7 +1584,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("day", "month", "year", "note", "amount", "currency", "amountAfter", "currencyAfter") //
                                                         .match("^(?<day>[\\d]{2})[\\s]$")
-                                                        .match("^(?<month>[\\wä]{3,4}([\\.]{1})?) Kartentransaktion (?<note>.*) (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) (?<amountAfter>[\\.,\\d]+) (?<currencyAfter>\\p{Sc})$") //
+                                                        .match("^(?<month>" + REGEX_MONTHS + "([\\.]{1})?) Kartentransaktion (?<note>.*) (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) (?<amountAfter>[\\.,\\d]+) (?<currencyAfter>\\p{Sc})$") //
                                                         .match("^(?<year>[\\d]{4})$") //
                                                         .assign((t, v) -> {
                                                             DocumentContext context = type.getCurrentContext();
@@ -1612,7 +1614,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("day", "month", "year", "amount", "currency") //
                                                         .match("^(?<day>[\\d]{2})[\\s]$")
-                                                        .match("^(?<month>[\\wä]{3,4}([\\.]{1})?) .berweisung Einzahlung akzeptiert: .* (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
+                                                        .match("^(?<month>" + REGEX_MONTHS + "([\\.]{1})?) .berweisung Einzahlung akzeptiert: .* (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
                                                         .match("^(?<year>[\\d]{4})$") //
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("day") + " " + v.get("month") + " " + v.get("year")));
@@ -1630,7 +1632,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         // 03 Apr.
         // 2024 Gebühren Trade Republic Card 5,00 € 49.997,41 €
         // @formatter:on
-        Block feesBlock = new Block("^[\\d]{2} [\\w]{3,4}([\\.]{1})?[\\s]$");
+        Block feesBlock = new Block("^[\\d]{2} " + REGEX_MONTHS + "([\\.]{1})?[\\s]$");
         type.addBlock(feesBlock);
         feesBlock.setMaxSize(2);
         feesBlock.set(new Transaction<AccountTransaction>()
@@ -1642,7 +1644,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .section("date", "year", "amount", "currency").optional() //
-                        .match("^(?<date>[\\d]{2} [\\wä]{3,4}([\\.]{1})?)[\\s]$")
+                        .match("^(?<date>[\\d]{2} " + REGEX_MONTHS + "([\\.]{1})?)[\\s]$")
                         .match("^(?<year>[\\d]{4}) Geb.hren Trade Republic Card (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date") + " " + v.get("year")));
@@ -1659,7 +1661,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         // @formatter:off
         // 01 Apr. 2024 Zinszahlung Your interest payment 172,23 € 50.172,23 €
         // @formatter:on
-        Block interestBlock_Format01 = new Block("^[\\d]{2} [\\wä]{3,4}([\\.]{1})? [\\d]{4} Zinszahlung .*$");
+        Block interestBlock_Format01 = new Block("^[\\d]{2} " + REGEX_MONTHS + "([\\.]{1})? [\\d]{4} Zinszahlung .*$");
         type.addBlock(interestBlock_Format01);
         interestBlock_Format01.setMaxSize(1);
         interestBlock_Format01.set(new Transaction<AccountTransaction>()
@@ -1671,7 +1673,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .section("date", "amount", "currency") //
-                        .match("^(?<date>[\\d]{2} ([\\wä]{3,4}([\\.]{1})?) [\\d]{4}) Zinszahlung .* (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
+                        .match("^(?<date>[\\d]{2} (" + REGEX_MONTHS + "([\\.]{1})?) [\\d]{4}) Zinszahlung .* (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -1684,7 +1686,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         // 01 Apr.
         // 2024 Zinszahlung Your interest payment 147,34 € 50.152,41 €
         // @formatter:on
-        Block interestBlock_Format02 = new Block("^[\\d]{2} [\\wä]{3,4}([\\.]{1})?[\\s]$");
+        Block interestBlock_Format02 = new Block("^[\\d]{2} " + REGEX_MONTHS + "([\\.]{1})?[\\s]$");
         type.addBlock(interestBlock_Format02);
         interestBlock_Format02.setMaxSize(2);
         interestBlock_Format02.set(new Transaction<AccountTransaction>()
@@ -1696,7 +1698,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .section("date", "year", "amount", "currency").optional() //
-                        .match("^(?<date>[\\d]{2} [\\wä]{3,4}([\\.]{1})?)[\\s]$")
+                        .match("^(?<date>[\\d]{2} " + REGEX_MONTHS + "([\\.]{1})?)[\\s]$")
                         .match("^(?<year>[\\d]{4}) Zinszahlung Your interest payment (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date") + " " + v.get("year")));
@@ -1728,7 +1730,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
                         .section("day", "month", "year", "amount", "currency").optional() //
                         .match("^(?<day>[\\d]{2})[\\s]$")
-                        .match("^(?<month>[\\wä]{3,4}([\\.]{1})?) Zinszahlung Your interest payment (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
+                        .match("^(?<month>" + REGEX_MONTHS + "([\\.]{1})?) Zinszahlung Your interest payment (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
                         .match("^(?<year>[\\d]{4})$") //
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("day") + " " + v.get("month") + " " + v.get("year")));
@@ -1760,7 +1762,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
                         .section("day", "month", "year", "amount", "currency").optional() //
                         .match("^(?<day>[\\d]{2})[\\s]$")
-                        .match("^(?<month>[\\wä]{3,4}([\\.]{1})?) Steuern Steueroptimierung .* (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
+                        .match("^(?<month>" + REGEX_MONTHS + "([\\.]{1})?) Steuern Steueroptimierung .* (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) [\\.,\\d]+ \\p{Sc}$") //
                         .match("^(?<year>[\\d]{4})$") //
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("day") + " " + v.get("month") + " " + v.get("year")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UBSAGBankingAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UBSAGBankingAGPDFExtractor.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.REGEX_MONTHS;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetFee;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
 import static name.abuchen.portfolio.util.TextUtil.concatenate;
@@ -501,7 +502,7 @@ public class UBSAGBankingAGPDFExtractor extends AbstractPDFExtractor
                         // Zu Lasten Konto 292-123456.40R, Valuta 30. Juni 2021
                         // @formatter:on
                         .section("date") //
-                        .match("^Zu Lasten Konto .* Valuta (?<date>[\\d]{1,2}.\\ .* [\\d]{4})$") //
+                        .match("^Zu Lasten Konto .* Valuta (?<date>[\\d]{1,2}.\\ " + REGEX_MONTHS + " [\\d]{4})$") //
                         .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WealthsimpleInvestmentsIncPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WealthsimpleInvestmentsIncPDFExtractor.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.REGEX_MONTHS;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetTax;
 import static name.abuchen.portfolio.util.TextUtil.trim;
@@ -60,18 +61,18 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
         final DocumentType type = new DocumentType("Portfolio Performance Report", (context, lines) -> {
             Pattern pYear = Pattern.compile("^.*(?<year>[\\d]{4}) Performance Report .*$");
             Pattern pCurrency = Pattern.compile("^.* Canada Conversion rate \\p{Sc}[\\.,\\d]+ [\\w]{3} = \\p{Sc}[\\.,\\d]+ (?<currency>[\\w]{3})$");
-            Pattern pDividendTaxTransactions = Pattern.compile("^(?<month>[\\w]{3,4}) "
+            Pattern pDividendTaxTransactions = Pattern.compile("^(?<month>" + REGEX_MONTHS + ") "
                             + "(?<day>[\\d]{2}) "
                             + "(?<tickerSymbol>[A-Z]{3,4})"
                             + "[\\W]{1,3}.*: .* tax .* \\([\\.,\\d]+ [\\w]{3}, .* "
                             + "(?<currency>[\\w]{3})"
                             + " .([\\.,\\d]+\\))? .* "
                             + "\\-\\p{Sc}(?<tax>[\\.,\\d]+)$");
-            Pattern pFeeRefundTransactions = Pattern.compile("^(?<month>[\\w]{3,4}) "
+            Pattern pFeeRefundTransactions = Pattern.compile("^(?<month>" + REGEX_MONTHS + ") "
                             + "(?<day>[\\d]{2}) "
                             + "Promotions and discounts applied to Wealthsimple fee [\\W]{1,3} "
                             + "\\p{Sc}(?<feeRefund>[\\.,\\d]+)$");
-            Pattern pFeeTaxTransactions = Pattern.compile("^(?<month>[\\w]{3,4}) "
+            Pattern pFeeTaxTransactions = Pattern.compile("^(?<month>" + REGEX_MONTHS + ") "
                             + "(?<day>[\\d]{2}) "
                             + "Sales tax on management fee to Wealthsimple [\\W]{1,3} "
                             + "\\-\\p{Sc}(?<tax>[\\.,\\d]+)$");
@@ -146,7 +147,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
                 })
 
                 .section("month", "day", "type", "amount", "currency")
-                .match("^(?<month>[\\w]{3,4}) "
+                .match("^(?<month>" + REGEX_MONTHS + ") "
                                 + "(?<day>[\\d]{2}) "
                                 + ".* Transfer "
                                 + "(?<type>(In|Out)): "
@@ -186,7 +187,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
                 })
 
                 .section("month", "day", "type", "tickerSymbol", "name", "amount", "currency", "shares")
-                .match("^(?<month>[\\w]{3,4}) "
+                .match("^(?<month>" + REGEX_MONTHS + ") "
                                 + "(?<day>[\\d]{2}) "
                                 + ".* "
                                 + "(?<type>(Bought|Sold)) "
@@ -248,7 +249,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
                 .oneOf(
                                 section -> section
                                         .attributes("month", "day", "tickerSymbol", "name", "shares", "fxCurrency", "amount", "currency", "exchangeRate")
-                                        .match("^(?<month>[\\w]{3,4}) "
+                                        .match("^(?<month>" + REGEX_MONTHS + ") "
                                                         + "(?<day>[\\d]{2}) "
                                                         + "(?<tickerSymbol>[A-Z]{3,4})"
                                                         + "[\\W]{1,3}(?<name>.*): .* "
@@ -289,7 +290,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
                                 ,
                                 section -> section
                                         .attributes("month", "day", "tickerSymbol", "name", "shares", "fxCurrency", "currency", "amount", "exchangeRate")
-                                        .match("^(?<month>[\\w]{3,4}) "
+                                        .match("^(?<month>" + REGEX_MONTHS + ") "
                                                         + "(?<day>[\\d]{2}) "
                                                         + "(?<tickerSymbol>[A-Z]{3,4})"
                                                         + "[\\W]{1,3}"
@@ -335,7 +336,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
                                 ,
                                 section -> section
                                         .attributes("month", "day", "tickerSymbol", "name", "shares", "fxCurrency", "currency", "exchangeRate", "amount")
-                                        .match("^(?<month>[\\w]{3,4}) "
+                                        .match("^(?<month>" + REGEX_MONTHS + ") "
                                                         + "(?<day>[\\d]{2}) "
                                                         + "(?<tickerSymbol>[A-Z]{3,4})"
                                                         + "[\\W]{1,3}"
@@ -382,7 +383,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
                                 ,
                                 section -> section
                                         .attributes("month", "day", "tickerSymbol", "name", "shares", "amount")
-                                        .match("^(?<month>[\\w]{3,4}) "
+                                        .match("^(?<month>" + REGEX_MONTHS + ") "
                                                         + "(?<day>[\\d]{2}) "
                                                         + "(?<tickerSymbol>[A-Z]{3,4})"
                                                         + "[\\W]{1,3}(?<name>.*)"
@@ -447,7 +448,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
                 })
 
                 .section("month", "day", "name", "shares", "amount")
-                .match("^(?<month>[\\w]{3,4}) "
+                .match("^(?<month>" + REGEX_MONTHS + ") "
                                 + "(?<day>[\\d]{2}) "
                                 + "(?<name>[\\w]{5,}[\\W]{1,3}.*): .* \\(record date\\) "
                                 + "(?<shares>[\\.,\\d]+) "
@@ -487,7 +488,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
                 })
 
                 .section("month", "day", "amount")
-                .match("^(?<month>[\\w]{3,4}) (?<day>[\\d]{2}) Gross management fee to Wealthsimple [\\W]{1,3} \\-\\p{Sc}(?<amount>[\\.,\\d]+)$")
+                .match("^(?<month>" + REGEX_MONTHS + ") (?<day>[\\d]{2}) Gross management fee to Wealthsimple [\\W]{1,3} \\-\\p{Sc}(?<amount>[\\.,\\d]+)$")
                 .assign((t, v) -> {
                     DocumentContext context = type.getCurrentContext();
 


### PR DESCRIPTION
Improvement of the regular expression in the date by replacing the regex pattern in the format MMMM (LLLL) and MMM (LLL). This is defined in the ExtractorUtils as a static variable.

Remove .replace("Mar", "Mar") (JDK7 vs. JDK8)

https://github.com/portfolio-performance/portfolio/pull/4029#discussion_r1612042728 and ff.

@buchen -> https://github.com/portfolio-performance/portfolio/issues/2683