### PR TITLE
SecurityDetailsViewer: Another attempt to fix ScrolledComposite artifact

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityDetailsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityDetailsViewer.java
@@ -419,6 +419,12 @@ public class SecurityDetailsViewer
                 container.setMinSize(container1.computeSize(SWT.DEFAULT, SWT.DEFAULT));
             }
         });
+
+        // After adding all children, explicitly calculate size and layout
+        // ScrolledComposite's content container. This is again to avoid
+        // artifact when scrollbar covers this container's right edge.
+        container1.setSize(container1.computeSize(SWT.DEFAULT, SWT.DEFAULT, true));
+        container1.layout();
     }
 
     public Control getControl()


### PR DESCRIPTION
Additional code to avoide situation when ScrolledComposite's scrollbar covers right edge of its internal container, obscuring information there (like last digits of quotes, etc.). Instead, we want to layout this container set so that inner content container took ScrolledComposite's width without scrollbar.

For reference, this is based on hint in this StackOverflow question: https://stackoverflow.com/questions/35123/prevent-swt-scrolledcomposite-from-eating-part-of-its-children