### PR TITLE
Allow collapsing taxonomies on Statement of Assets

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -1446,6 +1446,7 @@ public class Messages extends NLS
     public static String WatchlistRename;
     public static String Website;
     public static String YearlyPerformanceHeatmapToolTip;
+    public static String ColumnCollapser;
     static
     {
         // initialize resource bundle

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -2883,3 +2883,5 @@ WatchlistRename = Rename Watchlist
 Website = Website
 
 YearlyPerformanceHeatmapToolTip = Yearly rate of return displayed as heatmap\n\nTo calculate the yearly rate of return, the true-time weighted rate of return (TTWROR) is used.\n\nThe rate of return is always calculated for the full year - even if the reporting interval ends or starts in the middle of a year.
+
+ColumnCollapser = Expand/Collapse

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -102,6 +102,8 @@ BtnLabelRestartNow = Restart now
 
 BtnTooltipInvertExchangeRate = Invert the exchange rate value.\n\nPlease note: this operation does not change the notation of the exchange rate, but simply divides 1 by the current value.
 
+ColumnCollapser = Expand/Collapse
+
 CSVConfigCSVImportLabelFileJSON = JSON files (*.json)
 
 CSVConfigDelete = Delete configuration
@@ -2883,5 +2885,3 @@ WatchlistRename = Rename Watchlist
 Website = Website
 
 YearlyPerformanceHeatmapToolTip = Yearly rate of return displayed as heatmap\n\nTo calculate the yearly rate of return, the true-time weighted rate of return (TTWROR) is used.\n\nThe rate of return is always calculated for the full year - even if the reporting interval ends or starts in the middle of a year.
-
-ColumnCollapser = Expand/Collapse


### PR DESCRIPTION
Implement a new (optional) Collapse/Expand column on the Statement of Assets page, allowing you to collapse each taxonomy. Collapsed/expanded state is persisted to the GUI settings. 

Closes #4420

![Peek 2025-04-19 08-56](https://github.com/user-attachments/assets/734c4bd6-c462-4e0f-bd1d-e14f5f0efe07)
