### PR TITLE
Add support for importing account transfers with currency conversion from CSV

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVAccountTransactionExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVAccountTransactionExtractor.java
@@ -99,8 +99,18 @@ import name.abuchen.portfolio.money.Money;
             case TRANSFER_IN:
             case TRANSFER_OUT:
                 AccountTransferEntry entry = new AccountTransferEntry();
-                entry.setAmount(Math.abs(amount.getAmount()));
-                entry.setCurrencyCode(amount.getCurrencyCode());
+                if (grossAmount.isPresent())
+                {
+                    Unit grossAmountUnit = grossAmount.get();
+                    entry.getSourceTransaction().setMonetaryAmount(grossAmountUnit.getAmount());
+                    entry.getTargetTransaction().setMonetaryAmount(grossAmountUnit.getForex());
+                    entry.getSourceTransaction().addUnit(grossAmountUnit);
+                }
+                else
+                {
+                    entry.setAmount(Math.abs(amount.getAmount()));
+                    entry.setCurrencyCode(amount.getCurrencyCode());
+                }
                 entry.setDate(date);
                 entry.setNote(note);
                 item = new AccountTransferItem(entry, type == Type.TRANSFER_OUT);


### PR DESCRIPTION
Hey, love the app. When trying to automate imports for some of my accounts I ran into the following issue.

Currently, the UI allows you to manually create a transfer between two accounts of different currencies. This feature, however, is not available via the CSV importer and always results in an error: `Transaction currency XXX does not match account currency YYY`.

In this PR I'm adding support for creating account transfers with currency conversion when using the CSV importer. 

In order for this to work:
- you must provide values in the `Value`, `Transaction Currency`, `Gross Amount`, `Currency Gross Amount`, `Exchange Rate` columns
- the `Transaction Currency` must be different from `Currency Gross Amount`
- the `Type` must be either `Transfer (Inbound)` or `Transfer (Outbound)`

Considerations:
- only one side of each transfer should be provided in the CSV (either inbound or outbound), otherwise duplicate transactions may be created
- the amount in the `Value` field is always ignored and the source amount is always calculated using `(Gross Amount) * (Exchange Rate)`

Fixes #2250