### PR TITLE
fix non visible 0% tick axis since the switch to swtchart 0.14

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChart.java
@@ -1,6 +1,5 @@
 package name.abuchen.portfolio.ui.util.chart;
 
-import java.text.DecimalFormat;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -31,6 +30,7 @@ import org.eclipse.swtchart.internal.PlotArea;
 
 import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.format.PercentNumberFormat;
 
 public class TimelineChart extends Chart // NOSONAR
 {
@@ -120,7 +120,7 @@ public class TimelineChart extends Chart // NOSONAR
         IAxis y3Axis = getAxisSet().getYAxis(axisId3rd);
         y3Axis.getTitle().setVisible(false);
         y3Axis.getTick().setVisible(false);
-        y3Axis.getTick().setFormat(new DecimalFormat("+#.##%;-#.##%")); //$NON-NLS-1$
+        y3Axis.getTick().setFormat(new PercentNumberFormat("+#.##%;-#.##%")); //$NON-NLS-1$
         y3Axis.getGrid().setStyle(LineStyle.NONE);
         y3Axis.setPosition(Position.Primary);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/format/PercentNumberFormat.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/format/PercentNumberFormat.java
@@ -1,0 +1,35 @@
+package name.abuchen.portfolio.ui.util.format;
+
+import java.text.DecimalFormat;
+import java.text.FieldPosition;
+import java.text.Format;
+import java.text.ParsePosition;
+
+public class PercentNumberFormat extends Format
+{
+    private String decimalFormat;
+    private static final long serialVersionUID = 1L;
+
+    public PercentNumberFormat(String decimalFormat)
+    {
+        this.decimalFormat = decimalFormat;
+    }
+
+    @Override
+    public StringBuffer format(Object obj, StringBuffer toAppendTo, FieldPosition pos)
+    {
+        if (!(obj instanceof Number))
+            throw new IllegalArgumentException("object must be a subclass of Number"); //$NON-NLS-1$
+
+        toAppendTo.append(new DecimalFormat(decimalFormat).format(((Number) obj).doubleValue()));
+
+        return toAppendTo;
+    }
+
+    @Override
+    public Object parseObject(String source, ParsePosition pos)
+    {
+        pos.setErrorIndex(0);
+        return null;
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
@@ -39,6 +39,7 @@ import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.chart.TimelineChart;
 import name.abuchen.portfolio.ui.util.chart.TimelineChartCSVExporter;
+import name.abuchen.portfolio.ui.util.format.PercentNumberFormat;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeries;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeriesCache;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeriesChartLegend;
@@ -114,7 +115,7 @@ public class PerformanceChartView extends AbstractHistoricView
         chart = new TimelineChart(composite);
         chart.getTitle().setText(getTitle());
         chart.getTitle().setVisible(false);
-        chart.getAxisSet().getYAxis(0).getTick().setFormat(new DecimalFormat("0.#%")); //$NON-NLS-1$
+        chart.getAxisSet().getYAxis(0).getTick().setFormat(new PercentNumberFormat("0.#%")); //$NON-NLS-1$
         chart.getToolTip().setDefaultValueFormat(new DecimalFormat(Values.Percent2.pattern()));
         chart.getToolTip().reverseLabels(true);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ReturnsVolatilityChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ReturnsVolatilityChartView.java
@@ -39,6 +39,7 @@ import name.abuchen.portfolio.ui.util.LabelOnly;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.chart.ScatterChart;
 import name.abuchen.portfolio.ui.util.chart.ScatterChartCSVExporter;
+import name.abuchen.portfolio.ui.util.format.PercentNumberFormat;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeries;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeriesCache;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeriesChartLegend;
@@ -192,11 +193,11 @@ public class ReturnsVolatilityChartView extends AbstractHistoricView
 
         IAxis xAxis = chart.getAxisSet().getXAxis(0);
         xAxis.getTitle().setText(this.riskMetric.toString());
-        xAxis.getTick().setFormat(new DecimalFormat("0.##%")); //$NON-NLS-1$
+        xAxis.getTick().setFormat(new PercentNumberFormat("0.##%")); //$NON-NLS-1$
 
         IAxis yAxis = chart.getAxisSet().getYAxis(0);
         yAxis.getTitle().setText(useIRR ? Messages.LabelPerformanceIRR : Messages.LabelPerformanceTTWROR);
-        yAxis.getTick().setFormat(new DecimalFormat("0.##%")); //$NON-NLS-1$
+        yAxis.getTick().setFormat(new PercentNumberFormat("0.##%")); //$NON-NLS-1$
 
         configurator = new DataSeriesConfigurator(this, DataSeries.UseCase.RETURN_VOLATILITY);
         configurator.addListener(this::updateChart);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ChartWidget.java
@@ -34,6 +34,7 @@ import name.abuchen.portfolio.ui.util.LabelOnly;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.chart.TimelineChart;
 import name.abuchen.portfolio.ui.util.format.AmountNumberFormat;
+import name.abuchen.portfolio.ui.util.format.PercentNumberFormat;
 import name.abuchen.portfolio.ui.util.format.ThousandsNumberFormat;
 import name.abuchen.portfolio.ui.views.ChartViewConfig;
 import name.abuchen.portfolio.ui.views.PerformanceChartView;
@@ -295,7 +296,7 @@ public class ChartWidget extends WidgetDelegate<Object>
             if (useCase == DataSeries.UseCase.STATEMENT_OF_ASSETS)
                 chart.getAxisSet().getYAxis(0).getTick().setFormat(new ThousandsNumberFormat());
             else
-                chart.getAxisSet().getYAxis(0).getTick().setFormat(new DecimalFormat("0.#%")); //$NON-NLS-1$
+                chart.getAxisSet().getYAxis(0).getTick().setFormat(new PercentNumberFormat("0.#%")); //$NON-NLS-1$
 
             chart.getAxisSet().getYAxis(0).getTick().setVisible(get(ChartShowYAxisConfig.class).getIsShowYAxis());
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/DrawdownChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/DrawdownChartWidget.java
@@ -17,6 +17,7 @@ import name.abuchen.portfolio.model.Dashboard.Widget;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.chart.TimelineChart;
+import name.abuchen.portfolio.ui.util.format.PercentNumberFormat;
 import name.abuchen.portfolio.ui.views.dashboard.ChartHeightConfig;
 import name.abuchen.portfolio.ui.views.dashboard.ChartShowYAxisConfig;
 import name.abuchen.portfolio.ui.views.dashboard.DashboardData;
@@ -111,7 +112,7 @@ public class DrawdownChartWidget extends WidgetDelegate<Object>
             for (var s : chart.getSeriesSet().getSeries())
                 chart.getSeriesSet().deleteSeries(s.getId());
 
-            chart.getAxisSet().getYAxis(0).getTick().setFormat(new DecimalFormat("0.#%")); //$NON-NLS-1$
+            chart.getAxisSet().getYAxis(0).getTick().setFormat(new PercentNumberFormat("0.#%")); //$NON-NLS-1$
             chart.getAxisSet().getYAxis(0).getTick().setVisible(get(ChartShowYAxisConfig.class).getIsShowYAxis());
 
             Interval reportingPeriod = get(ReportingPeriodConfig.class).getReportingPeriod()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/StackedChartViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/StackedChartViewer.java
@@ -8,6 +8,7 @@ import org.eclipse.swtchart.Range;
 
 import name.abuchen.portfolio.ui.editor.PortfolioPart;
 import name.abuchen.portfolio.ui.util.chart.StackedTimelineChart;
+import name.abuchen.portfolio.ui.util.format.PercentNumberFormat;
 
 public class StackedChartViewer extends AbstractStackedChartViewer
 {
@@ -20,7 +21,7 @@ public class StackedChartViewer extends AbstractStackedChartViewer
     @Override
     protected void configureChart(StackedTimelineChart chart)
     {
-        chart.getAxisSet().getYAxis(0).getTick().setFormat(new DecimalFormat("#0.0%")); //$NON-NLS-1$
+        chart.getAxisSet().getYAxis(0).getTick().setFormat(new PercentNumberFormat("#0.0%")); //$NON-NLS-1$
         chart.getToolTip().setDefaultValueFormat(new DecimalFormat("#0.0%")); //$NON-NLS-1$
     }
 


### PR DESCRIPTION
Hello,

Issue : https://github.com/portfolio-performance/portfolio/pull/4312#issuecomment-2481683966

Since switching to swtchart 0.14, the tick on chart axis for 0% does not appear anymore. As per the linked comment, it may be already fixed by swtchart but only available in the next release ? I am not sure.

I do not know why this works, but noticing than chart axis with the `ThousandAmountFormat` did not had this issue, I tried to use a similar approach. On my Windows it works. Maybe there is a simpler way to get it done ?


**Before :**
![Capture d’écran 2024-11-29 214649](https://github.com/user-attachments/assets/06c274be-f9ea-4869-ab46-01ea16373983)   ![Capture d’écran 2024-11-29 214705](https://github.com/user-attachments/assets/d9764f8e-abf6-4223-a4ff-6caf7dc0b26c)   ![Capture d’écran 2024-11-29 214719](https://github.com/user-attachments/assets/2fddfc74-fda0-4d3b-a76c-51c6ebff78e8)   ![Capture d’écran 2024-11-29 214743](https://github.com/user-attachments/assets/ddba2ce5-5de9-4e1b-869c-0f13d2583af2)

**After :**
![Capture d’écran 2024-11-29 215029](https://github.com/user-attachments/assets/d6843ce6-91a3-4002-81b5-1b43a036ac80)   ![Capture d’écran 2024-11-29 214404](https://github.com/user-attachments/assets/2c7dd8a6-d23e-4f98-84cb-3e56cfeb7598)   ![Capture d’écran 2024-11-29 214307](https://github.com/user-attachments/assets/29a75494-1642-46a4-b0fe-65ec6712bb2d)   ![Capture d’écran 2024-11-29 214439](https://github.com/user-attachments/assets/eecaa016-e702-4a02-b2e4-9858ce7bd2f5)

Maybe the naming could be improved for maintainability point of view ? `PercentNumberFormat` -> `AxisTickPercentNumberFormat` ?