### PR TITLE
sharpe ratio 's risk free input: allow french numpad decimal

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/EditClientPropertiesDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/EditClientPropertiesDialog.java
@@ -19,6 +19,7 @@ import name.abuchen.portfolio.model.AttributeType.PercentConverter;
 import name.abuchen.portfolio.model.ClientProperties;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.BindingHelper;
+import name.abuchen.portfolio.ui.util.text.FrenchKeypadSupport;
 
 public class EditClientPropertiesDialog extends AbstractDialog
 {
@@ -109,6 +110,7 @@ public class EditClientPropertiesDialog extends AbstractDialog
         l.setText(label);
 
         final Text txtValue = new Text(editArea, SWT.BORDER);
+        FrenchKeypadSupport.configure(txtValue);
         GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).grab(true, false).applyTo(txtValue);
 
         UpdateValueStrategy<String, Double> input2model = new UpdateValueStrategy<>();


### PR DESCRIPTION
In the the recently added sharpe ratio widget, there is an input field where the 'french numpad decimal' setup can be used to permit the use of the numpad '.' decimal'.