### PR TITLE
Modify ArkeaDirectBank PDF-Importer to support new transaction

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/ArkeaDirectBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/ArkeaDirectBankPDFExtractorTest.java
@@ -15,6 +15,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
@@ -372,11 +373,11 @@ public class ArkeaDirectBankPDFExtractorTest
                         hasTaxes("EUR", 0.00), hasFees("EUR", 4.90))));
 
         // check buy sell transaction
-        assertThat(results, hasItem(purchase( //
+        assertThat(results, hasItem(sale( //
                         hasDate("2025-03-06T09:33:30"), hasShares(45.00), //
                         hasSource("Achat09.txt"), //
                         hasNote("Référence 00F2010542700105"), //
-                        hasAmount("EUR", 24923.35), hasGrossValue("EUR", 24885.91), //
+                        hasAmount("EUR", 24923.35), hasGrossValue("EUR", 24960.79), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 37.44))));
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ArkeaDirectBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ArkeaDirectBankPDFExtractor.java
@@ -82,6 +82,14 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
                             return portfolioTransaction;
                         })
 
+                        // Is type --> "Vente" change from BUY to SELL
+                        .section("type").optional() //
+                        .match(".* Sens (?<type>(Achat|Vente)).*$") //
+                        .assign((t, v) -> {
+                            if ("Vente".equals(v.get("type")))
+                                t.setType(PortfolioTransaction.Type.SELL);
+                        })
+
                         // @formatter:off
                         // Quantité 46 Cours 10,646 €
                         // Quantité 1 450 Cours 5,4941 €


### PR DESCRIPTION
Hello Nirus,

As per https://forum.portfolio-performance.info/t/pdf-import-from-arkea-direct-bank-fortuneo-banque-france/28131/22 and https://forum.portfolio-performance.info/t/pdf-import-from-arkea-direct-bank-fortuneo-banque-france/28131/25 I have added the Sale case for the importer. This is the only "Sale" example so far, it is the last transaction of Achat09.txt (it may be renamed as AchatVente01.txt ? Achat=Buy, Vente =Sell).
So this is also correcting the GrossAmount for this transaction, I understand that for a Sale, gross amount > net amount. And this new gross amount matches the value of Achat09.txt line 55.

