### PR TITLE
Fix NullPointerException in TextUtil.compare

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TextUtilTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TextUtilTest.java
@@ -191,4 +191,12 @@ public class TextUtilTest
         assertEquals("first-second", TextUtil.concatenate("first", "second", "-"));
     }
 
+    @Test
+    public void testCompareNullCheck()
+    {
+        assertEquals(-1, TextUtil.compare(null, "a"));
+        assertEquals(1, TextUtil.compare("a", null));
+        assertEquals(0, TextUtil.compare(null, null));
+    }
+
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TextUtil.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TextUtil.java
@@ -325,6 +325,13 @@ public final class TextUtil
      */
     public static int compare(String left, String right)
     {
+        if (left == null && right == null)
+            return 0;
+        else if (left == null)
+            return -1;
+        else if (right == null)
+            return 1;
+
         return COLLATOR.compare(left, right);
     }
 


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/fehlermeldung-internal-error/32110

I dont know why, but it seems at least one security name is ``null``. So I added a global fix for all users of ``TextUtil.compare`` and also created simple unittest.

---

One additional point I thought about: In the code there are plenty of this nullchecks for comparisons (e.g. https://github.com/portfolio-performance/portfolio/blob/master/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Security.java#L53-L58).
Would it be helpful/better to create a commonly used method where this nullcheckss are executed and use this everywhere?
Of course this is only possible by using ``Optional`` to also realize the path when both objects/values are not null.
Does that make sense?