### PR TITLE
Add PDF issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/pdf.md
+++ b/.github/ISSUE_TEMPLATE/pdf.md
@@ -1,0 +1,29 @@
+---
+name: PDF import issue
+about: Report an issue with the PDF importer
+title: ''
+labels: pdf
+assignees: ''
+
+---
+
+Note: You can report PDF import issues in either English, or German.
+
+**Affected bank**
+Which bank are you trying to import PDFs from? If you're experiencing issues with different banks, please open one issue per bank.
+
+**Describe the issue**
+Please provide a clear and concise description of what isn't working.
+
+For example: The document can't be read at all, or single transactions are missing (which ones?), or transactions are imported with wrong amounts (with which amounts are they imported and what would be the correct amounts?), or any other issue.
+
+**Text extracted from PDF**
+Open Portfolio Performance, click on File → Import → Debug: Create text from PDF… and choose the file you're trying to import. Please do NOT upload PDFs to GitHub or post screenshots of documents, use the mentioned debug feature instead.
+
+Follow the instructions on the screen. Make sure to anonymize the text before pasting it here (use the built-in anonymization feature). Please only anonymize your personal data (e.g. your name, address, deposit number), don't anonymize the bank's address, stock names, or dates. Please anonymize amounts only if you ensure that they are still consistent. Then hit "Copy to Clipboard" and paste the anonymized text below:
+
+```
+```
+
+**Additional context**
+If you want to add any other context about the isue, e.g. suggested code fixes, please do so here.


### PR DESCRIPTION
I skimmed through a few issues here on GitHub and feel like that users often don't provide all necessary information. Adding a issue template for PDF import issues might be a good idea, WDYT?