### PR TITLE
Modify FlatEx PDF-Importer and implement getTickerSymbolForCrypto

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatExDegiroCryptoKauf01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatExDegiroCryptoKauf01.txt
@@ -1,0 +1,58 @@
+PDFBox Version: 3.0.3
+Portfolio Performance Version: 0.74.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+flatexDEGIRO Bank AG
+Postfach 100551
+41405 Neuss
+USt-IdNr.: DE 246 786 363
+Kundenservice:
+Tel.: +49 9221 7035898
+E-Mail: info@flatex.de
+flatexDEGIRO Bank AG -  Hammfelddamm 4 - 41460 Neuss, Deutschland
+0006172000004701649260
+Herrn
+raotQFh pmGBei
+NrClSOgUum 7
+50988 bJkppIg
+          Frankfurt, 31.03.2025
+Sammelabrechnung (Kauf/-verkauf Kryptowerte)
+Ihr Verwahrkonto bei Tangany GmbH: 5883379732
+Inhaber: PXHQXKZ izbgpT
+Nr.293999994/1    Kauf                           BITCOIN                      
+Ordervolumen   : 0,00014 St.             Handelsplatz  :               Tradias
+davon ausgef.  : 0,00014 St.             Schlusstag    : 30.03.2025, 18:55 Uhr
+Kurs           : 76.064,2600 EUR         Kurswert      :             10,65 EUR
+Devisenkurs    :                         Provision     :              0,05 EUR
+Bew-Faktor     : 1,0000
+Verwahrart     : Kryptoverwahrung
+Kryptoverwahrer: Tangany GmbH
+Gewinn/Verlust : 0,00 EUR
+Valuta         : 31.03.2025              Endbetrag     :            -10,70 EUR
+Veräußerungen von Kryptowerten werden in Deutschland als private Veräußerungs-
+geschäfte besteuert.
+Private Veräußerungsgeschäfte sind grundsätzlich steuerpflichtig.
+Die Verrechnung der Endbeträge erfolgt über Ihr Konto Nr.: 0862605075
+Den Euro Gegenwert werden wir entsprechend der Abrechnung mit dem angegebenen
+Valutatag buchen. Die Kryptowerte werden entsprechend der Abrechnung durch die
+Tangany GmbH in ihrem Verwahrkonto, mit dem angegebenen Valutatag,
+bei Tangany GmbH gebucht.
+Bitte prüfen Sie diese Abrechnung auf Richtigkeit und Vollständigkeit.
+Etwaige Einwendungen gegen diese Abrechnung müssen unverzüglich nach Zugang
+bei der flatexDEGIRO Bank oder bei Tangany GmbH erhoben werden.
+Die Unterlassung rechtzeitiger Einwendung gilt als Genehmigung.
+______________________________________________________________________________
+                                                                     Seite 1/2
+BLZ 101 308 00 / BIC: BIWBDE33XXX  -  Aktiengesellschaft, Sitz Frankfurt  -  Amtsgericht Frankfurt am Main (HRB 105687)
+Vorsitzender des Aufsichtsrats: Martin Korbmacher  -  Vorstand: Oliver Behrens (Vorsitzender), Dr. Benon Janos (stellv. Vorsitzender),
+ Stephan Simmang, Dr. Matthias Heinrich, Steffen Jentsch, Jens Möbitz
+5601964692034233 8584552037048154
+Diese  Mitteilung  ist  maschinell  erstellt  und  wird  nicht unterschrieben.
+Irrtum vorbehalten.
+Für weitergehende Fragen wenden Sie sich bitte an Ihr flatex-Service-Team.
+______________________________________________________________________________
+                                                                     Seite 2/2
+BLZ 101 308 00 / BIC: BIWBDE33XXX  -  Aktiengesellschaft, Sitz Frankfurt  -  Amtsgericht Frankfurt am Main (HRB 105687)
+Vorsitzender des Aufsichtsrats: Martin Korbmacher  -  Vorstand: Oliver Behrens (Vorsitzender), Dr. Benon Janos (stellv. Vorsitzender),
+ Stephan Simmang, Dr. Matthias Heinrich, Steffen Jentsch, Jens Möbitz
+2429051671641461

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatExDegiroCryptoVerkauf01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatExDegiroCryptoVerkauf01.txt
@@ -1,0 +1,58 @@
+PDFBox Version: 3.0.3
+Portfolio Performance Version: 0.74.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+flatexDEGIRO Bank AG
+Postfach 100551
+41405 Neuss
+USt-IdNr.: DE 246 786 363
+Kundenservice:
+Tel.: +49 9221 7035898
+E-Mail: info@flatex.de
+flatexDEGIRO Bank AG -  Hammfelddamm 4 - 41460 Neuss, Deutschland
+0006172000004779419960
+Herrn
+HbBHJuu qtVWeR
+XzuaqywugA 1
+69039 XPzGhPM
+          Frankfurt, 02.04.2025
+Sammelabrechnung (Kauf/-verkauf Kryptowerte)
+Ihr Verwahrkonto bei Tangany GmbH: 4335913460
+Inhaber: WmaEUWr whwSZd
+Nr.293580145/1    Verkauf                        BITCOIN                      
+Ordervolumen   : 0,00014 St.             Handelsplatz  :               Tradias
+davon ausgef.  : 0,00014 St.             Schlusstag    : 01.04.2025, 17:16 Uhr
+Kurs           : 78.467,4900 EUR         Kurswert      :             10,99 EUR
+Devisenkurs    :                         Provision     :              0,05 EUR
+Bew-Faktor     : 1,0000
+Verwahrart     : Kryptoverwahrung
+Kryptoverwahrer: Tangany GmbH
+Gewinn/Verlust : 0,34 EUR
+Valuta         : 02.04.2025              Endbetrag     :             10,94 EUR
+Veräußerungen von Kryptowerten werden in Deutschland als private Veräußerungs-
+geschäfte besteuert.
+Private Veräußerungsgeschäfte sind grundsätzlich steuerpflichtig.
+Die Verrechnung der Endbeträge erfolgt über Ihr Konto Nr.: 3077632923
+Den Euro Gegenwert werden wir entsprechend der Abrechnung mit dem angegebenen
+Valutatag buchen. Die Kryptowerte werden entsprechend der Abrechnung durch die
+Tangany GmbH in ihrem Verwahrkonto, mit dem angegebenen Valutatag,
+bei Tangany GmbH gebucht.
+Bitte prüfen Sie diese Abrechnung auf Richtigkeit und Vollständigkeit.
+Etwaige Einwendungen gegen diese Abrechnung müssen unverzüglich nach Zugang
+bei der flatexDEGIRO Bank oder bei Tangany GmbH erhoben werden.
+Die Unterlassung rechtzeitiger Einwendung gilt als Genehmigung.
+______________________________________________________________________________
+                                                                     Seite 1/2
+BLZ 101 308 00 / BIC: BIWBDE33XXX  -  Aktiengesellschaft, Sitz Frankfurt  -  Amtsgericht Frankfurt am Main (HRB 105687)
+Vorsitzender des Aufsichtsrats: Martin Korbmacher  -  Vorstand: Oliver Behrens (Vorsitzender), Dr. Benon Janos (stellv. Vorsitzender),
+ Stephan Simmang, Dr. Matthias Heinrich, Steffen Jentsch, Jens Möbitz
+2000004779419960 0113006170000101
+Diese  Mitteilung  ist  maschinell  erstellt  und  wird  nicht unterschrieben.
+Irrtum vorbehalten.
+Für weitergehende Fragen wenden Sie sich bitte an Ihr flatex-Service-Team.
+______________________________________________________________________________
+                                                                     Seite 2/2
+BLZ 101 308 00 / BIC: BIWBDE33XXX  -  Aktiengesellschaft, Sitz Frankfurt  -  Amtsgericht Frankfurt am Main (HRB 105687)
+Vorsitzender des Aufsichtsrats: Martin Korbmacher  -  Vorstand: Oliver Behrens (Vorsitzender), Dr. Benon Janos (stellv. Vorsitzender),
+ Stephan Simmang, Dr. Matthias Heinrich, Steffen Jentsch, Jens Möbitz
+2000004779419960

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
@@ -15,6 +15,7 @@ import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -259,7 +260,7 @@ public class ExtractorUtils
 
         if (rate.isPresent())
         {
-            Money fxTax = rate.get().convert(t.getCurrencyCode(), tax);
+            var fxTax = rate.get().convert(t.getCurrencyCode(), tax);
 
             if (t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
                 t.addUnit(new Unit(Unit.Type.TAX, fxTax));
@@ -291,7 +292,7 @@ public class ExtractorUtils
 
         if (rate.isPresent())
         {
-            Money fxFee = rate.get().convert(t.getCurrencyCode(), fee);
+            var fxFee = rate.get().convert(t.getCurrencyCode(), fee);
 
             if (t.getCurrencyCode().equals(t.getSecurity().getCurrencyCode()))
                 t.addUnit(new Unit(Unit.Type.FEE, fxFee));
@@ -302,7 +303,7 @@ public class ExtractorUtils
 
     public static long convertToNumberLong(String value, Values<Long> valueType, String language, String country)
     {
-        DecimalFormat newNumberFormat = (DecimalFormat) NumberFormat
+        var newNumberFormat = (DecimalFormat) NumberFormat
                         .getInstance(Locale.forLanguageTag(language + "-" + country));
 
         /**
@@ -335,7 +336,7 @@ public class ExtractorUtils
              * 8217?) instead. This is wrong, ASCII 39 was the correct
              * character.
              */
-            DecimalFormatSymbols decimalFormatSymbols = new DecimalFormatSymbols();
+            var decimalFormatSymbols = new DecimalFormatSymbols();
             decimalFormatSymbols.setDecimalSeparator('.');
             decimalFormatSymbols.setGroupingSeparator('\'');
             newNumberFormat.setDecimalFormatSymbols(decimalFormatSymbols);
@@ -375,7 +376,7 @@ public class ExtractorUtils
          */
         value = trim(value).replaceAll("\\s", "");
 
-        DecimalFormat newNumberFormat = (DecimalFormat) NumberFormat
+        var newNumberFormat = (DecimalFormat) NumberFormat
                         .getInstance(Locale.forLanguageTag(language + "-" + country));
 
         if ("CH".equals(country))
@@ -387,7 +388,7 @@ public class ExtractorUtils
              * 8217?) instead. This is wrong, ASCII 39 was the correct
              * character.
              */
-            DecimalFormatSymbols decimalFormatSymbols = new DecimalFormatSymbols();
+            var decimalFormatSymbols = new DecimalFormatSymbols();
             decimalFormatSymbols.setDecimalSeparator('.');
             decimalFormatSymbols.setGroupingSeparator('\'');
             newNumberFormat.setDecimalFormatSymbols(decimalFormatSymbols);
@@ -414,13 +415,13 @@ public class ExtractorUtils
         // the box anymore
         value = value.replaceAll("(?i)\\bMrz\\b", "Mär");
 
-        Locale[] locales = hints.length > 0 ? hints
+        var locales = hints.length > 0 ? hints
                         : new Locale[] { Locale.GERMANY, Locale.FRENCH, Locale.US, Locale.CANADA, Locale.CANADA_FRENCH,
                                         Locale.UK, AdditionalLocales.SPAIN, AdditionalLocales.MEXICO };
 
         for (Locale l : locales)
         {
-            DateTimeFormatter[] formatters = LOCALE2DATE.get(l);
+            var formatters = LOCALE2DATE.get(l);
             if (formatters == null)
             {
                 continue; // Skip this locale if no formatters are found
@@ -465,7 +466,7 @@ public class ExtractorUtils
         // the box anymore
         date = date.replaceAll("(?i)\\bMrz\\b", "Mär");
 
-        String value = String.format("%s %s", date, time);
+        var value = String.format("%s %s", date, time);
 
         for (DateTimeFormatter formatter : DATE_TIME_FORMATTER)
         {
@@ -482,6 +483,39 @@ public class ExtractorUtils
         throw new DateTimeParseException(MessageFormat.format(Messages.MsgErrorNotAValidDate, value), value, 0);
     }
 
+    public static String getTickerSymbolForCrypto(String cryptoAssetName)
+    {
+        if (cryptoAssetName == null || cryptoAssetName.isBlank())
+            return "";
+
+        cryptoAssetName = cryptoAssetName.trim().toUpperCase();
+
+        Map<String, String> cryptoTickerMap = new HashMap<>();
+
+        cryptoTickerMap.put("AAVE", "AAVE");
+        cryptoTickerMap.put("AVALANCHE", "AVAX");
+        cryptoTickerMap.put("BITCOIN", "BTC");
+        cryptoTickerMap.put("BITCOIN CASH", "BCH");
+        cryptoTickerMap.put("CARDANO", "ADA");
+        cryptoTickerMap.put("CHAINLINK", "LINK");
+        cryptoTickerMap.put("COMPOUND", "COMP");
+        cryptoTickerMap.put("COSMOS", "ATOM");
+        cryptoTickerMap.put("DOGECOIN", "DOGE");
+        cryptoTickerMap.put("EOS", "EOS");
+        cryptoTickerMap.put("ETHEREUM", "ETH");
+        cryptoTickerMap.put("ETHEREUM CLASSIC", "ETC");
+        cryptoTickerMap.put("LITECOIN", "LTC");
+        cryptoTickerMap.put("POLKADOT", "DOT");
+        cryptoTickerMap.put("POLYGON", "MATIC");
+        cryptoTickerMap.put("RIPPLE", "XRP");
+        cryptoTickerMap.put("SOLANA", "SOL");
+        cryptoTickerMap.put("STELLAR LUMEN", "XLM");
+        cryptoTickerMap.put("TRON", "TRX");
+        cryptoTickerMap.put("UNISWAP", "UNI");
+
+        return cryptoTickerMap.getOrDefault(cryptoAssetName, "");
+    }
+
     public static Consumer<Transaction> fixGrossValue()
     {
         return t -> {
@@ -496,19 +530,19 @@ public class ExtractorUtils
 
             // check if the reported gross value fits to the
             // expected gross value
-            Optional<Unit> actualGross = t.getUnit(Unit.Type.GROSS_VALUE);
+            var actualGross = t.getUnit(Unit.Type.GROSS_VALUE);
 
             if (actualGross.isPresent())
             {
-                Unit grossUnit = actualGross.get();
-                Money expectedGross = t.getGrossValue();
+                var grossUnit = actualGross.get();
+                var expectedGross = t.getGrossValue();
 
                 if (!expectedGross.equals(grossUnit.getAmount()))
                 {
                     // check if it a rounding difference that is acceptable
                     try
                     {
-                        Unit u = new Unit(Unit.Type.GROSS_VALUE, expectedGross, grossUnit.getForex(),
+                        var u = new Unit(Unit.Type.GROSS_VALUE, expectedGross, grossUnit.getForex(),
                                         grossUnit.getExchangeRate());
 
                         t.removeUnit(grossUnit);
@@ -520,7 +554,7 @@ public class ExtractorUtils
                         // recalculate the unit to fix the gross value
                     }
 
-                    Money caculatedGrossValue = Money.of(grossUnit.getForex().getCurrencyCode(),
+                    var caculatedGrossValue = Money.of(grossUnit.getForex().getCurrencyCode(),
                                     BigDecimal.valueOf(expectedGross.getAmount())
                                                     .divide(grossUnit.getExchangeRate(), Values.MC)
                                                     .setScale(0, RoundingMode.HALF_EVEN).longValue());


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/pdf-import-von-flatex/1752/277 
https://forum.portfolio-performance.info/t/pdf-import-von-flatex/1752/278 

------------------

Enhancement: Implement getTickerSymbolForCrypto Method Description

This enhancement introduces the getTickerSymbolForCrypto method, which maps cryptocurrency names to their respective ticker symbols. The method accepts a cryptocurrency name as input. It normalizes the input (trims whitespace and converts it to uppercase). A predefined mapping (cryptoTickerMap) returns the corresponding ticker symbol. If the name is missing or not found, an empty string ("") is returned.

Hello @buchen 
if you have time, can you please check the new method in the ExtractorUtils?

Thx 👍🏻 
Alex