### PR TITLE
fix weekly investment plan

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/InvestmentPlan.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/InvestmentPlan.java
@@ -365,8 +365,9 @@ public class InvestmentPlan implements Named, Adaptable, Attributable
 
             if (transactionDate.getDayOfWeek() != start.getDayOfWeek())
             {
-                previousDate = transactionDate.minusDays(
-                                transactionDate.getDayOfWeek().getValue() + 7L - start.getDayOfWeek().getValue());
+                int offset = transactionDate.getDayOfWeek().getValue() - start.getDayOfWeek().getValue();
+                offset = offset > 0 ? offset : offset + 7;
+                previousDate = transactionDate.minusDays(offset);
             }
 
             next = previousDate.plusWeeks((long) interval - WEEKS_THRESHOLD);


### PR DESCRIPTION
Hello,

Proposition of fix, as per https://github.com/portfolio-performance/portfolio/pull/4347#issuecomment-2508897541

Otherwise, with 
```
previousDate = transactionDate.minusDays(
                                transactionDate.getDayOfWeek().getValue() + 7L - start.getDayOfWeek().getValue());
```
I think we are going back in the past one week too much when `transactionDate.getDayOfWeek().getValue() start.getDayOfWeek().getValue` is already positive. Example : weekly plan starting on March 18 2024 was producing infinite loop.
![2024-11-30 12_25_53-Comparing portfolio-performance_master mierin12_fix_weeklyinvestmentplan · por](https://github.com/user-attachments/assets/f298ca3c-a933-4432-a2d7-efa7e8f0f4b3)

When `transactionDate.getDayOfWeek().getValue() - start.getDayOfWeek().getValue` is negative, I think it is correct to then add the 7 days.
To be double checked, I did it quickly. My other manual test is this one :
![2024-11-30 11_38_59-Paramètres](https://github.com/user-attachments/assets/ddf74bf9-4021-4874-af0c-a7554e259061)

Another thing to look into is why the test did not trigger, but I did not have time to look into itn-> hmm maybe because I only put a test related to the 2016 case, and not to the March 2024 case .. :/
