### PR TITLE
Fix ASX trade calendar

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
@@ -234,7 +234,7 @@ public class TradeCalendarManager
         // https://www.asx.com.au/markets/market-resources/trading-hours-calendar/cash-market-trading-hours/trading-calendar
         tc = new TradeCalendar("asx", Messages.LabelTradeCalendarASX, STANDARD_WEEKEND); //$NON-NLS-1$
         tc.add(fixed(NEW_YEAR, Month.JANUARY, 1).moveIf(DayOfWeek.SATURDAY, 2).moveIf(DayOfWeek.SUNDAY, 1));
-        tc.add(fixed(AUSTRALIA_DAY, Month.JANUARY, 26));
+        tc.add(fixed(AUSTRALIA_DAY, Month.JANUARY, 26).moveIf(DayOfWeek.SATURDAY, 2).moveIf(DayOfWeek.SUNDAY, 1));
         tc.add(easter(GOOD_FRIDAY, -2));
         tc.add(easter(EASTER_MONDAY, 1));
         tc.add(fixed(ANZAC_DAY, Month.APRIL, 25));


### PR DESCRIPTION
The ASX observes Australia Day on the following Monday if January 26 happens to fall on a weekend. This wasn’t represented in the PP trade calendar.

See the ASX trading calendar for 2025 and 2020 (Australia Day moved to January 27) and 2019 (Australia Day moved to January 28) on their website and on historic versions of it at the Internet Archive: https://www.asx.com.au/markets/market-resources/trading-hours-calendar/cash-market-trading-hours/trading-calendar