### PR TITLE
Add toString() method to LatestSecurityPrice that prints all security attributes

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/LatestSecurityPrice.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/LatestSecurityPrice.java
@@ -3,6 +3,8 @@ package name.abuchen.portfolio.model;
 import java.time.LocalDate;
 import java.util.Objects;
 
+import name.abuchen.portfolio.money.Values;
+
 public class LatestSecurityPrice extends SecurityPrice
 {
     private long high;
@@ -79,5 +81,12 @@ public class LatestSecurityPrice extends SecurityPrice
             return false;
         LatestSecurityPrice other = (LatestSecurityPrice) obj;
         return super.equals(other) && high == other.high && low == other.low && volume == other.volume;
+    }
+
+    @Override
+    @SuppressWarnings("nls")
+    public String toString()
+    {
+        return String.format("%s %,10.2f %,10.2f %,10d", super.toString(), high / Values.Quote.divider(), low / Values.Quote.divider(), volume);
     }
 }


### PR DESCRIPTION
This PR adds a toString() method to LatestSecurityPrice, that asso prints the high, low and volume attributes of the security.
Previously, only date and price where printed by the toString() method of the super class, leading to confusing and not helpful output from the test suute, when (e.g. in the tests of a quote feed) an assertion comparing two prices failed due to them only differing in the high, low and volume attributes.