### PR TITLE
add bold and currency code to taxonomy Pie chart caption

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyPieChartBrowser.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyPieChartBrowser.java
@@ -77,13 +77,13 @@ public class TaxonomyPieChartBrowser implements IPieChart
                         boolean excludeSecurities)
         {
             String name = JSONObject.escape(node.getName());
-            long actual = node.isRoot() ? total.getAmount() : node.getActual().getAmount();
+            Money actual = node.isRoot() ? total : node.getActual();
             long base = node.isRoot() ? total.getAmount() : node.getParent().getActual().getAmount();
 
             String totalPercentage = "";
             if (node.getParent() != null && !node.getParent().isRoot())
                 totalPercentage = "; " + MessageFormat.format(Messages.LabelTotalValuePercent,
-                                Values.Percent2.format(actual / (double) total.getAmount()));
+                                Values.Percent2.format(actual.getAmount() / (double) total.getAmount()));
 
             if (excludeSecurities && node.isAssignment())
             {
@@ -96,8 +96,10 @@ public class TaxonomyPieChartBrowser implements IPieChart
                 buffer.append("{\"uuid\":\"").append(node.getId());
                 buffer.append("\",\"name\":\"").append(name);
                 buffer.append("\",\"caption\":\"");
-                buffer.append(name).append(" ").append(Values.Amount.format(actual)).append(" (")
-                                .append(Values.Percent2.format(actual / (double) base)).append(totalPercentage)
+                buffer.append("<b>").append(name).append("</b> ").append(Values.Money.format(actual))
+                                .append(" (")
+                                .append(Values.Percent2.format(actual.getAmount() / (double) base))
+                                .append(totalPercentage)
                                 .append(")\",");
                 buffer.append("\"value\":").append(node.getActual().getAmount());
                 buffer.append(",\"color\":\"")


### PR DESCRIPTION
Hello, very small cosmetic change proposition (as all the other captions for pie chart/donut chart uses bold on name and the currency code) :

**Before**
![2024-09-03 22_20_09-Portfolio Performance](https://github.com/user-attachments/assets/b4f89d2e-65e0-4337-9726-eb17e3708a88)

**After**
![2024-09-03 22_20_38-Portfolio Performance](https://github.com/user-attachments/assets/b62b68bb-296d-46f7-8acc-4236af6a6fe4)


