### PR TITLE
Fix NullPointerException when security's event is null

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
@@ -29,7 +29,7 @@ public class Client
         String WATCHLISTS = "watchlists"; //$NON-NLS-1$
     }
 
-    public static final int CURRENT_VERSION = 63;
+    public static final int CURRENT_VERSION = 64;
     public static final int VERSION_WITH_CURRENCY_SUPPORT = 29;
     public static final int VERSION_WITH_UNIQUE_FILTER_KEY = 57;
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
@@ -1642,7 +1642,7 @@ public class ClientFactory
     {
         // see https://forum.portfolio-performance.info/t/fehlermeldung-cannot-invoke-name-abuchen-portfolio-model-securityevent-gettype-because-event-is-null/29406
 
-        for (Security security : client.getSecurities())
+        for (Security security : new ArrayList<>(client.getSecurities()))
         {
             var events = security.getEvents().toList();
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
@@ -1642,9 +1642,9 @@ public class ClientFactory
     {
         // see https://forum.portfolio-performance.info/t/fehlermeldung-cannot-invoke-name-abuchen-portfolio-model-securityevent-gettype-because-event-is-null/29406
 
-        for (Security security : new ArrayList<>(client.getSecurities()))
+        for (Security security : client.getSecurities())
         {
-            var events = security.getEvents().toList();
+            var events = new ArrayList<>(security.getEvents());
 
             for (SecurityEvent e : events)
             {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
@@ -901,6 +901,8 @@ public class ClientFactory
                 removePortfolioReportMarketProperties(client);
             case 62:
                 updateSecurityChartLabelConfiguration(client);
+            case 63:
+                fixNullSecurityEvents(client);
 
                 client.setVersion(Client.CURRENT_VERSION);
                 break;
@@ -1631,6 +1633,24 @@ public class ClientFactory
                 if (p == null)
                 {
                     security.removeProperty(null);
+                }
+            }
+        }
+    }
+
+    private static void fixNullSecurityEvents(Client client)
+    {
+        // see https://forum.portfolio-performance.info/t/fehlermeldung-cannot-invoke-name-abuchen-portfolio-model-securityevent-gettype-because-event-is-null/29406
+
+        for (Security security : client.getSecurities())
+        {
+            var events = security.getEvents().toList();
+
+            for (SecurityEvent e : events)
+            {
+                if (e == null)
+                {
+                    security.removeEvent(null);
                 }
             }
         }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ProtobufWriter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ProtobufWriter.java
@@ -871,6 +871,9 @@ import name.abuchen.portfolio.money.Money;
             newSecurity.addAllAttributes(security.getAttributes().toProto(client));
 
             security.getEvents().forEach(event -> {
+                if (event == null)
+                    return;
+                
                 PSecurityEvent.Builder newEvent = PSecurityEvent.newBuilder();
 
                 switch (event.getType())


### PR DESCRIPTION
Reported here: https://forum.portfolio-performance.info/t/fehlermeldung-cannot-invoke-name-abuchen-portfolio-model-securityevent-gettype-because-event-is-null/29406

Seems similar to #3895 with fix a27997045f4c7558e357c43268b0e1b4d4fac6f8.

Currently I dont have a working IDE so I decided to make the changes via browser and used the fix a27997045f4c7558e357c43268b0e1b4d4fac6f8 as template.
So no automatic code style was executed and I was not able to check if the project can be built.

But maybe it will help you to apply the fix quickly.