### PR TITLE
Improve Usage of convertType in YahooSymbolSearch for Standardized Security Types

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/SecuritySearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/SecuritySearchProvider.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.online;
 
+import static name.abuchen.portfolio.util.TextUtil.trim;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -65,30 +67,36 @@ public interface SecuritySearchProvider
     @SuppressWarnings("nls")
     static String convertType(String type)
     {
+        if (type == null)
+            return null;
+        
+        type = trim(type).toLowerCase();
+        
         // Convert the security type to a standard value
         Map<String, String> typeMap = new HashMap<>();
 
-        typeMap.put("common stock", Messages.LabelSearchShare);
-        typeMap.put("common", Messages.LabelSearchShare);
-        typeMap.put("new york registered shares", Messages.LabelSearchShare);
-        typeMap.put("preferred stock", Messages.LabelSearchPreferredStock);
         typeMap.put("bond", Messages.LabelSearchBond);
-        typeMap.put("warrant", Messages.LabelSearchWarrant);
+        typeMap.put("closed-end fund", Messages.LabelSearchCloseEndFund);
+        typeMap.put("common", Messages.LabelSearchShare);
+        typeMap.put("common stock", Messages.LabelSearchShare);
+        typeMap.put("currency", Messages.LabelSearchCurrency);
+        typeMap.put("digital currency", Messages.LabelSearchCryptoCurrency);
+        typeMap.put("cryptocurrency", Messages.LabelSearchCryptoCurrency);
         typeMap.put("etf", Messages.LabelSearchETF);
         typeMap.put("etc", Messages.LabelSearchETC);
         typeMap.put("exchange-traded note", Messages.LabelSearchETN);
+        typeMap.put("equity", Messages.LabelSearchShare);
         typeMap.put("fund", Messages.LabelSearchFund);
+        typeMap.put("future", Messages.LabelSearchFuture);
+        typeMap.put("index", Messages.LabelSearchIndex);
         typeMap.put("mutual fund", Messages.LabelSearchMutualFund);
         typeMap.put("mutualfund", Messages.LabelSearchMutualFund);
-        typeMap.put("closed-end fund", Messages.LabelSearchCloseEndFund);
-        typeMap.put("digital currency", Messages.LabelSearchCryptoCurrency);
-        typeMap.put("cryptocurrency", Messages.LabelSearchCryptoCurrency);
-        typeMap.put("index", Messages.LabelSearchIndex);
-        typeMap.put("reit", Messages.LabelSearchReit);
-        typeMap.put("real estate investment trust (reit)", Messages.LabelSearchReit);
-        typeMap.put("future", Messages.LabelSearchFuture);
-        typeMap.put("currency", Messages.LabelSearchCurrency);
+        typeMap.put("new york registered shares", Messages.LabelSearchShare);
         typeMap.put("physical currency", Messages.LabelSearchCurrency);
+        typeMap.put("preferred stock", Messages.LabelSearchPreferredStock);
+        typeMap.put("real estate investment trust (reit)", Messages.LabelSearchReit);
+        typeMap.put("reit", Messages.LabelSearchReit);
+        typeMap.put("warrant", Messages.LabelSearchWarrant);
 
         return typeMap.getOrDefault(type, type);
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/LeewaySearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/LeewaySearchProvider.java
@@ -1,7 +1,5 @@
 package name.abuchen.portfolio.online.impl;
 
-import static name.abuchen.portfolio.util.TextUtil.trim;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -55,18 +53,19 @@ public class LeewaySearchProvider implements SecuritySearchProvider
         public static Result from(JSONObject json)
         {
             // Extract values from the JSON object
-            String tickerSymbol = (String) json.get("Code");
-            String exchange = (String) json.get("Exchange");
-            String name = (String) json.get("Name");
-            String type = (String) json.get("Type");
-            String isin = (String) json.get("ISIN");
-            String currencyCode = (String) json.get("currencyCode");
+            var tickerSymbol = (String) json.get("Code");
+            var exchange = (String) json.get("Exchange");
+            var name = (String) json.get("Name");
+            var type = (String) json.get("Type");
+            var isin = (String) json.get("ISIN");
+            var currencyCode = (String) json.get("currencyCode");
 
-            // Convert the security type using the SecuritySearchProvider instance
-            type = SecuritySearchProvider.convertType(trim(type.toLowerCase()));
+            // Convert the security type using the SecuritySearchProvider
+            // instance
+            type = SecuritySearchProvider.convertType(type);
 
             // Combine the symbol and exchange codes to create the security ID
-            StringBuilder symbol = new StringBuilder(tickerSymbol);
+            var symbol = new StringBuilder(tickerSymbol);
             symbol.append(".");
             symbol.append(exchange);
 
@@ -140,7 +139,7 @@ public class LeewaySearchProvider implements SecuritySearchProvider
         @Override
         public Security create(Client client)
         {
-            Security security = new Security(name, currencyCode);
+            var security = new Security(name, currencyCode);
             security.setTickerSymbol(symbol);
             security.setIsin(isin);
             security.setFeed(LeewayQuoteFeed.ID);
@@ -176,7 +175,7 @@ public class LeewaySearchProvider implements SecuritySearchProvider
     @SuppressWarnings("nls")
     private void addISINSearchPage(List<ResultItem> answer, String query) throws IOException
     {
-        String array = new WebAccess("api.leeway.tech", "/api/v1/public/general/isin/" + query) //
+        var array = new WebAccess("api.leeway.tech", "/api/v1/public/general/isin/" + query) //
                         .addParameter("apitoken", apiKey) //
                         .get();
 
@@ -185,14 +184,14 @@ public class LeewaySearchProvider implements SecuritySearchProvider
 
     void extract(List<ResultItem> answer, String array)
     {
-        JSONArray jsonArray = (JSONArray) JSONValue.parse(array);
+        var jsonArray = (JSONArray) JSONValue.parse(array);
 
         if (jsonArray.isEmpty())
             return;
 
         for (Object element : jsonArray)
         {
-            JSONObject item = (JSONObject) element;
+            var item = (JSONObject) element;
             answer.add(Result.from(item));
         }
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/TwelveDataSearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/TwelveDataSearchProvider.java
@@ -1,7 +1,5 @@
 package name.abuchen.portfolio.online.impl;
 
-import static name.abuchen.portfolio.util.TextUtil.trim;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +16,7 @@ import name.abuchen.portfolio.util.WebAccess;
 /**
  * @implNote https://twelvedata.com/docs#getting-started
  * @apiNote There are only 800 API/day and 8 API/minute available.
- *          The stock exchanges are created using the four-digit market identifier codes. 
+ *          The stock exchanges are created using the four-digit market identifier codes.
  *          These are listed according to ISO-10383.
  *
  * @formatter:off
@@ -54,18 +52,18 @@ public class TwelveDataSearchProvider implements SecuritySearchProvider
         public static Result from(JSONObject json)
         {
             // Extract values from the JSON object
-            String tickerSymbol = (String) json.get("symbol");
-            String name = (String) json.get("instrument_name");
-            String exchange = (String) json.get("mic_code");
-            String type = (String) json.get("instrument_type");
-            String currencyCode = (String) json.get("currency");
+            var tickerSymbol = (String) json.get("symbol");
+            var name = (String) json.get("instrument_name");
+            var exchange = (String) json.get("mic_code");
+            var type = (String) json.get("instrument_type");
+            var currencyCode = (String) json.get("currency");
 
             // Convert the security type using the SecuritySearchProvider
             // instance
-            type = SecuritySearchProvider.convertType(trim(type.toLowerCase()));
+            type = SecuritySearchProvider.convertType(type);
 
             // Combine the symbol and exchange codes to create the security ID
-            StringBuilder symbol = new StringBuilder(tickerSymbol);
+            var symbol = new StringBuilder(tickerSymbol);
             symbol.append(".");
             symbol.append(exchange);
 
@@ -138,7 +136,7 @@ public class TwelveDataSearchProvider implements SecuritySearchProvider
         @Override
         public Security create(Client client)
         {
-            Security security = new Security(name, currencyCode);
+            var security = new Security(name, currencyCode);
             security.setTickerSymbol(symbol);
             security.setFeed(TwelveDataQuoteFeed.ID);
             return security;
@@ -173,7 +171,7 @@ public class TwelveDataSearchProvider implements SecuritySearchProvider
     @SuppressWarnings("nls")
     private void addStockSearchPage(List<ResultItem> answer, String query) throws IOException
     {
-        String json = new WebAccess("api.twelvedata.com", "/symbol_search") //
+        var json = new WebAccess("api.twelvedata.com", "/symbol_search") //
                         .addParameter("apikey", apiKey) //
                         .addParameter("symbol", query) //
                         .get();
@@ -183,19 +181,19 @@ public class TwelveDataSearchProvider implements SecuritySearchProvider
 
     void extract(List<ResultItem> answer, String json)
     {
-        JSONObject jsonObject = (JSONObject) JSONValue.parse(json);
+        var jsonObject = (JSONObject) JSONValue.parse(json);
 
         if (jsonObject.isEmpty())
             return;
 
-        JSONArray jsonArray = (JSONArray) jsonObject.get("data"); //$NON-NLS-1$
+        var jsonArray = (JSONArray) jsonObject.get("data"); //$NON-NLS-1$
 
         if (jsonArray == null || jsonArray.isEmpty())
             return;
 
         for (Object element : jsonArray)
         {
-            JSONObject item = (JSONObject) element;
+            var item = (JSONObject) element;
             answer.add(Result.from(item));
         }
     }


### PR DESCRIPTION
Refactored YahooSymbolSearch to use the convertType method from SecuritySearchProvider for standardizing security types, improving maintainability and consistency across search providers.