### PR TITLE
adapt pie chart slice color to dark/light them

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/HoldingsChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/HoldingsChartWidget.java
@@ -74,7 +74,7 @@ public class HoldingsChartWidget extends CircularChartWidget<ClientSnapshot>
 
         ICircularSeries<?> circularSeries = (ICircularSeries<?>) getChart().getSeriesSet()
                         .createSeries(SeriesType.DOUGHNUT, Messages.ClientEditorLabelHoldings);
-        circularSeries.setSliceColor(Colors.WHITE);
+        circularSeries.setSliceColor(getChart().getPlotArea().getBackground());
         Node rootNode = circularSeries.getRootNode();
 
         CircularChart.PieColors colorWheel = new CircularChart.PieColors();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/TaxonomyChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/TaxonomyChartWidget.java
@@ -74,7 +74,7 @@ public class TaxonomyChartWidget extends CircularChartWidget<TaxonomyModel>
         {
             ICircularSeries<?> circularSeries = (ICircularSeries<?>) getChart().getSeriesSet()
                             .createSeries(SeriesType.DOUGHNUT, Messages.LabelErrorNoTaxonomySelected);
-            circularSeries.setSliceColor(Colors.WHITE);
+            circularSeries.setSliceColor(getChart().getPlotArea().getBackground());
             circularSeries.setSeries(new String[] { Messages.LabelErrorNoTaxonomySelected }, new double[] { 100 });
             circularSeries.setColor(Messages.LabelErrorNoTaxonomySelected, Colors.LIGHT_GRAY);
         }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/earnings/EarningsByTaxonomyChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/earnings/EarningsByTaxonomyChartWidget.java
@@ -208,7 +208,7 @@ public class EarningsByTaxonomyChartWidget extends CircularChartWidget<Map<Inves
         Map<String, Color> id2color = new HashMap<>();
         ICircularSeries<?> circularSeries = (ICircularSeries<?>) getChart().getSeriesSet()
                         .createSeries(SeriesType.DOUGHNUT, Messages.LabelEarningsByTaxonomy);
-        circularSeries.setSliceColor(Colors.WHITE);
+        circularSeries.setSliceColor(getChart().getPlotArea().getBackground());
         Node rootNode = circularSeries.getRootNode();
 
         for (Classification classification : taxonomy.getRoot().getChildren())

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/holdings/HoldingsPieChartSWT.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/holdings/HoldingsPieChartSWT.java
@@ -24,7 +24,6 @@ import name.abuchen.portfolio.snapshot.ClientSnapshot;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
-import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.chart.CircularChart;
 import name.abuchen.portfolio.ui.util.chart.CircularChart.RenderLabelsCenteredInPie;
 import name.abuchen.portfolio.ui.util.chart.CircularChart.RenderLabelsOutsidePie;
@@ -211,7 +210,7 @@ public class HoldingsPieChartSWT implements IPieChart
         circularSeries = (ICircularSeries<?>) chart.getSeriesSet().createSeries(SeriesType.DOUGHNUT,
                         Messages.LabelStatementOfAssetsHoldings);
         circularSeries.setSeries(labels.toArray(new String[0]), values.stream().mapToDouble(d -> d).toArray());
-        circularSeries.setSliceColor(Colors.WHITE);
+        circularSeries.setSliceColor(chart.getPlotArea().getBackground());
         lastLabels = new ArrayList<>(labels);
         Collections.sort(lastLabels, String.CASE_INSENSITIVE_ORDER);
         return circularSeries;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/DonutChartBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/DonutChartBuilder.java
@@ -34,7 +34,7 @@ public class DonutChartBuilder
         ICircularSeries<?> circularSeries = (ICircularSeries<?>) chart.getSeriesSet().createSeries(SeriesType.DOUGHNUT,
                         model.getTaxonomy().getName());
 
-        circularSeries.setSliceColor(Colors.WHITE);
+        circularSeries.setSliceColor(chart.getPlotArea().getBackground());
 
         Node rootNode = circularSeries.getRootNode();
         rootNode.setData(model.getChartRenderingRootNode());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyPieChartSWT.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyPieChartSWT.java
@@ -125,7 +125,7 @@ public class TaxonomyPieChartSWT implements IPieChart
         ICircularSeries<?> circularSeries = (ICircularSeries<?>) chart.getSeriesSet().createSeries(SeriesType.PIE,
                         taxRoot.getName());
 
-        circularSeries.setSliceColor(Colors.WHITE);
+        circularSeries.setSliceColor(chart.getPlotArea().getBackground());
 
         Node rootNode = circularSeries.getRootNode();
         rootNode.setData(taxRoot);


### PR DESCRIPTION
previously slices were white in any theme

Hello, this is a proposition to adapt the color of the slice of swtpiechart to the black/white them. The HTML pie charts do adapt their slice color already.

**Before :** 
![Capture d’écran 2024-10-22 200614](https://github.com/user-attachments/assets/cabc6528-3279-434d-9d59-a810d3478d1e)
![Capture d’écran 2024-10-22 200739](https://github.com/user-attachments/assets/03c8749a-d2e8-4a00-aca1-9abe048ef879)
![Capture d’écran 2024-10-22 200759](https://github.com/user-attachments/assets/6442f6f9-9f25-4118-ae83-eace28652d7f)

**After :**
![Capture d’écran 2024-10-22 200703](https://github.com/user-attachments/assets/ba8ab935-02ef-44dc-88ce-f50ea70de68c)
![Capture d’écran 2024-10-22 200717](https://github.com/user-attachments/assets/d86e341c-1360-4e81-90e1-58d86809c19c)
![Capture d’écran 2024-10-22 200819](https://github.com/user-attachments/assets/94b1472a-b1c3-4571-8958-6edf8842bff8)

also applicable to the pie chart widgets.

**HTML pie chart** : already adapting the slice color
![Capture d’écran 2024-10-22 200638](https://github.com/user-attachments/assets/e6b29257-7f09-4d96-beb2-951ad9c27383)

One little downside : I think it is a bit more noticeable when color sticks out of the pie, "toward the inside". Well, in white it was the opposite : noticeable "toward the outside", while no longer as much noticeable in black.

In white theme, I do not notice any change in behavior. 