### PR TITLE
Add NYSE closing day for funeral of Jimmy Carter

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TradeCalendarManager.java
@@ -149,6 +149,7 @@ public class TradeCalendarManager
         tc.add(fixed(HURRICANE_SANDY, Month.OCTOBER, 29).onlyIn(2012));
         tc.add(fixed(HURRICANE_SANDY, Month.OCTOBER, 30).onlyIn(2012));
         tc.add(fixed(STATE_FUNERAL, Month.DECEMBER, 5).onlyIn(2018)); // funeral of former president Bush Sr.
+        tc.add(fixed(STATE_FUNERAL, Month.JANUARY, 9).onlyIn(2025)); // funeral of former president Carter
         CACHE.put(tc.getCode(), tc);
 
         // see https://www.bolsadesantiago.com/mercado_horarios_feriados


### PR DESCRIPTION
The New York Stock Exchange [will remain closed on 2025-01-09](https://ir.theice.com/press/news-details/2024/The-New-York-Stock-Exchange-Will-Close-Markets-on-January-9-to-Honor-the-Passing-of-Former-President-Jimmy-Carter-on-National-Day-of-Mourning/default.aspx) because of the state funeral for Jimmy Carter, former president of the U.S. Add this to the NYSE trade calendar.