### PR TITLE
Enhancement of Arkea Direct Bank importer to import transactions from an OST pdf file

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/Achat06.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/Achat06.txt
@@ -1,0 +1,24 @@
+```
+PDFBox Version: 3.0.3 != 1.8.17
+Portfolio Performance Version: 0.74.2.qualifier
+System: win32 | x86_64 | 21.0.6+7-LTS | Eclipse Adoptium
+-----------------------------------------
+RESULTAT D'OST O AIzHtcm VzmVcF
+Au 8 octobre 2021 5 grt GpFR ufehu MriRxOnWB
+41901 PrqKU MXl LtVAkGB
+VOTRE COMPTE PEA N° 270217438715 c EMluVRh mdIJRA
+Objet : Souscription avec droits
+Monsieur,
+Nous vous informons que  nous avons procédé à la souscription de 16 titre(s) VEOLIA ENVIRON. (FR0000124141) et contre
+présentation de 84 droit(s) VEOLIA ENVIR.DS 21 (FR0014005GA0).
+Cette opération a été comptabilisée sur votre compte :
+montant net de  : - 363,20 EUR
+Veuillez agréer, Monsieur, l'expression de nos salutations distinguées.
+Le service OST
+Duplicata Internet
+Page 1/1
+Fortuneo est une marque commerciale d'Arkéa Direct Bank. Arkéa Direct Bank, Société Anonyme à Directoire et Conseil de Surveillance
+au capital de 89 198 952 euros. RCS Nanterre 384 288 890. Siège social : Tour Ariane - 5, place de la Pyramide 92088 Paris La Défense.
+Courtier en assurance n°ORIAS 07 008 441. Adresse postale : Fortuneo - Service Clients - TSA41707 - 35917 RENNES CEDEX 9.
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/ArkeaDirectBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/ArkeaDirectBankPDFExtractorTest.java
@@ -225,6 +225,36 @@ public class ArkeaDirectBankPDFExtractorTest
     }
 
     @Test
+    public void testCompteAchat06()
+    {
+        ArkeaDirectBankPDFExtractor extractor = new ArkeaDirectBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        List<Item> results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Achat06.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("FR0000124141"), hasWkn(null), hasTicker(null), //
+                        hasName("VEOLIA ENVIRON."), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2021-10-08T00:00:00"), hasShares(16), //
+                        hasSource("Achat06.txt"), //
+                        hasAmount("EUR", 363.20), hasGrossValue("EUR", 363.20), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
     public void testDividende01()
     {
         ArkeaDirectBankPDFExtractor extractor = new ArkeaDirectBankPDFExtractor(new Client());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ArkeaDirectBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ArkeaDirectBankPDFExtractor.java
@@ -111,7 +111,7 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction_Format02()
     {
-        final DocumentType type = new DocumentType("Souscription . titre r.ductible");
+        final DocumentType type = new DocumentType("(Souscription . titre r.ductible|Souscription avec droits)");
         this.addDocumentTyp(type);
 
         Transaction<BuySellEntry> pdfTransaction = new Transaction<>();


### PR DESCRIPTION
Previously, the importer was able to import a transaction from an OST pdf file containing "Objet: Souscription à titre réductible", now it is also able to import a transaction from files containing "Objet : Souscription avec droits"

It is a follow-up of #4543 