### PR TITLE
Fix: grouped accounts information pane lost title on recalculation

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/InformationPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/InformationPane.java
@@ -211,12 +211,7 @@ public class InformationPane
     {
         currentInput = input;
 
-        Named named = Adaptor.adapt(Named.class, input);
-        label.setText(named != null ? TextUtil.tooltip(named.getName()) : ""); //$NON-NLS-1$
-        if (named == null && input instanceof ClientFilterMenu.Item item)
-        {
-            label.setText(item.getLabel());
-        }
+        setLabelText();
 
         InformationPanePage page = (InformationPanePage) pagebook.getPage()
                         .getData(InformationPanePage.class.getName());
@@ -228,8 +223,7 @@ public class InformationPane
 
     /* package */ void onRecalculationNeeded()
     {
-        Named named = Adaptor.adapt(Named.class, currentInput);
-        label.setText(named != null ? TextUtil.tooltip(named.getName()) : ""); //$NON-NLS-1$
+        setLabelText();
 
         InformationPanePage page = (InformationPanePage) pagebook.getPage()
                         .getData(InformationPanePage.class.getName());
@@ -237,6 +231,16 @@ public class InformationPane
             page.onRecalculationNeeded();
 
         area.layout();
+    }
+
+    private void setLabelText()
+    {
+        Named named = Adaptor.adapt(Named.class, currentInput);
+        label.setText(named != null ? TextUtil.tooltip(named.getName()) : ""); //$NON-NLS-1$
+        if (named == null && currentInput instanceof ClientFilterMenu.Item item)
+        {
+            label.setText(item.getLabel());
+        }
     }
 
     /* package */ <P extends InformationPanePage> Optional<P> lookup(Class<P> type)


### PR DESCRIPTION
With https://github.com/portfolio-performance/portfolio/commit/4f7b25f24bd7292a786e29795bc10802f1ca15a2#diff-fa49fa48db91de952a1d82cf0491c4d67ba17200a00dbb678fe70c425d1f2e60R216-R219 updating label's text on selection change of grouped accounts was introduced. But same logic is also required in ``onRecalculationNeeded``, because label's text is also set there.
So this PR will outsource common code into separate function to reduce chance of such an implementing mistake happening again.