### PR TITLE
AbstractSecurityListWidget: Show infopane on clicking a security

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/AbstractFinanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/AbstractFinanceView.java
@@ -209,6 +209,12 @@ public abstract class AbstractFinanceView
 
     }
 
+    public void showPane()
+    {
+        if (isPaneHidden())
+            flipPane();
+    }
+
     protected abstract Control createBody(Composite parent);
 
     private final Control createHeader(Composite parent)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/lists/AbstractSecurityListWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/lists/AbstractSecurityListWidget.java
@@ -68,6 +68,7 @@ public abstract class AbstractSecurityListWidget<T extends AbstractSecurityListW
             return;
 
         view.setInformationPaneInput(((Item) item).getSecurity());
+        view.showPane();
     });
 
     public AbstractSecurityListWidget(Widget widget, DashboardData data)


### PR DESCRIPTION
Previously, there was a code to update infopane to show security on which user clicked in a dashboard list widget. But most people would probably never know about this functionality, unless they happen to have infopane enabled in the dashboard (which normally isn't). So, now explicitly show infopane on click, so this useful functionality didn't go unnoticed.