### PR TITLE
fix non hidden tooltips for some languages in securities chart

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -1228,7 +1228,7 @@ public class SecuritiesChart
                         .filter(t -> chartInterval.contains(t.getDateTime())) //
                         .sorted(Transaction.BY_DATE).toList();
 
-        addInvestmentMarkers(purchase, PortfolioTransaction.Type.BUY.toString(), colorEventPurchase,
+        addInvestmentMarkers(purchase, Messages.SecurityMenuBuy, colorEventPurchase,
                         PlotSymbolType.TRIANGLE);
 
         List<PortfolioTransaction> sales = client.getPortfolios().stream().flatMap(p -> p.getTransactions().stream())
@@ -1238,7 +1238,7 @@ public class SecuritiesChart
                         .filter(t -> chartInterval.contains(t.getDateTime())) //
                         .sorted(Transaction.BY_DATE).toList();
 
-        addInvestmentMarkers(sales, PortfolioTransaction.Type.SELL.toString(), colorEventSale,
+        addInvestmentMarkers(sales, Messages.SecurityMenuSell, colorEventSale,
                         PlotSymbolType.INVERTED_TRIANGLE);
     }
 


### PR DESCRIPTION
Hello, this is a proposition to fix an issue in the tooltips of securities chart, only happening for French, Dutch and Polish languages.
The string used to exclude the tooltip was generally the same of the tooltip label, but actually different for those three languages.
ex for French : `Messages.SecurityMenuBuy`: _Acheter_ (the verb) vs `PortfolioTransaction.Type.BUY.toString()`: _Achat_ (the noun).

**Before :**
![2024-10-22 19_04_16-Portfolio Performance](https://github.com/user-attachments/assets/6ec30578-9683-490b-bf7c-ceaafa65bb31)


**After :**
![2024-10-22 19_01_27-Portfolio Performance](https://github.com/user-attachments/assets/0ea466b7-7409-404e-a65d-75d7c2cae3f6)
