### PR TITLE
fix date tooltip for stacked charts

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedTimelineChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedTimelineChart.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.util.chart;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.eclipse.jface.action.IMenuManager;
@@ -19,6 +20,8 @@ import org.swtchart.ISeries.SeriesType;
 import org.swtchart.LineStyle;
 import org.swtchart.Range;
 
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.util.Dates;
 
@@ -41,6 +44,7 @@ public class StackedTimelineChart extends Chart // NOSONAR
         // x axis
         IAxis xAxis = getAxisSet().getXAxis(0);
         xAxis.getTitle().setVisible(false);
+        xAxis.getTitle().setText(Messages.ColumnDate);
         xAxis.getTick().setVisible(false);
         xAxis.getGrid().setStyle(LineStyle.NONE);
         setDates(dates);
@@ -68,6 +72,11 @@ public class StackedTimelineChart extends Chart // NOSONAR
         toolTip = new TimelineChartToolTip(this);
         toolTip.enableCategory(true);
         toolTip.reverseLabels(true);
+        toolTip.setXAxisFormat(obj -> {
+            Integer index = (Integer) obj;
+            DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE;
+            return Values.Date.format(LocalDate.parse(getAxisSet().getXAxis(0).getCategorySeries()[index], formatter));
+        });
 
         this.contextMenu = new ChartContextMenu(this);
     }


### PR DESCRIPTION
Hello, this is proposition to slightly change the date tooltip of taxonomy's stacked chart as they are using a default name "X axis" and a yyyy-mm-dd standard format independent of the language -> now same as the statement of assets tooltip.

**Before**
![2024-08-30 22_40_17-Portfolio Performance](https://github.com/user-attachments/assets/3c65e863-5ba9-439f-bf6e-9514b68dd833)

**After**
![2024-08-30 22_41_38-Portfolio Performance](https://github.com/user-attachments/assets/e33e7acf-2da0-4711-b42b-f475d0c4f779)

(the trading activity widget is using yyyy-mm, maybe it could be adjusted as well (?))