### PR TITLE
Improve Consorbank PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
@@ -24,7 +24,6 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
@@ -4595,17 +4594,17 @@ public class ConsorsbankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(2L));
-        assertThat(results.size(), is(2));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2024-03-31"), hasAmount("EUR", 68.98), //
-                        hasSource("Kontoauszug06.txt"), hasNote(null))));
-
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2024-03-31"), hasAmount("EUR", 261.56), //
-                        hasSource("Kontoauszug06.txt"), hasNote(null))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2024-03-31"), hasShares(0), //
+                        hasSource("Kontoauszug06.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 192.58), hasGrossValue("EUR", 261.56), //
+                        hasTaxes("EUR", 68.98), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -4620,8 +4619,8 @@ public class ConsorsbankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(6L));
-        assertThat(results.size(), is(6));
+        assertThat(countAccountTransactions(results), is(5L));
+        assertThat(results.size(), is(5));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transaction
@@ -4641,12 +4640,12 @@ public class ConsorsbankPDFExtractorTest
                         hasSource("Kontoauszug07.txt"), hasNote("Euro-Überweisung"))));
 
         // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2023-09-30"), hasAmount("EUR", 22.20), //
-                        hasSource("Kontoauszug07.txt"), hasNote(null))));
-
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2023-09-30"), hasAmount("EUR", 84.21), //
-                        hasSource("Kontoauszug07.txt"), hasNote(null))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2023-09-30"), hasShares(0), //
+                        hasSource("Kontoauszug07.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 62.01), hasGrossValue("EUR", 84.21), //
+                        hasTaxes("EUR", 22.20), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -4661,17 +4660,17 @@ public class ConsorsbankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(2L));
-        assertThat(results.size(), is(2));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2024-03-31"), hasAmount("EUR", 261.56), //
-                        hasSource("Kontoabschluss01.txt"), hasNote(null))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2024-03-31"), hasAmount("EUR", 68.98), //
-                        hasSource("Kontoabschluss01.txt"), hasNote(null))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2024-03-31"), hasShares(0), //
+                        hasSource("Kontoabschluss01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 192.58), hasGrossValue("EUR", 261.56), //
+                        hasTaxes("EUR", 68.98), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -4686,16 +4685,16 @@ public class ConsorsbankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(2L));
-        assertThat(results.size(), is(2));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2023-09-30"), hasAmount("EUR", 22.20), //
-                        hasSource("Kontoabschluss02.txt"), hasNote(null))));
-
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2023-09-30"), hasAmount("EUR", 84.21), //
-                        hasSource("Kontoabschluss02.txt"), hasNote(null))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2023-09-30"), hasShares(0), //
+                        hasSource("Kontoabschluss02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 62.01), hasGrossValue("EUR", 84.21), //
+                        hasTaxes("EUR", 22.20), hasFees("EUR", 0.00))));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -19,6 +19,7 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
@@ -811,8 +812,24 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                                                         .assign((ctx, v) -> {
                                                                             ctx.put("currency", asCurrencyCode(v.get("currency")));
                                                                             ctx.put("date", v.get("date"));
+                                                                        }))
 
-                                                                        })));
+                                        .optionalOneOf( //
+                                                        // @formatter:off
+                                                        // STEUER 28.03. 8800 31.03. 68,98-
+                                                        // SUMME STEUERN 68,98 S
+                                                        // @formatter:on
+                                                        section -> section //
+                                                                        .attributes("tax") //
+                                                                        .match("^STEUER [\\d]{2}\\.[\\d]{2}\\. [\\d]+ [\\d]{2}\\.[\\d]{2}\\. (?<tax>[\\.,\\d]+)\\-$") //
+                                                                        .assign((ctx, v) -> ctx.put("tax", v.get("tax"))),
+                                                        // @formatter:off
+                                                        // SUMME STEUERN 68,98 S
+                                                        // @formatter:on
+                                                        section -> section //
+                                                                        .attributes("tax") //
+                                                                        .match("^SUMME STEUERN (?<tax>[\\.,\\d]+) S$") //
+                                                                        .assign((ctx, v) -> ctx.put("tax", v.get("tax")))));
 
         this.addDocumentTyp(type);
 
@@ -911,6 +928,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
                         .section("date", "amount", "type") //
                         .documentContext("year", "currency") //
+                        .documentContextOptionally("tax") //
                         .match("^ABSCHLUSS [\\d]{2}\\.[\\d]{2}\\. [\\d]+ (?<date>[\\d]{2}\\.[\\d]{2}\\.) (?<amount>[\\.,\\d]+)(?<type>[\\-|\\+])$") //
                         .assign((t, v) -> {
                             // @formatter:off
@@ -922,6 +940,17 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                             t.setDateTime(asDate(v.get("date") + v.get("year")));
                             t.setCurrencyCode(v.get("currency"));
                             t.setAmount(asAmount(v.get("amount")));
+
+                            if (v.containsKey("tax"))
+                            {
+                                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                                t.addUnit(new Unit(Unit.Type.TAX, tax));
+
+                                if (t.getType() == AccountTransaction.Type.INTEREST)
+                                    t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
+                                else
+                                    t.setMonetaryAmount(t.getMonetaryAmount().add(tax));
+                            }
                         })
 
                         .wrap(TransactionItem::new));
@@ -941,6 +970,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
                         .section("amount", "type") //
                         .documentContext("currency", "date") //
+                        .documentContextOptionally("tax")
                         .match("^SUMME DER ABSCHLUSSPOSTEN (?<amount>[\\.,\\d]+) (?<type>[H|S])$") //
                         .assign((t, v) -> {
                             // @formatter:off
@@ -952,66 +982,17 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                             t.setDateTime(asDate(v.get("date")));
                             t.setCurrencyCode(v.get("currency"));
                             t.setAmount(asAmount(v.get("amount")));
-                        })
 
-                        .wrap(TransactionItem::new));
+                            if (v.containsKey("tax"))
+                            {
+                                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                                t.addUnit(new Unit(Unit.Type.TAX, tax));
 
-        // @formatter:off
-        // STEUER 28.03. 8800 31.03. 68,98-
-        // @formatter:on
-        Block taxesBlock_Format01 = new Block("^STEUER [\\d]{2}\\.[\\d]{2}\\. [\\d]+ [\\d]{2}\\.[\\d]{2}\\. [\\.,\\d]+[\\-|\\+]$");
-        type.addBlock(taxesBlock_Format01);
-        taxesBlock_Format01.set(new Transaction<AccountTransaction>()
-
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
-
-                        .section("date", "amount", "type") //
-                        .documentContext("year", "currency") //
-                        .match("^STEUER [\\d]{2}\\.[\\d]{2}\\. [\\d]+ (?<date>[\\d]{2}\\.[\\d]{2}\\.) (?<amount>[\\.,\\d]+)(?<type>[\\-|\\+])$") //
-                        .assign((t, v) -> {
-                            // @formatter:off
-                            // Is type --> "S" change from TAXES to TAX_REFUND
-                            // @formatter:on
-                            if ("+".equals(v.get("type")))
-                                t.setType(AccountTransaction.Type.TAX_REFUND);
-
-                            t.setDateTime(asDate(v.get("date") + v.get("year")));
-                            t.setCurrencyCode(v.get("currency"));
-                            t.setAmount(asAmount(v.get("amount")));
-                        })
-
-                        .wrap(TransactionItem::new));
-
-        // @formatter:off
-        // SUMME STEUERN 68,98 S
-        // @formatter:on
-        Block taxesBlock_Format02 = new Block("^SUMME STEUERN [\\.,\\d]+ [H|S]$");
-        type.addBlock(taxesBlock_Format02);
-        taxesBlock_Format02.set(new Transaction<AccountTransaction>()
-
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
-
-                        .section("amount", "type") //
-                        .documentContext("currency", "date") //
-                        .match("^SUMME STEUERN (?<amount>[\\.,\\d]+) (?<type>[H|S])$") //
-                        .assign((t, v) -> {
-                            // @formatter:off
-                            // Is type --> "S" change from TAX_REFUND to TAXES
-                            // @formatter:on
-                            if ("S".equals(v.get("type")))
-                                t.setType(AccountTransaction.Type.TAXES);
-
-                            t.setDateTime(asDate(v.get("date")));
-                            t.setCurrencyCode(v.get("currency"));
-                            t.setAmount(asAmount(v.get("amount")));
+                                if (t.getType() == AccountTransaction.Type.INTEREST)
+                                    t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
+                                else
+                                    t.setMonetaryAmount(t.getMonetaryAmount().add(tax));
+                            }
                         })
 
                         .wrap(TransactionItem::new));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
@@ -570,6 +570,8 @@ import name.abuchen.portfolio.model.TypedMap;
         private String[] attributes;
         /** attributes mixed in from the document context */
         private String[] documentAttributes;
+        /** attributes mixed in from the document context optionally */
+        private String[] documentAttributesOptionally;
         /** attributes mixed in from the document matched in the given range */
         private String[] rangeAttributes;
 
@@ -602,6 +604,12 @@ import name.abuchen.portfolio.model.TypedMap;
         public Section<T> documentContext(String... documentAttributes)
         {
             this.documentAttributes = documentAttributes;
+            return this;
+        }
+
+        public Section<T> documentContextOptionally(String... documentAttributesOptionally)
+        {
+            this.documentAttributesOptionally = documentAttributesOptionally;
             return this;
         }
 
@@ -685,6 +693,16 @@ import name.abuchen.portfolio.model.TypedMap;
                                 }
 
                                 values.put(attribute, documentContext.get(attribute));
+                            }
+                        }
+
+                        // enrich extracted values with context values (Optionally)
+                        if (documentAttributesOptionally != null)
+                        {
+                            for (String attribute : documentAttributesOptionally)
+                            {
+                                if (documentContext.containsKey(attribute))
+                                    values.put(attribute, documentContext.get(attribute));
                             }
                         }
 


### PR DESCRIPTION
Previously, taxes were posted separately for interest transactions on account statements.
These are now offset together and imported as one transaction.