### PR TITLE
Statement of Assets : add total perf for TTWROR, TTWROR p.a. and IRR

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -256,9 +256,12 @@ public class StatementOfAssetsViewer
             if (calculateTotalsPerformance)
             {
                 List<Exception> warnings = new ArrayList<>();
-            
+
                 // performance for sub totals (category) lines
-                elements.stream().filter(Element::isCategory).forEach(e -> e.setPerformanceForCategoryTotals(
+                elements.stream().filter(Element::isCategory)
+                                .filter(e -> !Objects.equals(Classification.UNASSIGNED_ID,
+                                                e.getCategory().getClassification().getId()))
+                                .forEach(e -> e.setPerformanceForCategoryTotals(
                                 currencyCode, interval,
                                 PerformanceIndex.forClassification(filteredClient, converter.with(currencyCode),
                                                 e.getCategory().getClassification(), interval, warnings)));
@@ -1339,14 +1342,14 @@ public class StatementOfAssetsViewer
             }
             else if (element.isCategory())
             {
-                if (collector == null && valueProviderTotal != null)
+                if (collector == null && valueProviderTotal != null && !Objects.equals(Classification.UNASSIGNED_ID,
+                                element.getCategory().getClassification().getId()))
                 {
-                    // assumption: performance index has been calculated
-                    // before by calculatePerformanceAndInjectIntoElements !
+                    // assumption: performance index has been calculated before
                     PerformanceIndex index = element.getPerformanceForCategoryTotals(currencyCode, interval);
                     return valueProviderTotal.apply(index);
                 }
-                if (collector == null)
+                else if (collector == null)
                     return null;
                 else
                     return collectValue(element.getChildren(), currencyCode, interval);
@@ -1355,8 +1358,7 @@ public class StatementOfAssetsViewer
             {
                 if (collector == null && valueProviderTotal != null)
                 {
-                    // assumption: performance index has been calculated
-                    // before by calculatePerformanceAndInjectIntoElements !
+                    // assumption: performance index has been calculated before
                     PerformanceIndex index = element.getPerformanceForCategoryTotals(currencyCode, interval);
                     return valueProviderTotal.apply(index);
                 }


### PR DESCRIPTION

Closes  https://github.com/portfolio-performance/portfolio/issues/2570
Hello,

This is a proposition to add the TTWROR cumulated, TTWROR annualized and the IRR to the Statement of Assets totals and subtotals (main category of Taxonomy) lines.
I think there were debates about adding those totals for Abs Perf % or Capital Gains %, so those are not added (not defined). I do not know if those argument were also applicable to TTWROR and IRR, I am assuming not.

I have checked some cases with the results from the associated widget, looks ok.
Not tested are the "new values" : subtotal per category with a portfolio filter activated (I do not think such values previoulsy existed elsewhere as it requires a "double filter" taxonomy+portfolio).

I have kept two commits to highlight one issue to consider in the review : without the second commit it was not working properly because of java heap space issues. I do not get it anymore with the second commit, but maybe it is still not optimized enough ? Should a LazyPerfomanceIndex methodology be used, as it is done for Security ? 

Also, this is showing 0 % for the _Without Classification_ line, which seems wrong. Now that I think of it, _Without Classification_ is never available as a data series. Is performance index defined for it ?


**Before** 
![Capture d’écran 2024-09-07 230019](https://github.com/user-attachments/assets/0785b30c-d7a0-4091-92b4-2ec0a7b72a5f)

**After**
![Capture d’écran 2024-09-07 230055](https://github.com/user-attachments/assets/267a0c5a-8f32-4d42-8faf-1fd9bef779ab)
