### PR TITLE
Allow to update quotes for several selected securities 

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/UpdateQuotesHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/UpdateQuotesHandler.java
@@ -34,8 +34,8 @@ public class UpdateQuotesHandler
             if ("security".equals(filter)) //$NON-NLS-1$
             {
                 selectionService.getSelection(client).ifPresent(s -> {
-                    new UpdateQuotesJob(client, s.getSecurity()).schedule();
-                    new UpdateDividendsJob(client, s.getSecurity()).schedule(5000);
+                    new UpdateQuotesJob(client, s.getSecurities()).schedule();
+                    new UpdateDividendsJob(client, s.getSecurities()).schedule(5000);
                 });
             }
             else if ("active".equals(filter)) //$NON-NLS-1$

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/selection/SecuritySelection.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/selection/SecuritySelection.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.ui.selection;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 import name.abuchen.portfolio.model.Client;
@@ -8,12 +10,18 @@ import name.abuchen.portfolio.model.Security;
 public class SecuritySelection
 {
     private final Client client;
-    private final Security security;
+    private final List<Security> securities;
 
     public SecuritySelection(Client client, Security security)
     {
         this.client = Objects.requireNonNull(client);
-        this.security = Objects.requireNonNull(security);
+        this.securities = Arrays.asList(Objects.requireNonNull(security));
+    }
+
+    public SecuritySelection(Client client, List<Security> securities)
+    {
+        this.client = Objects.requireNonNull(client);
+        this.securities = Objects.requireNonNull(securities);
     }
 
     public Client getClient()
@@ -23,6 +31,11 @@ public class SecuritySelection
 
     public Security getSecurity()
     {
-        return security;
+        return securities.get(0);
+    }
+
+    public List<Security> getSecurities()
+    {
+        return securities;
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
@@ -496,9 +496,12 @@ public class SecurityListView extends AbstractFinanceView
                         ((IStructuredSelection) event.getSelection()).getFirstElement()));
 
         securities.addSelectionChangedListener(event -> {
-            Security security = (Security) ((IStructuredSelection) event.getSelection()).getFirstElement();
-            if (security != null)
-                selectionService.setSelection(new SecuritySelection(getClient(), security));
+            IStructuredSelection selection = (IStructuredSelection) event.getSelection();
+
+            if (!selection.isEmpty())
+                selectionService.setSelection(new SecuritySelection(getClient(), selection.toList()));
+            else
+                selectionService.setSelection(null);
         });
 
         securities.addFilter(new ViewerFilter()


### PR DESCRIPTION
Some views in the app allow to select multiple securities, so allow to
perform operations on all of them. Without such support, behavior can
be confusing, for example, currently a user can select multiple securities
in "Securities" view, and choose "Update quotes (selected)" via main menu,
but only one will be actually updated.