### PR TITLE
Fix Disappearing filter in Transactions Panes

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/AccountTransactionsPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/AccountTransactionsPane.java
@@ -62,8 +62,8 @@ import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.LogoManager;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.TableViewerCSVExporter;
-import name.abuchen.portfolio.ui.util.searchfilter.TransactionSearchField;
 import name.abuchen.portfolio.ui.util.searchfilter.TransactionFilterDropDown;
+import name.abuchen.portfolio.ui.util.searchfilter.TransactionSearchField;
 import name.abuchen.portfolio.ui.util.viewers.Column;
 import name.abuchen.portfolio.ui.util.viewers.ColumnEditingSupport;
 import name.abuchen.portfolio.ui.util.viewers.ColumnEditingSupport.ModificationListener;
@@ -486,6 +486,7 @@ public class AccountTransactionsPane implements InformationPanePage, Modificatio
 
         toolBar.add(new Separator());
 
+        transactionFilter.dispose();
         toolBar.add(transactionFilter);
 
         toolBar.add(new SimpleAction(Messages.MenuExportData, Images.EXPORT,

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/TransactionsPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/TransactionsPane.java
@@ -29,8 +29,8 @@ import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
 import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.TableViewerCSVExporter;
-import name.abuchen.portfolio.ui.util.searchfilter.TransactionSearchField;
 import name.abuchen.portfolio.ui.util.searchfilter.TransactionFilterDropDown;
+import name.abuchen.portfolio.ui.util.searchfilter.TransactionSearchField;
 import name.abuchen.portfolio.ui.views.TransactionsViewer;
 
 public class TransactionsPane implements InformationPanePage
@@ -92,6 +92,7 @@ public class TransactionsPane implements InformationPanePage
 
         toolBar.add(new Separator());
 
+        transactionFilter.dispose();
         toolBar.add(transactionFilter);
 
         toolBar.add(new SimpleAction(Messages.MenuExportData, Images.EXPORT,


### PR DESCRIPTION
Fixes https://github.com/portfolio-performance/portfolio/pull/3985#issuecomment-2129064338 
Due to keeping Filter in Pane's property transactionFilter its widget was not null stoping DropDown::fill method from exectuion