### PR TITLE
Improve autoscale of icons for high definition screens 4K

### DIFF
--- a/portfolio-product/name.abuchen.portfolio.distro.product
+++ b/portfolio-product/name.abuchen.portfolio.distro.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Portfolio Performance" uid="name.abuchen.portfolio.distro.product" id="name.abuchen.portfolio.bootstrap.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="0.69.1.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Portfolio Performance" uid="name.abuchen.portfolio.distro.product" id="name.abuchen.portfolio.bootstrap.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="0.69.1.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>
@@ -13,6 +13,8 @@
       </vmArgsLin>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
+      <vmArgsWin>-Dswt.autoScale=quarter -Dswt.autoScale.method=nearest
+      </vmArgsWin>
    </launcherArgs>
 
    <splash
@@ -59,18 +61,17 @@
       <feature id="org.eclipse.ecf.filetransfer.feature"/>
       <feature id="org.eclipse.nebula.cwt.feature"/>
       <feature id="org.eclipse.nebula.widgets.cdatetime.feature"/>
-      
       <feature id="name.abuchen.zulu.jre.feature"/>
    </features>
 
    <configurations>
+      <plugin id="com.twelvemonkeys.imageio.bmp" autoStart="true" startLevel="4" />
       <plugin id="name.abuchen.portfolio.ui" autoStart="false" startLevel="4" />
-      <plugin id="com.twelvemonkeys.imageio.bmp" autoStart="true" startLevel="4"/>
-      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="1" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
-      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="1" />
       <plugin id="org.eclipse.osgi" autoStart="true" startLevel="-1" />
       <property name="osgi.instance.area.default" value="$LOCALAPPDATA$/PortfolioPerformance/workspace" os="win32" />
       <property name="osgi.instance.area.default" value="@user.home/Library/Application Support/name.abuchen.portfolio.product/workspace" os="macosx" />

--- a/portfolio-product/name.abuchen.portfolio.product
+++ b/portfolio-product/name.abuchen.portfolio.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Portfolio Performance" uid="name.abuchen.portfolio.product" id="name.abuchen.portfolio.bootstrap.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="0.69.1.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Portfolio Performance" uid="name.abuchen.portfolio.product" id="name.abuchen.portfolio.bootstrap.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="0.69.1.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>
@@ -13,6 +13,8 @@
       </vmArgsLin>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
+      <vmArgsWin>-Dswt.autoScale=quarter -Dswt.autoScale.method=nearest
+      </vmArgsWin>
    </launcherArgs>
 
    <splash
@@ -62,13 +64,13 @@
    </features>
 
    <configurations>
+      <plugin id="com.twelvemonkeys.imageio.bmp" autoStart="true" startLevel="4" />
       <plugin id="name.abuchen.portfolio.ui" autoStart="false" startLevel="4" />
-      <plugin id="com.twelvemonkeys.imageio.bmp" autoStart="true" startLevel="4"/>
-      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="1" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
-      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="1" />
       <plugin id="org.eclipse.osgi" autoStart="true" startLevel="-1" />
       <property name="osgi.instance.area.default" value="$LOCALAPPDATA$/PortfolioPerformance/workspace" os="win32" />
       <property name="osgi.instance.area.default" value="@user.home/Library/Application Support/name.abuchen.portfolio.product/workspace" os="macosx" />


### PR DESCRIPTION
Closes #411
Improved automatic scaling of icons for 4K high-resolution screens or additional scaling for font sizes > 100%

Hello @buchen 
Maybe it would be a cool idea to create a "HowTo" for the settings of the PortfolioPerformance.ini and to integrate a possibility in the "Settings" where we can easily select options by checkboxes. e.g. the memory from 
- 512Mbyte to 2Gbyte ... (Xms, Xmx, Xsss --> [here](https://forum.portfolio-performance.info/t/pp-wird-immer-langsamer/8819/9))
- Scale resolution
in the *.ini

**Question:**
_More simply, display the PortfolioPerformance.ini in a text field so that it can be edited or integrate a custom.ini for special modifications if necessary._

---
These settings can be added subsequently in PortfolioPerformance.ini.
```
-Dswt.enable.autoScale=true
-Dswt.autoScale=quarter
-Dswt.autoScale.method=nearest
```
---
It is also possible to set the autoscaling to a specific value, e.g. 150
```
-Dswt.autoScale=150
```

### Before:
![grafik](https://github.com/portfolio-performance/portfolio/assets/45203494/d22f6923-31ec-428b-a9dc-ba3c9a9a9d94)
![grafik](https://github.com/portfolio-performance/portfolio/assets/45203494/1fbab173-40d0-47e0-8d14-16bf9b7edfeb)

### After:
![grafik](https://github.com/portfolio-performance/portfolio/assets/45203494/d4518af4-a1c2-4bcc-ad43-e0e50d1d6bdf)
![grafik](https://github.com/portfolio-performance/portfolio/assets/45203494/5623f58b-df29-4a22-86fa-66ee8fb9a836)


---

###Another example:

Your screen settings
![grafik](https://github.com/portfolio-performance/portfolio/assets/45203494/3efd733a-687a-4bf4-b3a1-6631e28d2dd8)

with `-Dswt.autoScale=quarter`
![grafik](https://github.com/portfolio-performance/portfolio/assets/45203494/6d0fb6cf-efd3-4c58-9066-65258ef26f1b)
![grafik](https://github.com/portfolio-performance/portfolio/assets/45203494/b8687052-47ab-4e98-9af0-7c702c21a3ed)

with `-Dswt.autoScale=200`
![grafik](https://github.com/portfolio-performance/portfolio/assets/45203494/290bfd3f-160f-4627-bea9-a7743c726e96)
![grafik](https://github.com/portfolio-performance/portfolio/assets/45203494/284e782e-d5cc-4b6e-bea3-cb38a1e4fec5)


