### PR TITLE
Added option to strip carriage returns from extracted PDF text

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
@@ -45,6 +45,8 @@ import name.abuchen.portfolio.model.TypedMap;
         private Consumer<Transaction<DocumentContext>> contextBuilder;
         private Block[] contextRanges;
 
+        private boolean stripSingleCarriageReturns = false;
+
         public DocumentType(String mustInclude)
         {
             this.mustInclude.add(Pattern.compile(mustInclude));
@@ -90,6 +92,11 @@ import name.abuchen.portfolio.model.TypedMap;
             this.contextProvider = contextProvider;
         }
 
+        public void setStripSingleCarriageReturns(boolean stripSingleCarriageReturns)
+        {
+            this.stripSingleCarriageReturns = stripSingleCarriageReturns;
+        }
+
         public boolean matches(String text)
         {
             // Check if the text matches the mustInclude patterns
@@ -131,6 +138,11 @@ import name.abuchen.portfolio.model.TypedMap;
 
         public void parse(String filename, List<Item> items, String text)
         {
+            if (stripSingleCarriageReturns)
+            {
+                text = text.replace("\r", ""); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+
             String[] lines = text.split("\\r?\\n"); //$NON-NLS-1$
 
             // reset context and parse it from this file

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/QuirinBankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/QuirinBankAGPDFExtractor.java
@@ -123,6 +123,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
     private void addBuySellTransaction_Format02()
     {
         DocumentType type = new DocumentType("Abrechnungskonditionen");
+        type.setStripSingleCarriageReturns(true);
         this.addDocumentTyp(type);
 
         Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
@@ -388,6 +389,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
     {
         DocumentType type = new DocumentType("(Dividendenabrechnung" //
                         + "|Ertrag aus Investments)");
+        type.setStripSingleCarriageReturns(true);
         this.addDocumentTyp(type);
 
         Transaction<AccountTransaction> pdfTransaction = new Transaction<>();


### PR DESCRIPTION
Apparently, some Quirin Bank document contain single carriage returns. That carriage returns are not in the sample data, because the CreateTextFromPDFHandler strips all carriage returns from the raw text.

The difference has been introduced with commit
d88e9317bca8a370c271eec563ad5030da873e35

To limit the impact, this change applies it only to the Quirin extractor.