### PR TITLE
Improve C24 Bank GmbH PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/c24bankgmbh/C24BankGmbHPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/c24bankgmbh/C24BankGmbHPDFExtractorTest.java
@@ -3,17 +3,20 @@ package name.abuchen.portfolio.datatransfer.pdf.c24bankgmbh;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interest;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 import java.util.ArrayList;
@@ -68,17 +71,17 @@ public class C24BankGmbHPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(3L));
-        assertThat(results.size(), is(3));
+        assertThat(countAccountTransactions(results), is(2L));
+        assertThat(results.size(), is(2));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2024-05-31"), hasAmount("EUR", 2.29), //
-                        hasSource("Kontoauszug02.txt"), hasNote("Steuern"))));
-
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2024-05-31"), hasAmount("EUR", 1.93), //
-                        hasSource("Kontoauszug02.txt"), hasNote("Zinsen"))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2024-05-31"), hasShares(0), //
+                        hasSource("Kontoauszug02.txt"), //
+                        hasNote("Zinsen"), //
+                        hasAmount("EUR", 1.93), hasGrossValue("EUR", 4.22), //
+                        hasTaxes("EUR", 2.29), hasFees("EUR", 0.00))));
 
         // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2024-05-17"), hasAmount("EUR", 1460.11), //
@@ -97,17 +100,17 @@ public class C24BankGmbHPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(2L));
-        assertThat(results.size(), is(2));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2024-06-30"), hasAmount("EUR", 4.04), //
-                        hasSource("Kontoauszug03.txt"), hasNote("Steuern"))));
-
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2024-06-30"), hasAmount("EUR", 15.32), //
-                        hasSource("Kontoauszug03.txt"), hasNote("Zinsen"))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2024-06-30"), hasShares(0), //
+                        hasSource("Kontoauszug03.txt"), //
+                        hasNote("Zinsen"), //
+                        hasAmount("EUR", 15.32), hasGrossValue("EUR", 19.36), //
+                        hasTaxes("EUR", 4.04), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -122,17 +125,17 @@ public class C24BankGmbHPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(2L));
-        assertThat(results.size(), is(2));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(1));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2024-07-31"), hasAmount("EUR", 4.18), //
-                        hasSource("Kontoauszug04.txt"), hasNote("Steuern"))));
-
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2024-07-31"), hasAmount("EUR", 15.86), //
-                        hasSource("Kontoauszug04.txt"), hasNote("Zinsen"))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2024-07-31"), hasShares(0), //
+                        hasSource("Kontoauszug04.txt"), //
+                        hasNote("Zinsen"), //
+                        hasAmount("EUR", 15.86), hasGrossValue("EUR", 20.04), //
+                        hasTaxes("EUR", 4.18), hasFees("EUR", 0.00))));
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/C24BankGmbHPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/C24BankGmbHPDFExtractor.java
@@ -5,6 +5,8 @@ import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.Transaction.Unit;
+import name.abuchen.portfolio.money.Money;
 
 @SuppressWarnings("nls")
 public class C24BankGmbHPDFExtractor extends AbstractPDFExtractor
@@ -35,7 +37,22 @@ public class C24BankGmbHPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         .section("year") //
                                         .match("^(Vorl.ufiger )?Kontoauszug [\\d]{2}\\/(?<year>[\\d]{4}) .*$") //
-                                        .assign((ctx, v) -> ctx.put("year", v.get("year"))));
+                                        .assign((ctx, v) -> ctx.put("year", v.get("year")))
+
+
+                                        .optionalOneOf( //
+                                                        // @formatter:off
+                                                        // 31.05. 31.05. Steuern - 2,29 €
+                                                        // @formatter:on
+                                                        section -> section //
+                                                                        .attributes("year", "taxDate", "tax", "taxCurrency") //
+                                                                        .match("^(Vorl.ufiger )?Kontoauszug [\\d]{2}\\/(?<year>[\\d]{4}) .*$") //
+                                                                        .match("^(?<taxDate>[\\d]{2}\\.[\\d]{2}\\.) [\\d]{2}\\.[\\d]{2}\\. Steuern [\\-|\\+] (?<tax>[\\.,\\d]+) (?<taxCurrency>\\p{Sc}).*$") //
+                                                                        .assign((ctx, v) -> {
+                                                                            ctx.put("taxDate", v.get("taxDate") + v.get("year"));
+                                                                            ctx.put("tax", v.get("tax"));
+                                                                            ctx.put("taxCurrency", v.get("taxCurrency"));
+                                                                        })));
 
         this.addDocumentTyp(type);
 
@@ -68,7 +85,7 @@ public class C24BankGmbHPDFExtractor extends AbstractPDFExtractor
                                         + "(?<type>[\\-|\\+]) " //
                                         + "(?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}).*$") //
                         .assign((t, v) -> {
-                            // Is sign --> "-" change from DEPOSIT to REMOVAL
+                            // Is type --> "-" change from DEPOSIT to REMOVAL
                             if ("-".equals(v.get("type")))
                                 t.setType(AccountTransaction.Type.REMOVAL);
 
@@ -95,12 +112,13 @@ public class C24BankGmbHPDFExtractor extends AbstractPDFExtractor
 
                         .section("date", "note", "type", "amount", "currency") //
                         .documentContext("year") //
+                        .documentContextOptionally("taxDate", "tax", "taxCurrency") //)
                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.) [\\d]{2}\\.[\\d]{2}\\. " //
                                         + "(?<note>Zinsen) " //
                                         + "(?<type>[\\-|\\+]) " //
                                         + "(?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}).*$") //
                         .assign((t, v) -> {
-                            // Is sign --> "-" change from INTEREST to INTEREST_CHARGE
+                            // Is type --> "-" change from INTEREST to INTEREST_CHARGE
                             if ("-".equals(v.get("type")))
                                 t.setType(AccountTransaction.Type.INTEREST_CHARGE);
 
@@ -108,38 +126,13 @@ public class C24BankGmbHPDFExtractor extends AbstractPDFExtractor
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setNote(v.get("note"));
-                        })
 
-                        .wrap(TransactionItem::new));
-
-        // @formatter:off
-        // 30.06. 30.06. Steuern - 4,04 €
-        // @formatter:on
-        Block taxesBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. Steuern [\\-|\\+] [\\.,\\d]+ \\p{Sc}.*$");
-        type.addBlock(taxesBlock);
-        taxesBlock.set(new Transaction<AccountTransaction>()
-
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
-
-                        .section("date", "note", "type", "amount", "currency") //
-                        .documentContext("year") //
-                        .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.) [\\d]{2}\\.[\\d]{2}\\. " //
-                                        + "(?<note>Steuern) " //
-                                        + "(?<type>[\\-|\\+]) " //
-                                        + "(?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}).*$") //
-                        .assign((t, v) -> {
-                            // Is sign --> "-" change from TAXES to TAX_REFUND
-                            if ("-".equals(v.get("type")))
-                                t.setType(AccountTransaction.Type.TAXES);
-
-                            t.setDateTime(asDate(v.get("date") + v.get("year")));
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                            t.setNote(v.get("note"));
+                            if (v.containsKey("tax") && v.containsKey("taxCurrency")
+                                            && t.getDateTime().equals(asDate(v.get("taxDate"))))
+                            {
+                                Money tax = Money.of(asCurrencyCode(v.get("taxCurrency")), asAmount(v.get("tax")));
+                                t.addUnit(new Unit(Unit.Type.TAX, tax));
+                            }
                         })
 
                         .wrap(TransactionItem::new));


### PR DESCRIPTION
Previously, taxes were posted separately for interest transactions on account statements. 
These are now offset together and imported as one transaction.