### PR TITLE
Security: Make toString() be "ticker (name)"

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
@@ -880,7 +880,12 @@ public final class Security implements Attributable, InvestmentVehicle
     @Override
     public String toString()
     {
-        return getName();
+        if (getTickerSymbol() == null)
+            return getName();
+        else if (getTickerSymbol().equals(getName()))
+            return getTickerSymbol();
+        else
+            return getTickerSymbol() + " (" + getName() + ")";
     }
 
     public String toInfoString()


### PR DESCRIPTION
For many people, ticker is more familiar than security name/title (this is especially true for funds). toString() is used e.g. in dropdown boxes for security selection.

Partiall addresses #4182