### PR TITLE
Improve to support lookup by currency display name (e.g. "Euro")

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ABNAMROGroupPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ABNAMROGroupPDFExtractor.java
@@ -6,6 +6,7 @@ import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Transaction.Unit;
+import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 
 @SuppressWarnings("nls")
@@ -36,7 +37,7 @@ public class ABNAMROGroupPDFExtractor extends AbstractPDFExtractor
                                                         // @formatter:on
                                                         section -> section //
                                                                         .attributes("currency") //
-                                                                        .match("^Tagesgeldkonto \\(alle Betr.* in (?<currency>[\\w]{3})\\).*$") //
+                                                                        .match("^Tagesgeldkonto \\(alle Betr.* in (?<currency>[A-Z]{3})\\).*$") //
                                                                         .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency")))),
                                                         // @formatter:off
                                                         // Tagesgeldkonto 100,00 24.10.2011 100,00
@@ -44,7 +45,7 @@ public class ABNAMROGroupPDFExtractor extends AbstractPDFExtractor
                                                         section -> section //
                                                                         .attributes("currency") //
                                                                         .match("^Tagesgeldkonto (?<currency>.*)$") //
-                                                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode("EUR"))))
+                                                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(CurrencyUnit.EUR))))
 
                                         .optionalOneOf( //
                                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -301,7 +301,14 @@ public abstract class AbstractPDFExtractor implements Extractor
             return unit.getCurrencyCode();
 
         unit = CurrencyUnit.getInstanceBySymbol(currency.trim());
-        return unit == null ? client.getBaseCurrency() : unit.getCurrencyCode();
+        if (unit != null)
+            return unit.getCurrencyCode();
+
+        unit = CurrencyUnit.getInstanceByDisplayName(currency.trim());
+        if (unit != null)
+            return unit.getCurrencyCode();
+
+        return client.getBaseCurrency();
     }
 
     protected long asAmount(String value)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AvivaPLCPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AvivaPLCPDFExtractor.java
@@ -24,6 +24,8 @@ import name.abuchen.portfolio.money.Values;
 @SuppressWarnings("nls")
 public class AvivaPLCPDFExtractor extends AbstractPDFExtractor
 {
+    private static final String GBP = "GBP";
+
     public AvivaPLCPDFExtractor(Client client)
     {
         super(client);
@@ -80,7 +82,7 @@ public class AvivaPLCPDFExtractor extends AbstractPDFExtractor
                                                         .match("^SEDOL: (?<wkn>[A-Z0-9]{7})$") //
                                                         .match("^Citicode: (?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?)\\..*$") //
                                                         .assign((t, v) -> {
-                                                            v.put("currency", asCurrencyCode("GBP"));
+                                                            v.put("currency", asCurrencyCode(GBP));
 
                                                             t.setSecurity(getOrCreateSecurity(v));
                                                         }),
@@ -91,7 +93,7 @@ public class AvivaPLCPDFExtractor extends AbstractPDFExtractor
                                                         .attributes("name") //
                                                         .match("^Investment Name: (?<name>.*)$") //
                                                         .assign((t, v) -> {
-                                                            v.put("currency", asCurrencyCode("GBP"));
+                                                            v.put("currency", asCurrencyCode(GBP));
 
                                                             t.setSecurity(getOrCreateSecurity(v));
                                                         }))
@@ -119,7 +121,7 @@ public class AvivaPLCPDFExtractor extends AbstractPDFExtractor
                                                         .attributes("amount") //
                                                         .match("^Total Consideration \\p{Sc}(?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
-                                                            t.setCurrencyCode(asCurrencyCode("GBP"));
+                                                            t.setCurrencyCode(asCurrencyCode(GBP));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }),
                                         // @formatter:off
@@ -130,7 +132,7 @@ public class AvivaPLCPDFExtractor extends AbstractPDFExtractor
                                                         .attributes("amount") //
                                                         .match("^Consideration([:])? \\p{Sc}(?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
-                                                            t.setCurrencyCode(asCurrencyCode("GBP"));
+                                                            t.setCurrencyCode(asCurrencyCode(GBP));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }))
                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
@@ -9,6 +9,7 @@ import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.money.CurrencyUnit;
 
 /**
  * @implNote Bondora Capital does not have a specific bank identifier.
@@ -112,7 +113,7 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                                             }
 
                                                             t.setAmount(asAmount(v.get("amount"), language, country));
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setNote(trim(v.get("note")));
                                                         }),
                                         // @formatter:off
@@ -161,7 +162,7 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                                             }
 
                                                             t.setAmount(asAmount(v.get("amount"), language, country));
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setNote(trim(v.get("note")));
                                                         }),
                                         // @formatter:off
@@ -186,7 +187,7 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setAmount(asAmount(v.get("amount"), "de", "DE"));
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setNote(trim(v.get("note")));
                                                         }))
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CetesDirectoPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CetesDirectoPDFExtractor.java
@@ -53,6 +53,7 @@ import name.abuchen.portfolio.util.AdditionalLocales;
  *
  * @formatter:on
  */
+
 @SuppressWarnings("nls")
 public class CetesDirectoPDFExtractor extends AbstractPDFExtractor
 {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
@@ -1417,10 +1417,9 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                         // den vorherigen Monat mit einem Entgelt in Höhe von 123,45 Euro. Das entspricht 0,0298 %
                         // @formatter:on
                         .section("currency", "amount") //
-                        .match("^.*(Buchung|H.he) von (?<amount>[\\.,\\d]+) (?<currency>.*).*$") //
+                        .match("^.*(Buchung|H.he) von (?<amount>[\\.,\\d]+) (?<currency>[A-Za-z\\s\\-\\'\\.,]+).*$") //
                         .assign((t, v) -> {
-                            if ("Euro".equals(trim(v.get("currency"))))
-                                v.put("currency", "EUR");
+                            v.put("currency", asCurrencyCode(v.get("currency")));
 
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComputersharePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComputersharePDFExtractor.java
@@ -11,6 +11,7 @@ import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Values;
 
 /**
@@ -120,9 +121,9 @@ public class ComputersharePDFExtractor extends AbstractPDFExtractor
                                         .documentContext(TICKERSYMBOL, WKN) //
                                         .match("^(?<date>[\\d]{2} [\\w]{3} [\\d]{4}) Purchase (?<amount>[\\.,\\d]+) (?<fee>[\\.,\\d]+) (?<netAmount>[\\.,\\d]+) (?<grantDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvGrant>[\\.,\\d]+) (?<purchaseDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvPurchase>[\\.,\\d]+) (?<sharePrice>[\\.,\\d]+) (?<shares>[\\.,\\d]+) (?<totalShares>[\\.,\\d]+).*") //
                                         .assign((t, v) -> {
-                                            v.put("currency", "USD");
+                                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
                                             t.setDate(asDate(v.get("date")));
-                                            t.setCurrencyCode(asCurrencyCode("USD"));
+                                            t.setCurrencyCode(v.get("currency"));
                                             t.setAmount(asAmount(v.get("amount")));
                                             t.setShares(asShares(v.get("shares")));
                                             t.setSecurity(getOrCreateSecurity(v));
@@ -133,7 +134,7 @@ public class ComputersharePDFExtractor extends AbstractPDFExtractor
                                         .documentContext(TICKERSYMBOL, WKN) //
                                         .match("^(?<date>[\\d]{2} [\\w]{3} [\\d]{4}) Purchase (?<amount>[\\.,\\d]+) (?<netAmount>[\\.,\\d]+) (?<grantDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvGrant>[\\.,\\d]+) (?<purchaseDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvPurchase>[\\.,\\d]+) (?<sharePrice>[\\.,\\d]+) (?<shares>[\\.,\\d]+) (?<totalShares>[\\.,\\d]+).*") //
                                         .assign((t, v) -> {
-                                            v.put("currency", "USD");
+                                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
                                             t.setDate(asDate(v.get("date")));
                                             t.setCurrencyCode(v.get("currency"));
                                             t.setAmount(asAmount(v.get("amount")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -1114,10 +1114,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                                                         section -> section //
                                                                         .attributes("currency") //
                                                                         .match("^Referenzw.hrung (?<currency>.*)$") //
-                                                                        .assign((ctx, v) -> {
-                                                                            if ("Euro".equals(trim(v.get("currency"))))
-                                                                                ctx.put("currency", "EUR");
-                                                                        }),
+                                                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency")))),
                                                         // @formatter:off
                                                         // 28.08.2024
                                                         // Buchung Valuta Buchungsinformation Soll Haben

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FidelityInternationalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FidelityInternationalPDFExtractor.java
@@ -9,6 +9,7 @@ import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Values;
 
 /**
@@ -197,7 +198,7 @@ public class FidelityInternationalPDFExtractor extends AbstractPDFExtractor
                                                         .find("Symbol:.*") //
                                                         .match("^(?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?).*$") //
                                                         .assign((t, v) -> {
-                                                            v.put("currency", asCurrencyCode("USD"));
+                                                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
                                                             t.setSecurity(getOrCreateSecurity(v));
                                                         }),
                                         // @formatter:off
@@ -214,7 +215,7 @@ public class FidelityInternationalPDFExtractor extends AbstractPDFExtractor
                                                         .find("Symbol:.*") //
                                                         .match("^(?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?).*$") //
                                                         .assign((t, v) -> {
-                                                            v.put("currency", asCurrencyCode("USD"));
+                                                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
                                                             t.setSecurity(getOrCreateSecurity(v));
                                                         }),
                                         // @formatter:off
@@ -230,7 +231,7 @@ public class FidelityInternationalPDFExtractor extends AbstractPDFExtractor
                                                         .find("Symbol:.*") //
                                                         .match("^(?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?).*$") //
                                                         .assign((t, v) -> {
-                                                            v.put("currency", asCurrencyCode("USD"));
+                                                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
                                                             t.setSecurity(getOrCreateSecurity(v));
                                                         }))
 
@@ -293,7 +294,8 @@ public class FidelityInternationalPDFExtractor extends AbstractPDFExtractor
                         .find("You (Bought|Sold) .*") //
                         .match("^.* Activity .*([\\s]{1,})(?<fee>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            v.put("currency", asCurrencyCode("USD"));
+                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
+
                             processFeeEntries(t, v, type);
                         })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/GenoBrokerPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/GenoBrokerPDFExtractor.java
@@ -13,6 +13,7 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 
 @SuppressWarnings("nls")
@@ -355,7 +356,7 @@ public class GenoBrokerPDFExtractor extends AbstractPDFExtractor
 
                             // No amount available
                             v.getTransactionContext().put(FAILURE, Messages.MsgErrorTransactionTypeNotSupported);
-                            t.setCurrencyCode("EUR");
+                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                             t.setAmount(0);
                         })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
@@ -635,24 +635,19 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                         documentContext -> documentContext //
                                         .oneOf( //
                                                         // @formatter:off
-                                                        // Valuta Vorgang Euro
+                                                        // Buchung Buchung / Verwendungszweck Betrag (EUR)
                                                         // @formatter:on
                                                         section -> section //
                                                                         .attributes("currency") //
-                                                                        .match("^Buchung Buchung \\/ Verwendungszweck Betrag \\((?<currency>[\\w]{3})\\)$") //
-                                                                        .assign((ctx, v) -> {
-                                                                            ctx.put("currency", asCurrencyCode("EUR"));
-                                                                        }),
+                                                                        .match("^Buchung Buchung \\/ Verwendungszweck Betrag \\((?<currency>[A-Z]{3})\\)$") //
+                                                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency")))),
                                                         // @formatter:off
                                                         // Valuta Vorgang Euro
                                                         // @formatter:on
                                                         section -> section //
                                                                         .attributes("currency") //
-                                                                        .match("^Valuta Vorgang (?<currency>Euro)$") //
-                                                                        .assign((ctx, v) -> {
-                                                                            if ("Euro".equals(v.get("currency")))
-                                                                                ctx.put("currency", asCurrencyCode("EUR"));
-                                                                        }))
+                                                                        .match("^Valuta Vorgang (?<currency>.*)$") //
+                                                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency")))))
 
                                         .optionalOneOf( //
                                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LimeTradingCorpPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LimeTradingCorpPDFExtractor.java
@@ -95,12 +95,12 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                 t.setType(PortfolioTransaction.Type.SELL);
 
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                             t.setDate(asDate(v.get("date")));
                             t.setShares(asShares(v.get("shares")));
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                            t.setCurrencyCode(v.get("currency"));
 
                             // if CUSIP lenght != 9
                             if (v.get("wkn").length() != 9)
@@ -155,12 +155,12 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                                         .match("^[\\w]{3} [\\d]{2} .* [\\w]{9} (NRA Withhold|Foreign Withholding) \\((?<tax>[\\.,\\d]+)\\)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                                                            v.put("currency", CurrencyUnit.USD);
+                                                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
                                                             t.setAmount(asAmount(v.get("amount")) - asAmount(v.get("tax")));
-                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                                                            t.setCurrencyCode(v.get("currency"));
 
                                                             // if CUSIP lenght != 9
                                                             if (v.get("wkn").length() != 9)
@@ -178,12 +178,12 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                                         .match("^[\\w]{3} [\\d]{2} .* [\\w]{9} (NRA Withhold|Foreign Withholding) \\((?<tax>[\\.,\\d]+)\\)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                                                            v.put("currency", CurrencyUnit.USD);
+                                                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
                                                             t.setAmount(asAmount(v.get("amount")) - asAmount(v.get("tax")));
-                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                                                            t.setCurrencyCode(v.get("currency"));
 
                                                             // if CUSIP lenght != 9
                                                             if (v.get("wkn").length() != 9)
@@ -201,12 +201,12 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                                         .match("^(?<month>.*) (?<day>[\\d]{1,2}) (?<name>.*) (?<shares>[\\.,\\d]+) (?<wkn>(?!Qualified).{9}) (Qualified )?Dividend (?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                                                            v.put("currency", CurrencyUnit.USD);
+                                                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
                                                             t.setAmount(asAmount(v.get("amount")));
-                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                                                            t.setCurrencyCode(v.get("currency"));
 
                                                             // if CUSIP lenght != 9
                                                             if (v.get("wkn").length() != 9)
@@ -243,13 +243,13 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                                         .match("^(?<name>.*)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                                                            v.put("currency", CurrencyUnit.USD);
+                                                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setShares(0L);
                                                             t.setAmount(asAmount(v.get("amount")));
                                                             t.setNote(v.get("note"));
-                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                                                            t.setCurrencyCode(v.get("currency"));
 
                                                             // if CUSIP lenght != 9
                                                             if (v.get("wkn").length() != 9)
@@ -292,12 +292,12 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                         .match("(?<nameContinued>.*)") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setShares(asShares(v.get("shares")));
                             t.setAmount(0L);
-                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                            t.setCurrencyCode(v.get("currency"));
 
                             // if CUSIP lenght != 9
                             if (v.get("wkn").length() != 9)
@@ -337,11 +337,11 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<month>[\\w]{3}) (?<day>[\\d]{1,2}) Ca Fee_spinoff.* (?<name>.*) (?<wkn>.*) Journal \\((?<amount>[\\.,\\d]+)\\)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                            t.setCurrencyCode(v.get("currency"));
 
                             // if CUSIP lenght != 9
                             if (v.get("wkn").length() != 9)
@@ -382,12 +382,12 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<name>.*)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setShares(0L);
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                            t.setCurrencyCode(v.get("currency"));
 
                             // if CUSIP lenght != 9
                             if (v.get("wkn").length() != 9)
@@ -426,11 +426,11 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<month>[\\w]{3}) (?<day>[\\d]{1,2}) Wire .* (?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                            t.setCurrencyCode(v.get("currency"));
                         })
 
                         .wrap(TransactionItem::new));
@@ -456,11 +456,11 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<month>[\\w]{3}) (?<day>[\\d]{1,2}) .* Credit Interest (?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                            t.setCurrencyCode(v.get("currency"));
                         })
 
                         .wrap(TransactionItem::new));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RevolutLtdPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RevolutLtdPDFExtractor.java
@@ -77,7 +77,7 @@ public class RevolutLtdPDFExtractor extends AbstractPDFExtractor
                         .section("tickerSymbol", "name", "isin") //
                         .match("^(?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?) (?<name>.*) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) Sell [\\.,\\d]+ \\p{Sc}[\\.,\\d]+ [\\d]{2} .* [\\d]{4}$") //
                         .assign((t, v) -> {
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                             t.setSecurity(getOrCreateSecurity(v));
                         })
@@ -103,7 +103,7 @@ public class RevolutLtdPDFExtractor extends AbstractPDFExtractor
                         .match("^[A-Z0-9]{3,4} .* [A-Z]{2}[A-Z0-9]{9}[0-9] Sell [\\.,\\d]+ \\p{Sc}(?<amount>[\\.,\\d]+) [\\d]{2} .* [\\d]{4}$") //
                         .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(CurrencyUnit.USD);
+                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
                         })
 
                         .wrap(BuySellEntryItem::new);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScorePriorityIncPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScorePriorityIncPDFExtractor.java
@@ -92,12 +92,12 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
 
                             Map<String, String> context = type.getCurrentContext();
                             v.put("date", v.get("day") + " " + v.get("month") + " " + context.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                             t.setDate(asDate(v.get("date")));
                             t.setShares(asShares(v.get("shares")));
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                            t.setCurrencyCode(v.get("currency"));
                             t.setSecurity(getOrCreateSecurity(v));
                         })
 
@@ -136,15 +136,15 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
                                                         .match("^[\\w]{3} [\\d]{2} .* [\\w]{9} (NRA Withhold|Foreign Withholding) \\((?<tax>[\\.,\\d]+)\\)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                                                            v.put("currency", CurrencyUnit.USD);
+                                                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
                                                             t.setAmount(asAmount(v.get("amount")) - asAmount(v.get("tax")));
-                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                                                            t.setCurrencyCode(v.get("currency"));
                                                             t.setSecurity(getOrCreateSecurity(v));
 
-                                                            Money tax = Money.of(asCurrencyCode(CurrencyUnit.USD), asAmount(v.get("tax")));
+                                                            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
 
                                                             checkAndSetTax(tax, t, type.getCurrentContext());
                                                         }),
@@ -154,12 +154,12 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
                                                         .match("^(?<month>.*) (?<day>[\\d]{2}) (?<name>.*) (?<shares>[\\.,\\d]+) (?<wkn>(?!Qualified).{9}) (Qualified )?Dividend (?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                                                            v.put("currency", CurrencyUnit.USD);
+                                                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
                                                             t.setAmount(asAmount(v.get("amount")));
-                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                                                            t.setCurrencyCode(v.get("currency"));
                                                             t.setSecurity(getOrCreateSecurity(v));
                                                         }))
 
@@ -190,12 +190,12 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
                         .match("(?<nameContinued>.*)") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setShares(asShares(v.get("shares")));
                             t.setAmount(0L);
-                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                            t.setCurrencyCode(v.get("currency"));
                             t.setSecurity(getOrCreateSecurity(v));
                         })
 
@@ -223,7 +223,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<month>[\\w]{3}) (?<day>[\\d]{2}) Ca Fee_spinoff.* (?<name>.*) (?<wkn>.*) Journal \\((?<amount>[\\.,\\d]+)\\)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                             // if CUSIP lenght != 9
                             if (trim(v.get("wkn")).length() < 9)
@@ -233,7 +233,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                            t.setCurrencyCode(v.get("currency"));
                         })
 
                         .wrap((t, ctx) -> {
@@ -268,12 +268,12 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<name>.*)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setShares(0L);
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                            t.setCurrencyCode(v.get("currency"));
                             t.setSecurity(getOrCreateSecurity(v));
                         })
 
@@ -300,11 +300,11 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<month>[\\w]{3}) (?<day>[\\d]{2}) Incoming Wire .* (?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                            t.setCurrencyCode(v.get("currency"));
                         })
 
                         .wrap(TransactionItem::new));
@@ -330,11 +330,11 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<month>[\\w]{3}) (?<day>[\\d]{2}) .* Credit Interest (?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(CurrencyUnit.USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.USD));
+                            t.setCurrencyCode(v.get("currency"));
                         })
 
                         .wrap(TransactionItem::new));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SimpelPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SimpelPDFExtractor.java
@@ -13,6 +13,7 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Values;
 
 /**
@@ -147,7 +148,7 @@ public class SimpelPDFExtractor extends AbstractPDFExtractor
                         .match("^Fondsname: (?<name>.*) Datum .*$") //
                         .match("^WKN \\/ ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) .*$") //
                         .assign((t, v) -> {
-                            v.put("currency", "EUR");
+                            v.put("currency", asCurrencyCode(CurrencyUnit.EUR));
 
                             t.setSecurity(getOrCreateSecurity(v));
                         })
@@ -183,7 +184,7 @@ public class SimpelPDFExtractor extends AbstractPDFExtractor
                         .match("^Zur (Wiederveranlagung|Wiederanlage/Auszahlung) zur Verf.gung stehend: (?<amount>[\\.'\\d]+)$") //
                         .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode("EUR");
+                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                         })
 
                         // @formatter:off
@@ -215,7 +216,8 @@ public class SimpelPDFExtractor extends AbstractPDFExtractor
                         .section("tax").optional() //
                         .match("^Kapitalertragssteuer \\(KESt\\) gesamt: (?<tax>[\\.'\\d]+)$") //
                         .assign((t, v) -> {
-                            v.put("currency", "EUR");
+                            v.put("currency", asCurrencyCode(CurrencyUnit.EUR));
+
                             processTaxEntries(t, v, type);
                         });
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SutorBankGmbHPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SutorBankGmbHPDFExtractor.java
@@ -13,6 +13,7 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 
 /**
@@ -496,7 +497,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date"), v.get("time")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             v.getTransactionContext().put(FAILURE, Messages.MsgErrorOrderCancellationUnsupported);
@@ -528,7 +529,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date"), v.get("time")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             Money tax1 = Money.of(t.getPortfolioTransaction().getCurrencyCode(), asAmount(v.get("tax1")));
@@ -561,7 +562,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date"), v.get("time")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }),
                                         // @formatter:off
@@ -587,7 +588,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date"), v.get("time")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }),
                                         // @formatter:off
@@ -610,7 +611,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }),
                                         // @formatter:off
@@ -632,7 +633,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }),
                                         // @formatter:off
@@ -653,7 +654,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }),
                                         // @formatter:off
@@ -675,7 +676,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note"));
@@ -698,7 +699,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note"));
@@ -749,7 +750,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                             t.setDateTime(asDate(v.get("date")));
                             t.setShares(0L);
 
-                            t.setCurrencyCode("EUR");
+                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                             t.setAmount(asAmount(v.get("amount")));
 
                             Money tax1 = Money.of(t.getCurrencyCode(), asAmount(v.get("tax1")));
@@ -789,7 +790,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note"));
@@ -812,7 +813,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
                                                             t.setDateTime(asDate(v.get("date")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note"));
@@ -848,7 +849,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date")));
 
-                            t.setCurrencyCode("EUR");
+                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                             t.setAmount(asAmount(v.get("amount")));
 
                             t.setNote(v.get("note"));
@@ -895,7 +896,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note"));
@@ -917,7 +918,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note"));
@@ -932,7 +933,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note"));
@@ -957,7 +958,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
                                                             t.setDateTime(asDate(v.get("date")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note1") + " " + v.get("note2") + " vom " + v.get("stornoDate"));
@@ -996,7 +997,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setSecurity(getOrCreateSecurity(v));
 
                                                             t.setAmount(0L);
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
 
                                                             t.setNote(v.get("note"));
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradegateAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradegateAGPDFExtractor.java
@@ -14,6 +14,7 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 
 @SuppressWarnings("nls")
@@ -321,7 +322,7 @@ public class TradegateAGPDFExtractor extends AbstractPDFExtractor
                         .section("amount") //
                         .match("^(Gutgeschriebener Betrag|Belastung) (\\-)?(?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            t.setCurrencyCode("EUR");
+                            t.setCurrencyCode(asCurrencyCode(CurrencyUnit.EUR));
                             t.setAmount(asAmount(v.get("amount")));
                         })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/CurrencyUnit.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/CurrencyUnit.java
@@ -99,6 +99,20 @@ public final class CurrencyUnit implements Comparable<CurrencyUnit>
         return null;
     }
 
+    public static CurrencyUnit getInstanceByDisplayName(String displayName)
+    {
+        if (displayName == null)
+            return null;
+
+        for (CurrencyUnit unit : CACHE.values())
+        {
+            if (displayName.equalsIgnoreCase(unit.getDisplayName()))
+                return unit;
+        }
+
+        return null;
+    }
+
     public static boolean containsCurrencyCode(String currencyCode)
     {
         return CACHE.containsKey(currencyCode);


### PR DESCRIPTION
Adds support for resolving currencies by their localized display name using CurrencyUnit.getInstanceByDisplayName(String). Also updates asCurrencyCode(String) to include display name lookup as a fallback.

Update PDF-Importers...

---

Hello @buchen 
sooo... please check out `AbstractPDFExtractor.java` and `CurrencyUnit.java` ...

Thx
Alex
