### PR TITLE
Monthly performance-neutral transfers widget

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -848,6 +848,7 @@ public class Messages extends NLS
     public static String LabelRatio;
     public static String LabelRefresh;
     public static String LabelRemoveDividends;
+    public static String LabelMonthlyPNTransfers;
     public static String LabelRemoveLogo;
     public static String LabelReportingAddPeriod;
     public static String LabelReportingDialogDay;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1554,6 +1554,8 @@ LabelMissingQuotes_Decsription = On these dates, there should be a security pric
 
 LabelMobileApp = Mobile App
 
+LabelMonthlyPNTransfers=Monthly performance-neutral transfers
+
 LabelMore = More
 
 LabelNamePlusCopy = {0} (copy)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MonthlyPNTransfersWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MonthlyPNTransfersWidget.java
@@ -1,0 +1,68 @@
+package name.abuchen.portfolio.ui.views.dashboard;
+
+import java.time.LocalDate;
+import java.util.stream.LongStream;
+
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.Dashboard.Widget;
+import name.abuchen.portfolio.snapshot.PerformanceIndex;
+import name.abuchen.portfolio.ui.views.dashboard.heatmap.AbstractMonhtlyHeatmapWidget;
+import name.abuchen.portfolio.ui.views.dashboard.heatmap.HeatmapModel;
+import name.abuchen.portfolio.ui.views.dataseries.DataSeries;
+import name.abuchen.portfolio.util.Interval;
+
+public class MonthlyPNTransfersWidget extends AbstractMonhtlyHeatmapWidget
+{
+    public MonthlyPNTransfersWidget(Widget widget, DashboardData data)
+    {
+        super(widget, data);
+        addConfig(new DataSeriesConfig(this, false));
+    }
+
+    @Override
+    protected void linkActivated()
+    {
+        // Nothing to do when clicking the title for now
+    }
+
+    @Override
+    protected void processTransactions(int startYear, Interval interval, HeatmapModel<Long> model,
+                    Client filteredClient)
+    {
+        Client client = getDashboardData().getClient();
+        DataSeries series = get(DataSeriesConfig.class).getDataSeries();
+
+        for (int year = interval.getStart().getYear(); year <= interval.getEnd().getYear(); year++)
+        {
+            int row = year - startYear;
+
+            for (int month = 1; month <= 12; month++)
+            {
+                int col = month - 1;
+
+                // Skip if this month is outside our interval
+                LocalDate startOfMonth = LocalDate.of(year, month, 1);
+                LocalDate endOfMonth = startOfMonth.plusMonths(1).minusDays(1);
+                if (endOfMonth.isBefore(interval.getStart()) || startOfMonth.isAfter(interval.getEnd()))
+                    continue;
+
+                // Calculate performance index of the month (including the day
+                // before for proper calculation)
+                Interval monthInterval = Interval.of(startOfMonth.minusDays(1), endOfMonth);
+                PerformanceIndex monthlyIndex = getDashboardData().calculate(series, monthInterval);
+
+                // Get transferals and sum them, skipping the first element (day
+                // before start)
+                long[] transferals = monthlyIndex.getTransferals();
+                long monthlyTransfers = transferals.length > 1 ? LongStream.of(transferals).skip(1).sum() : 0L;
+
+                // Set the value in the model
+                Long oldValue = model.getRow(row).getData(col);
+                if (oldValue != null)
+                {
+                    model.getRow(row).setData(col, monthlyTransfers);
+                }
+            }
+        }
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MonthlyPNTransfersWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MonthlyPNTransfersWidget.java
@@ -4,15 +4,22 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.stream.LongStream;
 
+import jakarta.inject.Inject;
+
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Dashboard.Widget;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;
+import name.abuchen.portfolio.ui.editor.PortfolioPart;
 import name.abuchen.portfolio.ui.views.dashboard.heatmap.AbstractMonhtlyHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dashboard.heatmap.HeatmapModel;
+import name.abuchen.portfolio.ui.views.AllTransactionsView;
 import name.abuchen.portfolio.util.Interval;
 
 public class MonthlyPNTransfersWidget extends AbstractMonhtlyHeatmapWidget
 {
+    @Inject
+    private PortfolioPart part;
+
     public MonthlyPNTransfersWidget(Widget widget, DashboardData data)
     {
         super(widget, data);
@@ -21,7 +28,7 @@ public class MonthlyPNTransfersWidget extends AbstractMonhtlyHeatmapWidget
     @Override
     protected void linkActivated()
     {
-        // No link action
+        part.activateView(AllTransactionsView.class, null);
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MonthlyPNTransfersWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MonthlyPNTransfersWidget.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.ui.views.dashboard;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.stream.LongStream;
 
 import name.abuchen.portfolio.model.Client;
@@ -8,7 +9,6 @@ import name.abuchen.portfolio.model.Dashboard.Widget;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;
 import name.abuchen.portfolio.ui.views.dashboard.heatmap.AbstractMonhtlyHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dashboard.heatmap.HeatmapModel;
-import name.abuchen.portfolio.ui.views.dataseries.DataSeries;
 import name.abuchen.portfolio.util.Interval;
 
 public class MonthlyPNTransfersWidget extends AbstractMonhtlyHeatmapWidget
@@ -16,21 +16,18 @@ public class MonthlyPNTransfersWidget extends AbstractMonhtlyHeatmapWidget
     public MonthlyPNTransfersWidget(Widget widget, DashboardData data)
     {
         super(widget, data);
-        addConfig(new DataSeriesConfig(this, false));
     }
 
     @Override
     protected void linkActivated()
     {
-        // Nothing to do when clicking the title for now
+        // No link action
     }
 
     @Override
     protected void processTransactions(int startYear, Interval interval, HeatmapModel<Long> model,
                     Client filteredClient)
     {
-        Client client = getDashboardData().getClient();
-        DataSeries series = get(DataSeriesConfig.class).getDataSeries();
 
         for (int year = interval.getStart().getYear(); year <= interval.getEnd().getYear(); year++)
         {
@@ -49,7 +46,8 @@ public class MonthlyPNTransfersWidget extends AbstractMonhtlyHeatmapWidget
                 // Calculate performance index of the month (including the day
                 // before for proper calculation)
                 Interval monthInterval = Interval.of(startOfMonth.minusDays(1), endOfMonth);
-                PerformanceIndex monthlyIndex = getDashboardData().calculate(series, monthInterval);
+                PerformanceIndex monthlyIndex = PerformanceIndex.forClient(filteredClient,
+                                getDashboardData().getCurrencyConverter(), monthInterval, new ArrayList<>());
 
                 // Get transferals and sum them, skipping the first element (day
                 // before start)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MonthlyPNTransfersWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MonthlyPNTransfersWidget.java
@@ -57,11 +57,7 @@ public class MonthlyPNTransfersWidget extends AbstractMonhtlyHeatmapWidget
                 long monthlyTransfers = transferals.length > 1 ? LongStream.of(transferals).skip(1).sum() : 0L;
 
                 // Set the value in the model
-                Long oldValue = model.getRow(row).getData(col);
-                if (oldValue != null)
-                {
-                    model.getRow(row).setData(col, monthlyTransfers);
-                }
+                model.getRow(row).setData(col, monthlyTransfers);
             }
         }
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
@@ -35,6 +35,7 @@ import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsChartWidget;
 import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsListWidget;
 import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsListWidget.ExpansionSetting;
+
 import name.abuchen.portfolio.ui.views.dashboard.heatmap.CostHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dashboard.heatmap.InvestmentHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dashboard.heatmap.PerformanceHeatmapWidget;
@@ -128,6 +129,9 @@ public enum WidgetFactory
                                     }) //
                                     .withBenchmarkDataSeries(false) //
                                     .build()),
+
+    MONTHLY_PN_TRANSFERS(Messages.LabelMonthlyPNTransfers, Messages.LabelStatementOfAssets,
+                    MonthlyPNTransfersWidget::new),
 
     INVESTED_CAPITAL(Messages.LabelInvestedCapital, Messages.LabelStatementOfAssets, //
                     (widget, data) -> IndicatorWidget.<Money>create(widget, data) //


### PR DESCRIPTION
Implement a new Dashboard widget to show "Monthly Performance-Neutral Transfers" (with similar appearance to the "Monthly Earnings" widget).

Closes #2587
![2025-04-19_07 00 56](https://github.com/user-attachments/assets/266b220f-a6a3-42ea-911b-81287ad173d1)
![2025-04-19_06 59 21](https://github.com/user-attachments/assets/fae45099-b452-486d-808e-7cc8bd1e0b6e)
