### PR TITLE
Allow '.' from numpad as French decimal separator

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractTransactionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractTransactionDialog.java
@@ -63,6 +63,7 @@ import name.abuchen.portfolio.ui.util.IValidatingConverter;
 import name.abuchen.portfolio.ui.util.SimpleDateTimeDateSelectionProperty;
 import name.abuchen.portfolio.ui.util.SimpleDateTimeTimeSelectionProperty;
 import name.abuchen.portfolio.ui.util.StringToCurrencyConverter;
+import name.abuchen.portfolio.ui.util.text.FrenchKeypadSupport;
 
 public abstract class AbstractTransactionDialog extends TitleAreaDialog
 {
@@ -85,6 +86,8 @@ public abstract class AbstractTransactionDialog extends TitleAreaDialog
                     value.selectAll();
                 }
             });
+
+            FrenchKeypadSupport.configure(value);
 
             currency = new Label(editArea, SWT.NONE);
         }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BindingHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BindingHelper.java
@@ -47,6 +47,7 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.util.text.FrenchKeypadSupport;
 import name.abuchen.portfolio.util.Isin;
 import name.abuchen.portfolio.util.TradeCalendar;
 import name.abuchen.portfolio.util.TradeCalendarManager;
@@ -394,6 +395,7 @@ public class BindingHelper
                     int lenghtInCharacters)
     {
         Text txtValue = createTextInput(editArea, label, style, lenghtInCharacters);
+        FrenchKeypadSupport.configure(txtValue);
         bindMandatoryDecimalInput(label, property, txtValue, Values.Amount);
         return txtValue;
     }
@@ -401,6 +403,7 @@ public class BindingHelper
     public final Control bindMandatoryQuoteInput(Composite editArea, final String label, String property)
     {
         Text txtValue = createTextInput(editArea, label);
+        FrenchKeypadSupport.configure(txtValue);
         bindMandatoryDecimalInput(label, property, txtValue, Values.Quote);
         return txtValue;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/text/FrenchKeypadSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/text/FrenchKeypadSupport.java
@@ -1,0 +1,38 @@
+package name.abuchen.portfolio.ui.util.text;
+
+import java.util.Locale;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.widgets.Text;
+
+import name.abuchen.portfolio.util.TextUtil;
+
+public class FrenchKeypadSupport
+{
+    private static final boolean IS_FRENCH = Locale.getDefault().getLanguage().equals(Locale.FRENCH.getLanguage());
+
+    private FrenchKeypadSupport()
+    {
+    }
+
+    public static void configure(Text text)
+    {
+        if (IS_FRENCH)
+        {
+            text.addKeyListener(new KeyAdapter()
+            {
+                @Override
+                public void keyPressed(KeyEvent e)
+                {
+                    if ((e.keyCode == SWT.KEYPAD_DECIMAL))
+                    {
+                        e.doit = false;
+                        text.insert(String.valueOf(TextUtil.DECIMAL_SEPARATOR));
+                    }
+                }
+            });
+        }
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/AttributeEditingSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/AttributeEditingSupport.java
@@ -10,6 +10,7 @@ import name.abuchen.portfolio.model.Attributable;
 import name.abuchen.portfolio.model.AttributeType;
 import name.abuchen.portfolio.model.Attributes;
 import name.abuchen.portfolio.ui.util.NumberVerifyListener;
+import name.abuchen.portfolio.ui.util.text.FrenchKeypadSupport;
 
 public class AttributeEditingSupport extends ColumnEditingSupport
 {
@@ -26,6 +27,10 @@ public class AttributeEditingSupport extends ColumnEditingSupport
         TextCellEditor textEditor = new TextCellEditor(composite);
         if (attribute.isNumber())
             ((Text) textEditor.getControl()).addVerifyListener(new NumberVerifyListener(true));
+
+        if (attribute.isNumber() || attribute.getConverter() instanceof AttributeType.LimitPriceConverter)
+            FrenchKeypadSupport.configure((Text) textEditor.getControl());
+
         return textEditor;
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ValueEditingSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ValueEditingSupport.java
@@ -13,6 +13,7 @@ import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.CurrencyToStringConverter;
 import name.abuchen.portfolio.ui.util.NumberVerifyListener;
 import name.abuchen.portfolio.ui.util.StringToCurrencyConverter;
+import name.abuchen.portfolio.ui.util.text.FrenchKeypadSupport;
 
 public class ValueEditingSupport extends PropertyEditingSupport
 {
@@ -46,8 +47,10 @@ public class ValueEditingSupport extends PropertyEditingSupport
     public CellEditor createEditor(Composite composite)
     {
         TextCellEditor textEditor = new TextCellEditor(composite);
-        ((Text) textEditor.getControl()).setTextLimit(20);
-        ((Text) textEditor.getControl()).addVerifyListener(new NumberVerifyListener());
+        var text = (Text) textEditor.getControl();
+        text.setTextLimit(20);
+        text.addVerifyListener(new NumberVerifyListener());
+        FrenchKeypadSupport.configure(text);
         return textEditor;
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AttributesPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AttributesPage.java
@@ -44,6 +44,7 @@ import name.abuchen.portfolio.ui.PortfolioPlugin;
 import name.abuchen.portfolio.ui.util.BindingHelper;
 import name.abuchen.portfolio.ui.util.IValidatingConverter;
 import name.abuchen.portfolio.ui.util.LabelOnly;
+import name.abuchen.portfolio.ui.util.text.FrenchKeypadSupport;
 import name.abuchen.portfolio.ui.wizards.security.EditSecurityModel.AttributeDesignation;
 import name.abuchen.portfolio.util.ImageUtil;
 
@@ -270,6 +271,11 @@ public class AttributesPage extends AbstractPage implements IMenuListener
         else
         {
             value = new Text(container, SWT.BORDER);
+            if ((attribute.getType().isNumber()
+                            || attribute.getType().getConverter() instanceof AttributeType.LimitPriceConverter))
+            {
+                FrenchKeypadSupport.configure((Text) value);
+            }
             GridDataFactory.fillDefaults().align(SWT.FILL, SWT.CENTER).grab(true, false).applyTo(value);
 
             ToAttributeObjectConverter input2model = new ToAttributeObjectConverter(attribute);


### PR DESCRIPTION
When entering a number of a French keyboard, the dot from the numpad is usually automatically converted into the French decimal separator ','.

We do not have to change the NumberVerifyListener. It is not triggered because the KeyListener is directly inserting the decimal. However, that is not a problem because we know it is a valid character for numbers.

Issue: #4143
Issue: #3780
Issue: https://forum.portfolio-performance.info/t/decimal-separator-on-french-keyboard/28939

[squashed commits; refactored code into utility class; rebased to master]