### PR TITLE
Add "Ausschüttung Investmentfonds" to MerkurPrivatBankPDFExtractor an…

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/merkurprivatbank/Dividende02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/merkurprivatbank/Dividende02.txt
@@ -1,0 +1,60 @@
+```
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.70.4
+-----------------------------------------
+Am Marktplatz 10 · 97762 Hammelburg    Seite 1
+Depotnummer
+ 60123832
+ Kundennummer 614726605
+MZjZWP anwjU ujfZQks
+ Abrechnungsnr. 13354957156
+KdcMwt hpWfE jjSYJit Datum 12.09.2024
+OYsrGIpZx. 7 Ihr Berater Herr wtv HSlocOkRiXq
+90402 Nürnberg Telefon +49 951 836772-33   
+                                                        
+                                                        
+                                                        
+Ausschüttung Investmentfonds
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 2.950 VANECK MSTR.DM DIVIDEND.UC.ETF NL0011683594 (A2JAHJ)
+AANDELEN OOP TOONDER O.N.
+Zahlbarkeitstag 11.09.2024 Ausschüttung pro St. 0,310000000 EUR
+Bestandsstichtag 03.09.2024 mit Teilfreistellung (Aktien-
+Ex-Tag 04.09.2024 fonds) 0,217000000 EUR
+Geschäftsjahr 01.01.2024 - 31.12.2024 Herkunftsland Niederlande
+Ausschüttung 914,50+ EUR
+davon steuerfreier Anteil wg. Teilfreistellung 274,35 EUR
+Einbehaltene Quellensteuer 15 % auf 914,50 EUR 137,18- EUR
+Anrechenbare Quellensteuer pro Stück 0,0465 EUR 137,18 EUR
+Kapitalertragsteuerpfl. Ertrag nach Teilfreistellung 640,15 EUR
+Verrechnete anrechenbare ausländische Quellensteuer
+(Verhältnis 100/25) auf 137,18 EUR 548,72 - EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 91,43 EUR
+Kapitalertragsteuer 25 % auf 91,43 EUR 22,86- EUR
+Solidaritätszuschlag 5,5 % auf 22,86 EUR 1,26- EUR
+Ausmachender Betrag 753,20+ EUR
+Lagerstelle CBF w/7268 w/DZ Bank (160382 / 66364508)
+Den Betrag buchen wir mit Wertstellung 12.09.2024 zu Gunsten des Kontos 0072812 (IBAN DE65 1642 5260 7516 5630
+25), BLZ 701 308 00 (BIC GENODEF1M06). 
+Keine Steuerbescheinigung. 
+Bitte ggf. Rückseite beachten.
+6175.09130101.0000094ER03
+
+Seite 2
+Depotnummer 61705912
+Kundennummer 986789205
+Abrechnungsnr. 95216722965
+Datum 12.09.2024
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verrechnungstöpfe 2024 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien und Sonstige
+Pauschbetrag Quellensteuer
+Vorher 0,00 0,00 0,00 0,00 27.078,11
+Ertrag 137,18
+0,00 0,00 0,00 137,18- 91,43
+Nachher 0,00 0,00 0,00 0,00 27.169,54
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+6175.09130101.0000095ER03
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/merkurprivatbank/MerkurPrivatBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/merkurprivatbank/MerkurPrivatBankPDFExtractorTest.java
@@ -267,6 +267,9 @@ public class MerkurPrivatBankPDFExtractorTest
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende02.txt"), errors);
 
         assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
@@ -280,7 +283,7 @@ public class MerkurPrivatBankPDFExtractorTest
         assertThat(results, hasItem(dividend( //
                         hasDate("2024-09-11T00:00"), hasShares(2950), //
                         hasSource("Dividende02.txt"), //
-                        hasNote("Abrechnungsnr. 13354957156"),
+                        hasNote("Abrechnungsnr. 13354957156"), //
                         hasAmount("EUR", 753.20), hasGrossValue("EUR", 914.50), //
                         hasTaxes("EUR", 137.18 + 22.86 + 1.26), hasFees("EUR", 0.00))));
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/merkurprivatbank/MerkurPrivatBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/merkurprivatbank/MerkurPrivatBankPDFExtractorTest.java
@@ -258,6 +258,34 @@ public class MerkurPrivatBankPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierDividende02()
+    {
+        MerkurPrivatBankPDFExtractor extractor = new MerkurPrivatBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("NL0011683594"), hasWkn("A2JAHJ"), hasTicker(null), //
+                        hasName("VANECK MSTR.DM DIVIDEND.UC.ETF AANDELEN OOP TOONDER O.N."), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2024-09-11T00:00"), hasShares(2950), //
+                        hasSource("Dividende02.txt"), //
+                        hasNote("Abrechnungsnr. 13354957156"),
+                        hasAmount("EUR", 753.20), hasGrossValue("EUR", 914.50), //
+                        hasTaxes("EUR", 137.18 + 22.86 + 1.26), hasFees("EUR", 0.00))));
+    }
+
+    @Test
     public void testKontoauszug01()
     {
         MerkurPrivatBankPDFExtractor extractor = new MerkurPrivatBankPDFExtractor(new Client());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MerkurPrivatBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MerkurPrivatBankPDFExtractor.java
@@ -4,7 +4,6 @@ import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
-import name.abuchen.portfolio.datatransfer.pdf.PDFParser.ParsedData;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.AccountTransaction.Type;
@@ -16,15 +15,9 @@ import name.abuchen.portfolio.model.PortfolioTransaction;
 @SuppressWarnings("nls")
 public class MerkurPrivatBankPDFExtractor extends AbstractPDFExtractor
 {
-
-    private static final String DEPOSIT_REMOVAL = "^(?<date>[\\d]{2}\\.[\\d]{2}\\.) [\\d]{2}\\.[\\d]{2}\\. (?<note>.*) PN:\\d+[\\s]{1,}(?<amount>[\\.,\\d]+) (?<type>[H|S])$";
-
     public MerkurPrivatBankPDFExtractor(Client client)
     {
         super(client);
-
-        // New documents only seem to have a graphical company logo
-        // addBankIdentifier("MERKUR PRIVATBANK KGaA");
 
         addBankIdentifier("Am Marktplatz 10");
         addBankIdentifier("97762 Hammelburg");
@@ -209,9 +202,42 @@ public class MerkurPrivatBankPDFExtractor extends AbstractPDFExtractor
                                         .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency")))));
         this.addDocumentTyp(type);
 
-        Block depositRemovalBlock = new Block(DEPOSIT_REMOVAL);
-        depositRemovalBlock.set(depositRemovalTransaction(type, DEPOSIT_REMOVAL));
+        Block depositRemovalBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. .* PN:\\d+[\\s]{1,}[\\.,\\d]+ [H|S]$");
         type.addBlock(depositRemovalBlock);
+        depositRemovalBlock.set(new Transaction<AccountTransaction>()
+
+                        .subject(() -> {
+                            AccountTransaction accountTransaction = new AccountTransaction();
+                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
+                            return accountTransaction;
+                        })
+
+                        .section("date", "note", "amount", "type") //
+                        .documentContext("currency", "year") //
+                        .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.) [\\d]{2}\\.[\\d]{2}\\. (?<note>.*) PN:\\d+[\\s]{1,}(?<amount>[\\.,\\d]+) (?<type>[H|S])$") //
+                        .assign((t, v) -> {
+                            // Is type is "S" change from DEPOSIT to REMOVAL
+                            if ("S".equals(v.get("type")))
+                                t.setType(Type.REMOVAL);
+
+                            t.setDateTime(asDate(v.get("date") + v.get("year")));
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+
+                            // Formatting some notes
+                            if ("DAUERAUFTRAG".equals(v.get("note")))
+                                v.put("note", "Dauerauftrag");
+
+                            if ("GUTSCHRIFT".equals(v.get("note")))
+                                v.put("note", "Gutschrift");
+
+                            if ("FESTGELDANLAGE".equals(v.get("note")))
+                                v.put("note", "Festgeldanlage");
+
+                            t.setNote(v.get("note"));
+                        })
+
+                        .wrap(TransactionItem::new));
     }
 
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
@@ -222,7 +248,7 @@ public class MerkurPrivatBankPDFExtractor extends AbstractPDFExtractor
                         // Kapitalertragsteuer 25,00% auf 12.960,18 EUR 3.240,05- EUR
                         // @formatter:on
                         .section("tax", "currency").optional() //
-                        .match("^Kapitalertragsteuer [\\.,\\d]+([\\s]+)?% .* (?<tax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$") //
+                        .match("^Kapitalertrags(s?)teuer [\\.,\\d]+([\\s]+)?% .* (?<tax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$") //
                         .assign((t, v) -> processTaxEntries(t, v, type))
 
                         // @formatter:off
@@ -232,11 +258,19 @@ public class MerkurPrivatBankPDFExtractor extends AbstractPDFExtractor
                         .match("^Solidarit.tszuschlag [\\.,\\d]+([\\s]+)?% .* (?<tax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$") //
                         .assign((t, v) -> processTaxEntries(t, v, type))
 
+                        // @formatter:off
                         // Einbehaltene Quellensteuer 15 % auf 914,50 EUR
-                        // 137,18- EUR
-                        .section("tax", "currency").optional()
-                        .match("^Einbehaltene Quellensteuer [\\.,\\d]+([\\s]+)?% .* (?<tax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
-                        .assign((t, v) -> processTaxEntries(t, v, type));
+                        // @formatter:on
+                        .section("withHoldingTax", "currency").optional()
+                        .match("^Einbehaltene Quellensteuer [\\.,\\d]+([\\s]+)?% .* (?<withHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                        .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
+
+                        // @formatter:off
+                        // Anrechenbare Quellensteuer pro Stück 0,0465 EUR 137,18 EUR
+                        // @formatter:on
+                        .section("creditableWithHoldingTax", "currency").optional()
+                        .match("^Anrechenbare Quellensteuer pro St.ck [\\.,\\d]+ [\\w]{3} (?<creditableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$")
+                        .assign((t, v) -> processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type));
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
@@ -256,48 +290,5 @@ public class MerkurPrivatBankPDFExtractor extends AbstractPDFExtractor
                         .section("fee", "currency").optional()
                         .match("^.bertragungs-\\/Liefergeb.hr (?<fee>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$")
                         .assign((t, v) -> processFeeEntries(t, v, type));
-    }
-
-    private Transaction<AccountTransaction> depositRemovalTransaction(DocumentType type, String regex)
-    {
-        return new Transaction<AccountTransaction>() //
-
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
-
-                        .section("date", "note", "amount", "type") //
-                        .documentContext("currency", "year") //
-                        .match(regex) //
-                        .assign((t, v) -> {
-                            // Is type is "S" change from DEPOSIT to REMOVAL
-                            if ("S".equals(v.get("type")))
-                                t.setType(Type.REMOVAL);
-
-                            assignmentsProvider(t, v);
-                        })
-
-                        .wrap(TransactionItem::new);
-    }
-
-    private void assignmentsProvider(AccountTransaction t, ParsedData v)
-    {
-        t.setDateTime(asDate(v.get("date") + v.get("year")));
-        t.setAmount(asAmount(v.get("amount")));
-        t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-
-        // Formatting some notes
-        if ("DAUERAUFTRAG".equals(v.get("note")))
-            v.put("note", "Dauerauftrag");
-
-        if ("GUTSCHRIFT".equals(v.get("note")))
-            v.put("note", "Gutschrift");
-
-        if ("FESTGELDANLAGE".equals(v.get("note")))
-            v.put("note", "Festgeldanlage");
-
-        t.setNote(v.get("note"));
     }
 }


### PR DESCRIPTION
Add "Ausschüttung Investmentfonds" to MerkurPrivatBankPDFExtractor and associated test testWertpapierDividende02

New documents only seem to have a graphical company logo that the pdf text extractor is not able to read hence the BankIdentifier was changed to match the full address instead.

In addition new "Quellensteuer" was added and regexes extended to accommodate this variation of a dividend type.