### PR TITLE
Improve Timeline Chart Tooltip Size

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChartToolTip.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChartToolTip.java
@@ -23,6 +23,7 @@ import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.LocalResourceManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
@@ -230,11 +231,17 @@ public class TimelineChartToolTip extends AbstractChartToolTip
         Object focus = getFocusedObject();
         extraInfoProvider.forEach(provider -> provider.accept(container, focus));
 
-        Label hint = new Label(data, SWT.NONE);
+        Label hint = new Label(data, SWT.WRAP);
         hint.setText(Messages.TooltipHintPressAlt);
         hint.setFont(this.resourceManager
                         .create(FontDescriptor.createFrom(data.getFont()).increaseHeight(-3).withStyle(SWT.ITALIC)));
-        GridDataFactory.fillDefaults().span(2, 1).applyTo(hint);
+        // first set a small width and then update later
+        GridData hintData = GridDataFactory.fillDefaults().span(2, 1).hint(10, SWT.DEFAULT).span(2, 1).create();
+        hint.setLayoutData(hintData);
+
+        hint.getParent().pack();
+        hintData.widthHint = hint.getBounds().width;
+        hint.getParent().pack();
     }
 
     private List<Pair<ISeries, Double>> computeValues(ISeries[] allSeries)


### PR DESCRIPTION
This small PR prevents the timeline chart tooltip getting too wide because of the hint label on the bottom.
This avoids e.g. that the tooltip gets larger than the window on dashboards.

**Before:**
<img width="436" alt="Bildschirmfoto 2024-10-22 um 11 59 17" src="https://github.com/user-attachments/assets/74cc2d5a-bc7c-4267-8de0-49e29edf371c">

**After:**
<img width="409" alt="Bildschirmfoto 2024-10-22 um 11 59 40" src="https://github.com/user-attachments/assets/8a04af3d-1aa6-444f-8144-e699110fb997">

Closes #2784