### PR TITLE
fix tick format of Payments charts

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsAccumulatedChartBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsAccumulatedChartBuilder.java
@@ -18,6 +18,7 @@ import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.TabularDataSource;
 import name.abuchen.portfolio.ui.util.chart.TimelineChartToolTip;
 import name.abuchen.portfolio.ui.util.format.AmountNumberFormat;
+import name.abuchen.portfolio.ui.util.format.ThousandsNumberFormat;
 
 public class PaymentsAccumulatedChartBuilder implements PaymentsChartBuilder
 {
@@ -41,6 +42,9 @@ public class PaymentsAccumulatedChartBuilder implements PaymentsChartBuilder
         xAxis.enableCategory(true);
         // format symbols returns 13 values as some calendars have 13 months
         xAxis.setCategorySeries(Arrays.copyOfRange(new DateFormatSymbols().getMonths(), 0, 12));
+
+        IAxis yAxis = chart.getAxisSet().getYAxis(0);
+        yAxis.getTick().setFormat(new ThousandsNumberFormat());
 
         TimelineChartToolTip toolTip = new TimelineChartToolTip(chart);
         toolTip.enableCategory(true);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsChartTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsChartTab.java
@@ -12,14 +12,11 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swtchart.Chart;
 import org.eclipse.swtchart.IAxis;
 import org.eclipse.swtchart.IAxis.Position;
-import org.eclipse.swtchart.Range;
 
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
 import name.abuchen.portfolio.ui.util.chart.PlainChart;
-import name.abuchen.portfolio.ui.util.format.AmountNumberFormat;
-import name.abuchen.portfolio.ui.util.format.ThousandsNumberFormat;
 
 public class PaymentsChartTab implements PaymentsTab
 {
@@ -96,17 +93,6 @@ public class PaymentsChartTab implements PaymentsTab
         finally
         {
             chart.suspendUpdate(false);
-        }
-
-        // if max/min value of range is more than 1000, formatting is #.#k
-        Range r = yAxis.getRange();
-        if (r.lower < -1000.0 || r.upper > 1000.0)
-        {
-            yAxis.getTick().setFormat(new ThousandsNumberFormat());
-        }
-        else
-        {
-            yAxis.getTick().setFormat(new AmountNumberFormat());
         }
 
         model.addUpdateListener(this::updateChart);


### PR DESCRIPTION
Hello, 
This is a proposition to fix and simplify the tick format of Payments charts (use ThousandAmoundFormat for all payments charts). 
Y axis tick format are defined as `ThousandsNumberFormat` in `PaymentsPerMonthChartBuilder`, `PaymentsPerYearChartBuilder`, `PaymentsPerQuarterChartBuilder` but also in the higher level `PaymentsChartTab` where it is either `ThousandsNumberFormat `either `AmountNumberFormat`.

It seems that the `PaymentsChartTab` overwrites the other ones. 
But it also does not update the format on tab switching : if you first open a chart with low values, such as Fees, then `AmountNumberFormat` is set and then, even if you switch to Savings or a >1k chart, it will stays `AmountNumberFormat` :
![Capture d’écran 2024-12-03 220516](https://github.com/user-attachments/assets/5115e559-976c-4feb-b771-06ef1dc624c0)

But is `AmountNumberFormat` really needed ? Since https://github.com/portfolio-performance/portfolio/commit/3cb9ee13988f868b8a28c2e341a7c24a51480015, the ThousandsNumberFormat is not adding "k" to <1000 values. So fine even for small value.
AmountNumberFormat is more for tooltip I believe.

An even more simpler way than this PR would be to set the tick format as Thousands once in PaymentsChartTab and remove it in the four Payments charts (per month/quarter/year, accumulated). It should work too I guess.
