### PR TITLE
Improve ABN AMRO Group PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/abnamrogroup/ABNAMROGroupPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/abnamrogroup/ABNAMROGroupPDFExtractorTest.java
@@ -3,17 +3,20 @@ package name.abuchen.portfolio.datatransfer.pdf.abnamrogroup;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interest;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 import java.util.ArrayList;
@@ -48,26 +51,37 @@ public class ABNAMROGroupPDFExtractorTest
         assertThat(results.size(), is(7));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2011-10-19"), hasAmount("EUR", 100.00), //
                         hasSource("Kontoauszug01.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2011-10-27"), hasAmount("EUR", 2900.00), //
                         hasSource("Kontoauszug01.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2011-11-16"), hasAmount("EUR", 40500.00), //
                         hasSource("Kontoauszug01.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(removal(hasDate("2011-12-16"), hasAmount("EUR", 2000.00), //
                         hasSource("Kontoauszug01.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2011-12-21"), hasAmount("EUR", 1500.00), //
                         hasSource("Kontoauszug01.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2011-12-23"), hasAmount("EUR", 3000.00), //
                         hasSource("Kontoauszug01.txt"), hasNote(null))));
 
-        assertThat(results, hasItem(interest(hasDate("2012-01-01"), hasAmount("EUR", 114.34), //
-                        hasSource("Kontoauszug01.txt"), hasNote(null))));
+        // assert transaction
+        assertThat(results, hasItem(interest( //
+                        hasDate("2012-01-01"), hasShares(0), //
+                        hasSource("Kontoauszug01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 114.34), hasGrossValue("EUR", 114.34), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -82,84 +96,124 @@ public class ABNAMROGroupPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(25L));
-        assertThat(results.size(), is(25));
+        assertThat(countAccountTransactions(results), is(23L));
+        assertThat(results.size(), is(23));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2011-10-19"), hasAmount("EUR", 100.00), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2011-10-27"), hasAmount("EUR", 2900.00), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2011-11-16"), hasAmount("EUR", 40500.00), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(removal(hasDate("2011-12-16"), hasAmount("EUR", 2000.00), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2011-12-21"), hasAmount("EUR", 1500.00), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2011-12-23"), hasAmount("EUR", 3000.00), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
-        assertThat(results, hasItem(interest(hasDate("2012-01-01"), hasAmount("EUR", 114.34), //
-                        hasSource("Kontoauszug02.txt"), hasNote(null))));
+        // assert transaction
+        assertThat(results, hasItem(interest( //
+                        hasDate("2012-01-01"), hasShares(0), //
+                        hasSource("Kontoauszug02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 114.34), hasGrossValue("EUR", 114.34), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2012-02-24"), hasAmount("EUR", 2500.00), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2012-02-27"), hasAmount("EUR", 1500.00), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(removal(hasDate("2012-03-12"), hasAmount("EUR", 91.72), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(removal(hasDate("2012-03-22"), hasAmount("EUR", 406.88), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2012-03-29"), hasAmount("EUR", 384.26), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
-        assertThat(results, hasItem(interest(hasDate("2012-04-01"), hasAmount("EUR", 325.73), //
-                        hasSource("Kontoauszug02.txt"), hasNote(null))));
+        // assert transaction
+        assertThat(results, hasItem(interest( //
+                        hasDate("2012-04-01"), hasShares(0), //
+                        hasSource("Kontoauszug02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 325.73), hasGrossValue("EUR", 325.73), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
+        // assert transaction
         assertThat(results, hasItem(removal(hasDate("2012-04-11"), hasAmount("EUR", 50000.00), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
-        assertThat(results, hasItem(interest(hasDate("2012-07-01"), hasAmount("EUR", 39.66), //
-                        hasSource("Kontoauszug02.txt"), hasNote(null))));
+        // assert transaction
+        assertThat(results, hasItem(interest( //
+                        hasDate("2012-07-01"), hasShares(0), //
+                        hasSource("Kontoauszug02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 39.66), hasGrossValue("EUR", 39.66), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2012-07-18"), hasAmount("EUR", 2400.00), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2012-08-01"), hasAmount("EUR", 234.61), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(removal(hasDate("2012-08-01"), hasAmount("EUR", 3000.00), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
-        assertThat(results, hasItem(interest(hasDate("2012-10-01"), hasAmount("EUR", 3.01), //
-                        hasSource("Kontoauszug02.txt"), hasNote(null))));
+        // assert transaction
+        assertThat(results, hasItem(interest( //
+                        hasDate("2012-10-01"), hasShares(0), //
+                        hasSource("Kontoauszug02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 3.01), hasGrossValue("EUR", 3.01), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
-        assertThat(results, hasItem(interest(hasDate("2012-10-11"), hasAmount("EUR", 596.33), //
-                        hasSource("Kontoauszug02.txt"), hasNote(null))));
-
+        // assert transaction
+        assertThat(results, hasItem(interest( //
+                        hasDate("2012-10-11"), hasShares(0), //
+                        hasSource("Kontoauszug02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 596.33), hasGrossValue("EUR", 596.33), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+        // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2012-10-11"), hasAmount("EUR", 50000.00), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
+        // assert transaction
         assertThat(results, hasItem(removal(hasDate("2012-12-17"), hasAmount("EUR", 45000.00), //
                         hasSource("Kontoauszug02.txt"), hasNote(null))));
 
-        assertThat(results, hasItem(taxes(hasDate("2013-01-01"), hasAmount("EUR", 49.74), //
-                        hasSource("Kontoauszug02.txt"), hasNote(null))));
-
-        assertThat(results, hasItem(taxes(hasDate("2013-01-01"), hasAmount("EUR", 2.73), //
-                        hasSource("Kontoauszug02.txt"), hasNote(null))));
-
-        assertThat(results, hasItem(interest(hasDate("2013-01-01"), hasAmount("EUR", 198.97), //
-                        hasSource("Kontoauszug02.txt"), hasNote(null))));
+        // assert transaction
+        assertThat(results, hasItem(interest( //
+                        hasDate("2013-01-01"), hasShares(0), //
+                        hasSource("Kontoauszug02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 198.97), hasGrossValue("EUR", 251.44), //
+                        hasTaxes("EUR", 49.74 + 2.73), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -178,8 +232,12 @@ public class ABNAMROGroupPDFExtractorTest
         assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
-        assertThat(results, hasItem(interest(hasDate("2019-07-01"), hasAmount("EUR", 63.28), //
-                        hasSource("Kontoauszug03.txt"), hasNote(null))));
+        // assert transaction
+        assertThat(results, hasItem(interest( //
+                        hasDate("2019-07-01"), hasShares(0), //
+                        hasSource("Kontoauszug03.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 63.28), hasGrossValue("EUR", 63.28), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
-
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ABNAMROGroupPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ABNAMROGroupPDFExtractor.java
@@ -2,36 +2,22 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
-import name.abuchen.portfolio.datatransfer.pdf.PDFParser.ParsedData;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.Transaction.Unit;
+import name.abuchen.portfolio.money.Money;
 
 @SuppressWarnings("nls")
 public class ABNAMROGroupPDFExtractor extends AbstractPDFExtractor
 {
-    // 24.10.2011 19.10.2011 12030000-001 Zahlungseingang 100,00
-    // 11.10.2012 11.10.2012 B2D11BI5S00A Ru¨ckzahlung Ihres Festgeldes
-    // 50.000,00
-    private static final String DEPOSIT = "^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .* (Zahlungseingang|Ru.ckzahlung Ihres Festgeldes)[\\s]{1,}(?<amount>[\\.,\\d]+)";
-    // 16.12.2011 16.12.2011 12030000-001 Zahlungsausgang 2.000,00
-    // 11.04.2012 11.04.2012 B2D11BI5S00A Abschluss eines Festgeldes 50.000,00
-    private static final String REMOVAL = "^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .* (Zahlungsausgang|Abschluss eines Festgeldes)[\\s]{1,}(?<amount>[\\.,\\d]+)";
-    // 28.06.2019 01.07.2019 DE5050324040 Ihre Zinsabrechnung 63,28
-    // 30.12.2011 01.01.2012 5000510765 Ihre Tagesgeldzinsen 114,34
-    // 11.10.2012 11.10.2012 B2D11BI5S00A Zinszahlung Festgeld 596,33
-    private static final String INTEREST = "^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .* (Ihre (Zinsabrechnung|Tagesgeldzinsen)|Zinszahlung Festgeld)[\\s]{1,}(?<amount>[\\.,\\d]+)";
-    // 31.12.2012 01.01.2013 1000130541 Abgeltungssteuer 49,74
-    // 31.12.2012 01.01.2013 1000130541 Solidarita¨tszuschlag 2,73
-    private static final String TAXES = "^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .* (Abgeltungssteuer|Solidarita.tszuschlag)[\\s]{1,}(?<amount>[\\.,\\d]+)";
-
     public ABNAMROGroupPDFExtractor(Client client)
     {
         super(client);
 
         addBankIdentifier("ABN AMRO Bank N.V.");
 
-        addTransactions();
+        addAccountStatementTransaction();
     }
 
     @Override
@@ -40,48 +26,71 @@ public class ABNAMROGroupPDFExtractor extends AbstractPDFExtractor
         return "ABN AMRO Group / MoneYou";
     }
 
-    private void addTransactions()
+    private void addAccountStatementTransaction()
     {
         final DocumentType type = new DocumentType("Kontoauszug", //
                         documentContext -> documentContext //
-                        .oneOf( //
-                                        // @formatter:off
-                                        // Tagesgeldkonto (alle Betra¨ge in EUR) 63,28 28.06.2019 85.288,02
-                                        // @formatter:on
-                                        section -> section.attributes("currency") //
-                                        .match("^Tagesgeldkonto \\(alle Betr.* in (?<currency>[\\w]{3}).*$") //
-                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency"))))
-                                        ,
-                                        // @formatter:off
-                                        // Tagesgeldkonto 100,00 24.10.2011 100,00
-                                        // @formatter:on
-                                        section -> section.attributes("currency") //
-                                        .match("^Tagesgeldkonto (?<currency>.*)$") //
-                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode("EUR"))))
-                        );
+                                        .oneOf( //
+                                                        // @formatter:off
+                                                        // Tagesgeldkonto (alle Betra¨ge in EUR) 63,28 28.06.2019 85.288,02
+                                                        // @formatter:on
+                                                        section -> section //
+                                                                        .attributes("currency") //
+                                                                        .match("^Tagesgeldkonto \\(alle Betr.* in (?<currency>[\\w]{3})\\).*$") //
+                                                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency")))),
+                                                        // @formatter:off
+                                                        // Tagesgeldkonto 100,00 24.10.2011 100,00
+                                                        // @formatter:on
+                                                        section -> section //
+                                                                        .attributes("currency") //
+                                                                        .match("^Tagesgeldkonto (?<currency>.*)$") //
+                                                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode("EUR"))))
+
+                                        .optionalOneOf( //
+                                                        // @formatter:off
+                                                        // 31.12.2012 01.01.2013 5000510765 Abgeltungssteuer 49,74
+                                                        // @formatter:on
+                                                        section -> section //
+                                                                        .attributes("taxDate1", "tax1").multipleTimes() //
+                                                                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<taxDate1>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .* Abgeltungssteuer[\\s]{1,}(?<tax1>[\\.,\\d]+)$") //
+                                                                        .assign((ctx, v) -> {
+                                                                            ctx.put("taxDate1", v.get("taxDate1"));
+                                                                            ctx.put("tax1", v.get("tax1"));
+                                                                        }))
+
+                                        .optionalOneOf( //
+                                                        // @formatter:off
+                                                        // 31.12.2012 01.01.2013 5000510765 Solidarita¨tszuschlag 2,73
+                                                        // @formatter:on
+                                                        section -> section //
+                                                                        .attributes("taxDate2", "tax2") //
+                                                                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<taxDate2>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .* Solidarit.*tszuschlag[\\s]{1,}(?<tax2>[\\.,\\d]+)$") //
+                                                                        .assign((ctx, v) -> {
+                                                                            ctx.put("taxDate2", v.get("taxDate2"));
+                                                                            ctx.put("tax2", v.get("tax2"));
+                                                                        }))
+
+                                        .optionalOneOf( //
+                                                        // @formatter:off
+                                                        // 31.12.2012 01.01.2013 5000510765 Kirchensteuer X,XX
+                                                        // @formatter:on
+                                                        section -> section //
+                                                                        .attributes("taxDate3", "tax3") //
+                                                                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<taxDate3>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .* Kirchensteuer[\\s]{1,}(?<tax3>[\\.,\\d]+)$") //
+                                                                        .assign((ctx, v) -> {
+                                                                            ctx.put("taxDate3", v.get("taxDate3"));
+                                                                            ctx.put("tax3", v.get("tax3"));
+                                                                        })));
 
         this.addDocumentTyp(type);
 
-        Block depositBlock = new Block(DEPOSIT);
-        depositBlock.set(depositTransaction(type, DEPOSIT));
+        // @formatter:off
+        // 24.10.2011 19.10.2011 12030000-001 Zahlungseingang 100,00
+        // 11.10.2012 11.10.2012 B2D11BI5S00A Ru¨ckzahlung Ihres Festgeldes 50.000,00
+        // @formatter:on
+        Block depositBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} .* (Zahlungseingang|Ru.ckzahlung Ihres Festgeldes)[\\s]{1,}[\\.,\\d]+$");
         type.addBlock(depositBlock);
-
-        Block removalBlock = new Block(REMOVAL);
-        removalBlock.set(removalTransaction(type, REMOVAL));
-        type.addBlock(removalBlock);
-
-        Block interestBlock = new Block(INTEREST);
-        interestBlock.set(interestTransaction(type, INTEREST));
-        type.addBlock(interestBlock);
-
-        Block taxesBlock = new Block(TAXES);
-        taxesBlock.set(taxesTransaction(type, TAXES));
-        type.addBlock(taxesBlock);
-    }
-
-    private Transaction<AccountTransaction> depositTransaction(DocumentType type, String regex)
-    {
-        return new Transaction<AccountTransaction>()
+        depositBlock.set(new Transaction<AccountTransaction>()
 
                         .subject(() -> {
                             AccountTransaction accountTransaction = new AccountTransaction();
@@ -91,17 +100,26 @@ public class ABNAMROGroupPDFExtractor extends AbstractPDFExtractor
 
                         .section("date", "amount") //
                         .documentContext("currency") //
-                        .match(regex) //
+                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} " //
+                                        + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .* " //
+                                        + "(Zahlungseingang" //
+                                        + "|Ru.ckzahlung Ihres Festgeldes)[\\s]{1,}" //
+                                        + "(?<amount>[\\.,\\d]+)$")
                         .assign((t, v) -> {
-                            assignmentsProvider(t, v);
+                            t.setDateTime(asDate(v.get("date")));
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setCurrencyCode(v.get("currency"));
                         })
 
-                        .wrap(TransactionItem::new);
-    }
+                        .wrap(TransactionItem::new));
 
-    private Transaction<AccountTransaction> removalTransaction(DocumentType type, String regex)
-    {
-        return new Transaction<AccountTransaction>()
+        // @formatter:off
+        // 16.12.2011 16.12.2011 12030000-001 Zahlungsausgang 2.000,00
+        // 11.04.2012 11.04.2012 B2D11BI5S00A Abschluss eines Festgeldes 50.000,0
+        // @formatter:on
+        Block removalBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} .* (Zahlungsausgang|Abschluss eines Festgeldes)[\\s]{1,}[\\.,\\d]+$");
+        type.addBlock(removalBlock);
+        removalBlock.set(new Transaction<AccountTransaction>()
 
                         .subject(() -> {
                             AccountTransaction accountTransaction = new AccountTransaction();
@@ -111,17 +129,30 @@ public class ABNAMROGroupPDFExtractor extends AbstractPDFExtractor
 
                         .section("date", "amount") //
                         .documentContext("currency") //
-                        .match(regex) //
+                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .* " //
+                                        + "(Zahlungsausgang" //
+                                        + "|Abschluss eines Festgeldes)[\\s]{1,}" //
+                                        + "(?<amount>[\\.,\\d]+)$")
                         .assign((t, v) -> {
-                            assignmentsProvider(t, v);
+                            t.setDateTime(asDate(v.get("date")));
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setCurrencyCode(v.get("currency"));
                         })
 
-                        .wrap(TransactionItem::new);
-    }
+                        .wrap(TransactionItem::new));
 
-    private Transaction<AccountTransaction> interestTransaction(DocumentType type, String regex)
-    {
-        return new Transaction<AccountTransaction>()
+        // @formatter:off
+        // 28.06.2019 01.07.2019 DE5050324040 Ihre Zinsabrechnung 63,28
+        // 30.12.2011 01.01.2012 5000510765 Ihre Tagesgeldzinsen 114,34
+        // 11.10.2012 11.10.2012 B2D11BI5S00A Zinszahlung Festgeld 596,33
+        //
+        // 31.12.2012 01.01.2013 5000510765 Abgeltungssteuer 49,74
+        // 31.12.2012 01.01.2013 5000510765 Solidarita¨tszuschlag 2,73
+        // 31.12.2012 01.01.2013 5000510765 Ihre Tagesgeldzinsen 198,97
+        // @formatter:on
+        Block interestBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} .* (Ihre (Zinsabrechnung|Tagesgeldzinsen)|Zinszahlung Festgeld)[\\s]{1,}[\\.,\\d]+$");
+        type.addBlock(interestBlock);
+        interestBlock.set(new Transaction<AccountTransaction>()
 
                         .subject(() -> {
                             AccountTransaction accountTransaction = new AccountTransaction();
@@ -131,38 +162,38 @@ public class ABNAMROGroupPDFExtractor extends AbstractPDFExtractor
 
                         .section("date", "amount") //
                         .documentContext("currency") //
-                        .match(regex) //
+                        .documentContextOptionally("taxDate1", "taxDate2", "taxDate3", "tax1", "tax2", "tax3")
+                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .* " //
+                                        + "(Ihre (Zinsabrechnung|Tagesgeldzinsen)" //
+                                        + "|Zinszahlung Festgeld)[\\s]{1,}" //
+                                        + "(?<amount>[\\.,\\d]+)$")
                         .assign((t, v) -> {
-                            assignmentsProvider(t, v);
+                            t.setDateTime(asDate(v.get("date")));
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setCurrencyCode(v.get("currency"));
+
+                            if (v.containsKey("taxDate1") && v.containsKey("tax1")
+                                            && t.getDateTime().equals(asDate(v.get("taxDate1"))))
+                            {
+                                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax1")));
+                                t.addUnit(new Unit(Unit.Type.TAX, tax));
+                            }
+
+                            if (v.containsKey("taxDate2") && v.containsKey("tax2")
+                                            && t.getDateTime().equals(asDate(v.get("taxDate2"))))
+                            {
+                                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax2")));
+                                t.addUnit(new Unit(Unit.Type.TAX, tax));
+                            }
+
+                            if (v.containsKey("taxDate3") && v.containsKey("tax3")
+                                            && t.getDateTime().equals(asDate(v.get("taxDate3"))))
+                            {
+                                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax3")));
+                                t.addUnit(new Unit(Unit.Type.TAX, tax));
+                            }
                         })
 
-                        .wrap(TransactionItem::new);
-    }
-
-    private Transaction<AccountTransaction> taxesTransaction(DocumentType type, String regex)
-    {
-        return new Transaction<AccountTransaction>()
-
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
-
-                        .section("date", "amount") //
-                        .documentContext("currency") //
-                        .match(regex) //
-                        .assign((t, v) -> {
-                            assignmentsProvider(t, v);
-                        })
-
-                        .wrap(TransactionItem::new);
-    }
-
-    private void assignmentsProvider(AccountTransaction t, ParsedData v)
-    {
-        t.setDateTime(asDate(v.get("date")));
-        t.setAmount(asAmount(v.get("amount")));
-        t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                        .wrap(TransactionItem::new));
     }
 }


### PR DESCRIPTION
Previously, taxes were posted separately for interest transactions on account statements. 
These are now offset together and imported as one transaction.