### PR TITLE
SecurityEvent: Move "source" field to the parent SecurityEvent class

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/SecurityEvent.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/SecurityEvent.java
@@ -37,7 +37,6 @@ public class SecurityEvent
     {
         private LocalDate paymentDate;
         private Money amount;
-        private String source;
 
         public DividendEvent()
         {
@@ -46,10 +45,9 @@ public class SecurityEvent
 
         public DividendEvent(LocalDate exDate, LocalDate payDate, Money amount, String source)
         {
-            super(exDate, Type.DIVIDEND_PAYMENT, null);
+            super(exDate, Type.DIVIDEND_PAYMENT, null, source);
             this.paymentDate = payDate;
             this.amount = amount;
-            this.source = source;
         }
 
         @Override
@@ -79,22 +77,12 @@ public class SecurityEvent
             this.amount = amount;
         }
 
-        public String getSource()
-        {
-            return source;
-        }
-
-        public void setSource(String source)
-        {
-            this.source = source;
-        }
-
         @Override
         public int hashCode()
         {
             final int prime = 31;
             int result = super.hashCode();
-            result = prime * result + Objects.hash(amount, paymentDate, source);
+            result = prime * result + Objects.hash(amount, paymentDate);
             return result;
         }
 
@@ -108,14 +96,18 @@ public class SecurityEvent
             if (getClass() != obj.getClass())
                 return false;
             DividendEvent other = (DividendEvent) obj;
-            return Objects.equals(amount, other.amount) && Objects.equals(paymentDate, other.paymentDate)
-                            && Objects.equals(source, other.source);
+            return Objects.equals(amount, other.amount) && Objects.equals(paymentDate, other.paymentDate);
         }
     }
 
     private LocalDate date;
     private Type type;
     private String details;
+    /**
+     * Machine-readable identifier of external source used to create (and
+     * manage) this event.
+     */
+    private String source;
 
     public SecurityEvent()
     {
@@ -127,6 +119,12 @@ public class SecurityEvent
         this.date = date;
         this.type = type;
         this.details = details;
+    }
+
+    public SecurityEvent(LocalDate date, Type type, String details, String source)
+    {
+        this(date, type, details);
+        this.source = source;
     }
 
     public LocalDate getDate()
@@ -159,10 +157,20 @@ public class SecurityEvent
         this.details = details;
     }
 
+    public String getSource()
+    {
+        return source;
+    }
+
+    public void setSource(String source)
+    {
+        this.source = source;
+    }
+
     @Override
     public int hashCode()
     {
-        return Objects.hash(date, details, type);
+        return Objects.hash(date, details, type, source);
     }
 
     @Override
@@ -175,6 +183,7 @@ public class SecurityEvent
         if (getClass() != obj.getClass())
             return false;
         SecurityEvent other = (SecurityEvent) obj;
-        return Objects.equals(date, other.date) && Objects.equals(details, other.details) && type == other.type;
+        return Objects.equals(date, other.date) && Objects.equals(details, other.details)
+            && Objects.equals(source, other.source) && type == other.type;
     }
 }


### PR DESCRIPTION
Previously, "source" field was available only in the DividendEvent subclass. But it makes sense to have it on the parent class, to streamline integration with external tools to manage events. Thus, "source" is a generic machine-readable field to record source and/or "ownership" of the event information. A typical workflow would be:

1. An external tool TOOL1 creates an event and sets its source attribute to "TOOL1" to designate this event is "owned" by the tool, which it's free to modify or even delete later.
2. This attribute eventually gets rendered as <source> element within <event> element in PortfolioPerformance XML.
3. PP preserves the value of the source attributes across load/save cycle of the portfolio.
4. On the next run, TOOL1 can identify events originally create by itself, and update them as needed. This is important, because event information provided by external source if often tentative and subject to change.

As mentioned above, the "source" field is intended to be machine-readable, and as such, it's currently now shown anywhere in the PP UI. It might be useful to address that at later time, if the need for that is found.

WARNING:
This change doesn't include steps which would be required to migrate Protobuf binary format. It's expected that developers familiar with this format would step in to help with the migration.