### PR TITLE
SecurityListView: Properly show short holdings for "Shares held != 0" filter

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityListView.java
@@ -245,8 +245,11 @@ public class SecurityListView extends AbstractFinanceView
          */
         private long getSharesHeld(Client client, Security security)
         {
-            // collect all shares and return a value greater 0
-            return Math.max(security.getTransactions(client).stream()
+            // TODO: This calculation is simplistic and may be incorrect.
+            // e.g., if one account has 1 (long) share and another - -1 (short) share,
+            // this calculation returns 0. But it's clear that it's not the case that
+            // we have 0 (i.e. none) shares.
+            return security.getTransactions(client).stream()
                             .filter(t -> t.getTransaction() instanceof PortfolioTransaction) //
                             .map(t -> (PortfolioTransaction) t.getTransaction()) //
                             .mapToLong(t -> {
@@ -261,7 +264,7 @@ public class SecurityListView extends AbstractFinanceView
                                     default:
                                         return 0L;
                                 }
-                            }).sum(), 0);
+                            }).sum();
         }
 
         private boolean isLimitPriceExceeded(Security security)


### PR DESCRIPTION
Don't forcibly clamp negative (short) holdings to zero. However, add comment that the calculation is still not entirely correct, as it may return 0 in case one account have positive number of shares, and another - same number, but negative amount of shares.