### PR TITLE
Improves the group width dynamically based on the widest element

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AttributeSettingsPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AttributeSettingsPane.java
@@ -215,11 +215,19 @@ public class AttributeSettingsPane implements InformationPanePage
             // before
             stylingEngine.style(gpColors);
 
-            int width = SWTHelper.widest(positiveExceeded.getFirst(), negativelyExceeded.getSecond());
+            // Compute the widest element width in the group using
+            int width = SWTHelper.widest(positiveExceeded.getFirst(), negativelyExceeded.getFirst(), button,
+                            resetButton);
 
-            FormDataFactory.startingWith(positiveExceeded.getFirst()).width(width + 20)
-                            .thenBelow(negativelyExceeded.getFirst()).width(width + 20).thenBelow(button)
-                            .left(new FormAttachment(0)).thenRight(resetButton);
+            // Set the width of the gpColors group to the widest element's width
+            // plus padding
+            gpColors.setSize(width, gpColors.computeSize(SWT.DEFAULT, SWT.DEFAULT).y);
+
+            FormDataFactory.startingWith(positiveExceeded.getFirst()).width(width + 20) //
+                            .thenBelow(negativelyExceeded.getFirst()).width(width + 20) //
+                            .thenBelow(button).left(new FormAttachment(0)).thenRight(resetButton);
+
+            stylingEngine.style(gpColors);
         }
 
         private static Triple<CLabel, ColoredLabel, Button> createColorButtons(Composite parent,


### PR DESCRIPTION
Fixes the width calculation of the FormLayout for larger resolutions and fonts.

### Before:
![grafik](https://github.com/portfolio-performance/portfolio/assets/45203494/c7792e28-2897-4063-b32a-fe3e1e7ef334)

### After:
![grafik](https://github.com/portfolio-performance/portfolio/assets/45203494/3f7157f3-6dfc-41e0-a8ec-eeeb22cbaa2e)

---

Hello @buchen 
What I have not been able to customize so far is this problem here. Do you have any ideas?
[I think here](https://github.com/portfolio-performance/portfolio/blob/a01b34a49b738b5e510e8fb058409e7c384b4a6d/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/OpenPreferenceDialogHandler.java#L97:L113)

![grafik](https://github.com/portfolio-performance/portfolio/assets/45203494/12987870-9060-4b96-a9c8-533e16a16e39)
![grafik](https://github.com/portfolio-performance/portfolio/assets/45203494/e51d5f7e-566f-45fa-bf86-2d7f3db2948d)


