### PR TITLE
Fix yearly Payment barchart color with full change to eclipse.swtchart

### DIFF
--- a/name.abuchen.portfolio.ui/plugin.xml
+++ b/name.abuchen.portfolio.ui/plugin.xml
@@ -184,7 +184,7 @@
                class="name.abuchen.portfolio.ui.editor.Sidebar">
          </widget>
          <widget
-               class="org.swtchart.Chart">
+               class="org.eclipse.swtchart.Chart">
          </widget>
          <widget
                class="name.abuchen.portfolio.ui.util.Colors$Theme">

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ChartCSSHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ChartCSSHandler.java
@@ -5,12 +5,12 @@ import org.eclipse.e4.ui.css.core.dom.properties.converters.ICSSValueConverter;
 import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.properties.AbstractCSSPropertySWTHandler;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.ILegend;
-import org.swtchart.ITitle;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.ILegend;
+import org.eclipse.swtchart.IPlotArea;
+import org.eclipse.swtchart.ITitle;
 import org.w3c.dom.css.CSSValue;
 
 import name.abuchen.portfolio.ui.util.chart.ScatterChart;
@@ -70,7 +70,7 @@ public class ChartCSSHandler extends AbstractCSSPropertySWTHandler implements IC
 
             chart.setBackground(newColor);
 
-            Composite plotArea = chart.getPlotArea();
+            IPlotArea plotArea = chart.getPlotArea();
             if (plotArea != null)
                 plotArea.setBackground(newColor);
             ILegend legend = chart.getLegend();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ChartElementAdapter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ChartElementAdapter.java
@@ -2,7 +2,7 @@ package name.abuchen.portfolio.ui.theme;
 
 import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.dom.CompositeElement;
-import org.swtchart.Chart;
+import org.eclipse.swtchart.Chart;
 
 @SuppressWarnings("restriction")
 public class ChartElementAdapter extends CompositeElement

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ElementProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ElementProvider.java
@@ -10,7 +10,7 @@ import org.eclipse.e4.ui.internal.css.swt.definition.IFontDefinitionOverridable;
 import org.eclipse.e4.ui.internal.css.swt.definition.IThemesExtension;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.Tree;
-import org.swtchart.Chart;
+import org.eclipse.swtchart.Chart;
 import org.w3c.dom.Element;
 
 import name.abuchen.portfolio.ui.editor.Sidebar;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/AbstractChartToolTip.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/AbstractChartToolTip.java
@@ -173,12 +173,12 @@ public abstract class AbstractChartToolTip implements Listener
 
     private Rectangle calculateBounds(Event event, Point size)
     {
-        Rectangle plotArea = ((Composite) getPlotArea().getControl()).getClientArea();
+        Rectangle plotArea = ((Composite) getPlotArea()).getClientArea();
 
         int x = event.x + (size.x / 2) > plotArea.width ? plotArea.width - size.x : event.x - (size.x / 2);
         x = Math.max(x, 0);
 
-        Point pt = getPlotArea().getControl().toDisplay(x, event.y);
+        Point pt = ((Composite) getPlotArea()).toDisplay(x, event.y);
         // show above
         int y = pt.y - size.y - PADDING;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/AbstractChartToolTip.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/AbstractChartToolTip.java
@@ -13,7 +13,6 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtchart.Chart;
-import org.eclipse.swtchart.IPlotArea;
 
 import name.abuchen.portfolio.ui.UIConstants;
 
@@ -34,11 +33,11 @@ public abstract class AbstractChartToolTip implements Listener
     {
         this.chart = chart;
 
-        IPlotArea plotArea = getPlotArea();
-        plotArea.getControl().addListener(SWT.MouseDown, this);
-        plotArea.getControl().addListener(SWT.MouseMove, this);
-        plotArea.getControl().addListener(SWT.MouseUp, this);
-        plotArea.getControl().addListener(SWT.Dispose, this);
+        Composite plotArea = getPlotArea();
+        plotArea.addListener(SWT.MouseDown, this);
+        plotArea.addListener(SWT.MouseMove, this);
+        plotArea.addListener(SWT.MouseUp, this);
+        plotArea.addListener(SWT.Dispose, this);
     }
 
     public void setActive(boolean isActive)
@@ -173,22 +172,22 @@ public abstract class AbstractChartToolTip implements Listener
 
     private Rectangle calculateBounds(Event event, Point size)
     {
-        Rectangle plotArea = ((Composite) getPlotArea()).getClientArea();
+        Rectangle plotArea = getPlotArea().getClientArea();
 
         int x = event.x + (size.x / 2) > plotArea.width ? plotArea.width - size.x : event.x - (size.x / 2);
         x = Math.max(x, 0);
 
-        Point pt = ((Composite) getPlotArea()).toDisplay(x, event.y);
+        Point pt = getPlotArea().toDisplay(x, event.y);
         // show above
         int y = pt.y - size.y - PADDING;
 
         return new Rectangle(pt.x, y, size.x, size.y);
     }
 
-    protected final IPlotArea getPlotArea()
+    protected final Composite getPlotArea()
     {
         if (chart != null)
-            return chart.getPlotArea();
+            return (Composite) chart.getPlotArea();
         else
             throw new IllegalArgumentException("no plot area found"); //$NON-NLS-1$
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/AbstractChartToolTip.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/AbstractChartToolTip.java
@@ -13,6 +13,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IPlotArea;
 
 import name.abuchen.portfolio.ui.UIConstants;
 
@@ -33,11 +34,11 @@ public abstract class AbstractChartToolTip implements Listener
     {
         this.chart = chart;
 
-        Control plotArea = chart.getPlotArea().getControl();
-        plotArea.addListener(SWT.MouseDown, this);
-        plotArea.addListener(SWT.MouseMove, this);
-        plotArea.addListener(SWT.MouseUp, this);
-        plotArea.addListener(SWT.Dispose, this);
+        IPlotArea plotArea = getPlotArea();
+        plotArea.getControl().addListener(SWT.MouseDown, this);
+        plotArea.getControl().addListener(SWT.MouseMove, this);
+        plotArea.getControl().addListener(SWT.MouseUp, this);
+        plotArea.getControl().addListener(SWT.Dispose, this);
     }
 
     public void setActive(boolean isActive)
@@ -172,22 +173,22 @@ public abstract class AbstractChartToolTip implements Listener
 
     private Rectangle calculateBounds(Event event, Point size)
     {
-        Rectangle plotArea = getPlotArea().getClientArea();
+        Rectangle plotArea = ((Composite) getPlotArea().getControl()).getClientArea();
 
         int x = event.x + (size.x / 2) > plotArea.width ? plotArea.width - size.x : event.x - (size.x / 2);
         x = Math.max(x, 0);
 
-        Point pt = getPlotArea().toDisplay(x, event.y);
+        Point pt = getPlotArea().getControl().toDisplay(x, event.y);
         // show above
         int y = pt.y - size.y - PADDING;
 
         return new Rectangle(pt.x, y, size.x, size.y);
     }
 
-    protected final Composite getPlotArea()
+    protected final IPlotArea getPlotArea()
     {
         if (chart != null)
-            return (Composite) chart.getPlotArea();
+            return chart.getPlotArea();
         else
             throw new IllegalArgumentException("no plot area found"); //$NON-NLS-1$
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/AbstractChartToolTip.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/AbstractChartToolTip.java
@@ -12,6 +12,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swtchart.Chart;
 
 import name.abuchen.portfolio.ui.UIConstants;
 
@@ -19,8 +20,7 @@ public abstract class AbstractChartToolTip implements Listener
 {
     public static final int PADDING = 5;
 
-    private org.swtchart.Chart chartV10 = null;
-    private org.eclipse.swtchart.Chart chartV13 = null;
+    private Chart chart = null;
 
     private Shell tip = null;
     private Object focus = null;
@@ -29,22 +29,11 @@ public abstract class AbstractChartToolTip implements Listener
     private boolean showToolTip = false;
     private boolean isAltPressed = false;
 
-    protected AbstractChartToolTip(org.swtchart.Chart chart)
+    protected AbstractChartToolTip(Chart chart)
     {
-        this(chart, null);
-    }
+        this.chart = chart;
 
-    protected AbstractChartToolTip(org.eclipse.swtchart.Chart chart)
-    {
-        this(null, chart);
-    }
-
-    private AbstractChartToolTip(org.swtchart.Chart chartV10, org.eclipse.swtchart.Chart chartV13)
-    {
-        this.chartV10 = chartV10;
-        this.chartV13 = chartV13;
-
-        Composite plotArea = getPlotArea();
+        Control plotArea = chart.getPlotArea().getControl();
         plotArea.addListener(SWT.MouseDown, this);
         plotArea.addListener(SWT.MouseMove, this);
         plotArea.addListener(SWT.MouseUp, this);
@@ -60,14 +49,9 @@ public abstract class AbstractChartToolTip implements Listener
 
     protected abstract void createComposite(Composite parent);
 
-    protected org.swtchart.Chart getChart()
+    protected Chart getChart()
     {
-        return chartV10;
-    }
-
-    protected org.eclipse.swtchart.Chart getSWTChart()
-    {
-        return chartV13;
+        return chart;
     }
 
     protected Object getFocusedObject()
@@ -202,10 +186,8 @@ public abstract class AbstractChartToolTip implements Listener
 
     protected final Composite getPlotArea()
     {
-        if (chartV10 != null)
-            return chartV10.getPlotArea();
-        else if (chartV13 != null)
-            return (Composite) chartV13.getPlotArea();
+        if (chart != null)
+            return (Composite) chart.getPlotArea();
         else
             throw new IllegalArgumentException("no plot area found"); //$NON-NLS-1$
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
@@ -12,8 +12,8 @@ import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Menu;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
 
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.PortfolioPlugin;
@@ -39,9 +39,9 @@ import name.abuchen.portfolio.util.TextUtil;
         menuMgr.addMenuListener(manager -> configMenuAboutToShow(manager));
 
         contextMenu = menuMgr.createContextMenu(chart);
-        chart.getPlotArea().setMenu(contextMenu);
+        chart.getPlotArea().getControl().setMenu(contextMenu);
 
-        chart.getPlotArea().addDisposeListener(e -> dispose());
+        chart.getPlotArea().getControl().addDisposeListener(e -> dispose());
     }
 
     private void configMenuAboutToShow(IMenuManager manager)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartToolsManager.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartToolsManager.java
@@ -106,11 +106,11 @@ public class ChartToolsManager
     public ChartToolsManager(TimelineChart chart)
     {
         this.chart = chart;
-        chart.getPlotArea().addListener(SWT.MouseDown, this::onMouseDown);
-        chart.getPlotArea().addListener(SWT.MouseMove, this::onMouseMove);
-        chart.getPlotArea().addListener(SWT.MouseUp, this::onMouseUp);
+        chart.getPlotArea().getControl().addListener(SWT.MouseDown, this::onMouseDown);
+        chart.getPlotArea().getControl().addListener(SWT.MouseMove, this::onMouseMove);
+        chart.getPlotArea().getControl().addListener(SWT.MouseUp, this::onMouseUp);
 
-        chart.getPlotArea().addPaintListener(this::paintControl);
+        chart.getPlotArea().getControl().addPaintListener(this::paintControl);
     }
 
     private void onMouseDown(Event e)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartUtil.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartUtil.java
@@ -7,9 +7,9 @@ import org.eclipse.swt.graphics.ImageDataProvider;
 import org.eclipse.swt.graphics.ImageLoader;
 import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.Point;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.Range;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.Range;
 
 public final class ChartUtil
 {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/CircularChartToolTip.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/CircularChartToolTip.java
@@ -53,7 +53,7 @@ public class CircularChartToolTip extends AbstractChartToolTip
     @Override
     protected Object getFocusObjectAt(Event event)
     {
-        Optional<Node> node = ((CircularChart) getSWTChart()).getNodeAt(event.x, event.y);
+        Optional<Node> node = ((CircularChart) getChart()).getNodeAt(event.x, event.y);
         return node.isPresent() ? node.get() : null;
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/CrosshairTool.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/CrosshairTool.java
@@ -7,7 +7,7 @@ import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Event;
-import org.swtchart.IAxis;
+import org.eclipse.swtchart.IAxis;
 
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.util.Colors;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/MeasurementTool.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/MeasurementTool.java
@@ -8,6 +8,7 @@ import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 
 import name.abuchen.portfolio.money.Values;
@@ -119,7 +120,7 @@ class MeasurementTool implements ChartTool
             var text = buffer.toString();
 
             Point txtExtend = e.gc.textExtent(text);
-            Rectangle plotArea = chart.getPlotArea().getClientArea();
+            Rectangle plotArea = ((Composite) chart.getPlotArea().getControl()).getClientArea();
 
             e.gc.setBackground(Colors.brighter(color));
             e.gc.setForeground(Colors.getTextColor(color));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/MovePlotKeyListener.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/MovePlotKeyListener.java
@@ -3,8 +3,8 @@ package name.abuchen.portfolio.ui.util.chart;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
 
 public class MovePlotKeyListener implements Listener
 {
@@ -18,7 +18,7 @@ public class MovePlotKeyListener implements Listener
     public static void attachTo(Chart chart)
     {
         Listener listener = new MovePlotKeyListener(chart);
-        chart.getPlotArea().addListener(SWT.KeyDown, listener);
+        chart.getPlotArea().getControl().addListener(SWT.KeyDown, listener);
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/PlainChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/PlainChart.java
@@ -1,7 +1,7 @@
 package name.abuchen.portfolio.ui.util.chart;
 
 import org.eclipse.swt.widgets.Composite;
-import org.swtchart.Chart;
+import org.eclipse.swtchart.Chart;
 
 public class PlainChart extends Chart // NOSONAR
 {
@@ -21,6 +21,6 @@ public class PlainChart extends Chart // NOSONAR
 
         // fix: never force focus on the legend but focus the plot area instead
 
-        return getPlotArea().setFocus();
+        return getPlotArea().getControl().setFocus();
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ScatterChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ScatterChart.java
@@ -5,14 +5,13 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.IAxis.Position;
-import org.swtchart.ICustomPaintListener;
-import org.swtchart.ILineSeries;
-import org.swtchart.IPlotArea;
-import org.swtchart.ISeries.SeriesType;
-import org.swtchart.LineStyle;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.IAxis.Position;
+import org.eclipse.swtchart.ICustomPaintListener;
+import org.eclipse.swtchart.ILineSeries;
+import org.eclipse.swtchart.ISeries.SeriesType;
+import org.eclipse.swtchart.LineStyle;
 
 import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.util.Colors;
@@ -34,7 +33,7 @@ public class ScatterChart extends Chart // NOSONAR
         IAxis yAxis = getAxisSet().getYAxis(0);
         yAxis.setPosition(Position.Secondary);
 
-        ((IPlotArea) getPlotArea()).addCustomPaintListener(new ICustomPaintListener()
+        getPlotArea().addCustomPaintListener(new ICustomPaintListener()
         {
             @Override
             public void paintControl(PaintEvent e)
@@ -65,7 +64,7 @@ public class ScatterChart extends Chart // NOSONAR
         ZoomMouseWheelListener.attachTo(this);
         MovePlotKeyListener.attachTo(this);
         ZoomInAreaListener.attachTo(this);
-        getPlotArea().addTraverseListener(event -> event.doit = true);
+        getPlotArea().getControl().addTraverseListener(event -> event.doit = true);
 
         this.contextMenu = new ChartContextMenu(this);
     }
@@ -121,6 +120,6 @@ public class ScatterChart extends Chart // NOSONAR
     @Override
     public boolean setFocus()
     {
-        return getPlotArea().setFocus();
+        return getPlotArea().getControl().setFocus();
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ScatterChartCSVExporter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ScatterChartCSVExporter.java
@@ -10,7 +10,7 @@ import java.text.NumberFormat;
 
 import org.apache.commons.csv.CSVPrinter;
 import org.eclipse.swt.widgets.Shell;
-import org.swtchart.ISeries;
+import org.eclipse.swtchart.ISeries;
 
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.AbstractCSVExporter;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ScatterChartToolTip.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ScatterChartToolTip.java
@@ -7,10 +7,10 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.ILineSeries;
-import org.swtchart.ISeries;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.ILineSeries;
+import org.eclipse.swtchart.ISeries;
 
 import name.abuchen.portfolio.ui.util.swt.ColoredLabel;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedChartCSVExporter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedChartCSVExporter.java
@@ -10,7 +10,7 @@ import java.text.NumberFormat;
 
 import org.apache.commons.csv.CSVPrinter;
 import org.eclipse.swt.widgets.Shell;
-import org.swtchart.ISeries;
+import org.eclipse.swtchart.ISeries;
 
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.AbstractCSVExporter;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedTimelineChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedTimelineChart.java
@@ -9,16 +9,15 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.IAxis.Position;
-import org.swtchart.ICustomPaintListener;
-import org.swtchart.ILineSeries;
-import org.swtchart.ILineSeries.PlotSymbolType;
-import org.swtchart.IPlotArea;
-import org.swtchart.ISeries.SeriesType;
-import org.swtchart.LineStyle;
-import org.swtchart.Range;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.IAxis.Position;
+import org.eclipse.swtchart.ICustomPaintListener;
+import org.eclipse.swtchart.ILineSeries;
+import org.eclipse.swtchart.ILineSeries.PlotSymbolType;
+import org.eclipse.swtchart.ISeries.SeriesType;
+import org.eclipse.swtchart.LineStyle;
+import org.eclipse.swtchart.Range;
 
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Messages;
@@ -54,7 +53,7 @@ public class StackedTimelineChart extends Chart // NOSONAR
         yAxis.getTitle().setVisible(false);
         yAxis.setPosition(Position.Secondary);
 
-        ((IPlotArea) getPlotArea()).addCustomPaintListener(new ICustomPaintListener()
+        getPlotArea().addCustomPaintListener(new ICustomPaintListener()
         {
             @Override
             public void paintControl(PaintEvent e)
@@ -138,7 +137,7 @@ public class StackedTimelineChart extends Chart // NOSONAR
     @Override
     public boolean setFocus()
     {
-        return getPlotArea().setFocus();
+        return getPlotArea().getControl().setFocus();
     }
 
     public void exportMenuAboutToShow(IMenuManager manager, String label)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimeGridHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimeGridHelper.java
@@ -6,8 +6,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.function.ToIntFunction;
 
 import org.eclipse.swt.events.PaintEvent;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
 
 import name.abuchen.portfolio.util.Dates;
 import name.abuchen.portfolio.util.Triple;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChart.java
@@ -20,17 +20,16 @@ import org.eclipse.swt.events.PaintListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Composite;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.IAxis.Position;
-import org.swtchart.IBarSeries;
-import org.swtchart.ICustomPaintListener;
-import org.swtchart.ILineSeries;
-import org.swtchart.ILineSeries.PlotSymbolType;
-import org.swtchart.IPlotArea;
-import org.swtchart.ISeries.SeriesType;
-import org.swtchart.LineStyle;
-import org.swtchart.Range;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.IAxis.Position;
+import org.eclipse.swtchart.IBarSeries;
+import org.eclipse.swtchart.ICustomPaintListener;
+import org.eclipse.swtchart.ILineSeries;
+import org.eclipse.swtchart.ILineSeries.PlotSymbolType;
+import org.eclipse.swtchart.ISeries.SeriesType;
+import org.eclipse.swtchart.LineStyle;
+import org.eclipse.swtchart.Range;
 
 import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.util.Colors;
@@ -120,7 +119,7 @@ public class TimelineChart extends Chart // NOSONAR
         y3Axis.getGrid().setStyle(LineStyle.NONE);
         y3Axis.setPosition(Position.Primary);
 
-        ((IPlotArea) getPlotArea()).addCustomPaintListener(new ICustomPaintListener()
+        getPlotArea().addCustomPaintListener(new ICustomPaintListener()
         {
             @Override
             public void paintControl(PaintEvent e)
@@ -136,7 +135,7 @@ public class TimelineChart extends Chart // NOSONAR
             }
         });
 
-        getPlotArea().addPaintListener(this::paintMarkerLines);
+        getPlotArea().getControl().addPaintListener(this::paintMarkerLines);
 
         toolTip = new TimelineChartToolTip(this);
 
@@ -145,7 +144,7 @@ public class TimelineChart extends Chart // NOSONAR
         ZoomMouseWheelListener.attachTo(this);
         MovePlotKeyListener.attachTo(this);
         ZoomInAreaListener.attachTo(this);
-        getPlotArea().addTraverseListener(event -> event.doit = true);
+        getPlotArea().getControl().addTraverseListener(event -> event.doit = true);
 
         this.contextMenu = new ChartContextMenu(this);
     }
@@ -184,7 +183,7 @@ public class TimelineChart extends Chart // NOSONAR
 
     public void addPlotPaintListener(PaintListener listener)
     {
-        ((IPlotArea) getPlotArea()).addCustomPaintListener(new ICustomPaintListener()
+        getPlotArea().addCustomPaintListener(new ICustomPaintListener()
         {
             @Override
             public void paintControl(PaintEvent e)
@@ -386,7 +385,7 @@ public class TimelineChart extends Chart // NOSONAR
     @Override
     public boolean setFocus()
     {
-        return getPlotArea().setFocus();
+        return getPlotArea().getControl().setFocus();
     }
 
     public IAxis getOrCreateAxis(Object key, Supplier<IAxis> axisFactory)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChartCSVExporter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChartCSVExporter.java
@@ -15,7 +15,7 @@ import java.util.Set;
 
 import org.apache.commons.csv.CSVPrinter;
 import org.eclipse.swt.widgets.Shell;
-import org.swtchart.ISeries;
+import org.eclipse.swtchart.ISeries;
 
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.AbstractCSVExporter;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChartToolTip.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChartToolTip.java
@@ -27,11 +27,11 @@ import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.IBarSeries;
-import org.swtchart.ILineSeries;
-import org.swtchart.ISeries;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.IBarSeries;
+import org.eclipse.swtchart.ILineSeries;
+import org.eclipse.swtchart.ISeries;
 
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Messages;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ZoomInAreaListener.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ZoomInAreaListener.java
@@ -1,22 +1,23 @@
 package name.abuchen.portfolio.ui.util.chart;
 
-import name.abuchen.portfolio.ui.PortfolioPlugin;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Tracker;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.Range;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.Range;
+
+import name.abuchen.portfolio.ui.PortfolioPlugin;
 
 public class ZoomInAreaListener implements Listener
 {
     public static void attachTo(Chart chart)
     {
         Listener listener = new ZoomInAreaListener(chart);
-        chart.getPlotArea().addListener(SWT.MouseDown, listener);
+        chart.getPlotArea().getControl().addListener(SWT.MouseDown, listener);
     }
 
     private final Chart chart;
@@ -31,7 +32,7 @@ public class ZoomInAreaListener implements Listener
     {
         if (event.button == 1 && event.stateMask == SWT.MOD1)
         {
-            Tracker tracker = new Tracker(chart.getPlotArea(), SWT.RESIZE);
+            Tracker tracker = new Tracker((Composite) chart.getPlotArea().getControl(), SWT.RESIZE);
             tracker.setRectangles(new Rectangle[] { new Rectangle(event.x, event.y, 0, 0) });
             if (tracker.open())
             {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ZoomMouseWheelListener.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ZoomMouseWheelListener.java
@@ -3,9 +3,9 @@ package name.abuchen.portfolio.ui.util.chart;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.Range;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.Range;
 
 public class ZoomMouseWheelListener implements Listener
 {
@@ -14,7 +14,7 @@ public class ZoomMouseWheelListener implements Listener
     public static void attachTo(Chart chart)
     {
         Listener listener = new ZoomMouseWheelListener(chart);
-        chart.getPlotArea().addListener(SWT.MouseWheel, listener);
+        chart.getPlotArea().getControl().addListener(SWT.MouseWheel, listener);
     }
 
     private final Chart chart;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountBalanceChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AccountBalanceChart.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.swt.widgets.Composite;
-import org.swtchart.ISeries;
+import org.eclipse.swtchart.ISeries;
 
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.AccountTransaction;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
@@ -24,7 +24,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.swtchart.ISeries;
+import org.eclipse.swtchart.ISeries;
 
 import com.google.common.collect.Lists;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioBalanceChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioBalanceChart.java
@@ -25,9 +25,9 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
-import org.swtchart.ILegend;
-import org.swtchart.ILineSeries;
-import org.swtchart.ISeries;
+import org.eclipse.swtchart.ILegend;
+import org.eclipse.swtchart.ILineSeries;
+import org.eclipse.swtchart.ISeries;
 
 import com.google.common.base.Objects;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ReturnsVolatilityChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ReturnsVolatilityChartView.java
@@ -25,10 +25,10 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-import org.swtchart.IAxis;
-import org.swtchart.ILineSeries;
-import org.swtchart.ILineSeries.PlotSymbolType;
-import org.swtchart.ISeries;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.ILineSeries;
+import org.eclipse.swtchart.ILineSeries.PlotSymbolType;
+import org.eclipse.swtchart.ISeries;
 
 import com.google.common.collect.Lists;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -39,15 +39,15 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
-import org.swtchart.IAxis;
-import org.swtchart.IAxis.Position;
-import org.swtchart.ILegend;
-import org.swtchart.ILineSeries;
-import org.swtchart.ILineSeries.PlotSymbolType;
-import org.swtchart.ISeries;
-import org.swtchart.ISeries.SeriesType;
-import org.swtchart.LineStyle;
-import org.swtchart.Range;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.IAxis.Position;
+import org.eclipse.swtchart.ILegend;
+import org.eclipse.swtchart.ILineSeries;
+import org.eclipse.swtchart.ILineSeries.PlotSymbolType;
+import org.eclipse.swtchart.ISeries;
+import org.eclipse.swtchart.ISeries.SeriesType;
+import org.eclipse.swtchart.LineStyle;
+import org.eclipse.swtchart.Range;
 
 import com.google.common.primitives.Doubles;
 
@@ -428,7 +428,7 @@ public class SecuritiesChart
 
         chart.addPlotPaintListener(event -> customPaintListeners.forEach(l -> l.paintControl(event)));
         chart.addPlotPaintListener(this.messagePainter);
-        chart.getPlotArea().addDisposeListener(this.messagePainter);
+        chart.getPlotArea().getControl().addDisposeListener(this.messagePainter);
 
         messagePainter.setMessage(Messages.SecuritiesChart_NoDataMessage_NoSecuritySelected);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsHistoryView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsHistoryView.java
@@ -18,7 +18,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Menu;
-import org.swtchart.ISeries;
+import org.eclipse.swtchart.ISeries;
 
 import com.google.common.collect.Lists;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/currency/ExchangeRatesListTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/currency/ExchangeRatesListTab.java
@@ -19,7 +19,7 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
-import org.swtchart.ISeries;
+import org.eclipse.swtchart.ISeries;
 
 import name.abuchen.portfolio.money.ExchangeRate;
 import name.abuchen.portfolio.money.ExchangeRateProvider;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ActivityWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ActivityWidget.java
@@ -20,15 +20,14 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.IAxis.Position;
-import org.swtchart.IBarSeries;
-import org.swtchart.ICustomPaintListener;
-import org.swtchart.IPlotArea;
-import org.swtchart.ISeries;
-import org.swtchart.ISeries.SeriesType;
-import org.swtchart.LineStyle;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.IAxis.Position;
+import org.eclipse.swtchart.IBarSeries;
+import org.eclipse.swtchart.ICustomPaintListener;
+import org.eclipse.swtchart.ISeries;
+import org.eclipse.swtchart.ISeries.SeriesType;
+import org.eclipse.swtchart.LineStyle;
 
 import name.abuchen.portfolio.model.Dashboard;
 import name.abuchen.portfolio.model.Dashboard.Widget;
@@ -266,8 +265,8 @@ public class ActivityWidget extends WidgetDelegate<List<TransactionPair<?>>>
         yAxis.getTick().setVisible(get(ChartShowYAxisConfig.class).getIsShowYAxis());
         yAxis.setPosition(Position.Secondary);
 
-        chart.getPlotArea().addTraverseListener(event -> event.doit = true);
-        ((IPlotArea) chart.getPlotArea()).addCustomPaintListener(new TimeGridPaintListener(chart));
+        chart.getPlotArea().getControl().addTraverseListener(event -> event.doit = true);
+        chart.getPlotArea().addCustomPaintListener(new TimeGridPaintListener(chart));
 
         container.layout();
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ChartWidget.java
@@ -17,9 +17,9 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swtchart.ISeries;
 import org.eclipse.ui.forms.events.HyperlinkAdapter;
 import org.eclipse.ui.forms.events.HyperlinkEvent;
-import org.swtchart.ISeries;
 
 import com.google.common.collect.Lists;
 
@@ -228,7 +228,7 @@ public class ChartWidget extends WidgetDelegate<Object>
 
         getDashboardData().getStylingEngine().style(chart);
 
-        HoverButton.build(title, container, chart, chart.getPlotArea()).withListener(new HyperlinkAdapter()
+        HoverButton.build(title, container, chart, chart.getPlotArea().getControl()).withListener(new HyperlinkAdapter()
         {
             @Override
             public void linkActivated(HyperlinkEvent e)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/ClientDataSeriesChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/ClientDataSeriesChartWidget.java
@@ -15,9 +15,9 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
-import org.swtchart.IBarSeries;
-import org.swtchart.ILineSeries;
-import org.swtchart.ISeries;
+import org.eclipse.swtchart.IBarSeries;
+import org.eclipse.swtchart.ILineSeries;
+import org.eclipse.swtchart.ISeries;
 
 import name.abuchen.portfolio.model.Dashboard;
 import name.abuchen.portfolio.model.Dashboard.Widget;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/DrawdownChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/DrawdownChartWidget.java
@@ -12,8 +12,8 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
-import org.swtchart.ILineSeries;
-import org.swtchart.ISeries;
+import org.eclipse.swtchart.ILineSeries;
+import org.eclipse.swtchart.ISeries;
 
 import name.abuchen.portfolio.model.Dashboard.Widget;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/earnings/EarningsChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/earnings/EarningsChartWidget.java
@@ -12,11 +12,11 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.ISeries;
 import org.eclipse.ui.forms.events.HyperlinkAdapter;
 import org.eclipse.ui.forms.events.HyperlinkEvent;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.ISeries;
 
 import name.abuchen.portfolio.model.Dashboard.Widget;
 import name.abuchen.portfolio.money.CurrencyConverter;
@@ -118,11 +118,11 @@ public class EarningsChartWidget extends WidgetDelegate<PaymentsViewModel>
         int yHint = get(ChartHeightConfig.class).getPixel();
         GridDataFactory.fillDefaults().hint(SWT.DEFAULT, yHint).grab(true, false).applyTo(chart);
 
-        chart.getPlotArea().addTraverseListener(event -> event.doit = true);
+        chart.getPlotArea().getControl().addTraverseListener(event -> event.doit = true);
 
         container.layout();
 
-        HoverButton.build(title, container, chart, chart.getPlotArea()).withListener(new HyperlinkAdapter()
+        HoverButton.build(title, container, chart, chart.getPlotArea().getControl()).withListener(new HyperlinkAdapter()
         {
             @Override
             public void linkActivated(HyperlinkEvent e)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/AbstractChartSeriesBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/AbstractChartSeriesBuilder.java
@@ -3,8 +3,8 @@ package name.abuchen.portfolio.ui.views.dataseries;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.LocalResourceManager;
 import org.eclipse.swt.graphics.Color;
-import org.swtchart.IBarSeries;
-import org.swtchart.ILineSeries;
+import org.eclipse.swtchart.IBarSeries;
+import org.eclipse.swtchart.ILineSeries;
 
 import name.abuchen.portfolio.ui.util.chart.TimelineChart;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeries.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeries.java
@@ -5,7 +5,7 @@ import java.util.function.Function;
 
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.RGB;
-import org.swtchart.LineStyle;
+import org.eclipse.swtchart.LineStyle;
 
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.Adaptable;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesChartLegend.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesChartLegend.java
@@ -37,10 +37,10 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Layout;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Menu;
+import org.eclipse.swtchart.LineStyle;
 import org.eclipse.ui.forms.events.HyperlinkAdapter;
 import org.eclipse.ui.forms.events.HyperlinkEvent;
 import org.eclipse.ui.forms.widgets.ImageHyperlink;
-import org.swtchart.LineStyle;
 
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.Security;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesSerializer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesSerializer.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.swtchart.LineStyle;
+import org.eclipse.swtchart.LineStyle;
 
 import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeries.ClientDataSeries;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/PerformanceChartSeriesBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/PerformanceChartSeriesBuilder.java
@@ -1,7 +1,7 @@
 package name.abuchen.portfolio.ui.views.dataseries;
 
-import org.swtchart.IBarSeries;
-import org.swtchart.ILineSeries;
+import org.eclipse.swtchart.IBarSeries;
+import org.eclipse.swtchart.ILineSeries;
 
 import name.abuchen.portfolio.snapshot.Aggregation;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/StatementOfAssetsSeriesBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/StatementOfAssetsSeriesBuilder.java
@@ -4,8 +4,8 @@ import static name.abuchen.portfolio.util.ArraysUtil.accumulateAndToDouble;
 import static name.abuchen.portfolio.util.ArraysUtil.add;
 import static name.abuchen.portfolio.util.ArraysUtil.toDouble;
 
-import org.swtchart.IBarSeries;
-import org.swtchart.ILineSeries;
+import org.eclipse.swtchart.IBarSeries;
+import org.eclipse.swtchart.ILineSeries;
 
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsAccumulatedChartBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsAccumulatedChartBuilder.java
@@ -7,11 +7,11 @@ import java.util.Arrays;
 import java.util.function.Consumer;
 
 import org.eclipse.swt.SWT;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.ILineSeries;
-import org.swtchart.ILineSeries.PlotSymbolType;
-import org.swtchart.ISeries.SeriesType;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.ILineSeries;
+import org.eclipse.swtchart.ILineSeries.PlotSymbolType;
+import org.eclipse.swtchart.ISeries.SeriesType;
 
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Messages;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsChartBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsChartBuilder.java
@@ -2,7 +2,7 @@ package name.abuchen.portfolio.ui.views.payments;
 
 import java.util.function.Consumer;
 
-import org.swtchart.Chart;
+import org.eclipse.swtchart.Chart;
 
 import name.abuchen.portfolio.ui.util.TabularDataSource;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsChartTab.java
@@ -9,11 +9,11 @@ import org.eclipse.jface.resource.LocalResourceManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.IAxis.Position;
-import org.swtchart.ISeries;
-import org.swtchart.Range;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.IAxis.Position;
+import org.eclipse.swtchart.ISeries;
+import org.eclipse.swtchart.Range;
 
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.UIConstants;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerMonthChartBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerMonthChartBuilder.java
@@ -7,12 +7,12 @@ import java.util.function.Consumer;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.IAxis.Position;
-import org.swtchart.IBarSeries;
-import org.swtchart.ISeries.SeriesType;
-import org.swtchart.LineStyle;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.IAxis.Position;
+import org.eclipse.swtchart.IBarSeries;
+import org.eclipse.swtchart.ISeries.SeriesType;
+import org.eclipse.swtchart.LineStyle;
 
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Messages;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerQuarterChartBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerQuarterChartBuilder.java
@@ -5,12 +5,12 @@ import java.util.function.Consumer;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.IAxis.Position;
-import org.swtchart.IBarSeries;
-import org.swtchart.ISeries.SeriesType;
-import org.swtchart.LineStyle;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.IAxis.Position;
+import org.eclipse.swtchart.IBarSeries;
+import org.eclipse.swtchart.ISeries.SeriesType;
+import org.eclipse.swtchart.LineStyle;
 
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Messages;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerYearChartBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerYearChartBuilder.java
@@ -15,7 +15,6 @@ import org.eclipse.swtchart.LineStyle;
 
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Messages;
-import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.TabularDataSource;
 import name.abuchen.portfolio.ui.util.TabularDataSource.Column;
 import name.abuchen.portfolio.ui.util.chart.TimelineChartToolTip;
@@ -140,8 +139,6 @@ public class PaymentsPerYearChartBuilder implements PaymentsChartBuilder
 
         double[] series = new double[LocalDate.now().getYear() - startYear + 1];
 
-        boolean hasNegativeNumber = false;
-
         for (int index = 0; index < model.getNoOfMonths(); index += 12)
         {
             int year = (index / 12);
@@ -153,23 +150,9 @@ public class PaymentsPerYearChartBuilder implements PaymentsChartBuilder
                 total += model.getSum().getValue(index + ii);
 
             series[year] = total / Values.Amount.divider();
-
-            if (total < 0L)
-                hasNegativeNumber = true;
         }
 
-        if (hasNegativeNumber)
-        {
-            IBarSeries barSeries = (IBarSeries) chart.getSeriesSet().createSeries(SeriesType.BAR,
-                            Messages.LabelPaymentsPerYear);
-            barSeries.setYSeries(series);
-            barSeries.setBarColor(Colors.DARK_BLUE);
-        }
-        else
-        {
-            // reverse the order because stacked series are sorted in reverse
-            // order in the legend by SWTChart
-            for (int i = series.length - 1; i >= 0; i--)
+        for (int i = 0; i <= series.length - 1; i++)
             {
                 int year = model.getStartYear() + i;
                 IBarSeries barSeries = (IBarSeries) chart.getSeriesSet().createSeries(SeriesType.BAR,
@@ -182,18 +165,8 @@ public class PaymentsPerYearChartBuilder implements PaymentsChartBuilder
 
                 barSeries.setBarColor(PaymentsColors.getColor(year));
                 barSeries.setBarPadding(25);
-                barSeries.enableStack(true);
+                barSeries.setBarOverlay(true);
             }
-
-            // Un-suspend chart to force SWTChart to update the stackSeries.
-            // Otherwise the internal metadata is not correct and SWTChart does
-            // not recognized them fully as stacked series
-            if (chart.isUpdateSuspended())
-            {
-                chart.suspendUpdate(false);
-                chart.suspendUpdate(true);
-            }
-        }
     }
 
     private void updateCategorySeries(Chart chart, PaymentsViewModel model)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerYearChartBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerYearChartBuilder.java
@@ -6,12 +6,12 @@ import java.util.function.Consumer;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
-import org.swtchart.Chart;
-import org.swtchart.IAxis;
-import org.swtchart.IAxis.Position;
-import org.swtchart.IBarSeries;
-import org.swtchart.ISeries.SeriesType;
-import org.swtchart.LineStyle;
+import org.eclipse.swtchart.Chart;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.IAxis.Position;
+import org.eclipse.swtchart.IBarSeries;
+import org.eclipse.swtchart.ISeries.SeriesType;
+import org.eclipse.swtchart.LineStyle;
 
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Messages;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/securitychart/SharesHeldChartSeries.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/securitychart/SharesHeldChartSeries.java
@@ -5,12 +5,12 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.swtchart.IAxis;
-import org.swtchart.IAxis.Position;
-import org.swtchart.ILineSeries;
-import org.swtchart.ILineSeries.PlotSymbolType;
-import org.swtchart.ISeries.SeriesType;
-import org.swtchart.LineStyle;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.IAxis.Position;
+import org.eclipse.swtchart.ILineSeries;
+import org.eclipse.swtchart.ILineSeries.PlotSymbolType;
+import org.eclipse.swtchart.ISeries.SeriesType;
+import org.eclipse.swtchart.LineStyle;
 
 import com.google.common.primitives.Doubles;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractStackedChartViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractStackedChartViewer.java
@@ -23,7 +23,7 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
-import org.swtchart.ISeries;
+import org.eclipse.swtchart.ISeries;
 
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.InvestmentVehicle;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/StackedChartViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/StackedChartViewer.java
@@ -4,7 +4,7 @@ import java.text.DecimalFormat;
 
 import jakarta.inject.Inject;
 
-import org.swtchart.Range;
+import org.eclipse.swtchart.Range;
 
 import name.abuchen.portfolio.ui.editor.PortfolioPart;
 import name.abuchen.portfolio.ui.util.chart.StackedTimelineChart;


### PR DESCRIPTION
Issue : https://github.com/portfolio-performance/portfolio/pull/1760
Closes : https://github.com/portfolio-performance/portfolio/issues/1949

Hello,

This is a draft proposition to fix the Payment/Year bar charts which are not colored in case of negative values (so always for Taxes/Fees, and sometimes for Closed Trades / Sum / Savings if one year is negative).

As per this comments : https://github.com/portfolio-performance/portfolio/pull/1760#issuecomment-698347352, new swtchart revisions have the `barOverlay` attribute which is exactly what is needed here and avoid the stack workaround. Once switched to `eclipse.swtchart`, the fix is trivial.

The switch to `eclipse.swtchart` could either :

- be limited to a few charts only, by duplicating some files : https://github.com/portfolio-performance/portfolio/compare/master...mierin12:portfolio:partial_change_to_swtchart14_to_fix_yearly_negative_payment_color
- be propagated to all of the charts. This PR. First commit is the switch to `eclipse.swtchart`, second commit the fix itself.

CSS looks ok on my Windows.

**Before :**
![Capture d’écran 2024-10-22 221130](https://github.com/user-attachments/assets/01f5cb5b-a601-4697-8e29-d8735f68495d)

**After :** 
![Capture d’écran 2024-10-22 221205](https://github.com/user-attachments/assets/79a77600-2ca5-4f6f-aaf0-3edc1bbb2174)

![Capture d’écran 2024-10-22 221702](https://github.com/user-attachments/assets/42e88533-3967-44c4-bb33-c4b4b83f2779)

I put in draft as for the moment the switch to `eclipse.swtchart` only consists in resolving the Errors message. So mainly using `getPlotArea().getControl()` instead of `getPlotArea()` for Listeners. 
I followed a bit what was done in your branch https://github.com/portfolio-performance/portfolio/compare/master...feature_org.eclipse.swtchart. 
(It seems that removing entirely `getPlotArea().getControl()` and applying the Listener directly on the chart seems to work too. I do not understand if there is a difference between those two ways. or using `(Composite) getPlotArea()`

There are still Warnings. I do not know if they should be silenced or resolved (with <?> ?).
![Capture d’écran 2024-10-23 214621](https://github.com/user-attachments/assets/d03171ea-8f98-4c92-8be1-9d98443b2f5c)

and I am not sure how to double check that all is indeed working as before. At first glance it looks ok, but this is changing a lot of different files so who knows.
~~One example : holding down and moving the tooltip across the chart does not feel as smooth as before ?~~ resolved