### PR TITLE
Imrprove YahooFinance quote feed to fetch up to 30 years of historical data

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooFinanceQuoteFeed.java
@@ -179,7 +179,7 @@ public class YahooFinanceQuoteFeed implements QuoteFeed
         int days = Dates.daysBetween(startDate, LocalDate.now());
 
         // "max" only returns a sample of quotes
-        String range = "10y"; //$NON-NLS-1$
+        String range = "30y"; //$NON-NLS-1$
 
         if (days < 25)
             range = "1mo"; //$NON-NLS-1$
@@ -193,6 +193,10 @@ public class YahooFinanceQuoteFeed implements QuoteFeed
             range = "2y"; //$NON-NLS-1$
         else if (days < 1500)
             range = "5y"; //$NON-NLS-1$
+        else if (days < 3000)
+            range = "10y"; //$NON-NLS-1$
+        else if (days < 6000)
+            range = "20y"; //$NON-NLS-1$
 
         return new WebAccess("query1.finance.yahoo.com", "/v8/finance/chart/" + security.getTickerSymbol()) //
                         .addUserAgent("Mozilla/5.0 (" + ThreadLocalRandom.current().nextInt(100000, 999999) + ")") //


### PR DESCRIPTION
While the `validRanges` metadata field of the server response has 10y as the higest numeric entry in its list of possible values, other values like 20y or 30y do work as well, as also used in an example of the JSON quote feed in the documentation.