### PR TITLE
PDF Parser for Boursobank - Fix Foreign ccy  parsing

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/AChat07.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/AChat07.txt
@@ -1,0 +1,43 @@
+```
+PDFBox Version: 3.0.3 != 1.8.17
+Portfolio Performance Version: 0.76.3
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+OPERATION DE BOURSE
+le 11/06/2024
+ 000000
+P12345
+MR XXX XXX
+XXX XXX XXX XXX
+12345 XXX SSS LLL
+Références de votre compte titres
+12345 12345 00012345678 Résident Français
+ACHAT COMPTANT ETR
+ACTION
+Date et heure
+locale d'exécution Quantité Informations sur la valeur Informations sur l'exécution
+10/06/2024 18 NVIDIA Référence : 09R240610U2204
+Type d'ordre : non spécifié
+18:05:46
+Code ISIN : US67066G1040 Cours exécuté : 121,97 USD
+Lieu d'exécution : NASDAQ
+Montant transaction
+Montant transaction brut Intérêts total brut Courtages Montant transaction net
+2 195,46 USD  0,00 USD 2 195,46 USD 0,00 USD 2 195,46 USD
+000 jours
+ACHAT DEVISES A TERME Cours de change Montant transaction net contrevalorisé
+Contrevalorisation en EURO 1,07340300 2 045,33 EUR
+Commission Frais divers Montant total des frais
+6,95 EUR 0,00 EUR 6,95 EUR
+Montant net au débit de votre compte
+2 052,28 EUR
+Sous réserve de bonne fin.
+Cet avis ne tient pas compte des frais inhérents aux Taxes sur les Transactions Financières européennes (hors France), s'ils doivent s'appliquer.
+ 
+Service Clientèle : 01 46 09 49 49 ou +33 146 09 49 49 depuis l'étranger, du lundi au vendredi de 8h à 20h et le samedi de 8h45 à 16h30 – www.boursobank.com
+Boursorama S.A. au capital de 51 171 597,60 € - RCS Nanterre 351 058 151 - TVA 69 351 058 151 - 44 rue Traversière - CS 80134 - 92772 Boulogne Billancourt Cedex
+AA1
+Adresse du médiateur : Médiateur de l'AMF - 17, place de la Bourse - 75082 PARIS CEDEX 02
+000000 F1 P63374 1/1
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/AChat07.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/AChat07.txt
@@ -1,4 +1,3 @@
-```
 PDFBox Version: 3.0.3 != 1.8.17
 Portfolio Performance Version: 0.76.3
 System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
@@ -39,5 +38,3 @@ Boursorama S.A. au capital de 51 171 597,60 € - RCS Nanterre 351 058 151 - TVA
 AA1
 Adresse du médiateur : Médiateur de l'AMF - 17, place de la Bourse - 75082 PARIS CEDEX 02
 000000 F1 P63374 1/1
-
-```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/BoursoBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/BoursoBankPDFExtractorTest.java
@@ -41,7 +41,6 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
-import name.abuchen.portfolio.money.CurrencyUnit;
 
 @SuppressWarnings("nls")
 public class BoursoBankPDFExtractorTest
@@ -236,7 +235,7 @@ public class BoursoBankPDFExtractorTest
     @Test
     public void testCompteAChat06WithSecurityInEUR()
     {
-        var security = new Security("LOWE S", CurrencyUnit.EUR);
+        var security = new Security("LOWE S", "EUR");
         security.setIsin("US5486611073");
 
         var client = new Client();
@@ -253,7 +252,7 @@ public class BoursoBankPDFExtractorTest
         assertThat(countBuySell(results), is(1L));
         assertThat(countAccountTransactions(results), is(0L));
         assertThat(results.size(), is(1));
-        new AssertImportActions().check(results, CurrencyUnit.EUR);
+        new AssertImportActions().check(results, "EUR");
 
         // check buy sell transaction
         assertThat(results, hasItem(purchase( //
@@ -268,12 +267,43 @@ public class BoursoBankPDFExtractorTest
                             assertThat(s, is(Status.OK_STATUS));
                         }))));
     }
-    
 
     @Test
-    public void testCompteAchat07()
+    public void testCompteAChat07()
     {
-        var security = new Security("NVIDIA", CurrencyUnit.EUR);
+        var extractor = new BoursoBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "AChat07.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US67066G1040"), hasWkn(null), hasTicker(null), //
+                        hasName("NVIDIA"), //
+                        hasCurrencyCode("USD"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2024-06-10T18:05:46"), hasShares(18.00), //
+                        hasSource("AChat07.txt"), //
+                        hasNote("non spécifié | Référence : 09R240610U2204"), //
+                        hasAmount("EUR", 2052.28), hasGrossValue("EUR", 2045.33), //
+                        hasForexGrossValue("USD", 2195.46), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 6.95))));
+    }
+
+    @Test
+    public void testCompteAchat07WithSecurityInEUR()
+    {
+        var security = new Security("NVIDIA", "EUR");
         security.setIsin("US67066G1040");
 
         var client = new Client();
@@ -290,7 +320,7 @@ public class BoursoBankPDFExtractorTest
         assertThat(countBuySell(results), is(1L));
         assertThat(countAccountTransactions(results), is(0L));
         assertThat(results.size(), is(1));
-        new AssertImportActions().check(results, CurrencyUnit.EUR);
+        new AssertImportActions().check(results, "EUR");
 
         // check buy sell transaction
         assertThat(results, hasItem(purchase( //
@@ -427,7 +457,44 @@ public class BoursoBankPDFExtractorTest
                         hasSource("Vente04.txt"), //
                         hasNote("à cours limite | Référence : 09R241107U2540"), //
                         hasAmount("EUR", 2215.40), hasGrossValue("EUR", 2222.35), //
+                        hasForexGrossValue("USD", 2400.00), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 6.95))));
+    }
+
+    @Test
+    public void testCompteVenteWithSecurityInEUR()
+    {
+        var security = new Security("JPMORGAN CHASE", "EUR");
+        security.setIsin("US46625H1005");
+
+        var client = new Client();
+        client.addSecurity(security);
+
+        var extractor = new BoursoBankPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Vente04.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "EUR");
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2024-11-07T16:22:40"), hasShares(10.00), //
+                        hasSource("Vente04.txt"), //
+                        hasNote("à cours limite | Référence : 09R241107U2540"), //
+                        hasAmount("EUR", 2215.40), hasGrossValue("EUR", 2222.35), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 6.95), //
+                        check(tx -> {
+                            var c = new CheckCurrenciesAction();
+                            var s = c.process((PortfolioTransaction) tx, new Portfolio());
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/Vente04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/Vente04.txt
@@ -1,4 +1,3 @@
-```
 PDFBox Version: 3.0.3 != 1.8.17
 Portfolio Performance Version: 0.76.3
 System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
@@ -40,5 +39,3 @@ Boursorama S.A. au capital de 51 171 597,60 € - RCS Nanterre 351 058 151 - TVA
 AA1
 Adresse du médiateur : Médiateur de l'AMF - 17, place de la Bourse - 75082 PARIS CEDEX 02
 000000 F1 P46553 1/1
-
-```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/Vente04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/Vente04.txt
@@ -1,0 +1,44 @@
+```
+PDFBox Version: 3.0.3 != 1.8.17
+Portfolio Performance Version: 0.76.3
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+OPERATION DE BOURSE
+le 08/11/2024
+ 000000
+P46553
+MR XXX YYY
+123 XXX SSS FFF
+12345 DDD FFF DDD
+Références de votre compte titres
+12345 12345 00012345678 Résident Français
+VENTE COMPTANT ETR
+ACTION
+Date et heure
+locale d'exécution Quantité Informations sur la valeur Informations sur l'exécution
+07/11/2024 10 JPMORGAN CHASE Référence : 09R241107U2540
+Type d'ordre : à cours limite
+16:22:40
+Code ISIN : US46625H1005 Cours exécuté : 240 USD
+Lieu d'exécution : NEW YORK STOCK EXCHANGE I
+Montant transaction
+Montant transaction brut Intérêts total brut Courtages Montant transaction net
+2 400,00 USD  0,00 USD 2 400,00 USD 0,00 USD 2 400,00 USD
+000 jours
+VENTE DEVISES A TERME Cours de change Montant transaction net contrevalorisé
+Contrevalorisation en EURO 1,07994000 2 222,35 EUR
+Commission Frais divers Montant total des frais
+6,95 EUR 0,00 EUR 6,95 EUR
+Montant net au crédit de votre compte
+2 215,40 EUR
+Opération prise en compte au titre de l'année fiscale 2024
+Sous réserve de bonne fin.
+Cet avis ne tient pas compte des frais inhérents aux Taxes sur les Transactions Financières européennes (hors France), s'ils doivent s'appliquer.
+ 
+Service Clientèle : 01 46 09 49 49 ou +33 146 09 49 49 depuis l'étranger, du lundi au vendredi de 8h à 20h et le samedi de 8h45 à 16h30 – www.boursobank.com
+Boursorama S.A. au capital de 51 171 597,60 € - RCS Nanterre 351 058 151 - TVA 69 351 058 151 - 44 rue Traversière - CS 80134 - 92772 Boulogne Billancourt Cedex
+AA1
+Adresse du médiateur : Médiateur de l'AMF - 17, place de la Bourse - 75082 PARIS CEDEX 02
+000000 F1 P46553 1/1
+
+```

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BoursoBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BoursoBankPDFExtractor.java
@@ -180,7 +180,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                                                         .attributes("fxGross", "termCurrency", "exchangeRate", "baseCurrency") //
                                                         .find("Montant transaction brut.*") //
                                                         .match("^(?<fxGross>[\\d\\s]+,[\\d]{2}) (?<termCurrency>[\\w]{3}) .*$") //
-                                                        .match("^Contrevalorisation en .* (?<exchangeRate>[\\.,\\d]+) [\\d\\s]+,[\\d]{2} (?<baseCurrency>[\\w]{3})$") //
+                                                        .match("^Contrevalorisation en [\\w]+ (?<exchangeRate>[\\.,\\d]+) [\\d\\s]+,[\\d]{2} (?<baseCurrency>[\\w]{3})$") //
                                                         .assign((t, v) -> {
                                                             var rate = asExchangeRate(v);
                                                             type.getCurrentContext().putType(rate);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BoursoBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BoursoBankPDFExtractor.java
@@ -73,7 +73,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("name", "currency", "isin") //
                                                         .match("^[\\d]{2}\\/[\\d]{2}\\/[\\d]{4} [\\,\\d\\s]+ (?<name>.*)$") //
-                                                        .match("^Cours demand. : [\\,\\d\\s]+ (?<currency>[\\w]{3})$") //
+                                                        .match("^Cours demand. : [\\,\\d\\s]+ (?<currency>[A-Z]{3})$") //
                                                         .match("^Code ISIN : (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) .*$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
@@ -83,7 +83,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("name", "isin", "currency") //
                                                         .match("^[\\d]{2}\\/[\\d]{2}\\/[\\d]{4} [\\,\\d\\s]+ (?<name>.*)$") //
-                                                        .match("^Code ISIN : (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) Valeur liquidative : [\\,\\d\\s]+ (?<currency>[\\w]{3})$") //
+                                                        .match("^Code ISIN : (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) Valeur liquidative : [\\,\\d\\s]+ (?<currency>[A-Z]{3})$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
                                         // 29/09/2023 42 AM.PEA MSCI EM.MKTS UC.ETF FCP Référence : 493029272303
@@ -92,7 +92,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("name", "isin", "currency") //
                                                         .match("^[\\d]{2}\\/[\\d]{2}\\/[\\d]{4} [\\,\\d\\s]+ (?<name>.*) R.f.rence : .*$") //
-                                                        .match("^Code ISIN : (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) Cours ex.cu.. : [\\,\\d\\s]+ (?<currency>[\\w]{3})$") //
+                                                        .match("^Code ISIN : (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) Cours ex.cu.. : [\\,\\d\\s]+ (?<currency>[A-Z]{3})$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
                                         // 08/01/2024 7 AM.MSCI WORLD UCITS ETF EUR C
@@ -101,7 +101,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("name", "isin", "currency") //
                                                         .match("^[\\d]{2}\\/[\\d]{2}\\/[\\d]{4} [\\,\\d\\s]+ (?<name>.*)$") //
-                                                        .match("^Code ISIN : (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) Cours ex.cu.. : [\\,\\d\\s]+ (?<currency>[\\w]{3})$") //
+                                                        .match("^Code ISIN : (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) Cours ex.cu.. : [\\,\\d\\s]+ (?<currency>[A-Z]{3})$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
 
                         // @formatter:off
@@ -138,7 +138,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("amount", "currency") //
                                                         .find("Montant .*")
-                                                        .match("^(?<amount>[\\d\\s]+,[\\d]{2}) (?<currency>[\\w]{3})$") //
+                                                        .match("^(?<amount>[\\d\\s]+,[\\d]{2}) (?<currency>[A-Z]{3})$") //
                                                         .assign((t, v) -> {
                                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                                             t.setAmount(asAmount(v.get("amount")));
@@ -150,7 +150,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("amount", "currency") //
                                                         .find("Montant .*")
-                                                        .match("^[\\d\\s]+,[\\d]{2} [\\w]{3} [\\d\\s]+,[\\d]{2} [\\w]{3} (?<amount>[\\d\\s]+,[\\d]{2}) (?<currency>[\\w]{3})$") //
+                                                        .match("^[\\d\\s]+,[\\d]{2} [A-Z]{3} [\\d\\s]+,[\\d]{2} [A-Z]{3} (?<amount>[\\d\\s]+,[\\d]{2}) (?<currency>[A-Z]{3})$") //
                                                         .assign((t, v) -> {
                                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                                             t.setAmount(asAmount(v.get("amount")));
@@ -162,7 +162,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("amount", "currency") //
                                                         .find("Montant .*")
-                                                        .match("^[\\d\\s]+,[\\d]{2} [\\w]{3} [\\d\\s]+,[\\d]{2} [\\w]{3} [\\d\\s]+,[\\d]{2} [\\w]{3} (?<amount>[\\d\\s]+,[\\d]{2}) (?<currency>[\\w]{3})$") //
+                                                        .match("^[\\d\\s]+,[\\d]{2} [A-Z]{3} [\\d\\s]+,[\\d]{2} [A-Z]{3} [\\d\\s]+,[\\d]{2} [A-Z]{3} (?<amount>[\\d\\s]+,[\\d]{2}) (?<currency>[A-Z]{3})$") //
                                                         .assign((t, v) -> {
                                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                                             t.setAmount(asAmount(v.get("amount")));
@@ -179,8 +179,8 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("fxGross", "termCurrency", "exchangeRate", "baseCurrency") //
                                                         .find("Montant transaction brut.*") //
-                                                        .match("^(?<fxGross>[\\d\\s]+,[\\d]{2}) (?<termCurrency>[\\w]{3}) .*$") //
-                                                        .match("^Contrevalorisation en [\\w]+ (?<exchangeRate>[\\.,\\d]+) [\\d\\s]+,[\\d]{2} (?<baseCurrency>[\\w]{3})$") //
+                                                        .match("^(?<fxGross>[\\d\\s]+,[\\d]{2}) (?<termCurrency>[A-Z]{3}) .*$") //
+                                                        .match("^Contrevalorisation en [\\w]+ (?<exchangeRate>[\\.,\\d]+) [\\d\\s]+,[\\d]{2} (?<baseCurrency>[A-Z]{3})$") //
                                                         .assign((t, v) -> {
                                                             var rate = asExchangeRate(v);
                                                             type.getCurrentContext().putType(rate);
@@ -204,7 +204,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("note") //
-                                                        .match("^.*Type d.ordre : (?<note>.* [\\,\\d\\s]+ [\\w]{3})$")
+                                                        .match("^.*Type d.ordre : (?<note>.* [\\,\\d\\s]+ [A-Z]{3})$")
                                                         .assign((t, v) -> t.setNote(trim(v.get("note")))))
 
                         // @formatter:off
@@ -245,7 +245,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("name", "isin", "currency") //
                         .match("^[\\d]{2}\\/[\\d]{2}\\/[\\d]{4} [\\,\\d\\s]+ (?<name>.*) \\((?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\).*$") //
-                        .match("^COUPONS : NETS FISCAUX [\\,\\d\\s]+ (?<currency>[\\w]{3})$") //
+                        .match("^COUPONS : NETS FISCAUX [\\,\\d\\s]+ (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                         // @formatter:off
@@ -266,7 +266,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                         // COUPONS : NETS FISCAUX  28,24 EUR
                         // @formatter:on
                         .section("amount", "currency") //
-                        .match("^COUPONS : NETS FISCAUX (?<amount>[\\d\\s]+,[\\d]{2}) (?<currency>[\\w]{3})$") //
+                        .match("^COUPONS : NETS FISCAUX (?<amount>[\\d\\s]+,[\\d]{2}) (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> {
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -288,7 +288,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("currency", "tax").optional() //
                         .find("Revenus.*")
-                        .match("^TOTAL (?<currency>[\\w]{3}) [\\,\\d\\s]+ (?<tax>[\\,\\d\\s]+) [\\,\\d\\s]+ [\\,\\d\\s]+ [\\,\\d\\s]+$") //
+                        .match("^TOTAL (?<currency>[A-Z]{3}) [\\,\\d\\s]+ (?<tax>[\\,\\d\\s]+) [\\,\\d\\s]+ [\\,\\d\\s]+ [\\,\\d\\s]+$") //
                         .assign((t, v) -> processTaxEntries(t, v, type));
     }
 
@@ -302,7 +302,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("fee", "currency").optional() //
                         .find("Montant.*")
-                        .match("^[\\d\\s]+,[\\d]{2} [\\w]{3} (?<fee>[\\d\\s]+,[\\d]{2}) (?<currency>[\\w]{3}) [\\d\\s]+,[\\d]{2} [\\w]{3}$") //
+                        .match("^[\\d\\s]+,[\\d]{2} [A-Z]{3} (?<fee>[\\d\\s]+,[\\d]{2}) (?<currency>[A-Z]{3}) [\\d\\s]+,[\\d]{2} [A-Z]{3}$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
@@ -311,7 +311,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("fee", "currency").optional() //
                         .find("Commission Frais divers.*")
-                        .match("^(?<fee>[\\d\\s]+,[\\d]{2}) (?<currency>[\\w]{3}) [\\d\\s]+,[\\d]{2} [\\w]{3} [\\d\\s]+,[\\d]{2} [\\w]{3}$") //
+                        .match("^(?<fee>[\\d\\s]+,[\\d]{2}) (?<currency>[A-Z]{3}) [\\d\\s]+,[\\d]{2} [A-Z]{3} [\\d\\s]+,[\\d]{2} [A-Z]{3}$") //
                         .assign((t, v) -> processFeeEntries(t, v, type));
     }
 


### PR DESCRIPTION
This change fixes the PDF parser regular expressions so that Boursobank transactions executed in a foreign currency load properly.