### PR TITLE
Improve Audi Bank PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/audibank/AudiBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/audibank/AudiBankPDFExtractorTest.java
@@ -3,12 +3,14 @@ package name.abuchen.portfolio.datatransfer.pdf.audibank;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interest;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
@@ -22,7 +24,6 @@ import java.util.List;
 
 import org.junit.Test;
 
-import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.datatransfer.Extractor.Item;
 import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
 import name.abuchen.portfolio.datatransfer.pdf.AudiBankPDFExtractor;
@@ -45,25 +46,17 @@ public class AudiBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(4L));
-        assertThat(results.size(), is(4));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2021-12-25"), hasAmount("EUR", 0.83), //
-                        hasSource("Kontoauszug01.txt"), hasNote(null))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2021-12-25"), hasAmount("EUR", 0.01), //
-                        hasSource("Kontoauszug01.txt"), hasNote("Solidaritätszuschlag"))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2021-12-25"), hasAmount("EUR", 0.01), //
-                        hasSource("Kontoauszug01.txt"), hasNote("Kirchensteuer"))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2021-12-25"), hasAmount("EUR", 0.20), //
-                        hasSource("Kontoauszug01.txt"), hasNote("Abgeltungsteuer"))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2021-12-25"), hasShares(0), //
+                        hasSource("Kontoauszug01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 0.61), hasGrossValue("EUR", 0.83), //
+                        hasTaxes("EUR", (0.20 + 0.01 + 0.01)), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -78,8 +71,8 @@ public class AudiBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(7L));
-        assertThat(results.size(), is(7));
+        assertThat(countAccountTransactions(results), is(4L));
+        assertThat(results.size(), is(4));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transaction
@@ -95,24 +88,12 @@ public class AudiBankPDFExtractorTest
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2023-08-25"), hasAmount("EUR", 1.00), //
-                        hasSource("Kontoauszug02.txt"), hasNote(null))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2023-08-25"), hasAmount("EUR", 0.01), //
-                        hasSource("Kontoauszug02.txt"), hasNote("Solidaritätszuschlag"))));
-
-        // check cancellation transaction
-        assertThat(results, hasItem(withFailureMessage( //
-                        Messages.MsgErrorTransactionTypeNotSupported, //
-                        taxes( //
-                                        hasDate("2023-08-25"), hasAmount("EUR", 0.00), //
-                                        hasSource("Kontoauszug02.txt"), hasNote("Kirchensteuer")))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2023-08-25"), hasAmount("EUR", 0.25), //
-                        hasSource("Kontoauszug02.txt"), hasNote("Abgeltungsteuer"))));
-
+        assertThat(results, hasItem(interest( //
+                        hasDate("2023-08-25"), hasShares(0), //
+                        hasSource("Kontoauszug02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 0.74), hasGrossValue("EUR", 1.00), //
+                        hasTaxes("EUR", (0.25 + 0.00 + 0.01)), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -127,8 +108,8 @@ public class AudiBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(6L));
-        assertThat(results.size(), is(6));
+        assertThat(countAccountTransactions(results), is(3L));
+        assertThat(results.size(), is(3));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transaction
@@ -140,20 +121,11 @@ public class AudiBankPDFExtractorTest
                         hasSource("Kontoauszug03.txt"), hasNote(null))));
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2022-03-25"), hasAmount("EUR", 1.13), //
-                        hasSource("Kontoauszug03.txt"), hasNote(null))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2022-03-25"), hasAmount("EUR", 0.01), //
-                        hasSource("Kontoauszug03.txt"), hasNote("Solidaritätszuschlag"))));
-
-        // check cancellation transaction
-        assertThat(results, hasItem(taxes(hasDate("2022-03-25"), hasAmount("EUR", 0.02), //
-                        hasSource("Kontoauszug03.txt"), hasNote("Kirchensteuer"))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2022-03-25"), hasAmount("EUR", 0.27), //
-                        hasSource("Kontoauszug03.txt"), hasNote("Abgeltungsteuer"))));
-
+        assertThat(results, hasItem(interest( //
+                        hasDate("2022-03-25"), hasShares(0), //
+                        hasSource("Kontoauszug03.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 0.83), hasGrossValue("EUR", 1.13), //
+                        hasTaxes("EUR", (0.27 + 0.01 + 0.02)), hasFees("EUR", 0.00))));
     }
 }


### PR DESCRIPTION
Previously, taxes were posted separately for interest transactions on account statements. 
These are now offset together and imported as one transaction.