### PR TITLE
Security: Allow toString() be (in general) "ticker (name)"

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -1151,6 +1151,8 @@ public class Messages extends NLS
     public static String PrefLabelDisplayPA;
     public static String PrefLabelEnableExperimentalFeatures;
     public static String PrefLabelNote;
+    public static String PrefLabelPreferSecuritySymbol;
+    public static String PrefLabelPreferSecuritySymbolTooltip;
     public static String PrefLabelProxyHost;
     public static String PrefLabelProxyPort;
     public static String PrefLabelQuoteDigits;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/UIConstants.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/UIConstants.java
@@ -126,6 +126,11 @@ public interface UIConstants
         String FORMAT_CALCULATED_QUOTE_DIGITS = "FORMAT_CALCULATED_QUOTE_DIGITS"; //$NON-NLS-1$
 
         /**
+         * Preference key to display symbol (not just name) to identify security
+         */
+        String FORMAT_PREFER_SECURITY_SYMBOL = "FORMAT_PREFER_SECURITY_SYMBOL"; //$NON-NLS-1$
+
+        /**
          * Preference key to use indirect quotation ("Mengennotierung") when
          * displaying exchange rates.
          */

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/addons/Preference2EnvAddon.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/addons/Preference2EnvAddon.java
@@ -124,6 +124,13 @@ public class Preference2EnvAddon
     }
 
     @Inject
+    public void setPreferSecuritySymbol(
+                    @Preference(value = UIConstants.Preferences.FORMAT_PREFER_SECURITY_SYMBOL) boolean preferSecuritySymbol)
+    {
+        FormatHelper.setPreferSecuritySymbol(preferSecuritySymbol);
+    }
+
+    @Inject
     public void setDisplayBaseCurrencyCode(
                     @Preference(value = UIConstants.Preferences.ALWAYS_DISPLAY_CURRENCY_CODE) boolean alwaysDisplayCurrencyCode)
     {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -2302,6 +2302,10 @@ PrefLabelQuoteDigits = Display precision (digits) for calculated quotes
 
 PrefLabelSharesDigits = Display precision (digits) for number of shares
 
+PrefLabelPreferSecuritySymbol = Prefer 'symbol' to identify securities
+
+PrefLabelPreferSecuritySymbolTooltip = If enabled, use 'SYMBOL (Security Name)' to identify security if there's enough space available; otherwise, just 'SYMBOL'. If disabled, always use 'Security Name'.
+
 PrefLabelUseIndirectQuotation = Use indirect quotation for exchange rates
 
 PrefLabelUseSWTChartLibrary = SWTChart library for pie charts

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/FormattingPreferencePage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/FormattingPreferencePage.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.preferences;
 
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.IntegerFieldEditor;
 
 import name.abuchen.portfolio.money.Values;
@@ -26,5 +27,11 @@ public class FormattingPreferencePage extends FieldEditorPreferencePage
                         Messages.PrefLabelQuoteDigits, getFieldEditorParent(), 1);
         quotePrecisionEditor.setValidRange(0, Values.Quote.precision());
         addField(quotePrecisionEditor);
+
+        var preferSecuritySymEditor = new BooleanFieldEditor(Preferences.FORMAT_PREFER_SECURITY_SYMBOL,
+                        Messages.PrefLabelPreferSecuritySymbol, getFieldEditorParent());
+        var control = preferSecuritySymEditor.getDescriptionControl(getFieldEditorParent());
+        control.setToolTipText(Messages.PrefLabelPreferSecuritySymbolTooltip);
+        addField(preferSecuritySymEditor);
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/PreferencesInitializer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/PreferencesInitializer.java
@@ -23,6 +23,7 @@ public class PreferencesInitializer extends AbstractPreferenceInitializer
                                         : "https://updates.portfolio-performance.info/portfolio"); //$NON-NLS-1$
         store.setDefault(UIConstants.Preferences.FORMAT_SHARES_DIGITS, 1);
         store.setDefault(UIConstants.Preferences.FORMAT_CALCULATED_QUOTE_DIGITS, 2);
+        store.setDefault(UIConstants.Preferences.FORMAT_PREFER_SECURITY_SYMBOL, false);
         store.setDefault(UIConstants.Preferences.USE_INDIRECT_QUOTATION, true);
         store.setDefault(UIConstants.Preferences.ALWAYS_DISPLAY_CURRENCY_CODE, false);
         store.setDefault(UIConstants.Preferences.DISPLAY_PER_ANNUM, false);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 
 import name.abuchen.portfolio.money.CurrencyUnit;
+import name.abuchen.portfolio.util.FormatHelper;
 import name.abuchen.portfolio.util.Pair;
 import name.abuchen.portfolio.util.TextUtil;
 
@@ -880,7 +881,18 @@ public final class Security implements Attributable, InvestmentVehicle
     @Override
     public String toString()
     {
-        return getName();
+        // Classical PP behavior - just use name.
+        if (!FormatHelper.isPreferSecuritySymbol())
+            return getName();
+
+        // Otherwise, if corresponding preference is set by user, fit in
+        // security symbol if available.
+        if (getTickerSymbol() == null)
+            return getName();
+        else if (getTickerSymbol().equals(getName()))
+            return getTickerSymbol();
+        else
+            return getTickerSymbol() + " (" + getName() + ")";
     }
 
     public String toInfoString()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/FormatHelper.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/FormatHelper.java
@@ -14,6 +14,7 @@ public class FormatHelper
 
     private static boolean alwaysDisplayCurrencyCode = false;
     private static boolean displayPerAnnum = false;
+    private static boolean preferSecuritySymbol = false;
 
     private FormatHelper()
     {
@@ -64,5 +65,15 @@ public class FormatHelper
     public static void setDisplayPerAnnum(boolean displayPerAnnum)
     {
         FormatHelper.displayPerAnnum = displayPerAnnum;
+    }
+
+    public static boolean isPreferSecuritySymbol()
+    {
+        return preferSecuritySymbol;
+    }
+
+    public static void setPreferSecuritySymbol(boolean preferSecuritySymbol)
+    {
+        FormatHelper.preferSecuritySymbol = preferSecuritySymbol;
     }
 }


### PR DESCRIPTION
    
    For many people, ticker is more familiar than security name/title (this
    is especially true for funds). toString() is used e.g. in dropdown boxes
    for security selection. So, if a corresponding preference is enabled by
    user, include ticker in the display string.
    
    If ticker symbol is not available, or matches the security name, toString()
    will return just "name", as before.
