### PR TITLE
Improve PDF-Importer for case sensitivity in pattern

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -29,7 +29,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
     private static final String IS_JOINT_ACCOUNT = "isJointAccount";
 
     BiConsumer<DocumentContext, String[]> isJointAccount = (context, lines) -> {
-        Pattern pJointAccount = Pattern.compile("^.*(?i)(Kapitalertragssteuer|KAPST) ([\\s]+)?(anteilig|ANTEILIG) [\\d]{2},[\\d]{2}.*$");
+        Pattern pJointAccount = Pattern.compile("^(?i).*(Kapitalertragssteuer|KAPST) ([\\s]+)?(anteilig|ANTEILIG) [\\d]{2},[\\d]{2}.*$");
 
         for (String line : lines)
         {
@@ -74,7 +74,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
         Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
 
-        Block firstRelevantLine = new Block("(?i)^.*(Kauf" //
+        Block firstRelevantLine = new Block("^(?i).*(Kauf" //
                         + "|Bezug" //
                         + "|Verkauf" //
                         + "|VERK\\. TEIL\\-\\/BEZUGSR\\." //
@@ -91,15 +91,16 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         })
 
                         // Is type --> "VERKAUF" change from BUY to SELL
-                        .section("type").optional().match("(?i)^.*(?<type>Verkauf" //
+                        .section("type").optional() //
+                        .match("^(?i).*(?<type>Verkauf" //
                                         + "|VERK\\. TEIL\\-\\/BEZUGSR\\." //
                                         + "|VERKAUF KAPITALMA.*)[\\s]{1,}AM .*$")
                         .assign((t, v) -> {
-                            if ("VERKAUF".equals(v.get("type")) //
-                                            || "Verkauf".equals(v.get("type")) //
-                                            || "VERK. TEIL-/BEZUGSR.".equals(v.get("type")) //
-                                            || "VERKAUF KAPITALMAßN.".equals(v.get("type")) //
-                                            || "VERKAUF KAPITALMASSN.".equals(v.get("type")))
+                            if ("VERKAUF".equalsIgnoreCase(v.get("type")) //
+                                            || "Verkauf".equalsIgnoreCase(v.get("type")) //
+                                            || "VERK. TEIL-/BEZUGSR.".equalsIgnoreCase(v.get("type")) //
+                                            || "VERKAUF KAPITALMAßN.".equalsIgnoreCase(v.get("type")) //
+                                            || "VERKAUF KAPITALMASSN.".equalsIgnoreCase(v.get("type")))
                             {
                                 t.setType(PortfolioTransaction.Type.SELL);
                             }
@@ -207,7 +208,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         // KAUF AM 15.01.2015  UM 08:13:35 MUENCHEN NR. 12345670.001
                         // @formatter:on
                         .section("time").optional() //
-                        .match("(?i)^.*(Kauf" //
+                        .match("^(?i).*(Kauf" //
                                         + "|Bezug" //
                                         + "|Verkauf" //
                                         + "|VERK\\. TEIL\\-\\/BEZUGSR\\." //
@@ -220,7 +221,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         // KAUF AM 15.01.2015  UM 08:13:35 MUENCHEN NR. 12345670.001
                         // @formatter:on
                         .section("date") //
-                        .match("(?i)^.*(Kauf" //
+                        .match("^(?i).*(Kauf" //
                                         + "|Bezug" //
                                         + "|Verkauf" //
                                         + "|VERK\\. TEIL\\-\\/BEZUGSR\\." //
@@ -241,7 +242,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("currency", "amount") //
-                                                        .match("(?i)^([\\s]+)?Wert[\\s]{1,}[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}[\\s]{1,}(?<currency>[\\w]{3})[\\s]{1,}(?<amount>[\\.,\\d]+)$") //
+                                                        .match("^(?i)([\\s]+)?Wert[\\s]{1,}[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}[\\s]{1,}(?<currency>[\\w]{3})[\\s]{1,}(?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
                                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                                             t.setAmount(asAmount(v.get("amount")));
@@ -253,7 +254,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("currency", "amount") //
                                                         .match("^([\\s]+)?(?<currency>[\\w]{3})[\\s]{1,}(?<amount>[\\.,\\d]+)$") //
-                                                        .match("(?i)^([\\s]+)?WERT[\\s]{1,}[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}.*$") //
+                                                        .match("^(?i)([\\s]+)?WERT[\\s]{1,}[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}.*$") //
                                                         .assign((t, v) -> {
                                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                                             t.setAmount(asAmount(v.get("amount")));
@@ -264,7 +265,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("currency", "amount") //
-                                                        .match("(?i)^(zulasten|ZU LASTEN|zugunsten|ZU GUNSTEN)[\\s]{1,}Konto\\-Nr\\.[\\s]{1,}[\\d]+[\\s]{1,}(?<amount>[\\.,\\d]+)[\\s]{1,}(?<currency>[\\w]{3}).*$") //
+                                                        .match("^(?i)(zulasten|ZU LASTEN|zugunsten|ZU GUNSTEN)[\\s]{1,}Konto\\-Nr\\.[\\s]{1,}[\\d]+[\\s]{1,}(?<amount>[\\.,\\d]+)[\\s]{1,}(?<currency>[\\w]{3}).*$") //
                                                         .assign((t, v) -> {
                                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                                             t.setAmount(asAmount(v.get("amount")));
@@ -388,7 +389,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
         Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
 
-        Block firstRelevantLine = new Block("(?i)^(Dividendengutschrift" //
+        Block firstRelevantLine = new Block("^(?i)(Dividendengutschrift" //
                         + "|Ertragsgutschrift" //
                         + "|ERTRAGSTHESAURIERUNG)" //
                         + "( \\/ Neuabrechnung)?([\\s]+)?$");
@@ -422,7 +423,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                                         .match("^ST[\\s]{1,}[\\.,\\d]+[\\s]{1,}WKN:[\\s]{1,}(?<wkn>[A-Z0-9]{6}).*$") //
                                                         .match("^(?<name>.*)$") //
                                                         .match("^(?<nameContinued>.*)$") //
-                                                        .match("(?i)^(ZINS-\\/DIVIDENDENSATZ|(ERTRAGSAUSSCHUETTUNG|ERTRAGSTHESAURIERUNG) P\\. ST\\.) .* (?<currency>[\\w]{3}) SCHLUSSTAG PER [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}.*$") //
+                                                        .match("^(?i)(ZINS-\\/DIVIDENDENSATZ|(ERTRAGSAUSSCHUETTUNG|ERTRAGSTHESAURIERUNG) P\\. ST\\.) .* (?<currency>[\\w]{3}) SCHLUSSTAG PER [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}.*$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
                                         // OMNICOM GROUP INC. Registered Shares DL -,15 871706 US6819191064
@@ -457,14 +458,14 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("(?i)^WERT (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$") //
+                                                        .match("^(?i)WERT (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$") //
                                                         .assign((t, v) -> t.setDateTime(asDate(v.get("date")))),
                                         // @formatter:off
                                         // Valuta 09.01.2018 BIC CSDBDE71XXX
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("(?i)^Valuta (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$") //
+                                                        .match("^(?i)Valuta (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$") //
                                                         .assign((t, v) -> t.setDateTime(asDate(v.get("date")))))
 
                         .oneOf( //
@@ -473,7 +474,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("currency", "amount") //
-                                                        .match("(?i)^WERT (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})[\\s]{1,}(?<currency>[\\w]{3})[\\s]{1,}(?<amount>[\\.,\\d]+).*$") //
+                                                        .match("^(?i)WERT (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})[\\s]{1,}(?<currency>[\\w]{3})[\\s]{1,}(?<amount>[\\.,\\d]+).*$") //
                                                         .assign((t, v) -> {
                                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                                             t.setAmount(asAmount(v.get("amount")));
@@ -494,7 +495,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("currency", "amount") //
-                                                        .match("(?i)^GUTSCHRIFT AUS STEUERLIQUIDITAET[\\s]{1,}(?<currency>[\\w]{3})[\\s]{1,}(?<amount>[\\.,\\d]+).*$") //
+                                                        .match("^(?i)GUTSCHRIFT AUS STEUERLIQUIDITAET[\\s]{1,}(?<currency>[\\w]{3})[\\s]{1,}(?<amount>[\\.,\\d]+).*$") //
                                                         .assign((t, v) -> {
                                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                                             t.setAmount(asAmount(v.get("amount")));
@@ -504,7 +505,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("currency", "amount") //
-                                                        .match("(?i)^UMGER\\.ZUM DEV\\.\\-KURS[\\s]{1,}[\\.,\\d]+[\\s]{1,}(?<currency>[\\w]{3})[\\s]{1,}(?<amount>[\\.,\\d]+).*$") //
+                                                        .match("^(?i)UMGER\\.ZUM DEV\\.\\-KURS[\\s]{1,}[\\.,\\d]+[\\s]{1,}(?<currency>[\\w]{3})[\\s]{1,}(?<amount>[\\.,\\d]+).*$") //
                                                         .assign((t, v) -> {
                                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                                             t.setAmount(asAmount(v.get("amount")));
@@ -1369,7 +1370,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         // Börsenplatzgebühr EUR 2,95
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("(?i)^(abzgl\\. )?B.rsenplatzgeb.hr (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+).*$") //
+                        .match("^(?i)(abzgl\\. )?B.rsenplatzgeb.hr (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+).*$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
@@ -1377,21 +1378,21 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         // abzgl. Börsenplatzgebühr 1,50 EUR
                         // @formatter:on
                         .section("fee", "currency").optional() //
-                        .match("(?i)^(abzgl\\. )?B.rsenplatzgeb.hr (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*?$") //
+                        .match("^(?i)(abzgl\\. )?B.rsenplatzgeb.hr (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*?$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // Handelsentgelt EUR 3,00
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("(?i)^(abzgl\\. )?Handelsentgelt (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+).*$") //
+                        .match("^(?i)(abzgl\\. )?Handelsentgelt (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+).*$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // abzgl. Handelsentgelt 2,61 EUR
                         // @formatter:on
                         .section("fee", "currency").optional() //
-                        .match("(?i)^(abzgl\\. )?Handelsentgelt (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$") //
+                        .match("^(?i)(abzgl\\. )?Handelsentgelt (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
@@ -1400,7 +1401,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         //       PROVISION                                     EUR                   5,11
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("(?i)^([\\s]+)?(abzgl\\. )?Provision ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+).*$") //
+                        .match("^(?i)([\\s]+)?(abzgl\\. )?Provision ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+).*$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
@@ -1408,7 +1409,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         // abzgl. Provision 5,00 EUR
                         // @formatter:on
                         .section("fee", "currency").optional() //
-                        .match("(?i)^(abzgl\\. )?Provision (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$") //
+                        .match("^(?i)(abzgl\\. )?Provision (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
@@ -1416,7 +1417,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         // GRUNDGEBUEHR EUR 4,95
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("(?i)^(abzgl\\. )?(Grundgeb.hr|GRUNDGEBUEHR) (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+).*$") //
+                        .match("^(?i)(abzgl\\. )?(Grundgeb.hr|GRUNDGEBUEHR) (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+).*$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
@@ -1424,91 +1425,91 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         // abzgl. Grundgebühr 4,95 EUR
                         // @formatter:on
                         .section("fee", "currency").optional() //
-                        .match("(?i)^(abzgl\\. )?Grundgeb.hr (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$") //
+                        .match("^(?i)(abzgl\\. )?Grundgeb.hr (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // Consorsbank Ausgabegeb.hr 2,50% EUR 0,61
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("(?i)^(abzgl\\. )?Consorsbank Ausgabegeb.hr [\\.,\\d]+% (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+).*$") //
+                        .match("^(?i)(abzgl\\. )?Consorsbank Ausgabegeb.hr [\\.,\\d]+% (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+).*$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // Transaktionsentgelt EUR 11,54
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("(?i)^(abzgl\\. )?Transaktionsentgelt (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+).*$") //
+                        .match("^(?i)(abzgl\\. )?Transaktionsentgelt (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+).*$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // Transaktionsentgelt 5,96 EUR
                         // @formatter:on
                         .section("fee", "currency").optional() //
-                        .match("(?i)^(abzgl\\. )?Transaktionsentgelt (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$") //
+                        .match("^(?i)(abzgl\\. )?Transaktionsentgelt (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3}).*$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         //       COURTAGE                                      EUR                   1,53
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("(?i)^([\\s]+)?COURTAGE ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+).*$") //
+                        .match("^(?i)([\\s]+)?COURTAGE ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+).*$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // BONIFIKAT. 2,38100 % EUR 1,83
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("(?i)^BONIFIKAT\\. [\\.,\\d]+ % (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+).*$") //
+                        .match("^(?i)BONIFIKAT\\. [\\.,\\d]+ % (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+).*$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         //       EIG.SPESEN                                    EUR                   4,60
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("(?i)^([\\s]+)?EIG\\.SPESEN ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)$") //
+                        .match("^(?i)([\\s]+)?EIG\\.SPESEN ([\\s]+)?(?<currency>[\\w]{3}) ([\\s]+)?(?<fee>[\\.,\\d]+)$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // abz. CortalConsors Discount 2,38100 % EUR 1,83
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("(?i)^abz\\. CortalConsors Discount [\\.,\\d]+ % (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+)$") //
+                        .match("^(?i)abz\\. CortalConsors Discount [\\.,\\d]+ % (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+)$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // Eig. Spesen EUR 1,95
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("(?i)^(abzgl\\. )?Eig\\. Spesen (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+)$") //
+                        .match("^(?i)(abzgl\\. )?Eig\\. Spesen (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+)$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // Eig. Spesen 1,95 EUR
                         // @formatter:on
                         .section("fee", "currency").optional() //
-                        .match("(?i)^(abzgl\\. )?Eig\\. Spesen (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
+                        .match("^(?i)(abzgl\\. )?Eig\\. Spesen (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // FREMDE SPESEN                                 USD                  1,91
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("(?i)^(abzgl\\. )?FREMDE SPESEN [\\s]+(?<currency>[\\w]{3}) [\\s]+(?<fee>[\\.,\\d]+).*$") //
+                        .match("^(?i)(abzgl\\. )?FREMDE SPESEN [\\s]+(?<currency>[\\w]{3}) [\\s]+(?<fee>[\\.,\\d]+).*$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // abzgl. Fremde Spesen 0,07 USD
                         // @formatter:on
                         .section("fee", "currency").optional() //
-                        .match("(?i)^(abzgl\\. )?Fremde Spesen (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
+                        .match("^(?i)(abzgl\\. )?Fremde Spesen (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // Courtage EUR 2,71
                         // @formatter:on
                         .section("fee", "currency").optional() //
-                        .match("(?i)^Courtage (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
+                        .match("^(?i)Courtage (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
@@ -1516,14 +1517,14 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         // abzgl. Handelsplatzkosten 1,95 EUR
                         // @formatter:on
                         .section("fee", "currency").optional() //
-                        .match("(?i)^(abzgl\\. )?Handelsplatzkosten (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
+                        .match("^(?i)(abzgl\\. )?Handelsplatzkosten (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // Consorsbank Ausgabegebühr 1,00% 0,50 EUR
                         // @formatter:on
                         .section("fee", "currency").optional() //
-                        .match("(?i)^Consorsbank Ausgabegeb.hr [\\.,\\d]+% (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
+                        .match("^(?i)Consorsbank Ausgabegeb.hr [\\.,\\d]+% (?<fee>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
                         .assign((t, v) -> processFeeEntries(t, v, type));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -827,8 +827,8 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
                         .wrap(TransactionItem::new));
 
-        Block removalBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. " //
-                        + "(?i)(.berweisung" //
+        Block removalBlock = new Block("^(?i)[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. " //
+                        + "(.berweisung" //
                         + "|Dauerauftrag" //
                         + "|Basislastschrift" //
                         + "|Lastschrift" //
@@ -849,8 +849,8 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
                         .section("month1", "day", "month2", "note", "amount") //
                         .documentContext("nr", "year", "currency") //
-                        .match("^[\\d]{2}\\.(?<month1>[\\d]{2})\\. (?<day>[\\d]{2})\\.(?<month2>[\\d]{2})\\. " //
-                                        + "(?i)(?<note>(.berweisung" //
+                        .match("^(?i)[\\d]{2}\\.(?<month1>[\\d]{2})\\. (?<day>[\\d]{2})\\.(?<month2>[\\d]{2})\\. " //
+                                        + "(?<note>(.berweisung" //
                                         + "|Dauerauftrag" //
                                         + "|Basislastschrift" //
                                         + "|Lastschrift" //
@@ -900,8 +900,8 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
                         .wrap(TransactionItem::new));
 
-        Block depositBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. " //
-                        + "(?i)(Lohn, Gehalt, Rente" //
+        Block depositBlock = new Block("^(?i)[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. " //
+                        + "(Lohn, Gehalt, Rente" //
                         + "|Zahlungseingang" //
                         + "|Storno Gutschrift" //
                         + "|Bareinzahlung am GA" //
@@ -920,8 +920,8 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
                         .section("month1", "day", "month2", "note", "amount") //
                         .documentContext("nr", "year", "currency") //
-                        .match("^[\\d]{2}\\.(?<month1>[\\d]{2})\\. (?<day>[\\d]{2})\\.(?<month2>[\\d]{2})\\. " //
-                                        + "(?i)(?<note>(Lohn, Gehalt, Rente" //
+                        .match("^(?i)[\\d]{2}\\.(?<month1>[\\d]{2})\\. (?<day>[\\d]{2})\\.(?<month2>[\\d]{2})\\. " //
+                                        + "(?<note>(Lohn, Gehalt, Rente" //
                                         + "|Zahlungseingang" //
                                         + "|Storno Gutschrift" //
                                         + "|Bareinzahlung am GA" //
@@ -957,7 +957,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
                         .wrap(TransactionItem::new));
 
-        Block taxReturnBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. [\\d]+ (?i)Steuerausgleich [\\.,\\d]+$");
+        Block taxReturnBlock = new Block("^(?i)[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. [\\d]+ Steuerausgleich [\\.,\\d]+$");
         type.addBlock(taxReturnBlock);
         taxReturnBlock.set(new Transaction<AccountTransaction>()
 
@@ -969,8 +969,8 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
                         .section("month1", "day", "month2", "note", "amount") //
                         .documentContext("nr", "year", "currency") //
-                        .match("^[\\d]{2}\\.(?<month1>[\\d]{2})\\. (?<day>[\\d]{2})\\.(?<month2>[\\d]{2})\\. [\\d]+ " //
-                                        + "(?i)(?<note>Steuerausgleich) " //
+                        .match("^(?i)[\\d]{2}\\.(?<month1>[\\d]{2})\\. (?<day>[\\d]{2})\\.(?<month2>[\\d]{2})\\. [\\d]+ " //
+                                        + "(?<note>Steuerausgleich) " //
                                         + "(?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             // since year is not within the date correction
@@ -992,8 +992,8 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
                         .wrap(TransactionItem::new));
 
-        Block feesBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. " //
-                        + "(?i)(Rechnung" //
+        Block feesBlock = new Block("^(?i)[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. " //
+                        + "(Rechnung" //
                         + "|Buchung" //
                         + "|sonstige Entgelte) " //
                         + "[\\.,\\d]+$");
@@ -1008,12 +1008,12 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
                         .section("month1", "day", "month2", "note1", "amount", "note2") //
                         .documentContext("nr", "year", "currency") //
-                        .match("^[\\d]{2}\\.(?<month1>[\\d]{2})\\. (?<day>[\\d]{2})\\.(?<month2>[\\d]{2})\\. " //
-                                        + "(?i)(?<note1>(Rechnung" //
+                        .match("^(?i)[\\d]{2}\\.(?<month1>[\\d]{2})\\. (?<day>[\\d]{2})\\.(?<month2>[\\d]{2})\\. " //
+                                        + "(?<note1>(Rechnung" //
                                         + "|Buchung" //
                                         + "|sonstige Entgelte)) " //
                                         + "(?<amount>[\\.,\\d]+)$")
-                        .match("^.*(?i)(?<note2>(Bargeldeinzahlung" //
+                        .match("^(?i).*(?<note2>(Bargeldeinzahlung" //
                                         + "|R.ckruf\\/Nachforschung" //
                                         + "|Identifikationscode" //
                                         + "|Stornorechnung" //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
@@ -662,8 +662,8 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("day", "month", "note", "amount", "sign").optional() //
                         .documentContext("currency", "nr", "year") //
-                        .match("^[\\d]{2}\\.[\\d]{2}\\. (?<day>[\\d]{2})\\.(?<month>[\\d]{2})\\. " //
-                                        + "(?i)(?<note>Einnahmen" //
+                        .match("^(?i)[\\d]{2}\\.[\\d]{2}\\. (?<day>[\\d]{2})\\.(?<month>[\\d]{2})\\. " //
+                                        + "(?<note>Einnahmen" //
                                         + "|BASISLASTSCHRIFT" //
                                         + "|DAUERAUFTRAG" //
                                         + "|EURO\\-UEBERWEISUNG" //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -87,14 +87,13 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
-                        .match("(?i)^((Limit|Stop\\-Market|Market)\\-Order(\\s)?)?" //
+                        .match("^(?i)((Limit|Stop\\-Market|Market)\\-Order(\\s)?)?" //
                                         + "(?<type>(Kauf" //
                                         + "|Buy" //
                                         + "|Achat" //
                                         + "|Acquisto" //
                                         + "|Verkauf"
                                         + "|Sell" //
-                                        + "|SELL" //
                                         + "|Sparplanausf.hrung" //
                                         + "|SAVINGS PLAN" //
                                         + "|Ex.cution de l.investissement programm." //
@@ -103,11 +102,10 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         + "|TILGUNG))" //
                                         + ".*$") //
                         .assign((t, v) -> {
-                            if ("Verkauf".equals(v.get("type")) //
-                                            || "Sell".equals(v.get("type")) //
-                                            || "SELL".equals(v.get("type")) //
-                                            || "ZWANGSÜBERNAHME".equals(v.get("type")) //
-                                            || "TILGUNG".equals(v.get("type")))
+                            if ("Verkauf".equalsIgnoreCase(v.get("type")) //
+                                            || "Sell".equalsIgnoreCase(v.get("type")) //
+                                            || "ZWANGSÜBERNAHME".equalsIgnoreCase(v.get("type")) //
+                                            || "TILGUNG".equalsIgnoreCase(v.get("type")))
                                 t.setType(PortfolioTransaction.Type.SELL);
                         })
 
@@ -243,7 +241,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date", "time") //
-                                                        .match("(?i)^((Limit|Stop\\-Market|Market)\\-Order(\\s)?)?(Buy|Achat|Acquisto|Kauf|Verkauf|Sell) .*" //
+                                                        .match("^(?i)((Limit|Stop\\-Market|Market)\\-Order(\\s)?)?(Buy|Achat|Acquisto|Kauf|Verkauf|Sell) .*" //
                                                                         + "(?<date>([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}" //
                                                                         + "|[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}" //
                                                                         + "|[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}))" //
@@ -2291,7 +2289,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date", "time") //
-                                                        .match("(?i)^((Limit|Stop\\-Market|Market)\\-Order(\\s)?)?(Buy|Achat|Acquisto|Kauf|Verkauf|Sell) .* " //
+                                                        .match("^(?i)((Limit|Stop\\-Market|Market)\\-Order(\\s)?)?(Buy|Achat|Acquisto|Kauf|Verkauf|Sell) .* " //
                                                                         + "(?<date>([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}" //
                                                                         + "|[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}" //
                                                                         + "|[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}))" //


### PR DESCRIPTION
- Position correction of the (?i) regEx to the beginning of the patter string
- If (?i), case sensitivity, is deactivated, change the query equal() to equalsIgnoreCase().

@christen90 
Thank you for your comit #4071.
I have taken this and rolled it out to the other PDF importers as this is/was a common problem.