### PR TITLE
Improve IngDiBa PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
@@ -3841,12 +3841,12 @@ public class INGDiBaPDFExtractorTest
         List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "GiroKontoauszug02.txt"), errors);
 
         assertThat(errors, empty());
-        assertThat(results.size(), is(9));
+        assertThat(results.size(), is(5));
 
         // check transaction
         // get transactions
         Iterator<Extractor.Item> iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(9L));
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(5L));
 
         Item item = iter.next();
 
@@ -3892,60 +3892,13 @@ public class INGDiBaPDFExtractorTest
         assertThat(transaction.getSource(), is("GiroKontoauszug02.txt"));
         assertThat(transaction.getNote(), is("Gutschrift"));
 
-        item = iter.next();
-
         // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
-        assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-06-14T00:00")));
-        assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.40)));
-        assertThat(transaction.getSource(), is("GiroKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("01.01.2016 bis 14.06.2016 (0,50%)"));
-
-        item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
-        assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-12-31T00:00")));
-        assertThat(transaction.getAmount(), is(Values.Amount.factorize(5.22)));
-        assertThat(transaction.getSource(), is("GiroKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("15.06.2016 bis 31.12.2016 (0,35%)"));
-
-        item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.TAXES));
-        assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-12-30T00:00")));
-        assertThat(transaction.getAmount(), is(Values.Amount.factorize(1.38)));
-        assertThat(transaction.getSource(), is("GiroKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("Kapitalertragsteuer"));
-
-        item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.TAXES));
-        assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-12-30T00:00")));
-        assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.07)));
-        assertThat(transaction.getSource(), is("GiroKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("Solidaritätszuschlag"));
-
-        item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.TAXES));
-        assertThat(transaction.getCurrencyCode(), is(CurrencyUnit.EUR));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-12-30T00:00")));
-        assertThat(transaction.getAmount(), is(Values.Amount.factorize(0.11)));
-        assertThat(transaction.getSource(), is("GiroKontoauszug02.txt"));
-        assertThat(transaction.getNote(), is("Kirchensteuer"));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2016-12-30"), hasShares(0), //
+                        hasSource("GiroKontoauszug02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 0.40 + 5.22), hasGrossValue("EUR", 7.18), //
+                        hasTaxes("EUR", (1.38 + 0.07 + 0.11)), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -4061,8 +4014,12 @@ public class INGDiBaPDFExtractorTest
                         hasSource("ExtraKontoauszug01.txt"), hasNote("Gutschrift"))));
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2023-12-31"), hasAmount("EUR", 0.01), //
-                        hasSource("ExtraKontoauszug01.txt"), hasNote("16.12.2023 bis 31.12.2023 (3,750%)"))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2023-12-29"), hasShares(0), //
+                        hasSource("ExtraKontoauszug01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 0.01), hasGrossValue("EUR", 0.01), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -4077,8 +4034,8 @@ public class INGDiBaPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(15L));
-        assertThat(results.size(), is(15));
+        assertThat(countAccountTransactions(results), is(13L));
+        assertThat(results.size(), is(13));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transactions
@@ -4129,21 +4086,13 @@ public class INGDiBaPDFExtractorTest
         assertThat(results, hasItem(deposit(hasDate("2022-12-02"), hasAmount("EUR", 50.00), //
                         hasSource("ExtraKontoauszug02.txt"), hasNote("Gutschrift/Dauerauftrag"))));
 
-        assertThat(results, hasItem(withFailureMessage( //
-                        Messages.MsgErrorTransactionTypeNotSupported, //
-                        interest( //
-                                        hasDate("2022-12-05T00:00"), //
-                                        hasSource("ExtraKontoauszug02.txt"), //
-                                        hasNote(null), //
-                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
-                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
-        // assert transactions
-        assertThat(results, hasItem(interest(hasDate("2022-12-31"), hasAmount("EUR", 0.02), //
-                        hasSource("ExtraKontoauszug02.txt"), hasNote("06.12.2022 bis 31.12.2022 (0,300%)"))));
-
-        // assert transactions
-        assertThat(results, hasItem(taxes(hasDate("2022-12-30"), hasAmount("EUR", 0.01), //
-                        hasSource("ExtraKontoauszug02.txt"), hasNote("Kapitalertragsteuer"))));
+        // assert transaction
+        assertThat(results, hasItem(interest( //
+                        hasDate("2022-12-30"), hasShares(0), //
+                        hasSource("ExtraKontoauszug02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 0.02), hasGrossValue("EUR", 0.03), //
+                        hasTaxes("EUR", 0.01), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -4175,8 +4124,12 @@ public class INGDiBaPDFExtractorTest
                         hasSource("VLKontoauszug01.txt"), hasNote("Gutschrift-VWL"))));
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2020-12-31"), hasAmount("EUR", 0.02), //
-                        hasSource("VLKontoauszug01.txt"), hasNote("Zinsgutschrift"))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2020-12-31"), hasShares(0), //
+                        hasSource("VLKontoauszug01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 0.02), hasGrossValue("EUR", 0.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -4191,8 +4144,8 @@ public class INGDiBaPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(14L));
-        assertThat(results.size(), is(14));
+        assertThat(countAccountTransactions(results), is(11L));
+        assertThat(results.size(), is(11));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transactions
@@ -4236,20 +4189,12 @@ public class INGDiBaPDFExtractorTest
                         hasSource("VLKontoauszug02.txt"), hasNote("Gutschrift-VWL"))));
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2023-12-31"), hasAmount("EUR", 2.55), //
-                        hasSource("VLKontoauszug02.txt"), hasNote("Zinsgutschrift"))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2023-12-31"), hasAmount("EUR", 0.62), //
-                        hasSource("VLKontoauszug02.txt"), hasNote("Kapitalertragsteuer"))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2023-12-31"), hasAmount("EUR", 0.03), //
-                        hasSource("VLKontoauszug02.txt"), hasNote("Solidaritätszuschlag"))));
-
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2023-12-31"), hasAmount("EUR", 0.05), //
-                        hasSource("VLKontoauszug02.txt"), hasNote("Kirchensteuer"))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2023-12-31"), hasShares(0), //
+                        hasSource("VLKontoauszug02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 2.55), hasGrossValue("EUR", 3.25), //
+                        hasTaxes("EUR", (0.62 + 0.03 + 0.05)), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -4264,8 +4209,8 @@ public class INGDiBaPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(5L));
-        assertThat(results.size(), is(5));
+        assertThat(countAccountTransactions(results), is(4L));
+        assertThat(results.size(), is(4));
         new AssertImportActions().check(results, CurrencyUnit.EUR);
 
         // assert transactions
@@ -4277,12 +4222,12 @@ public class INGDiBaPDFExtractorTest
                         hasSource("VLKontoauszug03.txt"), hasNote("Gutschrift-VWL"))));
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2023-03-06"), hasAmount("EUR", 0.21), //
-                        hasSource("VLKontoauszug03.txt"), hasNote("Zinsgutschrift"))));
-
-        // assert transactions
-        assertThat(results, hasItem(taxes(hasDate("2023-03-06"), hasAmount("EUR", 0.05), //
-                        hasSource("VLKontoauszug03.txt"), hasNote("Kapitalertragsteuer"))));
+        assertThat(results, hasItem(interest( //
+                        hasDate("2023-03-06"), hasShares(0), //
+                        hasSource("VLKontoauszug03.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 0.21), hasGrossValue("EUR", 0.26), //
+                        hasTaxes("EUR", 0.05), hasFees("EUR", 0.00))));
 
         // assert transactions
         assertThat(results, hasItem(removal(hasDate("2023-03-06"), hasAmount("EUR", 1161.10), //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
@@ -20,6 +20,7 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 
@@ -652,6 +653,42 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                                                                         .assign((ctx, v) -> {
                                                                             if ("Euro".equals(v.get("currency")))
                                                                                 ctx.put("currency", asCurrencyCode("EUR"));
+                                                                        }))
+
+                                        .optionalOneOf( //
+                                                        // @formatter:off
+                                                        // 30.12.2016 Kapitalertragsteuer -1,38
+                                                        // @formatter:on
+                                                        section -> section //
+                                                                        .attributes("taxDate1", "tax1").multipleTimes() //
+                                                                        .match("^(?<taxDate1>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) Kapitalertrags(s)?teuer \\-(?<tax1>[\\.,\\d]+)$") //
+                                                                        .assign((ctx, v) -> {
+                                                                            ctx.put("taxDate1", v.get("taxDate1"));
+                                                                            ctx.put("tax1", v.get("tax1"));
+                                                                        }))
+
+                                        .optionalOneOf( //
+                                                        // @formatter:off
+                                                        // 30.12.2016 Solidaritätszuschlag -0,07
+                                                        // @formatter:on
+                                                        section -> section //
+                                                                        .attributes("taxDate2", "tax2") //
+                                                                        .match("^(?<taxDate2>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) Solidarit.tszuschlag \\-(?<tax2>[\\.,\\d]+)$") //
+                                                                        .assign((ctx, v) -> {
+                                                                            ctx.put("taxDate2", v.get("taxDate2"));
+                                                                            ctx.put("tax2", v.get("tax2"));
+                                                                        }))
+
+                                        .optionalOneOf( //
+                                                        // @formatter:off
+                                                        // 30.12.2016 Kirchensteuer -0,11
+                                                        // @formatter:on
+                                                        section -> section //
+                                                                        .attributes("taxDate3", "tax3") //
+                                                                        .match("^(?<taxDate3>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) Kirchensteuer \\-(?<tax3>[\\.,\\d]+)$") //
+                                                                        .assign((ctx, v) -> {
+                                                                            ctx.put("taxDate3", v.get("taxDate3"));
+                                                                            ctx.put("tax3", v.get("tax3"));
                                                                         })));
 
         this.addDocumentTyp(type);
@@ -740,7 +777,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
 
                         .wrap(TransactionItem::new));
 
-        Block interestBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (bis|Zinsen|Zinsgutschrift)( [\\d]{2}\\.[\\d]{2}\\.[\\d]{4})?.* [\\.,\\d]+$");
+        Block interestBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (Zinsertrag|Zinsgutschrift) [\\.,\\d]+$");
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
@@ -752,94 +789,40 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
 
                         .oneOf( //
                                         // @formatter:off
-                                        // 01.01.2016 bis 14.06.2016 0,50%  Zins 0,40
-                                        // 15.06.2016 bis 31.12.2016 0,35%  Zins 5,22
-                                        // 16.12.2023 bis 31.12.2023 3,750%  bis 250.000 Euro für das 1. Extra-Konto 0,01
-                                        // @formatter:on
-                                        section -> section //
-                                                        .attributes("note1", "date", "note2", "amount") //
-                                                        .documentContext("currency") //
-                                                        .match("^(?<note1>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} bis (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})) " //
-                                                                        + "(?<note2>[\\.,\\d]+%) " //
-                                                                        + ".* (?<amount>[\\.,\\d]+)$") //
-                                                        .assign((t, v) -> {
-                                                            t.setDateTime(asDate(v.get("date")));
-                                                            t.setAmount(asAmount(v.get("amount")));
-                                                            t.setCurrencyCode(v.get("currency"));
-                                                            t.setNote(v.get("note1") + " (" + v.get("note2") + ")");
-                                                        }),
-                                        // @formatter:off
-                                        // 01.01.2022 bis 05.12.2022 keine Zinsen erwirtschaftet 0,00
+                                        // 30.12.2016 Zinsertrag 5,62
+                                        // 31.12.2020 Zinsgutschrift 0,02
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date", "amount") //
                                                         .documentContext("currency") //
-                                                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} bis (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) " //
-                                                                        + "keine Zinsen erwirtschaftet " //
-                                                                        + "(?<amount>[\\.,\\d]+)$") //
+                                                        .documentContextOptionally("taxDate1", "taxDate2", "taxDate3", "tax1", "tax2", "tax3")
+                                                        .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (Zinsertrag|Zinsgutschrift) (?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
-                                                            v.getTransactionContext().put(FAILURE, Messages.MsgErrorTransactionTypeNotSupported);
+                                                            t.setDateTime(asDate(v.get("date")));
+                                                            t.setAmount(asAmount(v.get("amount")));
+                                                            t.setCurrencyCode(v.get("currency"));
 
-                                                            t.setDateTime(asDate(v.get("date")));
-                                                            t.setAmount(asAmount(v.get("amount")));
-                                                            t.setCurrencyCode(v.get("currency"));
-                                                        }),
-                                        // @formatter:off
-                                        // 31.12.2020 Zinsgutschrift 0,02
-                                        // @formatter:on
-                                        section -> section //
-                                                        .attributes("note1", "date", "amount") //
-                                                        .documentContext("currency") //
-                                                        .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) " //
-                                                                        + "(?<note1>Zinsgutschrift) " //
-                                                                        + "(?<amount>[\\.,\\d]+)$") //
-                                                        .assign((t, v) -> {
-                                                            t.setDateTime(asDate(v.get("date")));
-                                                            t.setAmount(asAmount(v.get("amount")));
-                                                            t.setCurrencyCode(v.get("currency"));
-                                                            t.setNote(v.get("note1"));
+                                                            if (v.containsKey("taxDate1") && v.containsKey("tax1")
+                                                                            && t.getDateTime().equals(asDate(v.get("taxDate1"))))
+                                                            {
+                                                                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax1")));
+                                                                t.addUnit(new Unit(Unit.Type.TAX, tax));
+                                                            }
+
+                                                            if (v.containsKey("taxDate2") && v.containsKey("tax2")
+                                                                            && t.getDateTime().equals(asDate(v.get("taxDate2"))))
+                                                            {
+                                                                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax2")));
+                                                                t.addUnit(new Unit(Unit.Type.TAX, tax));
+                                                            }
+
+                                                            if (v.containsKey("taxDate3") && v.containsKey("tax3")
+                                                                            && t.getDateTime().equals(asDate(v.get("taxDate3"))))
+                                                            {
+                                                                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax3")));
+                                                                t.addUnit(new Unit(Unit.Type.TAX, tax));
+                                                            }
                                                         }))
-
-                        .wrap((t, ctx) -> {
-                            TransactionItem item = new TransactionItem(t);
-
-                            if (ctx.getString(FAILURE) != null)
-                                item.setFailureMessage(ctx.getString(FAILURE));
-
-                            return item;
-                        }));
-
-        // @formatter:off
-        // 30.12.2016 Kapitalertragsteuer -1,38
-        // 30.12.2016 Solidaritätszuschlag -0,07
-        // 30.12.2016 Kirchensteuer -0,11
-        // @formatter:on
-        Block taxesBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} " //
-                        + "(Kapitalertrags(s)?teuer" //
-                        + "|Solidarit.tszuschlag" //
-                        + "|Kirchensteuer) \\-[\\.,\\d]+$");
-        type.addBlock(taxesBlock);
-        taxesBlock.set(new Transaction<AccountTransaction>()
-
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
-
-                        .section("date", "note", "amount") //
-                        .documentContext("currency") //
-                        .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) " //
-                                        + "(?<note>Kapitalertrags(s)?teuer" //
-                                        + "|Solidarit.tszuschlag" //
-                                        + "|Kirchensteuer) " //
-                                        + "\\-(?<amount>[\\.,\\d]+)$") //
-                        .assign((t, v) -> {
-                            t.setDateTime(asDate(v.get("date")));
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(v.get("currency"));
-                            t.setNote(v.get("note"));
-                        })
 
                         .wrap(TransactionItem::new));
 


### PR DESCRIPTION
Previously, taxes were posted separately for interest transactions on account statements. These are now offset together and imported as one transaction.