### PR TITLE
Improve ComDirect PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
@@ -19,7 +19,6 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interest;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interestCharge;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
@@ -5673,8 +5672,8 @@ public class ComdirectPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(24L));
-        assertThat(results.size(), is(24));
+        assertThat(countAccountTransactions(results), is(22L));
+        assertThat(results.size(), is(22));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transaction
@@ -5762,16 +5761,12 @@ public class ComdirectPDFExtractorTest
                         hasSource("Finanzreport01.txt"), hasNote("Versandpauschale"))));
 
         // assert transaction
-        assertThat(results, hasItem(interestCharge(hasDate("2015-12-31"), hasAmount("EUR", 0.07), //
-                        hasSource("Finanzreport01.txt"), hasNote("Kontoabschluss Abschluss Zinsen"))));
-
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2018-09-28"), hasAmount("EUR", 0.14), //
-                        hasSource("Finanzreport01.txt"), hasNote("Kontoabschluss Abschluss Zinsen"))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2018-09-28"), hasAmount("EUR", 0.05), //
-                        hasSource("Finanzreport01.txt"), hasNote("Kapitalertragsteuer"))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2018-09-28"), hasShares(0), //
+                        hasSource("Finanzreport01.txt"), //
+                        hasNote("30.06.2018 bis 30.09.2018"), //
+                        hasAmount("EUR", 0.14), hasGrossValue("EUR", 0.19), //
+                        hasTaxes("EUR", (0.05 + 0.00)), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -5918,8 +5913,7 @@ public class ComdirectPDFExtractorTest
         assertThat(countBuySell(results), is(0L));
         assertThat(countAccountTransactions(results), is(7L));
         assertThat(results.size(), is(7));
-        // new AssertImportActions().check(results, CurrencyUnit.EUR); <--
-        // Multiple currencies
+        new AssertImportActions().check(results, "EUR", "USD"); // Multiple currencies
 
         // assert transaction
         assertThat(results, hasItem(removal(hasDate("2017-06-14"), hasAmount("EUR", 501.00), //
@@ -5946,8 +5940,12 @@ public class ComdirectPDFExtractorTest
                         hasSource("Finanzreport04.txt"), hasNote("Kontoübertrag"))));
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2017-06-30"), hasAmount("EUR", 0.02), //
-                        hasSource("Finanzreport04.txt"), hasNote("Kontoabschluss Abschluss Zinsen"))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2017-06-30"), hasShares(0), //
+                        hasSource("Finanzreport04.txt"), //
+                        hasNote("31.03.2017 bis 30.06.2017"), //
+                        hasAmount("EUR", 0.02), hasGrossValue("EUR", 0.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Finanzreport01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Finanzreport01.txt
@@ -116,8 +116,6 @@ Finanzreport Nr. 9 per 01.10.2018 - Seite 6
 Kundennummer 102 0000000
 Buchungstag Vorgang Auftraggeber/Empfänger Buchungstext Ausgang
 Valuta Referenz IBAN/BIC Eingang
-31.12.2015 Kontoabschluss Abschluss Zinsen Kto -0,07
-31.12.2015 6BF1600000000000/000 383096500EUR
 28.09.2018 Kontoabschluss Abschluss Zinsen Kto 000000005EUR +0,14
 30.09.2018 1PF18271L0000 von 30.06.2018 bis 30.09.2018
 052/2794 Habenzinsen


### PR DESCRIPTION
Previously, taxes were posted separately for interest transactions on account statements. These are now offset together and imported as one transaction.