### PR TITLE
Improve akf bank GmbH PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/akfbank/AkfBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/akfbank/AkfBankPDFExtractorTest.java
@@ -4,17 +4,20 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.fee;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interest;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 import java.util.ArrayList;
@@ -323,25 +326,17 @@ public class AkfBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(4L));
-        assertThat(results.size(), is(4));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2023-09-30"), hasAmount("EUR", 1.03), //
-                        hasSource("Kontoauszug13.txt"), hasNote("31.08.2023 - 30.09.2023 (2,000 %)"))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2023-09-30"), hasAmount("EUR", 0.25), //
-                        hasSource("Kontoauszug13.txt"), hasNote("Abgeltungssteuer (1,03 EUR)"))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2023-09-30"), hasAmount("EUR", 0.01), //
-                        hasSource("Kontoauszug13.txt"), hasNote("Solidaritätszuschlag (0,25 EUR)"))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2023-09-30"), hasAmount("EUR", 0.02), //
-                        hasSource("Kontoauszug13.txt"), hasNote("Kirchensteuer (0,25 EUR)"))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2023-09-30"), hasShares(0), //
+                        hasSource("Kontoauszug13.txt"), //
+                        hasNote("31.08.2023 - 30.09.2023 (2,000 %)"), //
+                        hasAmount("EUR", 0.75), hasGrossValue("EUR", 1.03), //
+                        hasTaxes("EUR", (0.25 + 0.01 + 0.02)), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -356,28 +351,28 @@ public class AkfBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(6L));
-        assertThat(results.size(), is(6));
+        assertThat(countAccountTransactions(results), is(3L));
+        assertThat(results.size(), is(3));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2024-08-21"), hasAmount("EUR", 2.26), //
-                        hasSource("Kontoauszug14.txt"), hasNote("30.12.2023 - 21.08.2024 (3,550 %)"))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2024-08-21"), hasShares(0), //
+                        hasSource("Kontoauszug14.txt"), //
+                        hasNote("30.12.2023 - 21.08.2024 (3,550 %)"), //
+                        hasAmount("EUR", 2.26), hasGrossValue("EUR", 2.26), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2024-08-21"), hasAmount("EUR", 1.26), //
-                        hasSource("Kontoauszug14.txt"), hasNote("21.08.2023 - 30.12.2023 (3,550 %)"))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2024-08-21"), hasShares(0), //
+                        hasSource("Kontoauszug14.txt"), //
+                        hasNote("21.08.2023 - 30.12.2023 (3,550 %)"), //
+                        hasAmount("EUR", 0.28), hasGrossValue("EUR", 1.26), //
+                        hasTaxes("EUR", (0.86 + 0.05 + 0.07)), hasFees("EUR", 0.00))));
 
         // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2024-08-21"), hasAmount("EUR", 0.86), //
-                        hasSource("Kontoauszug14.txt"), hasNote("Abgeltungssteuer (3,52 EUR)"))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2024-08-21"), hasAmount("EUR", 0.05), //
-                        hasSource("Kontoauszug14.txt"), hasNote("Solidaritätszuschlag (0,86 EUR)"))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2024-08-21"), hasAmount("EUR", 0.07), //
-                        hasSource("Kontoauszug14.txt"), hasNote("Kirchensteuer (0,86 EUR)"))));
+        assertThat(results, hasItem(removal(hasDate("2024-08-21"), hasAmount("EUR", 101.54), //
+                        hasSource("Kontoauszug14.txt"), hasNote("Festgeld Anlage"))));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AkfBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AkfBankPDFExtractor.java
@@ -6,6 +6,8 @@ import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.AccountTransaction.Type;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.Transaction.Unit;
+import name.abuchen.portfolio.money.Money;
 
 @SuppressWarnings("nls")
 public class AkfBankPDFExtractor extends AbstractPDFExtractor
@@ -111,15 +113,8 @@ public class AkfBankPDFExtractor extends AbstractPDFExtractor
 
                         .wrap(TransactionItem::new));
 
-        // @formatter:off
-        // 02 30.11.2012 / 30.11.2012 Kontoabschluß 2,71
-        // Habenzinsen
-        // v. 31.10.2012 b. 30.11.2012
-        // Zinsen zu 2,150
-        // @formatter:on
         Block interestBlock = new Block("^[\\d]{2} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} \\/ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Kontoabschlu. [\\.,\\d]+$");
         type.addBlock(interestBlock);
-        interestBlock.setMaxSize(4);
         interestBlock.set(new Transaction<AccountTransaction>()
 
                         .subject(() -> {
@@ -128,11 +123,17 @@ public class AkfBankPDFExtractor extends AbstractPDFExtractor
                             return accountTransaction;
                         })
 
+                        // @formatter:off
+                        // 02 30.11.2012 / 30.11.2012 Kontoabschluß 2,71
+                        // Habenzinsen
+                        // v. 31.10.2012 b. 30.11.2012
+                        // Zinsen zu 2,150
+                        // @formatter:on
                         .section("date", "amount", "note1", "note2", "note3") //
                         .documentContext("currency") //
                         .match("^[\\d]{2} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) \\/ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Kontoabschlu. (?<amount>[\\.,\\d]+)$") //
-                        .match("v\\. (?<note1>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) b\\. (?<note2>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$")
-                        .match("Zinsen zu[\\s]{1,}(?<note3>[\\.,\\d]+).*$")
+                        .match("^v\\. (?<note1>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) b\\. (?<note2>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$") //
+                        .match("^Zinsen zu[\\s]{1,}(?<note3>[\\.,\\d]+).*$")
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -140,41 +141,51 @@ public class AkfBankPDFExtractor extends AbstractPDFExtractor
                             t.setNote(v.get("note1") + " - " + v.get("note2") + " (" + v.get("note3") + " %)");
                         })
 
-                        .wrap(TransactionItem::new));
-
-        Block taxesBlock = new Block("^[\\d]{2} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} \\/ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Kontoabschlu. \\-[\\.,\\d]+$");
-        type.addBlock(taxesBlock);
-        taxesBlock.setMaxSize(3);
-        taxesBlock.set(new Transaction<AccountTransaction>()
-
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
-
                         // @formatter:off
                         // 02 30.09.2023 / 30.09.2023 Kontoabschluß -0,25
                         // Abgeltungssteuer
-                        // aus EUR                1,03
-                        //
+                        // @formatter:on
+                        .section("tax").optional() //
+                        .documentContext("currency") //
+                        .match("^[\\d]{2} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} \\/ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Kontoabschlu. \\-(?<tax>[\\.,\\d]+)$") //
+                        .match("^Abgeltungssteuer.*$") //
+                        .assign((t, v) -> {
+                            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            t.addUnit(new Unit(Unit.Type.TAX, tax));
+
+                            t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
+                        })
+
+                        // @formatter:off
                         // 03 30.09.2023 / 30.09.2023 Kontoabschluß -0,01
                         // Solidaritätszuschlag
-                        // aus EUR                0,25
-                        //
+                        // @formatter:on
+                        .section("tax").optional() //
+                        .documentContext("currency") //
+                        .find("Abgeltungssteuer.*") //
+                        .match("^[\\d]{2} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) \\/ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Kontoabschlu. \\-(?<tax>[\\.,\\d]+)$") //
+                        .match("^Solidarit.tszuschlag.*$") //
+                        .assign((t, v) -> {
+                            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            t.addUnit(new Unit(Unit.Type.TAX, tax));
+
+                            t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
+                        })
+
+                        // @formatter:off
                         // 04 30.09.2023 / 30.09.2023 Kontoabschluß -0,02
                         // Kirchensteuer
-                        // aus EUR                0,25
                         // @formatter:on
-                        .section("date", "tax", "note", "currency", "taxAmount") //
+                        .section("tax").optional() //
+                        .documentContext("currency") //
+                        .find("Solidarit.tszuschlag.*") //
                         .match("^[\\d]{2} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) \\/ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Kontoabschlu. \\-(?<tax>[\\.,\\d]+)$") //
-                        .match("^(?<note>(Abgeltungssteuer|Solidarit.tszuschlag|Kirchensteuer)).*$")
-                        .match("^aus (?<currency>[\\w]{3})[\\s]{1,}(?<taxAmount>[\\.,\\d]+).*$")
+                        .match("^Kirchensteuer.*$") //
                         .assign((t, v) -> {
-                            t.setDateTime(asDate(v.get("date")));
-                            t.setAmount(asAmount(v.get("tax")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                            t.setNote(v.get("note") + " (" + v.get("taxAmount") + " " + v.get("currency") + ")");
+                            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            t.addUnit(new Unit(Unit.Type.TAX, tax));
+
+                            t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
                         })
 
                         .wrap(TransactionItem::new));


### PR DESCRIPTION
Previously, taxes were posted separately for interest transactions on account statements. 
These are now offset together and imported as one transaction.