### PR TITLE
Add more moving average columns in trades

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector5Test.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector5Test.java
@@ -1,0 +1,126 @@
+package name.abuchen.portfolio.snapshot.trades;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.junit.PortfolioBuilder;
+import name.abuchen.portfolio.junit.SecurityBuilder;
+import name.abuchen.portfolio.junit.TestCurrencyConverter;
+import name.abuchen.portfolio.model.Account;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.money.CurrencyUnit;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.Values;
+
+@SuppressWarnings("nls")
+public class TradeCollector5Test
+{
+    @Test
+    public void testTradesSimpleOpenPosition() throws TradeCollectorException
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder().addPrice("2022-03-01", Values.Quote.factorize(200)) //
+                        .addTo(client);
+        new PortfolioBuilder(new Account("one"))
+                        .inbound_delivery(security, "2022-01-01", Values.Share.factorize(5),
+                                        Values.Amount.factorize(520), Values.Amount.factorize(10),
+                                        Values.Amount.factorize(10))
+                        .inbound_delivery(security, "2022-02-01", Values.Share.factorize(10),
+                                        Values.Amount.factorize(1000))
+                        .addTo(client);
+
+        TradeCollector collector = new TradeCollector(client, new TestCurrencyConverter());
+
+        List<Trade> trades = collector.collect(security);
+
+        assertThat(trades.size(), is(1));
+
+        Trade firstTrade = trades.get(0);
+
+        assertThat(firstTrade.getStart(), is(LocalDateTime.parse("2022-01-01T00:00")));
+        assertThat(firstTrade.getEnd().isPresent(), is(false));
+
+        // 200*15-520-1000 = 1480
+        assertThat(firstTrade.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1480.00))));
+        assertThat(firstTrade.getProfitLossMovingAverage(), is(firstTrade.getProfitLoss()));
+
+        // 200*15-520-10-10-1000 = 1500
+        assertThat(firstTrade.getGrossProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1500.00))));
+        assertThat(firstTrade.getGrossProfitLossMovingAverage(), is(firstTrade.getGrossProfitLoss()));
+    }
+
+    @Test
+    public void testTradesProtitAndGrossProfitFIFOAndMovingAverage() throws TradeCollectorException
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder().addPrice("2023-03-01", Values.Quote.factorize(200)) //
+                        .addTo(client);
+        new PortfolioBuilder(new Account("one"))
+                        .inbound_delivery(security, "2022-01-01", Values.Share.factorize(5),
+                                        Values.Amount.factorize(520), Values.Amount.factorize(10),
+                                        Values.Amount.factorize(10))
+                        .inbound_delivery(security, "2022-02-01", Values.Share.factorize(10),
+                                        Values.Amount.factorize(1000))
+                        .outbound_delivery(security, "2022-03-01", Values.Share.factorize(10),
+                                        Values.Amount.factorize(1480), Values.Amount.factorize(10),
+                                        Values.Amount.factorize(10))
+                        .addTo(client);
+
+        TradeCollector collector = new TradeCollector(client, new TestCurrencyConverter());
+
+        List<Trade> trades = collector.collect(security);
+
+        assertThat(trades.size(), is(2));
+
+        Trade firstTrade = trades.get(0);
+
+        assertThat(firstTrade.getStart(), is(LocalDateTime.parse("2022-01-01T00:00")));
+        assertThat(firstTrade.getEnd().isPresent(), is(true));
+
+        // 1480 - (520 + 1000*5/10) = 460
+        assertThat(firstTrade.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(460.00))));
+        // 1480 - (520 + 1000)*10/15 = 466.67
+        assertThat(firstTrade.getProfitLossMovingAverage(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(466.67))));
+
+        // 1480+10+10 - (520-10-10 + 1000*5/10) = 500
+        assertThat(firstTrade.getGrossProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500.00))));
+        // 1480+10+10 - (520-10-10 + 1000)*10/15 = 500
+        assertThat(firstTrade.getGrossProfitLossMovingAverage(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500.00))));
+
+        // return : 1480/(520 + 1000*5/10)-1=0.45098
+        assertThat(firstTrade.getReturn(), closeTo(0.4510, 0.0001));
+        // return : 1480/[(520 + 1000)*10/15]-1=0.46052
+        assertThat(firstTrade.getReturnMovingAverage(), closeTo(0.4605, 0.0001));
+
+        Trade secondTrade = trades.get(1);
+        assertThat(secondTrade.getEnd().isPresent(), is(false));
+        // 200*5 - (1000*5/10) = 500
+        assertThat(secondTrade.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500.00))));
+        // 200*5 - (520 + 1000)*5/15 = 493.33
+        assertThat(secondTrade.getProfitLossMovingAverage(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(493.33))));
+
+        // 200*5 - (500*5/10) = 500
+        assertThat(secondTrade.getGrossProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500.00))));
+        // 200*5 - (520-10-10 + 1000)*5/15 = 500
+        assertThat(secondTrade.getGrossProfitLossMovingAverage(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500.00))));
+
+        // return : 200*5 / (1000*5/10)-1 = 1
+        assertThat(secondTrade.getReturn(), closeTo(1.0000, 0.0001));
+        // return : 200*5 / [(520 + 1000)*5/15]-1 = 0.97368
+        assertThat(secondTrade.getReturnMovingAverage(), closeTo(0.9737, 0.0001));
+    }
+
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
@@ -381,8 +381,21 @@ public class TradesTableViewer
         support.addColumn(column);
 
         column = new Column("return", Messages.ColumnReturn, SWT.RIGHT, 80); //$NON-NLS-1$
+        column.setGroupLabel(Messages.ColumnReturn);
+        column.setMenuLabel(Messages.ColumnReturn + " (" + Messages.LabelCapitalGainsMethodFIFO + ")"); //$NON-NLS-1$ //$NON-NLS-2$
         column.setLabelProvider(new NumberColorLabelProvider<>(Values.Percent2, t -> ((Trade) t).getReturn()));
         column.setSorter(ColumnViewerSorter.create(e -> ((Trade) e).getReturn()));
+        column.setVisible(false);
+        support.addColumn(column);
+
+        column = new Column("return moving average", //$NON-NLS-1$
+                        Messages.ColumnReturn + " (" + Messages.LabelCapitalGainsMethodMovingAverageAbbr + ")", //$NON-NLS-1$ //$NON-NLS-2$
+                        SWT.RIGHT, 80);
+        column.setGroupLabel(Messages.ColumnReturn);
+        column.setMenuLabel(Messages.ColumnReturn + " (" + Messages.LabelCapitalGainsMethodMovingAverage + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+        column.setLabelProvider(
+                        new NumberColorLabelProvider<>(Values.Percent2, t -> ((Trade) t).getReturnMovingAverage()));
+        column.setSorter(ColumnViewerSorter.create(e -> ((Trade) e).getReturnMovingAverage()));
         column.setVisible(false);
         support.addColumn(column);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
@@ -238,6 +238,8 @@ public class TradesTableViewer
         column = new Column("entryvalue-pershare", Messages.ColumnEntryValue + " (" + Messages.ColumnPerShare + ")", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
                         SWT.RIGHT, 80);
         column.setGroupLabel(Messages.ColumnEntryValue);
+        column.setMenuLabel(Messages.ColumnEntryValue + " (" + Messages.ColumnPerShare + ")" + " (" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                        + Messages.LabelCapitalGainsMethodFIFO + ")"); //$NON-NLS-1$
         column.setLabelProvider(new ColumnLabelProvider()
         {
             @Override
@@ -247,6 +249,32 @@ public class TradesTableViewer
             }
         });
         column.setSorter(ColumnViewerSorter.create(e -> averagePurchasePrice.apply((Trade) e)));
+        column.setVisible(false);
+        support.addColumn(column);
+
+        Function<Trade, Money> averagePurchasePriceMovingAverage = t -> {
+            Money entryValue = t.getEntryValueMovingAverage();
+            return Money.of(entryValue.getCurrencyCode(),
+                            Math.round(entryValue.getAmount() / (double) t.getShares() * Values.Share.factor()));
+        };
+
+        column = new Column("entryvalue-mvavg-pershare", //$NON-NLS-1$
+                        Messages.ColumnEntryValue + " (" + Messages.ColumnPerShare + ")" + " (" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                                        + Messages.LabelCapitalGainsMethodMovingAverageAbbr + ")", //$NON-NLS-1$
+                        SWT.RIGHT, 80);
+        column.setGroupLabel(Messages.ColumnEntryValue);
+        column.setMenuLabel(Messages.ColumnEntryValue + " (" + Messages.ColumnPerShare + ")" + " (" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                        + Messages.LabelCapitalGainsMethodMovingAverage + ")"); //$NON-NLS-1$
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object e)
+            {
+                return Values.Money.format(averagePurchasePriceMovingAverage.apply((Trade) e),
+                                view.getClient().getBaseCurrency());
+            }
+        });
+        column.setSorter(ColumnViewerSorter.create(e -> averagePurchasePriceMovingAverage.apply((Trade) e)));
         column.setVisible(false);
         support.addColumn(column);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
@@ -313,6 +313,18 @@ public class TradesTableViewer
         column.setVisible(false);
         support.addColumn(column);
 
+        column = new Column("gpl-mavg", //$NON-NLS-1$
+                        Messages.ColumnGrossProfitLoss + " (" + Messages.LabelCapitalGainsMethodMovingAverageAbbr + ")", //$NON-NLS-1$ //$NON-NLS-2$
+                        SWT.RIGHT, 80);
+        column.setGroupLabel(Messages.ColumnProfitLoss);
+        column.setMenuLabel(
+                        Messages.ColumnGrossProfitLoss + " (" + Messages.LabelCapitalGainsMethodMovingAverage + ")"); //$NON-NLS-1$ //$NON-NLS-2$
+        column.setLabelProvider(new MoneyColorLabelProvider(
+                        element -> ((Trade) element).getGrossProfitLossMovingAverage(), view.getClient()));
+        column.setSorter(ColumnViewerSorter.create(e -> ((Trade) e).getGrossProfitLossMovingAverage()));
+        column.setVisible(false);
+        support.addColumn(column);
+
         column = new Column("holdingperiod", Messages.ColumnHoldingPeriod, SWT.RIGHT, 80); //$NON-NLS-1$
         column.setLabelProvider(new ColumnLabelProvider()
         {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
@@ -133,6 +133,12 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
     private final LazyValue<Money> movingAverageCost = new LazyValue<>(() -> costCalculation.get().movingAverageCost());
 
     /**
+     * moving average cost of shares held without fees or taxes
+     */
+    private final LazyValue<Money> movingAverageGrossCost = new LazyValue<>(
+                    () -> costCalculation.get().netMovingAverageCost());
+
+    /**
      * market value - fifo cost of shares held
      */
     private final LazyValue<Money> capitalGainsOnHoldings = new LazyValue<>(
@@ -296,6 +302,11 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
     public LazyValue<Money> getMovingAverageCost()
     {
         return movingAverageCost;
+    }
+
+    public LazyValue<Money> getMovingAverageGrossCost()
+    {
+        return movingAverageGrossCost;
     }
 
     public LazyValue<Money> getCapitalGainsOnHoldings()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -256,6 +256,11 @@ public class Trade implements Adaptable
         return (exitValue.getAmount() / (double) entryValue.getAmount()) - 1;
     }
 
+    public double getReturnMovingAverage()
+    {
+        return (exitValue.getAmount() / (double) entryValueMovingAverage.get().getAmount()) - 1;
+    }
+
     /**
      * @brief Checks if the trade is closed
      * @return True if the trade has been closed, false otherwise

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -98,6 +98,7 @@ public class Trade implements Adaptable
                             .setScale(0, RoundingMode.HALF_UP).longValue();
 
             this.exitValue = converter.at(now).apply(Money.of(security.getCurrencyCode(), marketValue));
+            this.exitGrossValue = exitValue;
 
             this.holdingPeriod = Math.round(transactions.stream() //
                             .filter(t -> t.getTransaction().getType().isPurchase())

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -45,6 +45,7 @@ public class Trade implements Adaptable
     private double irr;
 
     private LazyValue<Money> entryValueMovingAverage;
+    private LazyValue<Money> entryGrossValueMovingAverage;
 
     public Trade(Security security, Portfolio portfolio, long shares)
     {
@@ -116,41 +117,8 @@ public class Trade implements Adaptable
 
         calculateIRR(converter);
 
-        this.entryValueMovingAverage = new LazyValue<>(() -> {
-            var closingTransaction = transactions.stream() //
-                            .filter(t -> t.getTransaction().getType().isLiquidation()) //
-                            .findFirst().map(t -> t.getTransaction());
-
-            Client filteredClient = client;
-            if (closingTransaction.isPresent())
-            {
-                // if a closing transaction is present, we need to calculate the
-                // moving average costs based on all transactions before the
-                // closing transaction
-                filteredClient = new ClientTransactionFilter(security, closingTransaction.get()).filter(client);
-            }
-
-            var snapshot = LazySecurityPerformanceSnapshot.create(filteredClient, converter,
-                            Interval.of(LocalDate.MIN,
-                                            closingTransaction.isPresent()
-                                                            ? closingTransaction.get().getDateTime().toLocalDate()
-                                                            : LocalDate.now()));
-            var r = snapshot.getRecord(security);
-            if (r.isEmpty())
-                return null;
-
-            // the trade might be a partial liquidation, so we have to calculate
-            // the moving average purchase value based on the number of shares
-            // sold
-
-            var totalCosts = r.get().getMovingAverageCost().get();
-            var totalShares = r.get().getSharesHeld().get();
-
-            var cost = BigDecimal.valueOf(shares / (double) totalShares) //
-                            .multiply(BigDecimal.valueOf(totalCosts.getAmount())) //
-                            .setScale(0, RoundingMode.HALF_DOWN).longValue();
-            return Money.of(totalCosts.getCurrencyCode(), cost);
-        });
+        this.entryValueMovingAverage = new LazyValue<>(() -> getMovingAverageCost(client, converter, true));
+        this.entryGrossValueMovingAverage = new LazyValue<>(() -> getMovingAverageCost(client, converter, false));
     }
 
     private void calculateIRR(CurrencyConverter converter)
@@ -266,6 +234,13 @@ public class Trade implements Adaptable
         return exitGrossValue.subtract(entryGrossValue);
     }
 
+    public Money getGrossProfitLossMovingAverage()
+    {
+        if (exitGrossValue == null)
+            return null;
+        return exitGrossValue.subtract(entryGrossValueMovingAverage.get());
+    }
+
     public long getHoldingPeriod()
     {
         return holdingPeriod;
@@ -322,5 +297,45 @@ public class Trade implements Adaptable
     {
         return String.format("<Trade sh=%s %s %s -> %s %s>", //$NON-NLS-1$
                         shares, start, entryValue, end, exitValue);
+    }
+
+    private Money getMovingAverageCost(Client client, CurrencyConverter converter, boolean withFeesAndTaxes)
+    {
+        var closingTransaction = transactions.stream() //
+                        .filter(t -> t.getTransaction().getType().isLiquidation()) //
+                        .findFirst().map(t -> t.getTransaction());
+
+        Client filteredClient = client;
+        if (closingTransaction.isPresent())
+        {
+            // if a closing transaction is present, we need to calculate the
+            // moving average costs based on all transactions before the
+            // closing transaction
+
+            filteredClient = new ClientTransactionFilter(security, closingTransaction.get()).filter(client);
+        }
+
+        var snapshot = LazySecurityPerformanceSnapshot.create(filteredClient, converter,
+                        Interval.of(LocalDate.MIN,
+                                        closingTransaction.isPresent()
+                                                        ? closingTransaction.get().getDateTime().toLocalDate()
+                                                        : LocalDate.now()));
+        var r = snapshot.getRecord(security);
+        if (r.isEmpty())
+            return null;
+
+        // the trade might be a partial liquidation, so we have to calculate
+        // the moving average purchase value based on the number of shares
+        // sold
+
+        var totalCosts = withFeesAndTaxes ? r.get().getMovingAverageCost().get()
+                        : r.get().getMovingAverageGrossCost().get();
+        var totalShares = r.get().getSharesHeld().get();
+
+        var cost = BigDecimal.valueOf(shares / (double) totalShares) //
+                        .multiply(BigDecimal.valueOf(totalCosts.getAmount())) //
+                        .setScale(0, RoundingMode.HALF_DOWN).longValue();
+
+        return Money.of(totalCosts.getCurrencyCode(), cost);
     }
 }


### PR DESCRIPTION
Hello,

This is to continue on https://github.com/portfolio-performance/portfolio/issues/4503 and https://github.com/portfolio-performance/portfolio/commit/ba6651ce64b567648228e187f8d3d2c92e22bd54
This is a proposition to add in the Trades view, commit by commit : 

- **Gross Profit/Loss for FIFO for Open trades** : was left empty until now, I am not sure why, in the manual it is stated : 

> This equals the value of the previous column plus taxes and fees. Because for closed trades, the taxes and fees of the sell transaction are included in the Gross Profit/Loss column, **this field cannot be calculated for the open trades**.

However I believe it makes also sense for open trades, as you can have fees (and in rare cases even taxes) on buy transactions.

- **Gross Profit/Loss for Moving average for Open trades** : for this one it is not complicated, but there I reached a naming definition issue on "net/gross cost" (whatever fifo or moving avg), either I am missing something, either the naming does not seem consistent across the different part of the code

In PortfolioTransaction the definition is
  ```
  /**
     * Returns the gross value, i.e. the value before taxes and fees are
     * applied. In the case of a buy transaction, that are the gross costs, i.e.
     * before adding additional taxes and fees. In the case of sell
     * transactions, that are the gross proceeds before the deduction of taxes
     * and fees.
     */
```
In CostCalculation the definition is
   ```
 /**
     * net investment, i.e. without fees and taxes
     */
```
I understand the latter. My understanding :
Value=G+C+F
G=net Gains, C=net Cost, F=acquisition Fees&Taxes
Value-C=G+F=gross gain (shows price movement only)
Value-G=C+F=gross cost
gross gain+net cost=net gain+gross cost

But in Trades, the naming is gross profit = gross exit value-gross entry value. which is a bit confusing to me
Anyway, I think the calculation themselves are correct, but it is a bit confusing, as at some points the two naming clash in what I have added :
 ```
   /**
     * moving average cost of shares held without fees or taxes
     */
    private final LazyValue<Money> movingAverageGrossCost = new LazyValue<>(
                    () -> costCalculation.get().netMovingAverageCost());
```

- **Entry value per share for moving average**

- **Return for moving average** 