### PR TITLE
fix legend of investment marker

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -410,6 +410,9 @@ public class SecuritiesChart
 
     private MessagePainter messagePainter = new MessagePainter();
 
+    private String investmentMarkerLabelBuy = PortfolioTransaction.Type.BUY.toString();
+    private String investmentMarkerLabelSell = PortfolioTransaction.Type.SELL.toString();
+
     public SecuritiesChart(Composite parent, Client client, CurrencyConverter converter)
     {
         this.client = client;
@@ -527,12 +530,12 @@ public class SecuritiesChart
         toolTip.addSeriesExclude(Messages.LabelChartDetailChartDevelopment + "Positive"); //$NON-NLS-1$
         toolTip.addSeriesExclude(Messages.LabelChartDetailChartDevelopment + "Negative"); //$NON-NLS-1$
         toolTip.addSeriesExclude(Messages.LabelChartDetailChartDevelopment + "Zero"); //$NON-NLS-1$
-        toolTip.addSeriesExclude(Messages.SecurityMenuBuy);
-        toolTip.addSeriesExclude(Messages.SecurityMenuBuy + "1"); //$NON-NLS-1$
-        toolTip.addSeriesExclude(Messages.SecurityMenuBuy + "2"); //$NON-NLS-1$
-        toolTip.addSeriesExclude(Messages.SecurityMenuSell);
-        toolTip.addSeriesExclude(Messages.SecurityMenuSell + "1"); //$NON-NLS-1$
-        toolTip.addSeriesExclude(Messages.SecurityMenuSell + "2"); //$NON-NLS-1$
+        toolTip.addSeriesExclude(investmentMarkerLabelBuy);
+        toolTip.addSeriesExclude(investmentMarkerLabelBuy + "1"); //$NON-NLS-1$
+        toolTip.addSeriesExclude(investmentMarkerLabelBuy + "2"); //$NON-NLS-1$
+        toolTip.addSeriesExclude(investmentMarkerLabelSell);
+        toolTip.addSeriesExclude(investmentMarkerLabelSell + "1"); //$NON-NLS-1$
+        toolTip.addSeriesExclude(investmentMarkerLabelSell + "2"); //$NON-NLS-1$
         toolTip.addSeriesExclude(Messages.LabelChartDetailMarkerDividends);
         toolTip.addSeriesExclude(Messages.LabelChartDetailMarkerDividends + "1"); //$NON-NLS-1$
         toolTip.addSeriesExclude(Messages.LabelChartDetailMarkerDividends + "2"); //$NON-NLS-1$
@@ -1259,7 +1262,7 @@ public class SecuritiesChart
                         .filter(t -> chartInterval.contains(t.getDateTime())) //
                         .sorted(Transaction.BY_DATE).toList();
 
-        addInvestmentMarkers(purchase, Messages.SecurityMenuBuy, colorEventPurchase,
+        addInvestmentMarkers(purchase, investmentMarkerLabelBuy, colorEventPurchase,
                         PlotSymbolType.TRIANGLE);
 
         List<PortfolioTransaction> sales = client.getPortfolios().stream().flatMap(p -> p.getTransactions().stream())
@@ -1269,7 +1272,7 @@ public class SecuritiesChart
                         .filter(t -> chartInterval.contains(t.getDateTime())) //
                         .sorted(Transaction.BY_DATE).toList();
 
-        addInvestmentMarkers(sales, Messages.SecurityMenuSell, colorEventSale,
+        addInvestmentMarkers(sales, investmentMarkerLabelSell, colorEventSale,
                         PlotSymbolType.INVERTED_TRIANGLE);
     }
 


### PR DESCRIPTION
This is an issue that I introduced in https://github.com/portfolio-performance/portfolio/pull/4298 sorry.
The non hidden tooltip itself was indeed fixed, but the common excluded label should have been `PortfolioTransaction.Type.BUY.toString()` instead of `Messages.SecurityMenuBuy`, as this label is used not only as the hidden tooltip, but also as the legend : so now `Messages.SecurityMenuBuy `is shown in the legend while it was`PortfolioTransaction.Type.BUY.toString()` beforehand;  so in French we now have "Acheter" the verb (="to buy") instead of "Achat" the noun (="purchase"), same for sell.
![Capture d'écran 2024-02-12 084104](https://github.com/user-attachments/assets/f3c4cdbc-3148-4450-a104-f601fb1d6ff8)

With this PR : the tooltip stays hidden for all languages, and the legend reverts to the original `PortfolioTransaction.Type.BUY.toString()`  label.

| Language| Messages.SecurityMenuBuy| PortfolioTransaction.Type.BUY.toString()|
| ------------- | ------------- |------------- |
| German| Kauf| Kauf|
| Chinese simplified| 买入| 买入|
| Chinese traditional| 購入| **買入**|
| Danish| Køb| Køb|
| English| Buy| Buy|
| Spanish| Compra| Compra|
| French| Acheter| **Achat**|
| Italian| Compra| Compra|
| Dutch| Aankopen| **Aankoop**|
| Polish| Kup| **Kupno**|
| Portugese| Comprar| Comprar|
| Portugese brasil| Comprar| Comprar|
| Russian| Покупка| Покупка|
| Slovak| Kúpiť| Kúpiť|
| Czech| Koupit| Koupit|

For French, having the noun in the legend is better. I believe in Dutch and Polish, Aankoop and Kupno are also the noun rather than the verb, so I think it makes sense also for them.