### PR TITLE
fix New File creation when no locale country is set

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/CurrencyUnit.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/CurrencyUnit.java
@@ -77,6 +77,9 @@ public final class CurrencyUnit implements Comparable<CurrencyUnit>
 
     public static CurrencyUnit getDefaultInstance()
     {
+        if (Locale.getDefault().getCountry().isEmpty())
+            return CurrencyUnit.getInstance(EUR);
+
         var defaultCurrencyISO4217 = java.util.Currency.getInstance(Locale.getDefault());
         if (defaultCurrencyISO4217 == null || defaultCurrencyISO4217.getCurrencyCode() == null)
             return CurrencyUnit.getInstance(EUR);


### PR DESCRIPTION
Closes https://github.com/portfolio-performance/portfolio/issues/4674

Hello,
This is a proposition to fix the new file issue when no country is set.
`java.util.Currency.getInstance(Locale.getDefault())` fails when the locale has no country, as `Locale.getDefault() `then outputs a "" country, while `Currency.getInstance` only accepts ISO 3166 country code.