### PR TITLE
Fix transaction search for numerics

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TextUtilTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TextUtilTest.java
@@ -5,7 +5,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 import org.junit.Test;
 
@@ -200,4 +205,76 @@ public class TextUtilTest
         assertEquals(0, TextUtil.compare("abc", "abc"));
     }
 
+    @Test
+    public void testIsNumericMatch()
+    {
+        char decimalSeparator = new DecimalFormatSymbols(Locale.getDefault()).getDecimalSeparator();
+        String decimalSep = String.valueOf(decimalSeparator);
+        char groupingSeparator = new DecimalFormatSymbols(Locale.getDefault()).getGroupingSeparator();
+        String groupSep = String.valueOf(groupingSeparator);
+
+        // Whole numbers
+        assertTrue(TextUtil.isNumericSearchMatch("2", 2601));
+        assertTrue(TextUtil.isNumericSearchMatch("26", 2601));
+        assertTrue(TextUtil.isNumericSearchMatch("260", 2601));
+        assertTrue(TextUtil.isNumericSearchMatch("2601", 2601));
+        assertFalse(TextUtil.isNumericSearchMatch("26010", 2601));
+
+        assertTrue(TextUtil.isNumericSearchMatch("2" + groupSep + "6", 2601));
+        assertTrue(TextUtil.isNumericSearchMatch("2" + groupSep + "60", 2601));
+        assertTrue(TextUtil.isNumericSearchMatch("2" + groupSep + "601", 2601));
+        assertFalse(TextUtil.isNumericSearchMatch("2" + groupSep + "6010", 2601));
+
+        // Decimal numbers
+        assertTrue(TextUtil.isNumericSearchMatch("2", 2601.26));
+        assertTrue(TextUtil.isNumericSearchMatch("26", 2601.26));
+        assertTrue(TextUtil.isNumericSearchMatch("260", 2601.26));
+        assertTrue(TextUtil.isNumericSearchMatch("2601", 2601.26));
+        assertTrue(TextUtil.isNumericSearchMatch("2601" + decimalSep, 2601.26));
+        assertTrue(TextUtil.isNumericSearchMatch("2601" + decimalSep + "2", 2601.26));
+        assertTrue(TextUtil.isNumericSearchMatch("2601" + decimalSep + "26", 2601.26));
+        assertFalse(TextUtil.isNumericSearchMatch("2601" + decimalSep + "261", 2601.26));
+
+        assertTrue(TextUtil.isNumericSearchMatch("2" + groupSep + "6", 2601.26));
+        assertTrue(TextUtil.isNumericSearchMatch("2" + groupSep + "60", 2601.26));
+        assertTrue(TextUtil.isNumericSearchMatch("2" + groupSep + "601", 2601.26));
+        assertTrue(TextUtil.isNumericSearchMatch("2" + groupSep + "601" + decimalSep, 2601.26));
+        assertTrue(TextUtil.isNumericSearchMatch("2" + groupSep + "601" + decimalSep + "2", 2601.26));
+        assertTrue(TextUtil.isNumericSearchMatch("2" + groupSep + "601" + decimalSep + "26", 2601.26));
+        assertFalse(TextUtil.isNumericSearchMatch("2" + groupSep + "601" + decimalSep + "261", 2601.26));
+
+        assertTrue(TextUtil.isNumericSearchMatch("2601" + decimalSep, 2601));
+        assertTrue(TextUtil.isNumericSearchMatch("2601" + decimalSep + "0", 2601));
+        assertTrue(TextUtil.isNumericSearchMatch("2601" + decimalSep + "00", 2601));
+        assertFalse(TextUtil.isNumericSearchMatch("2601" + decimalSep + "01", 2601));
+        assertTrue(TextUtil.isNumericSearchMatch("2" + groupSep + "601" + decimalSep, 2601));
+
+        assertFalse(TextUtil.isNumericSearchMatch("25", 1250));
+
+        assertTrue(TextUtil.isNumericSearchMatch("0", 0));
+        assertTrue(TextUtil.isNumericSearchMatch("0", 0.01));
+        assertTrue(TextUtil.isNumericSearchMatch("0" + decimalSep, 0.01));
+        assertTrue(TextUtil.isNumericSearchMatch("0" + decimalSep + "0", 0.01));
+        assertTrue(TextUtil.isNumericSearchMatch("0" + decimalSep + "01", 0.01));
+        assertFalse(TextUtil.isNumericSearchMatch("0" + decimalSep + "012", 0.01));
+        assertFalse(TextUtil.isNumericSearchMatch("0", 1));
+
+        assertFalse(TextUtil.isNumericSearchMatch("", 12));
+        assertFalse(TextUtil.isNumericSearchMatch("abc", 12));
+        assertFalse(TextUtil.isNumericSearchMatch("12a", 12));
+        assertFalse(TextUtil.isNumericSearchMatch("25.", 2500));
+        assertFalse(TextUtil.isNumericSearchMatch("25.0", 2500));
+        assertFalse(TextUtil.isNumericSearchMatch("25.33", 254.33));
+        assertFalse(TextUtil.isNumericSearchMatch("250000", 2500));
+        assertTrue(TextUtil.isNumericSearchMatch("12", 128));
+        assertTrue(TextUtil.isNumericSearchMatch("128" + decimalSep, 128));
+
+        // We don't care about sign because PP displays both positive and
+        // negative numbers as positive
+        assertTrue(TextUtil.isNumericSearchMatch("25", -25));
+        assertTrue(TextUtil.isNumericSearchMatch("25" + decimalSep + "0", -25));
+        assertTrue(TextUtil.isNumericSearchMatch("25" + decimalSep + "5", -25.5));
+        assertTrue(TextUtil.isNumericSearchMatch("25" + decimalSep + "5", -25.55));
+        assertTrue(TextUtil.isNumericSearchMatch("2" + groupSep + "500" + decimalSep + "0", -2500));
+    }
 }


### PR DESCRIPTION
The Transactions search often returns goofy/incorrect results - for example:
* Searching for "100000000" would return every transaction for 1 share
* Searching for "5000000" would return transactions for $500, $2500, etc (basically any amount ending in "500").
* Searching for "2000" would NOT return transactions for $2000 (you have to explicitly type a comma, i.e. "2,000").

This PR should fix it.

Note that it retains the ability to search with commas (i.e. 2,000) to avoid changing prior behavior.

Closes #2345