### PR TITLE
Allow '.' from numpad as Spanish decimal separator 

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/EditClientPropertiesDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/EditClientPropertiesDialog.java
@@ -19,7 +19,7 @@ import name.abuchen.portfolio.model.AttributeType.PercentConverter;
 import name.abuchen.portfolio.model.ClientProperties;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.BindingHelper;
-import name.abuchen.portfolio.ui.util.text.FrenchKeypadSupport;
+import name.abuchen.portfolio.ui.util.text.DecimalKeypadSupport;
 
 public class EditClientPropertiesDialog extends AbstractDialog
 {
@@ -110,7 +110,7 @@ public class EditClientPropertiesDialog extends AbstractDialog
         l.setText(label);
 
         final Text txtValue = new Text(editArea, SWT.BORDER);
-        FrenchKeypadSupport.configure(txtValue);
+        DecimalKeypadSupport.configure(txtValue);
         GridDataFactory.fillDefaults().align(SWT.FILL, SWT.FILL).grab(true, false).applyTo(txtValue);
 
         UpdateValueStrategy<String, Double> input2model = new UpdateValueStrategy<>();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractTransactionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractTransactionDialog.java
@@ -63,7 +63,7 @@ import name.abuchen.portfolio.ui.util.IValidatingConverter;
 import name.abuchen.portfolio.ui.util.SimpleDateTimeDateSelectionProperty;
 import name.abuchen.portfolio.ui.util.SimpleDateTimeTimeSelectionProperty;
 import name.abuchen.portfolio.ui.util.StringToCurrencyConverter;
-import name.abuchen.portfolio.ui.util.text.FrenchKeypadSupport;
+import name.abuchen.portfolio.ui.util.text.DecimalKeypadSupport;
 
 public abstract class AbstractTransactionDialog extends TitleAreaDialog
 {
@@ -87,7 +87,7 @@ public abstract class AbstractTransactionDialog extends TitleAreaDialog
                 }
             });
 
-            FrenchKeypadSupport.configure(value);
+            DecimalKeypadSupport.configure(value);
 
             currency = new Label(editArea, SWT.NONE);
         }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BindingHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BindingHelper.java
@@ -47,7 +47,7 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Messages;
-import name.abuchen.portfolio.ui.util.text.FrenchKeypadSupport;
+import name.abuchen.portfolio.ui.util.text.DecimalKeypadSupport;
 import name.abuchen.portfolio.util.Isin;
 import name.abuchen.portfolio.util.TradeCalendar;
 import name.abuchen.portfolio.util.TradeCalendarManager;
@@ -395,7 +395,7 @@ public class BindingHelper
                     int lenghtInCharacters)
     {
         Text txtValue = createTextInput(editArea, label, style, lenghtInCharacters);
-        FrenchKeypadSupport.configure(txtValue);
+        DecimalKeypadSupport.configure(txtValue);
         bindMandatoryDecimalInput(label, property, txtValue, Values.Amount);
         return txtValue;
     }
@@ -403,7 +403,7 @@ public class BindingHelper
     public final Control bindMandatoryQuoteInput(Composite editArea, final String label, String property)
     {
         Text txtValue = createTextInput(editArea, label);
-        FrenchKeypadSupport.configure(txtValue);
+        DecimalKeypadSupport.configure(txtValue);
         bindMandatoryDecimalInput(label, property, txtValue, Values.Quote);
         return txtValue;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/text/DecimalKeypadSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/text/DecimalKeypadSupport.java
@@ -10,13 +10,13 @@ import org.eclipse.swt.widgets.Text;
 import name.abuchen.portfolio.util.AdditionalLocales;
 import name.abuchen.portfolio.util.TextUtil;
 
-public class FrenchKeypadSupport
+public class DecimalKeypadSupport
 {
     private static final boolean IS_FRENCH = Locale.getDefault().getLanguage().equals(Locale.FRENCH.getLanguage());
     private static final boolean IS_SPANISH = Locale.getDefault().getLanguage()
                     .equals(AdditionalLocales.SPAIN.getLanguage());
 
-    private FrenchKeypadSupport()
+    private DecimalKeypadSupport()
     {
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/text/FrenchKeypadSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/text/FrenchKeypadSupport.java
@@ -7,11 +7,14 @@ import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.widgets.Text;
 
+import name.abuchen.portfolio.util.AdditionalLocales;
 import name.abuchen.portfolio.util.TextUtil;
 
 public class FrenchKeypadSupport
 {
     private static final boolean IS_FRENCH = Locale.getDefault().getLanguage().equals(Locale.FRENCH.getLanguage());
+    private static final boolean IS_SPANISH = Locale.getDefault().getLanguage()
+                    .equals(AdditionalLocales.SPAIN.getLanguage());
 
     private FrenchKeypadSupport()
     {
@@ -19,7 +22,7 @@ public class FrenchKeypadSupport
 
     public static void configure(Text text)
     {
-        if (IS_FRENCH)
+        if (IS_FRENCH || IS_SPANISH)
         {
             text.addKeyListener(new KeyAdapter()
             {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/AttributeEditingSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/AttributeEditingSupport.java
@@ -10,7 +10,7 @@ import name.abuchen.portfolio.model.Attributable;
 import name.abuchen.portfolio.model.AttributeType;
 import name.abuchen.portfolio.model.Attributes;
 import name.abuchen.portfolio.ui.util.NumberVerifyListener;
-import name.abuchen.portfolio.ui.util.text.FrenchKeypadSupport;
+import name.abuchen.portfolio.ui.util.text.DecimalKeypadSupport;
 
 public class AttributeEditingSupport extends ColumnEditingSupport
 {
@@ -29,7 +29,7 @@ public class AttributeEditingSupport extends ColumnEditingSupport
             ((Text) textEditor.getControl()).addVerifyListener(new NumberVerifyListener(true));
 
         if (attribute.isNumber() || attribute.getConverter() instanceof AttributeType.LimitPriceConverter)
-            FrenchKeypadSupport.configure((Text) textEditor.getControl());
+            DecimalKeypadSupport.configure((Text) textEditor.getControl());
 
         return textEditor;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ValueEditingSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ValueEditingSupport.java
@@ -13,7 +13,7 @@ import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.CurrencyToStringConverter;
 import name.abuchen.portfolio.ui.util.NumberVerifyListener;
 import name.abuchen.portfolio.ui.util.StringToCurrencyConverter;
-import name.abuchen.portfolio.ui.util.text.FrenchKeypadSupport;
+import name.abuchen.portfolio.ui.util.text.DecimalKeypadSupport;
 
 public class ValueEditingSupport extends PropertyEditingSupport
 {
@@ -50,7 +50,7 @@ public class ValueEditingSupport extends PropertyEditingSupport
         var text = (Text) textEditor.getControl();
         text.setTextLimit(20);
         text.addVerifyListener(new NumberVerifyListener());
-        FrenchKeypadSupport.configure(text);
+        DecimalKeypadSupport.configure(text);
         return textEditor;
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AttributesPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/AttributesPage.java
@@ -44,7 +44,7 @@ import name.abuchen.portfolio.ui.PortfolioPlugin;
 import name.abuchen.portfolio.ui.util.BindingHelper;
 import name.abuchen.portfolio.ui.util.IValidatingConverter;
 import name.abuchen.portfolio.ui.util.LabelOnly;
-import name.abuchen.portfolio.ui.util.text.FrenchKeypadSupport;
+import name.abuchen.portfolio.ui.util.text.DecimalKeypadSupport;
 import name.abuchen.portfolio.ui.wizards.security.EditSecurityModel.AttributeDesignation;
 import name.abuchen.portfolio.util.ImageUtil;
 
@@ -274,7 +274,7 @@ public class AttributesPage extends AbstractPage implements IMenuListener
             if ((attribute.getType().isNumber()
                             || attribute.getType().getConverter() instanceof AttributeType.LimitPriceConverter))
             {
-                FrenchKeypadSupport.configure((Text) value);
+                DecimalKeypadSupport.configure((Text) value);
             }
             GridDataFactory.fillDefaults().align(SWT.FILL, SWT.CENTER).grab(true, false).applyTo(value);
 


### PR DESCRIPTION
Issue : https://forum.portfolio-performance.info/t/decimal-separator-on-french-keyboard/28939/20
Comment : https://github.com/portfolio-performance/portfolio/pull/4143#issuecomment-2615286844 

Hello, this is a proposition to allow the numpad '.' to be detected and replaced by the Spanish decimal separator (','), as per the above comments.
To be noted:
- '.' is the Spain thousands separator, but thousands separator are not expected to be typed by users, right ?
- Some Spanish country (Mexico, Ecuador etc) already use '.' as decimal separator (as opposed to Spain). However this change will replace numpad '.' by their decimal separtor ('.') so not impact I believe.

![Capture d’écran 2025-02-01 003322](https://github.com/user-attachments/assets/fed04625-e9be-49ca-810d-6c3581ae01dc)
![Capture d’écran 2025-02-01 003411](https://github.com/user-attachments/assets/c7f3dded-4026-4b21-bd21-d48e40827e1b)

Proposition of rename for the method as it would no longer be only French related.