### PR TITLE
fix single quote issue in new label

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_fr.properties
@@ -2492,7 +2492,7 @@ RebalancingChartActualVsTarget = R\u00E9partition r\u00E9elle par rapport \u00E0
 
 SearchSecurityWizardPageSymbolAlreadyExistsInfo = Un titre portant le symbole ''{0}'' existe d\u00E9j\u00E0.
 
-SecuritiesChart_MaxSecuritiesReachedForBenchmarkHint = L'\u00E9valuation comparative pour plus de {0} instruments n'est pas prise en charge.
+SecuritiesChart_MaxSecuritiesReachedForBenchmarkHint = L''\u00E9valuation comparative pour plus de {0} instruments n''est pas prise en charge.
 
 SecuritiesChart_NoDataMessage_NoHoldings = Aucune participation existante
 


### PR DESCRIPTION
Hello,

One of the new label from 0.77.0 somehow escaped the double '' automatic correction from releng.
This is also the case for _TooltipCurrentDrawdown_, however for this one I changed a little bit the translation, the new translation does not contain a ', so it will work at the next sync of Poeditor.
I haven't seen other case for French, but it is strange that the automatic fix of last year did not catch them.

**Before :**
![Capture d’écran 2025-06-09 194129](https://github.com/user-attachments/assets/4468d890-4610-4cf1-b23a-31c2e2f7bb12)

**After :**
![Capture d’écran 2025-06-09 194037](https://github.com/user-attachments/assets/62f48a3d-58a4-43ac-9e18-571ff214b6cd)