### PR TITLE
add Ctrl+D accelerator for "Duplicate transaction" action

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TransactionContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TransactionContextMenu.java
@@ -82,6 +82,15 @@ public class TransactionContextMenu
             tx.withAccountTransaction().ifPresent(t -> createEditAccountTransactionAction(t).run());
             tx.withPortfolioTransaction().ifPresent(t -> createEditPortfolioTransactionAction(t).run());
         }
+        if (e.keyCode == 'd' && e.stateMask == SWT.MOD1)
+        {
+            if (selection.isEmpty())
+                return;
+
+            TransactionPair<?> tx = (TransactionPair<?>) selection.getFirstElement();
+            tx.withAccountTransaction().ifPresent(t -> createCopyAccountTransactionAction(t).run());
+            tx.withPortfolioTransaction().ifPresent(t -> createCopyPortfolioTransactionAction(t).run());
+        }
     }
 
     private void fillContextMenuPortfolioTxList(IMenuManager manager, IStructuredSelection selection)
@@ -131,7 +140,9 @@ public class TransactionContextMenu
         action.setAccelerator(SWT.MOD1 | 'E');
         manager.add(action);
 
-        manager.add(createCopyAccountTransactionAction(tx));
+        Action duplicateAction = createCopyAccountTransactionAction(tx);
+        duplicateAction.setAccelerator(SWT.MOD1 | 'D');
+        manager.add(duplicateAction);
 
         if (fullContextMenu)
         {
@@ -150,7 +161,9 @@ public class TransactionContextMenu
         editAction.setAccelerator(SWT.MOD1 | 'E');
         manager.add(editAction);
 
-        manager.add(createCopyPortfolioTransactionAction(tx));
+        Action duplicateAction = createCopyPortfolioTransactionAction(tx);
+        duplicateAction.setAccelerator(SWT.MOD1 | 'D');
+        manager.add(duplicateAction);
 
         manager.add(new Separator());
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/AccountTransactionsPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/AccountTransactionsPane.java
@@ -523,6 +523,14 @@ public class AccountTransactionsPane implements InformationPanePage, Modificatio
                     if (account != null && transaction != null)
                         createEditAction(account, transaction).run();
                 }
+                if (e.keyCode == 'd' && e.stateMask == SWT.MOD1)
+                {
+                    AccountTransaction transaction = (AccountTransaction) ((IStructuredSelection) transactions
+                                    .getSelection()).getFirstElement();
+
+                    if (account != null && transaction != null)
+                        createCopyAction(account, transaction).run();
+                }
             }
         });
     }
@@ -541,7 +549,9 @@ public class AccountTransactionsPane implements InformationPanePage, Modificatio
             action.setAccelerator(SWT.MOD1 | 'E');
             manager.add(action);
 
-            manager.add(createCopyAction(account, transaction));
+            Action duplicateAction = createCopyAction(account, transaction);
+            duplicateAction.setAccelerator(SWT.MOD1 | 'D');
+            manager.add(duplicateAction);
 
             manager.add(new Separator());
         }


### PR DESCRIPTION
Issue : https://github.com/portfolio-performance/portfolio/issues/1588

At the time of the above issue, the duplication operation itself did not exist, so it may very well be considered already resolved. This issue was proposing to have a shortcut for it, so this PR is proposing to add it.

D works with : 
Duplicate (English)
Dupliquer (French)
Duplizieren (German)
Dupliceren (Dutch)
Duplica (Italy) 
etc
Spanish is currently using "Replicar transacción..." but Google translate is showing that "Duplicar" also exist.
