### PR TITLE
Add Rebalance by Purchase value

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -927,6 +927,7 @@ public class Messages extends NLS
     public static String MenuConfigureCurrentDashboard;
     public static String MenuConfigureDashboards;
     public static String MenuConfigureRebalancingIndicator;
+    public static String MenuConfigureRebalancingPurchaseValue;
     public static String MenuConfigureView;
     public static String MenuConfirmDeleteAllTransactions;
     public static String MenuConvertToBuy;
@@ -1200,6 +1201,7 @@ public class Messages extends NLS
     public static String PresetsPrefPageTitle;
     public static String RebalanceAmbiguousTooltip;
     public static String RebalanceInexactTooltip;
+    public static String RebalancingPurchaseValue;
     public static String SearchSecurityWizardPageSymbolAlreadyExistsInfo;
     public static String SecuritiesChart_NoDataMessage_NoHoldings;
     public static String SecuritiesChart_NoDataMessage_NoPrices;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1846,6 +1846,8 @@ MenuConfigureDashboards = Configure dashboards
 
 MenuConfigureRebalancingIndicator = Configure {0}/{1} Rule
 
+MenuConfigureRebalancingPurchaseValue = Rebalancing by Purchase Value
+
 MenuConfigureView = Configure view
 
 MenuConfirmDeleteAllTransactions = Delete all transactions of securities {0}?
@@ -2391,6 +2393,8 @@ PresetsPrefPageTitle = Presets
 RebalanceAmbiguousTooltip = The rebalancing result is ambiguous.\n\nYou can refine the taxonomy or exclude some securities from the rebalancing to resolve the ambiguity.
 
 RebalanceInexactTooltip = The rebalancing result is not exact, because there is no exact solution.\n\nThis solution minimizes the mean square error while respecting that the results have to add up to 0.\n\nYou can coarsen the taxonomy or include more securities in the rebalancing to get an exact solution.
+
+RebalancingPurchaseValue = Purchase Value
 
 SearchSecurityWizardPageSymbolAlreadyExistsInfo = A security with the symbol ''{0}'' already exists.
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BindingHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BindingHelper.java
@@ -424,6 +424,31 @@ public class BindingHelper
                         new UpdateValueStrategy<Long, String>().setConverter(new CurrencyToStringConverter(type)));
     }
 
+    public final Control bindPositiveAmountInput(Composite editArea, final String label, String property, int style,
+                    int lenghtInCharacters)
+    {
+        Text txtValue = createTextInput(editArea, label, style, lenghtInCharacters);
+        FrenchKeypadSupport.configure(txtValue);
+        bindPositiveDecimalInput(label, property, txtValue, Values.Amount);
+        return txtValue;
+    }
+
+    private void bindPositiveDecimalInput(final String label, String property, Text txtValue, Values<?> type)
+    {
+        StringToCurrencyConverter converter = new StringToCurrencyConverter(type);
+
+        UpdateValueStrategy<String, Long> input2model = new UpdateValueStrategy<>();
+        input2model.setAfterGetValidator(converter);
+        input2model.setConverter(converter);
+        input2model.setAfterConvertValidator(v -> v != null && v.longValue() >= 0 ? ValidationStatus.ok()
+                        : ValidationStatus.error(MessageFormat.format(Messages.MsgDialogInputRequired, label)));
+
+        IObservableValue<String> targetObservable = WidgetProperties.text(SWT.Modify).observe(txtValue);
+        IObservableValue<Long> modelObservable = BeanProperties.value(property, Long.class).observe(model);
+        context.bindValue(targetObservable, modelObservable, input2model,
+                        new UpdateValueStrategy<Long, String>().setConverter(new CurrencyToStringConverter(type)));
+    }
+
     private Text createTextInput(Composite editArea, final String label)
     {
         return createTextInput(editArea, label, SWT.NONE, SWT.DEFAULT);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/EditRebalancingPurchaseValueDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/EditRebalancingPurchaseValueDialog.java
@@ -1,0 +1,23 @@
+package name.abuchen.portfolio.ui.views.taxonomy;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Shell;
+
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.dialogs.AbstractDialog;
+
+public class EditRebalancingPurchaseValueDialog extends AbstractDialog
+{
+    public EditRebalancingPurchaseValueDialog(Shell parentShell, RebalancingPurchaseValue purchaseValue)
+    {
+        super(parentShell, Messages.LabelViewReBalancing, purchaseValue);
+    }
+
+    @Override
+    protected void createFormElements(Composite editArea)
+    {
+        bindings().bindPositiveAmountInput(editArea, Messages.RebalancingPurchaseValue, "purchaseValue", //$NON-NLS-1$
+                        SWT.NONE, 10);
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/ReBalancingViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/ReBalancingViewer.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.ui.views.taxonomy;
 
+import java.beans.PropertyChangeListener;
 import java.text.MessageFormat;
 import java.time.LocalDate;
 
@@ -557,6 +558,18 @@ public class ReBalancingViewer extends AbstractNodeTreeViewer
         manager.add(new SimpleAction(MessageFormat.format(Messages.MenuConfigureRebalancingIndicator, //
                         rule.getAbsoluteThreshold(), rule.getRelativeThreshold()),
                         a -> new EditRebalancingColoringRuleDialog(ActiveShell.get(), rule).open()));
+
+        RebalancingPurchaseValue purchaseValue = new RebalancingPurchaseValue(getModel().getClient());
+        manager.add(new SimpleAction(Messages.MenuConfigureRebalancingPurchaseValue,
+                        a -> new EditRebalancingPurchaseValueDialog(ActiveShell.get(), purchaseValue).open()));
+
+        PropertyChangeListener listener = evt -> {
+            getModel().recalculate();
+            getNodeViewer().refresh();
+        };
+        getModel().getClient().addPropertyChangeListener(listener);
+        getNodeViewer().getControl()
+                        .addDisposeListener(e -> getModel().getClient().removePropertyChangeListener(listener));
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/RebalancingPurchaseValue.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/RebalancingPurchaseValue.java
@@ -1,0 +1,36 @@
+package name.abuchen.portfolio.ui.views.taxonomy;
+
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.util.BindingHelper;
+
+public class RebalancingPurchaseValue extends BindingHelper.Model
+{
+    private static final String KEY_PURCHASE_VALUE = "taxonomy.rebalancing.purchase"; //$NON-NLS-1$
+
+    private long purchaseValue = Values.Amount.factorize(100);
+
+    public RebalancingPurchaseValue(Client client)
+    {
+        super(client);
+
+        purchaseValue = client.getPropertyInt(KEY_PURCHASE_VALUE);
+    }
+
+    public long getPurchaseValue()
+    {
+        return purchaseValue;
+    }
+
+    public void setPurchaseValue(long purchaseValue)
+    {
+        firePropertyChange("purchaseValue", this.purchaseValue, this.purchaseValue = purchaseValue); // NOSONAR //$NON-NLS-1$
+    }
+
+    @Override
+    public void applyChanges()
+    {
+        Client client = getClient();
+        client.setProperty(KEY_PURCHASE_VALUE, String.valueOf(purchaseValue));
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/RecalculateTargetsAttachedModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/RecalculateTargetsAttachedModel.java
@@ -11,7 +11,11 @@ public class RecalculateTargetsAttachedModel implements TaxonomyModel.AttachedMo
         TaxonomyNode virtualRootNode = model.getVirtualRootNode();
         TaxonomyNode unassignedNode = model.getUnassignedNode();
 
-        virtualRootNode.setTarget(virtualRootNode.getActual().subtract(unassignedNode.getActual()));
+        RebalancingPurchaseValue purchaseValue = new RebalancingPurchaseValue(model.getClient());
+        Money purchaseMoney = Money.of(model.getCurrencyCode(), purchaseValue.getPurchaseValue());
+
+        virtualRootNode.setTarget(virtualRootNode.getActual().subtract(unassignedNode.getActual())
+                        .add(purchaseMoney));
 
         model.visitAll(node -> {
             if (node.isClassification() && !node.isRoot())


### PR DESCRIPTION
Possibility to set Purchase value for Rebalancing by additional purchases rather than sell off.
It changes Total Target values so it shows what you should purchase by available money.

![obrazek](https://github.com/user-attachments/assets/dbd414ac-6409-4c30-8f12-bcf0e258dd33)
![obrazek](https://github.com/user-attachments/assets/7c00cceb-f45d-40d8-b1f9-92d95036e18a)
![obrazek](https://github.com/user-attachments/assets/ebae01c0-67ed-4ec5-84b4-31362af0d9e1)
