### PR TITLE
update titles of Taxonomy/Payment/Calculation/Holdings views as per selected filter

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterDropDown.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterDropDown.java
@@ -44,4 +44,9 @@ public final class ClientFilterDropDown extends DropDown implements IMenuListene
     {
         return menu.hasActiveFilter();
     }
+
+    public ClientFilterMenu getClientFilterMenu()
+    {
+        return menu;
+    }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
@@ -109,7 +109,9 @@ public class PerformanceView extends AbstractHistoricView
     @Override
     protected String getDefaultTitle()
     {
-        return Messages.LabelPerformanceCalculation;
+        return (clientFilter == null || !clientFilter.hasActiveFilter()) ? Messages.LabelPerformanceCalculation
+                        : Messages.LabelPerformanceCalculation + " : " //$NON-NLS-1$
+                                        + clientFilter.getClientFilterMenu().getSelectedItem().getLabel();
     }
 
     @Override
@@ -176,6 +178,7 @@ public class PerformanceView extends AbstractHistoricView
     public void notifyModelUpdated()
     {
         reportingPeriodUpdated();
+        updateTitle(getDefaultTitle());
     }
 
     @Override
@@ -202,6 +205,7 @@ public class PerformanceView extends AbstractHistoricView
         folder.setSelection(0);
 
         reportingPeriodUpdated();
+        updateTitle(getDefaultTitle());
 
         return folder;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/holdings/HoldingsPieChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/holdings/HoldingsPieChartView.java
@@ -67,7 +67,9 @@ public class HoldingsPieChartView extends AbstractFinanceView
     @Override
     protected String getDefaultTitle()
     {
-        return Messages.LabelStatementOfAssetsHoldings;
+        return (clientFilter == null || !clientFilter.hasActiveFilter()) ? Messages.LabelStatementOfAssetsHoldings
+                        : Messages.LabelStatementOfAssetsHoldings + " : " //$NON-NLS-1$
+                                        + clientFilter.getClientFilterMenu().getSelectedItem().getLabel();
     }
 
     @Override
@@ -80,6 +82,7 @@ public class HoldingsPieChartView extends AbstractFinanceView
         chart.refresh(snapshot);
         
         updateWarningInToolBar();
+        updateTitle(getDefaultTitle());
 
         setInformationPaneInput(null);
     }
@@ -103,6 +106,8 @@ public class HoldingsPieChartView extends AbstractFinanceView
         }
 
         updateWarningInToolBar();
+        updateTitle(getDefaultTitle());
+
         return chart.createControl(parent);
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsView.java
@@ -124,7 +124,8 @@ public class PaymentsView extends AbstractFinanceView
     @Override
     protected String getDefaultTitle()
     {
-        return model.getMode().getLabel();
+        return (clientFilterMenu == null || !clientFilterMenu.hasActiveFilter()) ? model.getMode().getLabel()
+                        : model.getMode().getLabel() + " : " + clientFilterMenu.getSelectedItem().getLabel(); //$NON-NLS-1$
     }
 
     @Override
@@ -136,7 +137,7 @@ public class PaymentsView extends AbstractFinanceView
                             new SimpleAction(TextUtil.tooltip(mode.getLabel()), a -> {
                                 model.setMode(mode);
                                 updateIcons(toolBarManager);
-                                updateTitle(model.getMode().getLabel());
+                                updateTitle(getDefaultTitle());
                             }));
             item.setMode(ActionContributionItem.MODE_FORCE_TEXT);
             toolBarManager.add(item);
@@ -166,6 +167,8 @@ public class PaymentsView extends AbstractFinanceView
                         clientFilterMenu::menuAboutToShow);
         clientFilterMenu.addListener(f -> dropDown
                         .setImage(clientFilterMenu.hasActiveFilter() ? Images.FILTER_ON : Images.FILTER_OFF));
+        clientFilterMenu.addListener(filter -> updateTitle(getDefaultTitle()));
+
         toolBar.add(dropDown);
 
         toolBar.add(new DropDown(Messages.MenuExportData, Images.EXPORT, SWT.NONE, manager -> {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyView.java
@@ -72,11 +72,14 @@ public class TaxonomyView extends AbstractFinanceView implements PropertyChangeL
 
             clientFilterMenu.addListener(listener);
             clientFilterMenu.addListener(filter -> updateIcon());
+            clientFilterMenu.addListener(filter -> updateTitle(getUpdatedTitle()));
 
             loadPreselectedFilter(preferenceStore);
 
             if (clientFilterMenu.hasActiveFilter() || !model.getNodeFilters().isEmpty())
                 setImage(Images.FILTER_ON);
+
+            updateTitle(getUpdatedTitle());
 
             // As the taxonomy model is initially calculated in the #init
             // method, we must recalculate the values if an active filter
@@ -112,6 +115,12 @@ public class TaxonomyView extends AbstractFinanceView implements PropertyChangeL
         {
             boolean hasActiveFilter = clientFilterMenu.hasActiveFilter() || !model.getNodeFilters().isEmpty();
             setImage(hasActiveFilter ? Images.FILTER_ON : Images.FILTER_OFF);
+        }
+
+        private String getUpdatedTitle()
+        {
+            return !clientFilterMenu.hasActiveFilter() ? getDefaultTitle()
+                            : getDefaultTitle() + " : " + clientFilterMenu.getSelectedItem().getLabel(); //$NON-NLS-1$
         }
 
         @Override
@@ -310,7 +319,7 @@ public class TaxonomyView extends AbstractFinanceView implements PropertyChangeL
     {
         if (enableExperimentalFeatures)
         {
-            toolBar.add(new DropDown("Sync", Images.CLOUD, SWT.NONE, manager -> {
+            toolBar.add(new DropDown("Sync", Images.CLOUD, SWT.NONE, manager -> { //$NON-NLS-1$
 
                 String source = taxonomy.getSource();
 


### PR DESCRIPTION
Closes https://github.com/portfolio-performance/portfolio/issues/4045
Issue : https://forum.portfolio-performance.info/t/filter-name-im-diagramm-titel/6277
Issue : https://forum.portfolio-performance.info/t/anzeige-des-filters-bei-performance-berechnung/6715

Hello, this is a proposition to change the default title of the Taxonomy/Payment/Calculation/Holdings views in order to include the name of the selected filter in it. And in case "Whole Portfolio" is selected, the current default titles are used.

I did not put it in Securities Performance nor in Statement of Asset views as there can be many Tabs so the length for the title may be short.

The implementation is not exactly the same for all 4 views as sometimes we have access to ClientFilterMenu directly, sometimes ClientFilter. For HoldingsPieChartView, it seems that we do not need the call on line 109 in createBody, while we need it for PerformanceView. I kept it nonetheless.


What I have checked  : 
-title is correctly updated when there is a change of selected filter
-title is correct when the file opens on the view while a filter is already selected, or if we switch between the views

![Capture d’écran 2025-01-04 020037](https://github.com/user-attachments/assets/407d8437-d6c9-4900-8b76-ce3442541e6e)
![Capture d’écran 2025-01-04 020112](https://github.com/user-attachments/assets/fde3c3a6-4bea-4b82-9848-ec1b092bd7ee)
![Capture d’écran 2025-01-04 020140](https://github.com/user-attachments/assets/ac1924cd-9798-4c99-8728-73f5d87ec9a5)
![Capture d’écran 2025-01-04 020205](https://github.com/user-attachments/assets/40e9e29f-deae-41d0-ab51-f61f90f67f2b)
![Capture d’écran 2025-01-04 022301](https://github.com/user-attachments/assets/f9a7267f-1399-4407-b92c-f8442d82bd17)

I have also taken the opportunity to add a //$NON-NLS-1$ in Taxonomy view, silencing the last remaining warning in Eclipse, but maybe a proper translated MessageLabel is best instead of "Sync".
![2025-01-04 02_16_51-](https://github.com/user-attachments/assets/0879e559-c3d4-4b83-a55d-3c9c22b86cb0)

