### PR TITLE
zero percentage value shown as white and without arrow

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/NumberColorLabelProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/NumberColorLabelProvider.java
@@ -32,7 +32,7 @@ public final class NumberColorLabelProvider<N extends Number> extends ColumnLabe
     public Color getForeground(Object element)
     {
         Number value = label.apply(element);
-        if (value == null)
+        if (value == null || value.doubleValue() == 0)
             return null;
 
         return value.doubleValue() >= 0 ? Colors.theme().greenForeground() : Colors.theme().redForeground();
@@ -42,7 +42,7 @@ public final class NumberColorLabelProvider<N extends Number> extends ColumnLabe
     public Image getImage(Object element)
     {
         Number value = label.apply(element);
-        if (value == null)
+        if (value == null || value.doubleValue() == 0)
             return null;
 
         return value.doubleValue() >= 0 ? Images.GREEN_ARROW.image() : Images.RED_ARROW.image();


### PR DESCRIPTION
to be consistent with the format of Statement of Asset.

Hello, this is a proposition to apply the same color rule found in Statement of Assets : a 0% (performance, price delta) is not shown as green with green arrow, but white without arrow. Same also as for a 0.00 value when not a %.

**Before :**
Statement of assets: "white" behavior
![Capture d’écran 2024-10-22 193459](https://github.com/user-attachments/assets/2e5b21bb-92db-4fb9-9bbb-7213c1fd8606)
Securities Lists: "green behavior"
![Capture d’écran 2024-10-22 193555](https://github.com/user-attachments/assets/4203b9ad-76f3-4ac8-9c8b-88e049d9edd2)
Securities Performance View "green behavior"
![Capture d’écran 2024-10-22 193701](https://github.com/user-attachments/assets/5e5b07b1-a293-40b8-ac88-42fd5850a0d4)

**After :** 
![Capture d’écran 2024-10-22 194115](https://github.com/user-attachments/assets/db7a5c12-2bdc-4e72-9161-895b245afbe7)
![Capture d’écran 2024-10-22 194230](https://github.com/user-attachments/assets/0c36f553-3253-4235-8d17-8e852536dfc9)

(Also applicable for the Return column of Trades.)

0% IRR seems to be -0% so very very slightly negative ? 