### PR TITLE
fix filename of an investment plan CSV export

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/InvestmentPlan.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/InvestmentPlan.java
@@ -524,4 +524,10 @@ public class InvestmentPlan implements Named, Adaptable, Attributable
         account.addTransaction(transaction);
         return new TransactionPair<>(account, transaction);
     }
+
+    @Override
+    public String toString()
+    {
+        return name;
+    }
 }


### PR DESCRIPTION
Exporting the transactions of an Investment Plan was producing a strange default CSV filename.

Before :
![Capture d’écran 2024-06-16 223854](https://github.com/portfolio-performance/portfolio/assets/160436107/405e1017-958c-4990-812f-a8823c66d5ec)

After :
![Capture d’écran 2024-06-16 224456](https://github.com/portfolio-performance/portfolio/assets/160436107/f418d76e-32c3-42d5-95c3-86e135c0c23f)
