### PR TITLE
allow first level only for donut chart in taxonomy

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/DonutChartBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/DonutChartBuilder.java
@@ -74,22 +74,29 @@ public class DonutChartBuilder
 
         // classified nodes
         TaxonomyNode node = model.getClassificationRootNode();
-        addChildren(answer, node, node.getChildren());
+        addChildren(answer, node, node.getChildren(), model.isSecuritiesInPieChartExcluded());
 
         // add unclassified if included
         if (!model.isUnassignedCategoryInChartsExcluded())
         {
             TaxonomyNode unassigned = model.getUnassignedNode();
-            List<TaxonomyNode> children = new ArrayList<>(unassigned.getChildren());
-            Collections.sort(children, (r, l) -> l.getActual().compareTo(r.getActual()));
-            addChildren(answer, unassigned, children);
+            if (model.isSecuritiesInPieChartExcluded())
+            {
+                answer.add(new Pair<>(unassigned, unassigned));
+            }
+            else
+            {
+                List<TaxonomyNode> children = new ArrayList<>(unassigned.getChildren());
+                Collections.sort(children, (r, l) -> l.getActual().compareTo(r.getActual()));
+                addChildren(answer, unassigned, children, model.isSecuritiesInPieChartExcluded());
+            }
         }
 
         return answer;
     }
 
     private void addChildren(List<Pair<TaxonomyNode, TaxonomyNode>> answer, TaxonomyNode parent,
-                    List<TaxonomyNode> children)
+                    List<TaxonomyNode> children, boolean firstLevelOnly)
     {
         for (TaxonomyNode child : children)
         {
@@ -99,6 +106,10 @@ public class DonutChartBuilder
             if (child.isAssignment())
             {
                 answer.add(new Pair<>(parent, child));
+            }
+            else if (child.isClassification() && firstLevelOnly)
+            {
+                answer.add(new Pair<>(child, child));
             }
             else if (child.isClassification())
             {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/DonutViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/DonutViewer.java
@@ -3,12 +3,16 @@ package name.abuchen.portfolio.ui.views.taxonomy;
 import jakarta.inject.Inject;
 
 import org.eclipse.e4.core.di.extensions.Preference;
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
+import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
 import name.abuchen.portfolio.ui.util.EmbeddedBrowser;
+import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.views.IPieChart;
 
 /* package */class DonutViewer extends AbstractChartPage
@@ -26,6 +30,20 @@ import name.abuchen.portfolio.ui.views.IPieChart;
     {
         super(model, renderer);
         this.view = view;
+    }
+
+    @Override
+    public void configMenuAboutToShow(IMenuManager manager)
+    {
+        super.configMenuAboutToShow(manager);
+
+        Action action = new SimpleAction(Messages.LabelIncludeSecuritiesInPieChart, a -> {
+            getModel().setExcludeSecuritiesInPieChart(!getModel().isSecuritiesInPieChartExcluded());
+            getModel().fireTaxonomyModelChange(getModel().getVirtualRootNode());
+            chart.refresh(null);
+        });
+        action.setChecked(!getModel().isSecuritiesInPieChartExcluded());
+        manager.add(action);
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/PieChartViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/PieChartViewer.java
@@ -39,6 +39,7 @@ import name.abuchen.portfolio.ui.views.IPieChart;
 
         Action action = new SimpleAction(Messages.LabelIncludeSecuritiesInPieChart, a -> {
             getModel().setExcludeSecuritiesInPieChart(!getModel().isSecuritiesInPieChartExcluded());
+            getModel().fireTaxonomyModelChange(getModel().getVirtualRootNode());
             chart.refresh(null);
         });
         action.setChecked(!getModel().isSecuritiesInPieChartExcluded());


### PR DESCRIPTION
Hello,

This is a proposition to add in the Taxonomy's Donut Chart view an option to show only the first level of taxonomies (without the instrument). It is already available for Pie Chart, but not for Donut Chart.

I think it gives a nice and clear view of the allocation as it allows to see directly the % of the first level categories.

**New : First level only :**
![2025-01-05 22_53_30-Paramètres](https://github.com/user-attachments/assets/ad2d0656-d1df-4852-a68d-6df3bab0dbaa)
**vs As usual:**
![2025-01-05 22_52_11-Portfolio Performance](https://github.com/user-attachments/assets/0908a535-dd96-4a49-9382-58209f5ab566)

View with swtchart and Without classification :
**New : First level only :**
![2025-01-06 00_12_06-Portfolio Performance](https://github.com/user-attachments/assets/87437312-e645-45e6-b05d-ab2012348e0f)
**vs As usual**
![2025-01-06 00_12_48-Portfolio Performance](https://github.com/user-attachments/assets/874b2f11-cec5-4728-9c90-c52b62f5d7e8)

The parameter is the same for Pie Chart and Donut Chart : if you change it on one chart, it will be applied on the other one. But they could be separated.
