### PR TITLE
fix Y axis visibility on Rebalancing BarChart Widget

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/RebalancingChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/RebalancingChartWidget.java
@@ -62,6 +62,7 @@ public class RebalancingChartWidget extends WidgetDelegate<TaxonomyModel>
         GridDataFactory.fillDefaults().grab(true, false).applyTo(title);
 
         chart = new BarChart(container, title.getText());
+        chart.getAxisSet().getYAxis(0).getTick().setVisible(get(ChartShowYAxisConfig.class).getIsShowYAxis());
 
         int yHint = get(ChartHeightConfig.class).getPixel();
         GridDataFactory.fillDefaults().hint(SWT.DEFAULT, yHint).grab(true, false).applyTo(chart);
@@ -120,6 +121,8 @@ public class RebalancingChartWidget extends WidgetDelegate<TaxonomyModel>
 
             for (var s : chart.getSeriesSet().getSeries())
                 chart.getSeriesSet().deleteSeries(s.getId());
+
+            chart.getAxisSet().getYAxis(0).getTick().setVisible(get(ChartShowYAxisConfig.class).getIsShowYAxis());
 
             if (model == null)
                 return;


### PR DESCRIPTION
Hello,

On the newly introduced Rebalancing Bar Chart widget, the "Show Y axis" option is available but had no effect, the Y axis was always staying visible whatever the choice. This is to fix this and allows to toggle on/off the Y axis.