### PR TITLE
Fix "Only profitable trades" filter including trades with zero profit

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
@@ -407,7 +407,7 @@ public class TradeDetailsView extends AbstractFinanceView
         if (onlyLossMaking.isTrue())
             filteredTrades = filteredTrades.filter(Trade::isLoss);
         if (onlyProfitable.isTrue())
-            filteredTrades = filteredTrades.filter(t -> !t.isLoss());
+            filteredTrades = filteredTrades.filter(t -> t.getProfitLoss().isPositive());
 
         table.setInput(filteredTrades.collect(Collectors.toList()));
 


### PR DESCRIPTION
Bug fix: On the Trades page, the "Only profitable trades" filter option was including trades where profit is 0.