### PR TITLE
Fix: Problem with JSON provided dates which are given by strings containing unix timestamps

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
@@ -344,7 +344,16 @@ public class GenericJSONQuoteFeed implements QuoteFeed
             return LocalDate.parse(object.toString(), formatter);
         }
         if (object instanceof String s)
-            return YahooHelper.fromISODate(s);
+        {
+            try
+            {
+                return parseDateTimestamp(Long.parseLong(s));
+            }
+            catch (NumberFormatException e)
+            {
+                return YahooHelper.fromISODate(s);
+            }
+        }
         else if (object instanceof Long l)
             return parseDateTimestamp(l);
         else if (object instanceof Integer i)


### PR DESCRIPTION
I recently came across the following small issue:

When trying to get historic data with a JSON provider a problem can occur that gives an output like
`Text '1721433600' could not be parsed at index 0`.
The problem appears when the JSON path to the date yields a string that contains the date in form of a unix timestamp.

I guess this PR will fix this problem.