### PR TITLE
set up more CalculatedQuote format in SecuritiesChart tooltips

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -583,6 +583,18 @@ public class SecuritiesChart
         });
     }
 
+    private void setupTooltipDisplayCalculatedQuote(String seriesLabel)
+    {
+        TimelineChartToolTip toolTip = chart.getToolTip();
+
+        int precision = FormatHelper.getCalculatedQuoteDisplayPrecision();
+        DecimalFormat calculatedFormat = new DecimalFormat(Values.CalculatedQuote.pattern());
+        calculatedFormat.setMinimumFractionDigits(precision);
+        calculatedFormat.setMaximumFractionDigits(precision);
+
+        toolTip.overrideValueFormat(seriesLabel, calculatedFormat);
+    }
+
     private void addInvestmentTooltip(Composite composite, PortfolioTransaction t)
     {
         Label label = new Label(composite, SWT.NONE);
@@ -591,7 +603,7 @@ public class SecuritiesChart
 
         label = new Label(composite, SWT.NONE);
         label.setText(MessageFormat.format(Messages.LabelToolTipInvestmentDetails, Values.Share.format(t.getShares()),
-                        Values.Quote.format(
+                        Values.CalculatedQuote.format(
                                         t.getGrossPricePerShare(converter.with(t.getSecurity().getCurrencyCode())))));
     }
 
@@ -1749,6 +1761,8 @@ public class SecuritiesChart
 
         configureSeriesPainter(series, TimelineChart.toJavaUtilDate(dates.toArray(new LocalDate[0])),
                         Doubles.toArray(values), colorFifoPurchasePrice, 2, LineStyle.SOLID, false, seriesCounter == 0);
+
+        setupTooltipDisplayCalculatedQuote(label);
     }
 
     private void addMovingAveragePurchasePrice(ChartInterval chartInterval)
@@ -1843,6 +1857,8 @@ public class SecuritiesChart
         configureSeriesPainter(series, TimelineChart.toJavaUtilDate(dates.toArray(new LocalDate[0])),
                         Doubles.toArray(values), colorMovingAveragePurchasePrice, 2, LineStyle.SOLID, false,
                         seriesCounter == 0);
+
+        setupTooltipDisplayCalculatedQuote(label);
     }
 
     private Optional<Double> getLatestPurchasePrice()


### PR DESCRIPTION
for
- purchase cost when several holding periods exists
- calculated purchase/buy quote

Hello, this is a proposition to apply the CalculatedQuote format (number of decimal to be displayed as per the user setting) for those two data. 
For the purchase value (or rather purchase price), this format is already applied, but for the first holding period only. 

**Before :**
![2024-11-02 18_41_34-Portfolio Performance](https://github.com/user-attachments/assets/b8b29ddf-eae6-4c6e-97b7-ccabb6104b00)

**After :**
 ![2024-11-02 18_39_36-Portfolio Performance](https://github.com/user-attachments/assets/73e10426-1320-4271-a6f9-b0b99bdf9951)

I was wondering if this should also be done for dividends ?
![2024-11-02 18_49_46-Portfolio Performance](https://github.com/user-attachments/assets/53f7cbfe-afcd-4b02-9c6c-deffb0f7ea11)
