### PR TITLE
Improve of the date recognition of the PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorUtilsDateParserTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorUtilsDateParserTest.java
@@ -21,15 +21,15 @@ public class ExtractorUtilsDateParserTest
     {
         // Test valid date strings for each pattern in DATE_FORMATTER_GERMANY
         LocalDateTime expected = LocalDateTime.of(2022, 4, 11, 0, 0);
-        assertEquals(expected, ExtractorUtils.asDate("11.4.2022"));
         assertEquals(expected, ExtractorUtils.asDate("11.4.22"));
-        assertEquals(expected, ExtractorUtils.asDate("2022-4-11"));
-        assertEquals(expected, ExtractorUtils.asDate("11-4-2022"));
         assertEquals(expected, ExtractorUtils.asDate("11.04.22"));
+        assertEquals(expected, ExtractorUtils.asDate("11-4-2022"));
         assertEquals(expected, ExtractorUtils.asDate("11-04-2022"));
-        assertEquals(expected, ExtractorUtils.asDate("2022-04-11"));
-        assertEquals(expected, ExtractorUtils.asDate("11. April 2022"));
+        assertEquals(expected, ExtractorUtils.asDate("11/4/2022"));
         assertEquals(expected, ExtractorUtils.asDate("11/04/2022"));
+        assertEquals(expected, ExtractorUtils.asDate("11. April 2022"));
+        assertEquals(expected, ExtractorUtils.asDate("2022-4-11"));
+        assertEquals(expected, ExtractorUtils.asDate("2022-04-11"));
     }
 
     @Test(expected = DateTimeParseException.class)
@@ -45,44 +45,116 @@ public class ExtractorUtilsDateParserTest
         // Test valid date strings for each pattern in
         // DATE_FORMATTER_GERMANY with hints
         LocalDateTime expected = LocalDateTime.of(2023, 4, 11, 0, 0);
-        assertEquals(expected, ExtractorUtils.asDate("11.4.2023", Locale.GERMANY));
         assertEquals(expected, ExtractorUtils.asDate("11.4.23", Locale.GERMANY));
-        assertEquals(expected, ExtractorUtils.asDate("2023-4-11", Locale.GERMANY));
-        assertEquals(expected, ExtractorUtils.asDate("11-4-2023", Locale.GERMANY));
         assertEquals(expected, ExtractorUtils.asDate("11.04.23", Locale.GERMANY));
-        assertEquals(expected, ExtractorUtils.asDate("11-04-2023", Locale.GERMANY));
-        assertEquals(expected, ExtractorUtils.asDate("2023-04-11", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("11.4.2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("11.04.2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("11/4/2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("11/04/2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("11. April 23", Locale.GERMANY));
         assertEquals(expected, ExtractorUtils.asDate("11. April 2023", Locale.GERMANY));
         assertEquals(expected, ExtractorUtils.asDate("11. APRIL 2023", Locale.GERMANY));
-        assertEquals(expected, ExtractorUtils.asDate("11/04/2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("2023-4-11", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("2023-04-11", Locale.GERMANY));
+
+        expected = LocalDateTime.of(2023, 4, 1, 0, 0);
+        assertEquals(expected, ExtractorUtils.asDate("1.4.2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("01.4.2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("1.04.2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("01.04.2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("1-4-2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("01-4-2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("1-04-2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("01-04-2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("1/4/2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("01/4/2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("1/04/2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("01/04/2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("1 April 23", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("01 April 23", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("1. April 2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("01. April 2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("1. APRIL 2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("01. APRIL 2023", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("2023-4-1", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("2023-4-01", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("2023-04-1", Locale.GERMANY));
+        assertEquals(expected, ExtractorUtils.asDate("2023-04-01", Locale.GERMANY));
 
         // Test valid date strings for each pattern in
         // DATE_FORMATTER_US with hints
-        expected = LocalDateTime.of(2023, 4, 9, 0, 0);
-        assertEquals(expected, ExtractorUtils.asDate("9 Apr 2023", Locale.US));
-        assertEquals(expected, ExtractorUtils.asDate("09 Apr 2023", Locale.US));
-        assertEquals(expected, ExtractorUtils.asDate("20230409", Locale.US));
-        assertEquals(expected, ExtractorUtils.asDate("Apr/09/2023", Locale.US));
-        assertEquals(expected, ExtractorUtils.asDate("04-09-23", Locale.US));
-        assertEquals(expected, ExtractorUtils.asDate("APR/09/2023", Locale.US));
+        expected = LocalDateTime.of(2023, 4, 11, 0, 0);
+        assertEquals(expected, ExtractorUtils.asDate("11 Apr 2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("11 April 2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("04-11-23", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("04-11-2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("04/11/23", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("04/11/2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("Apr/11/2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("Apr 11, 2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("April/11/2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("April 11, 2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("2023Apr11", Locale.US));
+
+        expected = LocalDateTime.of(2023, 4, 1, 0, 0);
+        assertEquals(expected, ExtractorUtils.asDate("1 Apr 2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("01 Apr 2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("04-1-23", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("04-01-23", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("04-1-2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("04-01-2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("04/1/23", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("04/01/23", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("04/1/2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("04/01/2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("Apr/1/2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("Apr/01/2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("Apr 1, 2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("Apr 01, 2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("April/1/2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("April/01/2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("April 1, 2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("April 01, 2023", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("2023Apr1", Locale.US));
+        assertEquals(expected, ExtractorUtils.asDate("2023Apr01", Locale.US));
 
         // Test valid date strings for each pattern in
         // DATE_FORMATTER_CANADA with hints
         expected = LocalDateTime.of(2023, 04, 11, 0, 0);
         assertEquals(expected, ExtractorUtils.asDate("Apr. 11, 2023", Locale.CANADA));
 
+        expected = LocalDateTime.of(2023, 4, 1, 0, 0);
+        assertEquals(expected, ExtractorUtils.asDate("Apr. 1, 2023", Locale.CANADA));
+        assertEquals(expected, ExtractorUtils.asDate("Apr. 01, 2023", Locale.CANADA));
+
         // Test valid date strings for each pattern in
         // DATE_FORMATTER_CANADA_FRENCH with hints
         expected = LocalDateTime.of(2023, 4, 11, 0, 0);
         assertEquals(expected, ExtractorUtils.asDate("11 avr. 2023", Locale.CANADA_FRENCH));
 
+        expected = LocalDateTime.of(2023, 4, 1, 0, 0);
+        assertEquals(expected, ExtractorUtils.asDate("1 avr. 2023", Locale.CANADA_FRENCH));
+        assertEquals(expected, ExtractorUtils.asDate("01 avr. 2023", Locale.CANADA_FRENCH));
+
         // Test valid date strings for each pattern in
         // DATE_FORMATTER_UK with hints
         expected = LocalDateTime.of(2023, 4, 11, 0, 0);
-        assertEquals(expected, ExtractorUtils.asDate("11 Apr 2023", Locale.UK));
-        assertEquals(expected, ExtractorUtils.asDate("11 APR 2023", Locale.UK));
         assertEquals(expected, ExtractorUtils.asDate("04/11/2023", Locale.UK));
         assertEquals(expected, ExtractorUtils.asDate("11.04.2023", Locale.UK));
+        assertEquals(expected, ExtractorUtils.asDate("11 Apr 2023", Locale.UK));
+        assertEquals(expected, ExtractorUtils.asDate("11 APR 2023", Locale.UK));
+        assertEquals(expected, ExtractorUtils.asDate("11 April 2023", Locale.UK));
+        assertEquals(expected, ExtractorUtils.asDate("11 APRIL 2023", Locale.UK));
+
+        expected = LocalDateTime.of(2023, 4, 1, 0, 0);
+        assertEquals(expected, ExtractorUtils.asDate("4/1/2023", Locale.UK));
+        assertEquals(expected, ExtractorUtils.asDate("4/01/2023", Locale.UK));
+        assertEquals(expected, ExtractorUtils.asDate("04/1/2023", Locale.UK));
+        assertEquals(expected, ExtractorUtils.asDate("01.04.2023", Locale.UK));
+        assertEquals(expected, ExtractorUtils.asDate("1 Apr 2023", Locale.UK));
+        assertEquals(expected, ExtractorUtils.asDate("01 Apr 2023", Locale.UK));
+        assertEquals(expected, ExtractorUtils.asDate("1 APR 2023", Locale.UK));
+        assertEquals(expected, ExtractorUtils.asDate("01 APR 2023", Locale.UK));
     }
 
     @Test(expected = DateTimeParseException.class)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
@@ -39,54 +39,90 @@ public class ExtractorUtils
 
     // Date formatters with case-insensitive support for Germany
     private static final DateTimeFormatter[] DATE_FORMATTER_GERMANY = { //
-                    createFormatter("d.M.yyyy", Locale.GERMANY), //
                     createFormatter("d.M.yy", Locale.GERMANY), //
-                    createFormatter("yyyy-M-d", Locale.GERMANY), //
-                    createFormatter("d-M-yyyy", Locale.GERMANY), //
+                    createFormatter("dd.M.yy", Locale.GERMANY), //
+                    createFormatter("d.M.yyyy", Locale.GERMANY), //
+                    createFormatter("dd.M.yyyy", Locale.GERMANY), //
+                    createFormatter("d.MM.yy", Locale.GERMANY), //
                     createFormatter("dd.MM.yy", Locale.GERMANY), //
-                    createFormatter("dd-MM-yyyy", Locale.GERMANY), //
-                    createFormatter("yyyy-MM-dd", Locale.GERMANY), //
-                    createFormatter("dd. MMMM yyyy", Locale.GERMANY), //
-                    createFormatter("d. MMMM yyyy", Locale.GERMANY), //
-                    createFormatter("dd MMMM yyyy", Locale.GERMANY), //
-                    createFormatter("d MMMM yyyy", Locale.GERMANY), //
-                    createFormatter("dd MMM yyyy", Locale.GERMANY), //
+                    createFormatter("d MMM yy", Locale.GERMANY), //
+                    createFormatter("dd MMM yy", Locale.GERMANY), //
                     createFormatter("d MMM yyyy", Locale.GERMANY), //
-                    createFormatter("dd/MM/yyyy", Locale.GERMANY) };
+                    createFormatter("dd MMM yyyy", Locale.GERMANY), //
+                    createFormatter("d-M-yyyy", Locale.GERMANY), //
+                    createFormatter("dd-M-yyyy", Locale.GERMANY), //
+                    createFormatter("d-MM-yyyy", Locale.GERMANY), //
+                    createFormatter("dd-MM-yyyy", Locale.GERMANY), //
+                    createFormatter("d MMMM yy", Locale.GERMANY), //
+                    createFormatter("dd MMMM yy", Locale.GERMANY), //
+                    createFormatter("d. MMMM yy", Locale.GERMANY), //
+                    createFormatter("dd. MMMM yy", Locale.GERMANY), //
+                    createFormatter("d MMMM yyyy", Locale.GERMANY), //
+                    createFormatter("dd MMMM yyyy", Locale.GERMANY), //
+                    createFormatter("d. MMMM yyyy", Locale.GERMANY), //
+                    createFormatter("dd. MMMM yyyy", Locale.GERMANY), //
+                    createFormatter("yyyy-M-d", Locale.GERMANY), //
+                    createFormatter("yyyy-M-dd", Locale.GERMANY), //
+                    createFormatter("yyyy-MM-d", Locale.GERMANY), //
+                    createFormatter("yyyy-MM-dd", Locale.GERMANY), //
+                    createFormatter("d/MM/yyyy", Locale.GERMANY),
+                    createFormatter("dd/MM/yyyy", Locale.GERMANY),
+                    createFormatter("d/M/yyyy", Locale.GERMANY),
+                    createFormatter("dd/M/yyyy", Locale.GERMANY) };
 
     // Date formatters with case-insensitive support for the United States
     private static final DateTimeFormatter[] DATE_FORMATTER_US = { //
-                    createFormatter("dd LLLL yyyy", Locale.US), //
-                    createFormatter("d LLLL yyyy", Locale.US), //
-                    createFormatter("dd LLL yyyy", Locale.US), //
                     createFormatter("d LLL yyyy", Locale.US), //
-                    createFormatter("MM-dd-yy", Locale.US), //
-                    createFormatter("MM/dd/yy", Locale.US), //
-                    createFormatter("MMM/dd/yyyy", Locale.US), //
-                    createFormatter("MMM/d/yyyy", Locale.US), //
-                    createFormatter("LLL/dd/yyyy", Locale.US), //
-                    createFormatter("LLL/d/yyyy", Locale.US), //
-                    createFormatter("LL/dd/yyyy", Locale.US), //
+                    createFormatter("dd LLL yyyy", Locale.US), //
+                    createFormatter("d LLLL yyyy", Locale.US), //
+                    createFormatter("dd LLLL yyyy", Locale.US), //
+                    createFormatter("yyyyLLd", Locale.US), //
+                    createFormatter("yyyyLLdd", Locale.US), //
+                    createFormatter("yyyyLLLd", Locale.US), //
+                    createFormatter("yyyyLLLdd", Locale.US), //
+                    createFormatter("LL-d-yy", Locale.US), //
+                    createFormatter("LL-dd-yy", Locale.US), //
+                    createFormatter("LL-d-yyyy", Locale.US), //
+                    createFormatter("LL-dd-yyyy", Locale.US), //
+                    createFormatter("LL/d/yy", Locale.US), //
+                    createFormatter("LL/dd/yy", Locale.US), //
                     createFormatter("LL/d/yyyy", Locale.US), //
-                    createFormatter("yyyyMMdd", Locale.US) };
+                    createFormatter("LL/dd/yyyy", Locale.US), //
+                    createFormatter("LLL/d/yyyy", Locale.US), //
+                    createFormatter("LLL/dd/yyyy", Locale.US), //
+                    createFormatter("LLL d, yyyy", Locale.US), //
+                    createFormatter("LLL dd, yyyy", Locale.US), //
+                    createFormatter("LLLL/d/yyyy", Locale.US), //
+                    createFormatter("LLLL/dd/yyyy", Locale.US), //
+                    createFormatter("LLLL d, yyyy", Locale.US),
+                    createFormatter("LLLL dd, yyyy", Locale.US), };
 
     // Date formatters with case-insensitive support for Canada
     private static final DateTimeFormatter[] DATE_FORMATTER_CANADA = { //
-                    createFormatter("LLL dd, yyyy", Locale.CANADA) };
+                    createFormatter("LLL dd, yyyy", Locale.CANADA), //
+                    createFormatter("LLL d, yyyy", Locale.CANADA)};
 
     // Date formatters with case-insensitive support for Canadian French
     private static final DateTimeFormatter[] DATE_FORMATTER_CANADA_FRENCH = { //
-                    createFormatter("dd LLL yyyy", Locale.CANADA_FRENCH) };
+                    createFormatter("d LLL yyyy", Locale.CANADA_FRENCH), //
+                    createFormatter("dd LLL yyyy", Locale.CANADA_FRENCH)};
 
     // Date formatters with case-insensitive support for the United Kingdom
     private static final DateTimeFormatter[] DATE_FORMATTER_UK = { //
-                    createFormatter("dd LLLL yyyy", Locale.UK), //
                     createFormatter("d LLLL yyyy", Locale.UK), //
-                    createFormatter("dd LLL yyyy", Locale.UK), //
+                    createFormatter("dd LLLL yyyy", Locale.UK), //
                     createFormatter("d LLL yyyy", Locale.UK), //
+                    createFormatter("dd LLL yyyy", Locale.UK), //
+                    createFormatter("LL/d/yyyy", Locale.UK), //
                     createFormatter("LL/dd/yyyy", Locale.UK), //
                     createFormatter("L/d/yyyy", Locale.UK), //
-                    createFormatter("dd.LL.yyyy", Locale.UK) };
+                    createFormatter("L/dd/yyyy", Locale.UK), //
+                    createFormatter("d.LL.yyyy", Locale.UK), //
+                    createFormatter("dd.LL.yyyy", Locale.UK), //
+                    createFormatter("LLL/d/yyyy", Locale.UK), //
+                    createFormatter("LLL/dd/yyyy", Locale.UK), //
+                    createFormatter("LLLL/d/yyyy", Locale.UK), //
+                    createFormatter("LLLL/dd/yyyy", Locale.UK) };
 
     // Map associating locales with their respective date formatters
     private static final Map<Locale, DateTimeFormatter[]> LOCALE2DATE = Map.of( //
@@ -99,25 +135,41 @@ public class ExtractorUtils
     // DateTime formatters with case-insensitive support for various locales
     private static final DateTimeFormatter[] DATE_TIME_FORMATTER = { //
                     createFormatter("d.M.yyyy HH:mm", Locale.GERMANY), //
+                    createFormatter("dd.M.yyyy HH:mm", Locale.GERMANY), //
+                    createFormatter("d-MM-yyyy HH:mm", Locale.GERMANY), //
                     createFormatter("dd-MM-yyyy HH:mm", Locale.GERMANY), //
+                    createFormatter("d-MM-yyyy HH:mm", Locale.GERMANY), //
+                    createFormatter("dd-MM-yyyy HH:mm", Locale.GERMANY), //
+                    createFormatter("d-MM-yyyy HH:mm:ss", Locale.GERMANY), //
                     createFormatter("dd-MM-yyyy HH:mm:ss", Locale.GERMANY), //
-                    createFormatter("dd LLLL yyyy HH:mm:ss", Locale.GERMANY), //
-                    createFormatter("d LLLL yyyy HH:mm:ss", Locale.GERMANY), //
-                    createFormatter("dd LLL yyyy HH:mm:ss", Locale.GERMANY), //
-                    createFormatter("d LLLL yyyy HH:mm:ss", Locale.GERMANY), //
-                    createFormatter("d LLL yyyy HH:mm:ss", Locale.GERMANY), //
-                    createFormatter("d. MMMM yyyy HH:mm:ss", Locale.GERMANY), //
-                    createFormatter("d.M.yyyy HH:mm:ss", Locale.GERMANY), //
-                    createFormatter("dd/MM/yyyy HH:mm:ss", Locale.GERMANY), //
+                    createFormatter("d.MM.yyyy HH.mm.ss", Locale.GERMANY), //
                     createFormatter("dd.MM.yyyy HH.mm.ss", Locale.GERMANY), //
+                    createFormatter("d.MM.yyyy H:mm:ss", Locale.GERMANY), //
                     createFormatter("dd.MM.yyyy H:mm:ss", Locale.GERMANY), //
-                    createFormatter("yyyy-MM-dd HH:mm:ss", Locale.US), //
-                    createFormatter("yyyyMMdd HHmmss", Locale.US), //
-                    createFormatter("dd/MM/yyyy HH:mm", Locale.UK), //
+                    createFormatter("d LLL yyyy HH:mm:ss", Locale.GERMANY), //
+                    createFormatter("dd LLL yyyy HH:mm:ss", Locale.GERMANY), //
+                    createFormatter("d MMMM yyyy HH:mm:ss", Locale.GERMANY), //
+                    createFormatter("dd MMMM yyyy HH:mm:ss", Locale.GERMANY), //
+                    createFormatter("d. MMMM yyyy HH:mm:ss", Locale.GERMANY), //
+                    createFormatter("dd. MMMM yyyy HH:mm:ss", Locale.GERMANY), //
+                    createFormatter("d.M.yyyy HH:mm:ss", Locale.GERMANY), //
+                    createFormatter("dd.M.yyyy HH:mm:ss", Locale.GERMANY), //
+                    createFormatter("d/MM/yyyy HH:mm:ss", Locale.GERMANY), //
+                    createFormatter("dd/MM/yyyy HH:mm:ss", Locale.GERMANY), //
+                    createFormatter("yyyy-LL-d HH:mm:ss", Locale.US), //
+                    createFormatter("yyyy-LL-dd HH:mm:ss", Locale.US), //
+                    createFormatter("yyyyLLd HHmmss", Locale.US), //
+                    createFormatter("yyyyLLdd HHmmss", Locale.US), //
+                    createFormatter("d/LL/yyyy HH:mm", Locale.UK), //
+                    createFormatter("dd/LL/yyyy HH:mm", Locale.UK), //
+                    createFormatter("d.LL.yyyy hh:mm:ss a", Locale.UK), //
+                    createFormatter("dd.LL.yyyy hh:mm:ss a", Locale.UK), //
+                    createFormatter("d LLL yyyy HH:mm:ss", Locale.UK), //
                     createFormatter("dd LLL yyyy HH:mm:ss", Locale.UK), //
-                    createFormatter("dd.MM.yyyy hh:mm:ss a", Locale.UK), //
-                    createFormatter("dd/MM/yy HH.mm", Locale.UK), //
-                    createFormatter("d/MM/yy HH.mm", Locale.UK) };
+                    createFormatter("d/LL/yy HH.mm", Locale.UK), //
+                    createFormatter("dd/LL/yy HH.mm", Locale.UK), //
+                    createFormatter("d/LL/yy HH.mm", Locale.UK),
+                    createFormatter("dd/LL/yy HH.mm", Locale.UK)};
 
     private ExtractorUtils()
     {


### PR DESCRIPTION
The patter has been updated in the ExtractorUtils and the test cases.

The month recognition for non-German was changed from M to L in order to format the month designation according to the localized setting (locale) of the system.
It has also been added that the day can be a one-digit or two-digit number. The same applies to the month.

Hello @buchen 
Are you okay with this change and does it make sense to you?
I have therefore extended the test cases to cover even more.

Regards
Alex