### PR TITLE
Enhancement of Arkea Direct Bank pdf import to support more cases (#4534)

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/ArkeaDirectBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/ArkeaDirectBankPDFExtractorTest.java
@@ -227,6 +227,37 @@ public class ArkeaDirectBankPDFExtractorTest
     }
 
     @Test
+    public void testDividende02()
+    {
+        ArkeaDirectBankPDFExtractor extractor = new ArkeaDirectBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("FR0010208488"), hasWkn(null), hasTicker(null), //
+                        hasName("ENGIE"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2023-04-28T00:00"), hasShares(100.00), //
+                        hasSource("Dividende02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 140.00), hasGrossValue("EUR", 140.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
     public void testSteuern01()
     {
         ArkeaDirectBankPDFExtractor extractor = new ArkeaDirectBankPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/ArkeaDirectBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/ArkeaDirectBankPDFExtractorTest.java
@@ -1,15 +1,5 @@
 package name.abuchen.portfolio.datatransfer.pdf.arkeadirectbank;
 
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.Test;
-
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
@@ -27,10 +17,18 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
-
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
 
 import name.abuchen.portfolio.datatransfer.Extractor.Item;
 import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
@@ -254,6 +252,37 @@ public class ArkeaDirectBankPDFExtractorTest
                         hasSource("Dividende02.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 140.00), hasGrossValue("EUR", 140.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende03()
+    {
+        ArkeaDirectBankPDFExtractor extractor = new ArkeaDirectBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("LU2655993207"), hasWkn(null), hasTicker(null), //
+                        hasName("AMUND.MSCI WORLD D"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2024-12-10T00:00"), hasShares(211.00), //
+                        hasSource("Dividende03.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 44.31), hasGrossValue("EUR", 44.31), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/Dividende02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/Dividende02.txt
@@ -1,0 +1,24 @@
+PDFBox Version: 3.0.3 != 1.8.17
+Portfolio Performance Version: 0.74.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+AVIS D'ENCAISSEMENT COUPON M dsGVeLG FRKVnW
+Au 3 mai 2023 2 DVr EEUs DUawl eKPcrLWnt
+38496 nwvXi DJr CGUWSxu
+VOTRE COMPTE PEA N° 974973262593 M TwQPOZG yKeVZN
+Objet : Encaissement de coupons
+Monsieur,
+Nous avons le plaisir de vous informer que nous avons procédé à l'encaissement des coupons suivants pour votre compte :
+Date Opération Détail opération Débit Crédit
+  n       ACTION  ENGIE (FR0010208488))
+28/04/2023 Quantité 100
+Prélèvement fiscal 0,00 €
+Prélèvements sociaux 0,00 €
+Montant Net 140,00 € 140,00 €
+Veuillez agréer, Monsieur, l'expression de nos salutations distinguées.
+Le Service OST.
+Duplicata Internet
+Page 1/1
+Fortuneo est une marque commerciale d'Arkéa Direct Bank. Arkéa Direct Bank, Société Anonyme à Directoire et Conseil de Surveillance
+au capital de 89 198 952 euros. RCS Nanterre 384 288 890. Siège social : Tour Ariane - 5, place de la Pyramide 92088 Paris La Défense.
+Courtier en assurance n°ORIAS 07 008 441. Adresse postale : Fortuneo - Service Clients - TSA41707 - 35917 RENNES CEDEX 9.

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/Dividende03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/Dividende03.txt
@@ -1,0 +1,25 @@
+PDFBox Version: 3.0.3 != 1.8.17
+Portfolio Performance Version: 0.74.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+AVIS D'ENCAISSEMENT COUPON M VPKnScq PorezWZU
+Au 13 décembre 2024 28 gbr ltauWITKZ
+48644 ZeAVy
+VOTRE COMPTE PEA N° 299103952010 M gWILwwR bZCPieuP
+Objet : Encaissement de coupon OPC
+Monsieur,
+Nous avons le plaisir de vous informer que nous avons procédé à l'encaissement des coupons suivants pour votre compte :
+Date Opération Détail opération Débit Crédit
+  n       OPCVM  AMUND.MSCI WORLD D (LU2655993207)
+10/12/2024 Quantité 211,00
+Montant unitaire 0,21 EUR
+Prélèvement fiscal 0,00 €
+Prélèvements sociaux 0,00 €
+Montant Net 44,31 € 44,31 €
+Veuillez agréer, Monsieur, l'expression de nos salutations distinguées.
+Le Service OST.
+Duplicata Internet
+Page 1/1
+Fortuneo est une marque commerciale d'Arkéa Direct Bank. Arkéa Direct Bank, Société Anonyme à Directoire et Conseil de Surveillance
+au capital de 89 198 952 euros. RCS Nanterre 384 288 890. Siège social : Tour Trinity - 1bis, place de la Défense 92400 Courbevoie.
+Courtier en assurance n°ORIAS 07 008 441. Adresse postale : Fortuneo - Service Clients - TSA41707 - 35917 RENNES CEDEX 9.

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ArkeaDirectBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ArkeaDirectBankPDFExtractor.java
@@ -114,7 +114,7 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
 
         Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
 
-        Block firstRelevantLine = new Block("^AVIS D.ENCAISSEMENT COUPON$");
+        Block firstRelevantLine = new Block("^AVIS D.ENCAISSEMENT COUPON.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -127,34 +127,43 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
                         })
 
                         // @formatter:off
+                        // Supported patterns are:
                         //   n       ACTION  ORANGE (FR0000133308)
-                        // Montant unitaire 0,30 €
+                        //   n       ACTION  ENGIE (FR0010208488))
                         // @formatter:on
-                        .section("name", "isin", "currency") //
-                        .match("^.* ACTION (?<name>.*) \\((?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\)$") //
-                        .match("^Montant unitaire [\\,\\d\\s]+ (?<currency>\\p{Sc})$") //
-                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
-
+                        .section("name", "isin") //
+                        .match("^.* ACTION (?<name>.*) \\((?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\)*$") //
+                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))) //
+                        .oneOf( //
+                                        // @formatter:off
+                                        // 28/04/2023 Quantité 100
+                                        // @formatter:on
+                                        section -> section.attributes("date", "shares") //
+                                                        .match("^(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) Quantit. (?<shares>[\\,\\d\\s]+)$") //
+                                                        .assign((t, v) -> {
+                                                            t.setShares(asShares(v.get("shares")));
+                                                            t.setDateTime(asDate(v.get("date")));
+                                                        }),
+                                        // @formatter:off
+                                        // Quantité 450
+                                        // 04/12/2023
+                                        // @formatter:on
+                                        section -> section.attributes("date", "shares") //
+                                                        .match("^Quantit. (?<shares>[\\,\\d\\s]+)$") //
+                                                        .match("^(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4})$") //
+                                                        .assign((t, v) -> {
+                                                            t.setShares(asShares(v.get("shares")));
+                                                            t.setDateTime(asDate(v.get("date")));
+                                                        }))
                         // @formatter:off
-                        // Quantité 450
-                        // @formatter:on
-                        .section("shares") //
-                        .match("^Quantit. (?<shares>[\\,\\d\\s]+)$") //
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
-
-                        // @formatter:off
-                        // 04/12/2023
-                        // @formatter:on
-                        .section("date") //
-                        .match("^(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4})$") //
-                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
-
-                        // @formatter:off
+                        // Supported patterns are:
                         // Montant Net 135,00 €
+                        // Montant Net 140,00 € 140,00 €
                         // @formatter:on
                         .section("amount", "currency") //
-                        .match("^Montant Net (?<amount>[\\,\\d\\s]+) (?<currency>\\p{Sc})$") //
+                        .match("^Montant Net (?<amount>[\\,\\d\\s]+) (?<currency>\\p{Sc}).*$") //
                         .assign((t, v) -> {
+                            t.getSecurity().setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
                         })

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ArkeaDirectBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ArkeaDirectBankPDFExtractor.java
@@ -126,44 +126,57 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
                             return accountTransaction;
                         })
 
-                        // @formatter:off
-                        // Supported patterns are:
-                        //   n       ACTION  ORANGE (FR0000133308)
-                        //   n       ACTION  ENGIE (FR0010208488))
-                        // @formatter:on
-                        .section("name", "isin") //
-                        .match("^.* ACTION (?<name>.*) \\((?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\)*$") //
-                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))) //
                         .oneOf( //
                                         // @formatter:off
-                                        // 28/04/2023 Quantité 100
+                                        //   n       ACTION  ORANGE (FR0000133308)
+                                        // Montant unitaire 0,30 €
                                         // @formatter:on
-                                        section -> section.attributes("date", "shares") //
-                                                        .match("^(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) Quantit. (?<shares>[\\,\\d\\s]+)$") //
-                                                        .assign((t, v) -> {
-                                                            t.setShares(asShares(v.get("shares")));
-                                                            t.setDateTime(asDate(v.get("date")));
-                                                        }),
+                                        section -> section //
+                                                        .attributes("name", "isin", "currency") //
+                                                        .match("^.* (ACTION|OPCVM) (?<name>.*) \\((?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\).*$") //
+                                                        .match("^Montant unitaire [\\,\\d\\s]+ (?<currency>\\p{Sc})$") //
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
-                                        // Quantité 450
-                                        // 04/12/2023
+                                        //   n       OPCVM  AMUND.MSCI WORLD D (LU2655993207)
+                                        // Montant unitaire 0,21 EUR
                                         // @formatter:on
-                                        section -> section.attributes("date", "shares") //
-                                                        .match("^Quantit. (?<shares>[\\,\\d\\s]+)$") //
-                                                        .match("^(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4})$") //
-                                                        .assign((t, v) -> {
-                                                            t.setShares(asShares(v.get("shares")));
-                                                            t.setDateTime(asDate(v.get("date")));
-                                                        }))
+                                        section -> section //
+                                                        .attributes("name", "isin", "currency") //
+                                                        .match("^.* (ACTION|OPCVM) (?<name>.*) \\((?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\).*$") //
+                                                        .match("^Montant unitaire [\\,\\d\\s]+ (?<currency>[\\w]{3})$") //
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
+                                        // @formatter:off
+                                        //   n       ACTION  ENGIE (FR0010208488))
+                                        // Montant Net 140,00 € 140,00 €
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("name", "isin", "currency") //
+                                                        .match("^.* (ACTION|OPCVM) (?<name>.*) \\((?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\).*$") //
+                                                        .match("^Montant Net [\\,\\d\\s]+ (?<currency>\\p{Sc}).*$") //
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
+
                         // @formatter:off
-                        // Supported patterns are:
+                        // Quantité 450
+                        // 28/04/2023 Quantité 100
+                        // @formatter:on
+                        .section("shares") //
+                        .match("^.*Quantit. (?<shares>[\\,\\d\\s]+)$") //
+                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+
+                        // @formatter:off
+                        // 04/12/2023
+                        // @formatter:on
+                        .section("date") //
+                        .match("^(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}).*$") //
+                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
+
+                        // @formatter:off
                         // Montant Net 135,00 €
                         // Montant Net 140,00 € 140,00 €
                         // @formatter:on
                         .section("amount", "currency") //
                         .match("^Montant Net (?<amount>[\\,\\d\\s]+) (?<currency>\\p{Sc}).*$") //
                         .assign((t, v) -> {
-                            t.getSecurity().setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
                         })


### PR DESCRIPTION

 - Allows duplicate ')' at the end of ISIN
 - Quantity and date can be on the same line
 - Get security currency from amount instead of earlier from a data which is not always present

Closes #4534