### PR TITLE
Add column with graphical price range widget

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -283,6 +283,9 @@ public class Messages extends NLS
     public static String ColumnQuoteDistanceFromAthPercent;
     public static String ColumnQuoteDistanceFromAthPercent_Description;
     public static String ColumnQuoteDistanceFromAthPercent_Option;
+    public static String ColumnQuoteRangeWidget;
+    public static String ColumnQuoteRangeWidget_Description;
+    public static String ColumnQuoteRangeWidget_Option;
     public static String ColumnQuoteFeedHistoric;
     public static String ColumnQuoteFeedLatest;
     public static String ColumnRealizedCapitalGains;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -614,6 +614,12 @@ ColumnQuoteDistanceFromAthPercent_Description = Percentage distance from the las
 
 ColumnQuoteDistanceFromAthPercent_Option = \u0394 ATH {0} %
 
+ColumnQuoteRangeWidget = Range Widget
+
+ColumnQuoteRangeWidget_Description = Relative position of the current price vs low/high over the chosen period, represented graphically.
+
+ColumnQuoteRangeWidget_Option = Range {0}
+
 ColumnQuoteFeedHistoric = Quote Feed (historic)
 
 ColumnQuoteFeedLatest = Quote Feed (latest)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ParameterizedColumnLabelProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ParameterizedColumnLabelProvider.java
@@ -12,6 +12,11 @@ public class ParameterizedColumnLabelProvider extends ColumnLabelProvider
 {
     private TableColumn tableColumn;
 
+    public TableColumn getTableColumn()
+    {
+        return this.tableColumn;
+    }
+
     public void setTableColumn(TableColumn tableColumn)
     {
         if (this.tableColumn != null)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ParameterizedOwnerDrawLabelProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ParameterizedOwnerDrawLabelProvider.java
@@ -1,0 +1,73 @@
+package name.abuchen.portfolio.ui.util.viewers;
+
+import org.eclipse.jface.viewers.ColumnViewer;
+import org.eclipse.jface.viewers.ViewerColumn;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.TableItem;
+
+import name.abuchen.portfolio.PortfolioLog;
+
+/**
+ * ColumnLabelProvider subclass which allows to completely override rendering
+ * of cell foreground, e.g. fraw graphics, etc.
+ */
+public class ParameterizedOwnerDrawLabelProvider extends ParameterizedColumnLabelProvider implements Listener
+{
+    @Override
+    protected void initialize(ColumnViewer viewer, ViewerColumn column)
+    {
+        Control control = viewer.getControl();
+        control.addListener(SWT.MeasureItem, this);
+        control.addListener(SWT.EraseItem, this);
+        control.addListener(SWT.PaintItem, this);
+        super.initialize(viewer, column);
+    }
+
+    /**
+     * Measure size of contents - optional to override.
+     */
+    public void measure(Event event)
+    {
+    }
+
+    /**
+     * Actually paint contents via event.gc, etc. Column is passed
+     * to differentiate multiple columns with owner-draw contents.
+     */
+    public void paint(Event event)
+    {
+        PortfolioLog.error("paint() not implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public void handleEvent(Event event)
+    {
+        TableItem item = (TableItem) event.item;
+        Table table = item.getParent();
+        TableColumn tColumn = table.getColumn(event.index);
+        if (tColumn != getTableColumn())
+            return;
+
+        switch (event.type)
+        {
+            case SWT.MeasureItem:
+                this.measure(event);
+                break;
+            case SWT.PaintItem:
+                this.paint(event);
+                break;
+            case SWT.EraseItem:
+                // We're saying that we'll draw actual things ("foreground")
+                // ourselves. Things like background, selection, etc. will
+                // still be handled by SWT.
+                event.detail &= ~SWT.FOREGROUND;
+                break;
+            default:
+        }
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -101,6 +101,7 @@ import name.abuchen.portfolio.ui.views.columns.DistanceFromMovingAverageColumn;
 import name.abuchen.portfolio.ui.views.columns.DividendPaymentColumns;
 import name.abuchen.portfolio.ui.views.columns.IsinColumn;
 import name.abuchen.portfolio.ui.views.columns.NoteColumn;
+import name.abuchen.portfolio.ui.views.columns.RangeWidgetColumn;
 import name.abuchen.portfolio.ui.views.columns.SymbolColumn;
 import name.abuchen.portfolio.ui.views.columns.TaxonomyColumn;
 import name.abuchen.portfolio.ui.views.columns.WknColumn;
@@ -210,6 +211,8 @@ public final class SecuritiesTable implements ModificationListener
         addQuoteDeltaColumn();
         support.addColumn(new DistanceFromMovingAverageColumn(LocalDate::now));
         support.addColumn(new DistanceFromAllTimeHighColumn(LocalDate::now,
+                        view.getPart().getReportingPeriods().stream().collect(toMutableList())));
+        support.addColumn(new RangeWidgetColumn(LocalDate::now,
                         view.getPart().getReportingPeriods().stream().collect(toMutableList())));
 
         for (Taxonomy taxonomy : getClient().getTaxonomies())

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/RangeWidgetColumn.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/RangeWidgetColumn.java
@@ -1,0 +1,125 @@
+package name.abuchen.portfolio.ui.views.columns;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Event;
+
+import name.abuchen.portfolio.math.AllTimeHigh;
+import name.abuchen.portfolio.model.Adaptor;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.snapshot.ReportingPeriod;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.viewers.Column;
+import name.abuchen.portfolio.ui.util.viewers.ColumnViewerSorter;
+import name.abuchen.portfolio.ui.util.viewers.ParameterizedOwnerDrawLabelProvider;
+import name.abuchen.portfolio.ui.util.viewers.ReportingPeriodColumnOptions;
+import name.abuchen.portfolio.util.Interval;
+
+public class RangeWidgetColumn extends Column
+{
+    private static final class QuoteReportingPeriodLabelProvider extends ParameterizedOwnerDrawLabelProvider
+    {
+        private BiFunction<Object, ReportingPeriod, AllTimeHigh> valueProvider;
+
+        public QuoteReportingPeriodLabelProvider(BiFunction<Object, ReportingPeriod, AllTimeHigh> valueProvider)
+        {
+            this.valueProvider = valueProvider;
+        }
+
+        @Override
+        public String getToolTipText(Object e)
+        {
+            var range = valueProvider.apply(e, (ReportingPeriod) getOption());
+            if (range == null || range.getLow() == null || range.getHigh() == null)
+                return null;
+            Double value = range.getRelLowDistance();
+
+            return String.format("%s -%.2f%% (%s)\n%s +%.2f%% (%s)", //$NON-NLS-1$
+                Values.Quote.format(range.getHigh()),
+                (1 - value) * 100,
+                Values.Date.format(range.getHighDate()),
+
+                Values.Quote.format(range.getLow()),
+                value * 100,
+                Values.Date.format(range.getLowDate())
+            );
+        }
+
+        @Override
+        public void paint(Event event)
+        {
+            final int TICK_WIDTH = 3;
+            final int BAR_HEIGHT = 16;
+
+            ReportingPeriod option = (ReportingPeriod) getOption();
+            var range = valueProvider.apply(event.item.getData(), option);
+            if (range == null)
+                return;
+            Double value = range.getRelLowDistance();
+            if (value == null)
+                return;
+
+            double pos = value;
+            int width = getTableColumn().getWidth() - 2;  // Leave some space in case 2 such columns go side by side
+            int yOff = (event.height - BAR_HEIGHT) / 2;
+
+            event.gc.setBackground(Colors.LIGHT_GRAY);
+            event.gc.setForeground(Colors.BLACK);
+            event.gc.fillRectangle(event.x, event.y + yOff, width, BAR_HEIGHT);
+            event.gc.setLineWidth(TICK_WIDTH);
+
+            int tickX = (int) (width * pos);
+            // When line is drawn, its coordinates are midpoint of its width, but
+            // we don't want to see half a line width or something.
+            if (tickX < TICK_WIDTH / 2)
+                tickX = TICK_WIDTH / 2;
+            else if (tickX > (width - 1 - (TICK_WIDTH + 1) / 2))
+                tickX = width - 1 - (TICK_WIDTH + 1) / 2;
+
+            event.gc.drawLine(event.x + tickX, event.y + yOff, event.x + tickX, event.y + yOff + BAR_HEIGHT - 1);
+        }
+    }
+
+    public RangeWidgetColumn(Supplier<LocalDate> dateProvider, List<ReportingPeriod> options)
+    {
+        super("range-widget", Messages.ColumnQuoteRangeWidget, SWT.RIGHT, 80); //$NON-NLS-1$
+
+        BiFunction<Object, ReportingPeriod, AllTimeHigh> valueProvider = (element, option) -> {
+            Interval interval = option.toInterval(dateProvider.get());
+
+            Security security = Adaptor.adapt(Security.class, element);
+            if (security == null)
+                return null;
+
+            return new AllTimeHigh(security, interval);
+        };
+
+        this.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnQuoteRangeWidget_Option, options));
+        this.setDescription(Messages.ColumnQuoteRangeWidget_Description);
+        this.setLabelProvider(() -> new QuoteReportingPeriodLabelProvider(valueProvider));
+        this.setVisible(false);
+        this.setSorter(ColumnViewerSorter.create((o1, o2) -> {
+            ReportingPeriod option = (ReportingPeriod) ColumnViewerSorter.SortingContext.getColumnOption();
+
+            AllTimeHigh range1 = valueProvider.apply(o1, option);
+            AllTimeHigh range2 = valueProvider.apply(o2, option);
+            Double v1 = range1 != null ? range1.getRelLowDistance() : null;
+            Double v2 = range2 != null ? range2.getRelLowDistance() : null;
+
+            if (v1 == null && v2 == null)
+                return 0;
+            else if (v1 == null)
+                return -1;
+            else if (v2 == null)
+                return 1;
+
+            return Double.compare(v1.doubleValue(), v2.doubleValue());
+        }));
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/math/AllTimeHigh.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/math/AllTimeHigh.java
@@ -14,8 +14,11 @@ public class AllTimeHigh
     private Security security;
     private Interval interval;
     private Long athValue;
+    private Long atlValue;
     private LocalDate athDate;
+    private LocalDate atlDate;
     private Double athDistanceInPercent;
+    private Double relDistFromLow;
 
     public AllTimeHigh(Security security, Interval interval)
     {
@@ -34,14 +37,21 @@ public class AllTimeHigh
                         .filter(p -> interval.contains(p.getDate())) //
                         .max(Comparator.comparing(SecurityPrice::getValue));
 
-        if (!max.isPresent())
+        Optional<SecurityPrice> min = security.getPricesIncludingLatest().stream() //
+                        .filter(p -> interval.contains(p.getDate())) //
+                        .min(Comparator.comparing(SecurityPrice::getValue));
+
+        if (!max.isPresent() || !min.isPresent())
             return;
 
         SecurityPrice latest = security.getSecurityPrice(interval.getEnd());
 
         this.athValue = max.get().getValue();
         this.athDate = max.get().getDate();
+        this.atlValue = min.get().getValue();
+        this.atlDate = min.get().getDate();
         this.athDistanceInPercent = (latest.getValue() - max.get().getValue()) / (double) max.get().getValue();
+        this.relDistFromLow = (double) (latest.getValue() - atlValue) / (athValue - atlValue);
     }
 
     public Long getValue()
@@ -49,11 +59,36 @@ public class AllTimeHigh
         return this.athValue;
     }
 
+    public Long getLow()
+    {
+        return this.atlValue;
+    }
+
+    public Long getHigh()
+    {
+        return this.athValue;
+    }
+
+    public LocalDate getLowDate()
+    {
+        return this.atlDate;
+    }
+
+    public LocalDate getHighDate()
+    {
+        return this.athDate;
+    }
+
     public Double getDistance()
     {
         return this.athDistanceInPercent;
     }
     
+    public Double getRelLowDistance()
+    {
+        return this.relDistFromLow;
+    }
+
     public LocalDate getDate()
     {
         return this.athDate;


### PR DESCRIPTION
This PR builds on ParameterizedColumnLabelProvider introduced in https://github.com/portfolio-performance/portfolio/pull/4225, add to it owner-draw capabilities, as discussed in https://github.com/portfolio-performance/portfolio/issues/4226, and implements on top of it column which represent security price range within given (configurable) time interval in a graphical form, where full range is represented by a horizontal bar, and a notch on it shows current *relative* position. That's how almost every stock analysis site shows price ranges, and what IMHO was sorely missed in PP. This new column type is expected to supersede "Distance from ATH" column, issues with which are:

* "ATH" is so 2021, where's "ATL"?
* Showing distance in absolute terms doesn't make much sense. For example, if some bond ETF had ATH at 60, and currently at 59, it may seem it's barely off the top, but if its ATL over this time is 58, it's actually half way thru its range.
