### PR TITLE
SecuritiesChart: Add "Show/hide markings" toolbar icon

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -704,6 +704,7 @@ public class Messages extends NLS
     public static String LabelHeatmapOrnament;
     public static String LabelHeatmapTaxes;
     public static String LabelHide;
+    public static String LabelHideMarkings;
     public static String LabelHistoricalReturnsAndVolatiltity;
     public static String LabelImportNotesFromSource;
     public static String LabelIncludeSecuritiesInPieChart;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1400,6 +1400,8 @@ LabelHeatmapTaxes = Monthly taxes
 
 LabelHide = Hide
 
+LabelHideMarkings = Show/hide markings
+
 LabelHistoricalReturnsAndVolatiltity = Historical Returns and Volatility
 
 LabelIRR = Internal Rate of Return (IRR)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -399,6 +399,13 @@ public class SecuritiesChart
      * to be shown.
      */
     private IntervalOption intervalOption = IntervalOption.Y2;
+    /**
+     * Flag to quickly disable/enable showing additional markings on chart.
+     * The idea is that they are useful, but may make a chart very crowded.
+     * So, it's nice idea to let users with one click see either fully
+     * annotated chart, or pristine price chart.
+     */
+    private boolean showMarkings = true;
 
     private EnumSet<ChartDetails> chartConfig = EnumSet.of(ChartDetails.INVESTMENT, ChartDetails.EVENTS,
                     ChartDetails.SCALING_LINEAR, ChartDetails.SHOW_MAIN_HORIZONTAL_LINES);
@@ -695,6 +702,16 @@ public class SecuritiesChart
     public void addButtons(ToolBarManager toolBar)
     {
         chart.getChartToolsManager().addButtons(toolBar);
+
+        SimpleAction actionHideMarkings = new SimpleAction(null, IAction.AS_CHECK_BOX, Messages.LabelHideMarkings, a -> {
+            this.showMarkings = !this.showMarkings;
+            a.setChecked(this.showMarkings);
+            updateChart();
+        });
+        actionHideMarkings.setImageDescriptor(Images.NEW_TRANSACTION.descriptor());
+        actionHideMarkings.setChecked(this.showMarkings);
+        toolBar.add(actionHideMarkings);
+
         toolBar.add(new Separator());
 
         List<Action> viewActions = new ArrayList<>();
@@ -1136,12 +1153,15 @@ public class SecuritiesChart
             addEMAMarkerLines(chartInterval, Messages.LabelChartDetailMovingAverageEMA,
                             Messages.LabelChartDetailMovingAverage_200days, 200, colorEMA7);
 
-        if (chartConfig.contains(ChartDetails.SHOW_LIMITS))
+        if (this.showMarkings && chartConfig.contains(ChartDetails.SHOW_LIMITS))
             addLimitLines(range);
     }
 
     private void addChartMarkerForeground(ChartInterval chartInterval)
     {
+        if (!this.showMarkings)
+            return;
+
         if (chartConfig.contains(ChartDetails.FIFOPURCHASE))
             addFIFOPurchasePrice(chartInterval);
 


### PR DESCRIPTION
Chart markings are incredible useful, but they also may crowd a chart, especially at the longer timeframes. The idea is to allow user to quickly hide or show (default state) of markings, to either enjoy all the annotations that they provide, or vice versa, a pristine price chart.

Regarding what's being hidden are buy/sell operations, dividends, events, and additionally limit price lines. The idea regarding the latter is that the limit(s) may be considerably lower/higher than the level of prices on the chart shown, leading to skewed vertical scale. But other information, e.g. average purchase price, is shown in either case.