### PR TITLE
Fix "absolute deviation" in the "delta percentage indicator"

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/DeltaPercentageIndicatorLabelProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/DeltaPercentageIndicatorLabelProvider.java
@@ -36,7 +36,7 @@ public class DeltaPercentageIndicatorLabelProvider extends OwnerDrawLabelProvide
 
             Data data = new Data();
 
-            data.totalAmount = node.getRoot().getActual().getAmount();
+            data.totalAmount = node.getParent().getTarget().getAmount();
             data.targetAmount = node.getTarget().getAmount();
             data.actualAmount = node.getActual().getAmount();
 


### PR DESCRIPTION
`node.getRoot()` leaded to an "absolute deviation" calculated in relation to the total value of *all* (filtered) assets. The filtering worked, but the "root" TaxonomyNode includes the "Without Classification" class, which we don't want.

This commit fixes above issue, but goes further: multiple levels of asset classes can now be rebalanced correctly using the "delta percentage indicator", because only the current sub-class is taken into account, as opposed to the classification root.

Issue: https://forum.portfolio-performance.info/t/ohne-klassifizierungen-nicht-auswerten-filter-vergessen-ihre-einstellungen/655/9