### PR TITLE
Add support for changed BankIdentifier to Sunrise PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sunrise/Kauf05.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sunrise/Kauf05.txt
@@ -1,0 +1,37 @@
+PDFBox Version: 1.8.17
+Portfolio Performance Version: 0.72.2
+-----------------------------------------
+Ein Service von:
+Für Rückfragen wenden Sie sich 
+bitte an: info@sunrise.app
+Herr
+XXXXXXX YYYYYY Fondsabrechnung
+ZZZZ Straße. XX
+54321 XXXXXXXX Datum: 06.11.2024
+Deutschland  Depotnummer: 1234567890
+Hiermit bestätigen wir Ihnen folgende Transaktion für Sie ausgeführt zu haben:
+Transaktion Fondsname Betrag Preis Anteile 
+ISIN Preisdatum Bestand neu
+Verwahrart/Lagerland
+Verwahrort
+Kauf Standortfonds Deutschland 98.77 € 148.98 € 0.663
+AT0000A1Z882 05.11.2024 115.794
+Girosammelverwahrung/AT 
+Raiffeisen Bank International AG
+Abrechnungsbetrag: 98.77 €
+Ausgabeaufschlag/Provision: 0,00%
+Auftrags-Nummer: 202411011234567890000001386891
+Anlagen in Investmentfonds können erst nach Kenntnisnahme der gesetzlichen Verkaufsunterlagen 
+(Basisinformationsblatt) erfolgen. Diese Unterlagen haben Sie direkt über die Sunrise Kanäle erhalten bzw. vor 
+Auftragserteilung dort eingesehen.
+Die erworbenen Vermögenswerte fallen unter die Regelungen der Richtlinie 2014/65/EU („MiFID II“), insbesondere die 
+in dieser Richtlinie enthaltenen Bestimmungen zum Schutz Ihrer Vermögenswerte. Informationen und Risiken im 
+Zusammenhang mit der Sammelverwahrung entnehmen Sie bitte den "Allgemeinen Geschäftsbedingungen" unter 
+www.sunrise.app. 
+Wichtiger Hinweis: Einwendungen gegen diese Fondsabrechnung wegen Unrichtigkeit oder Unvollständigkeit richten 
+Sie bitte schriftlich spätestens einen Monat nach Zugang an: info@sunrise.app.
+Mit besten Grüßen
+Ihr Sunrise Team
+Sunrise Securities GmbH, Gußhausstraße 3/2, A-1040 Wien; UID-Nummer: ATU 68616777, Firmenbuchnummer: FN 410750w 
+Sunrise Securities GmbH nach österreichischem Recht Zweigniederlassung Deutschland, Rahel-Hirsch-Straße 10, D-10557 Berlin; Handelsregister: HRB 258310 B
+Version_2024_01_K

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sunrise/SunrisePDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sunrise/SunrisePDFExtractorTest.java
@@ -165,6 +165,38 @@ public class SunrisePDFExtractorTest
     }
 
     @Test
+    public void testWertpapierKauf05()
+    {
+        SunrisePDFExtractor extractor = new SunrisePDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf05.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(results.size(), is(2));
+
+        new AssertImportActions().check(results, CurrencyUnit.EUR);
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("AT0000A1Z882"), hasWkn(null), hasTicker(null), //
+                        hasName("Standortfonds Deutschland"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2024-11-05T00:00"), hasShares(0.663), //
+                        hasSource("Kauf05.txt"), //
+                        hasNote("Auftrags-Nummer: 202411011234567890000001386891"), //
+                        hasAmount("EUR", 98.77), hasGrossValue("EUR", 98.77), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
     public void testDividende22()
     {
         SunrisePDFExtractor extractor = new SunrisePDFExtractor(new Client());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SunrisePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SunrisePDFExtractor.java
@@ -35,7 +35,7 @@ public class SunrisePDFExtractor extends AbstractPDFExtractor
 
         addBankIdentifier("info@meetsunrise.com");
         addBankIdentifier("info@sunrise.app");
-        addBankIdentifier("Sunrise Securities GmbH")
+        addBankIdentifier("Sunrise Securities GmbH");
 
         addBuySellTransaction();
         addDividendeTransaction();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SunrisePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SunrisePDFExtractor.java
@@ -34,6 +34,8 @@ public class SunrisePDFExtractor extends AbstractPDFExtractor
         super(client);
 
         addBankIdentifier("info@meetsunrise.com");
+        addBankIdentifier("info@sunrise.app");
+        addBankIdentifier("Sunrise Securities GmbH")
 
         addBuySellTransaction();
         addDividendeTransaction();


### PR DESCRIPTION
Issue: https://github.com/portfolio-performance/portfolio/issues/4405

Fix the PDF import for Sunrise which changed the BankIdentifier. 

It will:
* add two new BankIdentifiers: `info@sunrise.app` + `Sunrise Securities GmbH` used within the PDFs
* add testCase for the changed PDF 

