### PR TITLE
allow '.' from numpad as French decimal separator

### DIFF
--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/utils/StringToCurrencyConverterTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/utils/StringToCurrencyConverterTest.java
@@ -145,6 +145,31 @@ public class StringToCurrencyConverterTest
         converter.convert("1.234,56");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidFRfrAmount()
+    {
+        Locale.setDefault(new Locale("fr", "FR"));
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount, false);
+        converter.convert("1.234,56");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidFRfrAmount2()
+    {
+        Locale.setDefault(new Locale("fr", "FR"));
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount, false);
+        converter.convert("123.45");
+    }
+
+    @Test
+    public void testValidFRfrAmount()
+    {
+        Locale.setDefault(new Locale("fr", "FR"));
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(Values.Amount);
+        assertThat(converter.convert("12,34"), is(1234l));
+        assertThat(converter.convert("1 234,56"), is(123456l));
+    }
+
     @Test
     public void testValidArithmetic()
     {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractTransactionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractTransactionDialog.java
@@ -93,7 +93,7 @@ public abstract class AbstractTransactionDialog extends TitleAreaDialog
             // on French keyboard, the numpad decimal is '.'
             // which should be catched and replaced by a ',' as
             // decimal separator
-            if ("FR".equals(Locale.getDefault().getCountry()) || "BE".equals(Locale.getDefault().getCountry())) //$NON-NLS-1$ //$NON-NLS-2$
+            if ("FR".equals(Locale.getDefault().getCountry())) //$NON-NLS-1$
             {
                 char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
                 value.addKeyListener(new KeyAdapter()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractTransactionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractTransactionDialog.java
@@ -2,11 +2,13 @@ package name.abuchen.portfolio.ui.dialogs.transactions;
 
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.MessageFormat;
 import java.text.NumberFormat;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -37,6 +39,8 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusAdapter;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.events.MouseListener;
 import org.eclipse.swt.layout.FormLayout;
@@ -71,6 +75,7 @@ public abstract class AbstractTransactionDialog extends TitleAreaDialog
         public final Label label;
         public final Text value;
         public final Label currency;
+        public static final char DECIMAL_SEPARATOR = new DecimalFormatSymbols().getDecimalSeparator();
 
         public Input(Composite editArea, String text)
         {
@@ -85,6 +90,25 @@ public abstract class AbstractTransactionDialog extends TitleAreaDialog
                     value.selectAll();
                 }
             });
+
+            // on French keyboard, the numpad decimal is '.'
+            // which should be catched and replaced by a ',' as
+            // decimal separator
+            if ("FR".equals(Locale.getDefault().getCountry())) //$NON-NLS-1$
+            {
+                value.addKeyListener(new KeyAdapter()
+                {
+                    @Override
+                    public void keyPressed(KeyEvent e)
+                    {
+                        if ((e.keyCode == SWT.KEYPAD_DECIMAL))
+                        {
+                            e.doit = false;
+                            value.insert(String.valueOf(DECIMAL_SEPARATOR));
+                        }
+                    }
+                });
+            }
 
             currency = new Label(editArea, SWT.NONE);
         }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractTransactionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractTransactionDialog.java
@@ -75,7 +75,6 @@ public abstract class AbstractTransactionDialog extends TitleAreaDialog
         public final Label label;
         public final Text value;
         public final Label currency;
-        public static final char DECIMAL_SEPARATOR = new DecimalFormatSymbols().getDecimalSeparator();
 
         public Input(Composite editArea, String text)
         {
@@ -94,8 +93,9 @@ public abstract class AbstractTransactionDialog extends TitleAreaDialog
             // on French keyboard, the numpad decimal is '.'
             // which should be catched and replaced by a ',' as
             // decimal separator
-            if ("FR".equals(Locale.getDefault().getCountry())) //$NON-NLS-1$
+            if ("FR".equals(Locale.getDefault().getCountry()) || "BE".equals(Locale.getDefault().getCountry())) //$NON-NLS-1$ //$NON-NLS-2$
             {
+                char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
                 value.addKeyListener(new KeyAdapter()
                 {
                     @Override
@@ -104,7 +104,7 @@ public abstract class AbstractTransactionDialog extends TitleAreaDialog
                         if ((e.keyCode == SWT.KEYPAD_DECIMAL))
                         {
                             e.doit = false;
-                            value.insert(String.valueOf(DECIMAL_SEPARATOR));
+                            value.insert(String.valueOf(decimalSeparator));
                         }
                     }
                 });

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BindingHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BindingHelper.java
@@ -409,7 +409,7 @@ public class BindingHelper
         // on French keyboard, the numpad decimal is '.'
         // which should be catched and replaced by a ',' as
         // decimal separator
-        if ("FR".equals(Locale.getDefault().getCountry()) || "BE".equals(Locale.getDefault().getCountry())) //$NON-NLS-1$ //$NON-NLS-2$
+        if ("FR".equals(Locale.getDefault().getCountry())) //$NON-NLS-1$
         {
             char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
             txtValue.addKeyListener(new KeyAdapter()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BindingHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BindingHelper.java
@@ -4,10 +4,12 @@ import static name.abuchen.portfolio.ui.util.SWTHelper.getAverageCharWidth;
 
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
+import java.text.DecimalFormatSymbols;
 import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.databinding.AggregateValidationStatus;
@@ -34,6 +36,8 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusAdapter;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.events.MouseListener;
 import org.eclipse.swt.widgets.Button;
@@ -401,6 +405,27 @@ public class BindingHelper
     public final Control bindMandatoryQuoteInput(Composite editArea, final String label, String property)
     {
         Text txtValue = createTextInput(editArea, label);
+
+        // on French keyboard, the numpad decimal is '.'
+        // which should be catched and replaced by a ',' as
+        // decimal separator
+        if ("FR".equals(Locale.getDefault().getCountry()) || "BE".equals(Locale.getDefault().getCountry())) //$NON-NLS-1$ //$NON-NLS-2$
+        {
+            char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
+            txtValue.addKeyListener(new KeyAdapter()
+            {
+                @Override
+                public void keyPressed(KeyEvent e)
+                {
+                    if (e.keyCode == SWT.KEYPAD_DECIMAL)
+                    {
+                        e.doit = false;
+                        txtValue.insert(String.valueOf(decimalSeparator));
+                    }
+                }
+            });
+        }
+
         bindMandatoryDecimalInput(label, property, txtValue, Values.Quote);
         return txtValue;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/NumberVerifyListener.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/NumberVerifyListener.java
@@ -36,7 +36,7 @@ public final class NumberVerifyListener implements VerifyListener
         // on French keyboard, the numpad decimal is '.'
         // which should be catched and replaced by a ',' as
         // decimal separator
-        if ("FR".equals(Locale.getDefault().getCountry()) || "BE".equals(Locale.getDefault().getCountry())) //$NON-NLS-1$ //$NON-NLS-2$
+        if ("FR".equals(Locale.getDefault().getCountry())) //$NON-NLS-1$
         {
             char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
             if (e.keyCode == SWT.KEYPAD_DECIMAL)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/NumberVerifyListener.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/NumberVerifyListener.java
@@ -1,7 +1,9 @@
 package name.abuchen.portfolio.ui.util;
 
 import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.VerifyEvent;
 import org.eclipse.swt.events.VerifyListener;
 
@@ -31,6 +33,16 @@ public final class NumberVerifyListener implements VerifyListener
     @Override
     public void verifyText(VerifyEvent e)
     {
+        // on French keyboard, the numpad decimal is '.'
+        // which should be catched and replaced by a ',' as
+        // decimal separator
+        if ("FR".equals(Locale.getDefault().getCountry()) || "BE".equals(Locale.getDefault().getCountry())) //$NON-NLS-1$ //$NON-NLS-2$
+        {
+            char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
+            if (e.keyCode == SWT.KEYPAD_DECIMAL)
+                e.text = String.valueOf(decimalSeparator);
+        }
+
         for (int ii = 0; e.doit && ii < e.text.length(); ii++)
             e.doit = pattern.indexOf(e.text.charAt(0)) >= 0;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/AttributeEditingSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/AttributeEditingSupport.java
@@ -34,8 +34,7 @@ public class AttributeEditingSupport extends ColumnEditingSupport
             ((Text) textEditor.getControl()).addVerifyListener(new NumberVerifyListener(true));
 
         if (attribute.getConverter() instanceof AttributeType.LimitPriceConverter
-                        && ("FR".equals(Locale.getDefault().getCountry()) //$NON-NLS-1$
-                                        || "BE".equals(Locale.getDefault().getCountry()))) //$NON-NLS-1$
+                        && ("FR".equals(Locale.getDefault().getCountry()))) //$NON-NLS-1$
         {
             char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
             Text textEditorValue = (Text) textEditor.getControl();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/AttributeEditingSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/AttributeEditingSupport.java
@@ -1,7 +1,13 @@
 package name.abuchen.portfolio.ui.util.viewers;
 
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.TextCellEditor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Text;
 
@@ -26,6 +32,27 @@ public class AttributeEditingSupport extends ColumnEditingSupport
         TextCellEditor textEditor = new TextCellEditor(composite);
         if (attribute.isNumber())
             ((Text) textEditor.getControl()).addVerifyListener(new NumberVerifyListener(true));
+
+        if (attribute.getConverter() instanceof AttributeType.LimitPriceConverter
+                        && ("FR".equals(Locale.getDefault().getCountry()) //$NON-NLS-1$
+                                        || "BE".equals(Locale.getDefault().getCountry()))) //$NON-NLS-1$
+        {
+            char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
+            Text textEditorValue = (Text) textEditor.getControl();
+            ((Text) textEditor.getControl()).addKeyListener(new KeyAdapter()
+            {
+                @Override
+                public void keyPressed(KeyEvent e)
+                {
+                    if ((e.keyCode == SWT.KEYPAD_DECIMAL))
+                    {
+                        e.doit = false;
+                        textEditorValue.insert(String.valueOf(decimalSeparator));
+                    }
+                }
+            });
+        }
+
         return textEditor;
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AttributesPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AttributesPage.java
@@ -276,8 +276,7 @@ public class AttributesPage extends AbstractPage implements IMenuListener
             value = new Text(container, SWT.BORDER);
             if ((attribute.getType().isNumber()
                             || attribute.getType().getConverter() instanceof AttributeType.LimitPriceConverter)
-                            && ("FR".equals(Locale.getDefault().getCountry()) //$NON-NLS-1$
-                            || "BE".equals(Locale.getDefault().getCountry()))) //$NON-NLS-1$
+                            && "FR".equals(Locale.getDefault().getCountry())) //$NON-NLS-1$
             {
                 char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
                 Text valueAsText = (Text) value;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AttributesPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AttributesPage.java
@@ -1,8 +1,10 @@
 package name.abuchen.portfolio.ui.wizards.security;
 
 import java.io.IOException;
+import java.text.DecimalFormatSymbols;
 import java.text.MessageFormat;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 import org.eclipse.core.databinding.Binding;
@@ -23,6 +25,8 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.MouseListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -270,6 +274,26 @@ public class AttributesPage extends AbstractPage implements IMenuListener
         else
         {
             value = new Text(container, SWT.BORDER);
+            if ((attribute.getType().isNumber()
+                            || attribute.getType().getConverter() instanceof AttributeType.LimitPriceConverter)
+                            && ("FR".equals(Locale.getDefault().getCountry()) //$NON-NLS-1$
+                            || "BE".equals(Locale.getDefault().getCountry()))) //$NON-NLS-1$
+            {
+                char decimalSeparator = new DecimalFormatSymbols().getDecimalSeparator();
+                Text valueAsText = (Text) value;
+                valueAsText.addKeyListener(new KeyAdapter()
+                {
+                    @Override
+                    public void keyPressed(KeyEvent e)
+                    {
+                        if ((e.keyCode == SWT.KEYPAD_DECIMAL))
+                        {
+                            e.doit = false;
+                            valueAsText.insert(String.valueOf(decimalSeparator));
+                        }
+                    }
+                });
+            }
             GridDataFactory.fillDefaults().align(SWT.FILL, SWT.CENTER).grab(true, false).applyTo(value);
 
             ToAttributeObjectConverter input2model = new ToAttributeObjectConverter(attribute);


### PR DESCRIPTION
Closes https://github.com/portfolio-performance/portfolio/issues/3780
Issue : https://forum.portfolio-performance.info/t/decimal-separator-on-french-keyboard/28939

Hello, this is a proposition to deal with the numpad decimal on French keyboard, which is a `.` and not the `,` official French decimal, therefore currently not accepted by PP as an input.

Notes :

- This is only dealing with the numpad `.`, and not dealing with the other `.` accessible under `SHIFT+;` but I do not see it as an issue.
- ~There are still some locations in PP where numpad `.` is not allowed, e.g. when manually editing a security Historical Price. Which I think is to be dealt into `NumberVerifyListener`. I am not sure yet what would be the clean way to do it there, but I think updating Historical Price manually happens a bit less often than creating/editing Transactions.~ -> done in second commit

edit: I am having second thought about the country condition `"FR".equals(Locale.getDefault().getCountry())`. This means it is only working for fr_FR, while if only the language is set but the country FR is not specified, it is not working. Would it be better to be more general and check for `Locale.getDefault().getLanguage()` instead ? On the other hand, there are so many possible countries possible under fr_XX, for which I have no idea if they should be considered.