### PR TITLE
Modify Trade Republic PDF-Importer to support new transactions

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Kontoauszug14.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Kontoauszug14.txt
@@ -1,47 +1,42 @@
+```
 PDFBox Version: 1.8.17
-Portfolio Performance Version: 0.68.5.qualifier
+Portfolio Performance Version: 0.69.0
 -----------------------------------------
-VORNAME NACHNAME DATUM 01 Feb. 2024 - 30 Apr. 2024
+VORNAME NACHNAME DATUM 01 Juni 2024 - 30 Juni 2024
 Straße 1, 12345 IBAN DE00000000000000000000
-Ort, DE BIC DEUTDEFFVAC
+Ort, DE BIC TRBKDEBBXXX
 KONTOÜBERSICHT
 PRODUKT ANFANGSSALDO ZAHLUNGSEINGANG ZAHLUNGSAUSGANG ENDSALDO
-Depotkonto 603,81 € 8.449,70 € 17.208,82 € 1.878,95 €
+Depotkonto 3.642,92 € 75.146,39 € 29.156,25 € 49.633,06 €
 UMSATZÜBERSICHT
 DATUM TYP BESCHREIBUNG ZAHLUNGSEINGANG ZAHLUNGSAUSGANG SALDO
-01 
-Feb. Zinszahlung Your interest payment 33,37 € 637,18 €
-2024
-19 
-Feb. Steuern Steueroptimierung null 0000000000000000 78,17 € 715,35 €
-2024
-01 
-März Zinszahlung Your interest payment 12,47 € 727,82 €
-2024
-01 
-März Überweisung Einzahlung akzeptiert: DE00000000000000000000 auf DE00000000000000000000 6.000,00 € 6.727,82 €
-2024
-01 
-Apr. Zinszahlung Your interest payment 7,68 € 1.030,97 €
+03 
+Juni Prämie Your Saveback payment 5,18 € 3.484,00 €
 2024
 04 
-Apr. Überweisung Einzahlung akzeptiert: DE00000000000000000000 auf DE00000000000000000000 2.000,00 € 3.030,97 €
+Juni Steuern Kapitalertragssteueroptimierung Depot Direktverkauf IE00BGJWWY63 INVESCOM2 
+2024 EUR GOVB1-3Y A 0000000000000000
+5,16 € 4.683,98 €
+07 
+Juni Erträge Ereignisausführung Ertrag LU1109942653 XTR.II EO H.YLD CORP.B.1D 0000000000000000 56,31 € 48.901,39 €2024
+09 
+Juni Kartentransaktion Lidl sagt Danke 33,21 € 48.868,18 €
 2024
-28 
-Apr. Kartentransaktion Hornbach Baumarkt AG FIL. 2,40 € 1.902,38 €
+14 
+Juni Überweisung PayOut to transit 6.500,00 € 50.860,76 €
 2024
-28 
-Apr. Kartentransaktion Hornbach Baumarkt AG FIL. 13,95 € 1.888,43 €
+14 
+Juni Steuern Tax Optimisation 0,01 € 50.860,75 €
 2024
-Seite 5 von 7
-Erstellt am 23 Mai 2024
+14 
+Juni Steuern Tax Optimisation 80,62 € 50.941,37 €
+2024
+Seite 3 von 6
+Erstellt am 01 Juli 2024
 Trade Republic Bank GmbH
 DATUM TYP BESCHREIBUNG ZAHLUNGSEINGANG ZAHLUNGSAUSGANG SALDO
-28 
-Apr. Kartentransaktion Hornbach Baumarkt AG FIL. 9,48 € 1.878,95 €
-2024
-Seite 6 von 7
-Erstellt am 23 Mai 2024
+Seite 5 von 6
+Erstellt am 01 Juli 2024
 Trade Republic Bank GmbH
 HAFTUNGSAUSSCHLUSS
 Sehr geehrte Kundin, sehr geehrter Kunde
@@ -52,6 +47,8 @@ Informationen entnehme bitte dem Merkblatt für den Einleger, das zusammen mit u
 Trade Republic Bank GmbH Kontakt Sitz der Gesellschaft: Berlin
 Brunnenstraße 19-21 www.traderepublic.com AG Charlottenburg HRB 244347 B
 10119 Berlin service@traderepublic.com Umsatzsteuer-ID DE307510626
-Seite 7 von 7
-Erstellt am 23 Mai 2024
+Seite 6 von 6
+Erstellt am 01 Juli 2024
 Trade Republic Bank GmbH
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -1882,6 +1882,43 @@ public class TradeRepublicPDFExtractorTest
     }
 
     @Test
+    public void testKontoauszug14()
+    {
+        TradeRepublicPDFExtractor extractor = new TradeRepublicPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kontoauszug14.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(5L));
+        assertThat(results.size(), is(5));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2024-06-03"), hasAmount("EUR", 5.18), //
+                        hasSource("Kontoauszug14.txt"), hasNote(null))));
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2024-06-09"), hasAmount("EUR", 33.21), // TODO should be removal
+                        hasSource("Kontoauszug14.txt"), hasNote("Lidl sagt Danke"))));
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2024-06-14"), hasAmount("EUR", 6500.00), //
+                        hasSource("Kontoauszug14.txt"), hasNote(null))));
+
+        // assert transaction
+        assertThat(results, hasItem(taxes(hasDate("2024-06-14"), hasAmount("EUR", 0.01), //
+                        hasSource("Kontoauszug14.txt"), hasNote(null))));
+
+        // assert transaction
+        assertThat(results, hasItem(taxRefund(hasDate("2024-06-14"), hasAmount("EUR", 80.62), //
+                        hasSource("Kontoauszug14.txt"), hasNote(null))));
+    }
+
+    @Test
     public void testSteuerabrechnung01()
     {
         TradeRepublicPDFExtractor extractor = new TradeRepublicPDFExtractor(new Client());


### PR DESCRIPTION
Hello @Nirus2000,
I added 2 tax refund formats and a saveback deposit booking.

Interesting is that Trade Republic labels tax payments as Tax Optimisation and removes 0,01 €. 😄Thats why I introduced the sign recognition switch also for tax refunds. After that Kontoauszug11 made some trouble - I fixed it manipulating the amounts after and start saldo.

There is still an issue with the recognition of deposit/removal. A credit card payment was recognized as refund because there was a sell booking before with bigger amount than payment.

See TODO note at name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java:1905

I think we might also need to search for other lines which will not imported (buy/sell).

I have no Idea how to accomplish this. Could you please help out?

BR Christian