### PR TITLE
add CSV export to Taxonomy stacked charts

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedChartCSVExporter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedChartCSVExporter.java
@@ -1,0 +1,94 @@
+package name.abuchen.portfolio.ui.util.chart;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+import org.apache.commons.csv.CSVPrinter;
+import org.eclipse.swt.widgets.Shell;
+import org.swtchart.ISeries;
+
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.util.AbstractCSVExporter;
+
+public class StackedChartCSVExporter extends AbstractCSVExporter
+{
+    private final StackedTimelineChart stackedchart;
+
+    private NumberFormat valueFormat = new DecimalFormat("#,##0.00"); //$NON-NLS-1$
+
+    public StackedChartCSVExporter(StackedTimelineChart stackedchart)
+    {
+        this.stackedchart = stackedchart;
+    }
+
+    public void setValueFormat(NumberFormat valueFormat)
+    {
+        this.valueFormat = valueFormat;
+    }
+
+    @Override
+    protected Shell getShell()
+    {
+            return stackedchart.getShell();
+    }
+
+    @Override
+    protected void writeToFile(File file) throws IOException
+    {
+        try (CSVPrinter printer = new CSVPrinter(
+                        new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8), STRATEGY))
+        {
+            ISeries[] series = stackedchart.getSeriesSet().getSeries();
+
+            // write header
+            printer.print(Messages.ColumnDate);
+            for (ISeries s : series)
+                printer.print(s.getDescription() != null ? s.getDescription() : s.getId());
+            printer.println();
+
+            // write body
+            SeriesAdapter[] adapters = new SeriesAdapter[series.length];
+            for (int ii = 0; ii < series.length; ii++)
+            {
+                adapters[ii] = new DefaultAdapter(series[ii]);
+            }
+
+            String[] dateSeriesStacked = stackedchart.getAxisSet().getXAxis(0).getCategorySeries();
+            for (int line = 0; line < dateSeriesStacked.length; line++)
+            {
+                printer.print(dateSeriesStacked[line]);
+
+                for (int col = 0; col < adapters.length; col++)
+                    printer.print(adapters[col].format(line));
+
+                printer.println();
+            }
+        }
+    }
+
+    private interface SeriesAdapter
+    {
+        String format(int line);
+    }
+
+    private class DefaultAdapter implements SeriesAdapter
+    {
+        private double[] values;
+
+        public DefaultAdapter(ISeries series)
+        {
+            this.values = series.getYSeries();
+        }
+
+        @Override
+        public String format(int line)
+        {
+            return valueFormat.format(values[line]);
+        }
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedTimelineChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedTimelineChart.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.ui.util.chart;
 import java.time.LocalDate;
 import java.util.List;
 
+import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.graphics.Color;
@@ -26,6 +27,8 @@ public class StackedTimelineChart extends Chart // NOSONAR
     private TimelineChartToolTip toolTip;
 
     private List<LocalDate> dates;
+
+    private ChartContextMenu contextMenu;
 
     public StackedTimelineChart(Composite parent, List<LocalDate> dates)
     {
@@ -66,7 +69,7 @@ public class StackedTimelineChart extends Chart // NOSONAR
         toolTip.enableCategory(true);
         toolTip.reverseLabels(true);
 
-        new ChartContextMenu(this);
+        this.contextMenu = new ChartContextMenu(this);
     }
 
     public void setDates(List<LocalDate> dates)
@@ -127,5 +130,10 @@ public class StackedTimelineChart extends Chart // NOSONAR
     public boolean setFocus()
     {
         return getPlotArea().setFocus();
+    }
+
+    public void exportMenuAboutToShow(IMenuManager manager, String label)
+    {
+        this.contextMenu.exportMenuAboutToShow(manager, label);
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractStackedChartViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractStackedChartViewer.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.ui.views.taxonomy;
 
+import java.text.DecimalFormat;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -16,6 +17,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.action.Separator;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -33,6 +35,7 @@ import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.editor.PortfolioPart;
 import name.abuchen.portfolio.ui.util.ReportingPeriodDropDown.ReportingPeriodListener;
 import name.abuchen.portfolio.ui.util.SimpleAction;
+import name.abuchen.portfolio.ui.util.chart.StackedChartCSVExporter;
 import name.abuchen.portfolio.ui.util.chart.StackedTimelineChart;
 import name.abuchen.portfolio.util.Interval;
 
@@ -146,6 +149,27 @@ public abstract class AbstractStackedChartViewer extends AbstractChartPage imple
         });
         action.setChecked(getModel().isOrderByTaxonomyInStackChart());
         manager.add(action);
+    }
+
+    @Override
+    public void exportMenuAboutToShow(IMenuManager manager)
+    {
+        manager.add(new Action(Messages.MenuExportChartData)
+        {
+            @Override
+            public void run()
+            {
+                StackedChartCSVExporter exporter = new StackedChartCSVExporter(chart);
+                // set decimal format if chart is a Percentage Stack Chart.
+                if (chart.getAxisSet().getYAxis(0).getTick().getFormat() instanceof DecimalFormat)
+                    exporter.setValueFormat(new DecimalFormat("0.##########")); //$NON-NLS-1$
+
+                exporter.export(chart.getTitle().getText() + ".csv"); //$NON-NLS-1$
+            }
+        });
+
+        manager.add(new Separator());
+        chart.exportMenuAboutToShow(manager, chart.getTitle().getText());
     }
 
     @Override


### PR DESCRIPTION
Issue: https://forum.portfolio-performance.info/t/daten-exportieren-button-ohne-funktion-unter-klassifizierungen/27371

Hello, this is a proposition to add (or re add??) the CSV export of chart data to the Taxonomy stacked charts.
Currently the export button is doing nothing for those charts. 
I duplicated `TimelineChartCSVExporter` with some simplifications (I do not think we can expect `discontinuousSeries` here). dateSeries is a bit different too since its a categorized graph.