### PR TITLE
Balance column now uses MoneyColorLabelProvider for foreground color

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/MoneyColorLabelProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/MoneyColorLabelProvider.java
@@ -27,6 +27,11 @@ public final class MoneyColorLabelProvider extends ColumnLabelProvider
     public Color getForeground(Object element)
     {
         Money money = valueProvider.apply(element);
+        return MoneyColorLabelProvider.getForeground(money);
+    }
+
+    public static Color getForeground(Money money)
+    {
         if (money == null || money.isZero())
             return null;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/AccountTransactionsPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/AccountTransactionsPane.java
@@ -71,6 +71,7 @@ import name.abuchen.portfolio.ui.util.viewers.ColumnViewerSorter;
 import name.abuchen.portfolio.ui.util.viewers.CopyPasteSupport;
 import name.abuchen.portfolio.ui.util.viewers.DateTimeEditingSupport;
 import name.abuchen.portfolio.ui.util.viewers.DateTimeLabelProvider;
+import name.abuchen.portfolio.ui.util.viewers.MoneyColorLabelProvider;
 import name.abuchen.portfolio.ui.util.viewers.SharesLabelProvider;
 import name.abuchen.portfolio.ui.util.viewers.ShowHideColumnHelper;
 import name.abuchen.portfolio.ui.util.viewers.TransactionOwnerListEditingSupport;
@@ -290,9 +291,10 @@ public class AccountTransactionsPane implements InformationPanePage, Modificatio
             }
 
             @Override
-            public Color getForeground(Object element)
+            public Color getForeground(Object e)
             {
-                return colorFor((AccountTransaction) element);
+                Money balance = transaction2balance.get(e);
+                return MoneyColorLabelProvider.getForeground(balance);
             }
         });
 


### PR DESCRIPTION
* https://forum.portfolio-performance.info/t/balance-figures-are-red-even-if-balance-is-positive/32001
* https://forum.portfolio-performance.info/t/inkonsistente-darstellung-der-sollbuchungen/27115

that means: red for negative balance, green for positive

before:
![grafik](https://github.com/user-attachments/assets/a78a61b5-5f18-47a5-bbdb-d32f8d26ec0b)

now:
![grafik](https://github.com/user-attachments/assets/bc61c680-566c-4d8c-8957-077f5e145d1d)

