### PR TITLE
Improve TradeRepublic PDF Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -8083,6 +8083,39 @@ public class TradeRepublicPDFExtractorTest
     }
 
     @Test
+    public void testZinsabrechnung07()
+    {
+        TradeRepublicPDFExtractor extractor = new TradeRepublicPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Zinsabrechnung07.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(2L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check interest transaction
+        assertThat(results, hasItem(interest( //
+                        hasDate("2024-07-01T00:00"), //
+                        hasSource("Zinsabrechnung07.txt"), //
+                        hasNote("Zinsen 01.06.2024 - 11.06.2024 (4,00%)"), //
+                        hasAmount("EUR", 21.02), hasGrossValue("EUR", 21.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check interest transaction
+        assertThat(results, hasItem(interest( //
+                        hasDate("2024-07-01T00:00"), //
+                        hasSource("Zinsabrechnung07.txt"), //
+                        hasNote("Zinsen 12.06.2024 - 30.06.2024 (3,75%)"), //
+                        hasAmount("EUR", 52.06), hasGrossValue("EUR", 52.06), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
     public void testRescontoInteressiMaturati01()
     {
         TradeRepublicPDFExtractor extractor = new TradeRepublicPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Zinsabrechnung07.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Zinsabrechnung07.txt
@@ -1,0 +1,20 @@
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.71.3.qualifier
+-----------------------------------------
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+JKPzDZ ELEXWvPTL SEITE 1 von 1
+EfeCspUiGehWvSAZ 89 DATUM 01.07.2024
+8051 Ipgs VERRECHNUNGSKONTO 7964603079
+STEUER-ID 542208021
+ABRECHNUNG ZINSEN
+zum 30.06.2024
+ÜBERSICHT
+VERMÖGENSWERT EINKOMMENSART ZINSEN DATUM GESAMT
+Cash Zinsen 4,00% 01.06.2024 - 11.06.2024 21,02 EUR
+Cash Zinsen 3,75% 12.06.2024 - 30.06.2024 52,06 EUR
+BUCHUNG
+IBAN BUCHUNGSDATUM GESAMT
+DE12321546856552266333 01.07.2024 74,08 EUR
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 service@traderepublic.com AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin USt-ID DE307510626 Gernot Mittendorfer

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -2528,9 +2528,13 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         //
                                         // VERRECHNUNGSKONTO DATUM DER ZAHLUNG BETRAG
                                         // DE12345678912345678912 28.09.2024 -0.27 EUR
+                                        //
+                                        // IBAN BUCHUNGSDATUM GESAMT
+                                        // DE12321546856552266333 01.07.2024 74,08 EUR
+                                        //
                                         // @formatter:on
                                         .section("date") //
-                                        .find("(IBAN BUCHUNGSDATUM GUTSCHRIFT NACH STEUERN|VERRECHNUNGSKONTO (VALUTA|WERTSTELLUNG|DATUM DER ZAHLUNG) BETRAG)") //
+                                        .find("(IBAN BUCHUNGSDATUM (GUTSCHRIFT NACH STEUERN|GESAMT)|VERRECHNUNGSKONTO (VALUTA|WERTSTELLUNG|DATUM DER ZAHLUNG) BETRAG)") //
                                         .match("^.* (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (\\-)?[\\.,\\d]+( [\\w]{3})?$") //
                                         .assign((ctx, v) -> {
                                             ctx.put("date", v.get("date"));
@@ -2883,11 +2887,16 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                         + "|INTEREST INVOICE)", //
                         documentContext -> documentContext //
                                         // @formatter:off
+                                        //
                                         // IBAN BUCHUNGSDATUM GUTSCHRIFT NACH STEUERN
                                         // DE10123456789123456789 01.02.2023 0,88 EUR
+                                        //
+                                        // IBAN BUCHUNGSDATUM GESAMT
+                                        // DE12321546856552266333 01.07.2024 74,08 EUR
+                                        //
                                         // @formatter:on
                                         .section("date") //
-                                        .find("IBAN (BUCHUNGSDATUM|DATA EMISSIONE|BOOKING DATE) (GUTSCHRIFT NACH STEUERN|TOTALE|TOTAL)") //
+                                        .find("IBAN (BUCHUNGSDATUM|DATA EMISSIONE|BOOKING DATE) (GUTSCHRIFT NACH STEUERN|GESAMT|TOTALE|TOTAL)") //
                                         .match("^.* (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) [\\.,\\d]+ [\\w]{3}$") //
                                         .assign((ctx, v) -> {
                                             ctx.put("date", v.get("date"));


### PR DESCRIPTION
Hello,

this pull request improves the TradeRepublic PDF importer by adding support for an additional type of interest transaction pdf.
It is contains the following identifying line, which was not supported previously:

"IBAN BUCHUNGSDATUM GESAMT"

Due to how PDFs with "ABRECHNUNG ZINSEN" are currently handled, a change was required in both 
`addTaxesStatementTransaction()` and `addInterestStatementTransaction()`. When only added to one of these, the parse in the other function would fail.

BR,
MonkeySon