### PR TITLE
Purchase Values menu entries are put in a single group

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -1019,6 +1019,8 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
 
         // cost value - FIFO
         column = new Column("pv", Messages.ColumnPurchaseValue, SWT.RIGHT, 75); //$NON-NLS-1$
+        column.setGroupLabel(Messages.ColumnPurchaseValue);
+        column.setHeading(Messages.LabelTaxesAndFeesIncluded);
         column.setMenuLabel(Messages.ColumnPurchaseValue_MenuLabel);
         column.setDescription(Messages.ColumnPurchaseValue_Description + TextUtil.PARAGRAPH_BREAK
                         + Messages.DescriptionDataRelativeToReportingPeriod);
@@ -1035,6 +1037,7 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
 
         // cost value - moving average
         column = new Column("pvmvavg", Messages.ColumnPurchaseValueMovingAverage, SWT.RIGHT, 75); //$NON-NLS-1$
+        column.setGroupLabel(Messages.ColumnPurchaseValue);
         column.setMenuLabel(Messages.ColumnPurchaseValueMovingAverage_MenuLabel);
         column.setDescription(Messages.ColumnPurchaseValueMovingAverage_Description + TextUtil.PARAGRAPH_BREAK
                         + Messages.DescriptionDataRelativeToReportingPeriod);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -540,6 +540,8 @@ public class StatementOfAssetsViewer
 
         // cost value - FIFO
         column = new Column("8", Messages.ColumnPurchaseValue, SWT.RIGHT, 80); //$NON-NLS-1$
+        column.setGroupLabel(Messages.ColumnPurchaseValue);
+        column.setHeading(Messages.LabelTaxesAndFeesIncluded);
         column.setMenuLabel(Messages.ColumnPurchaseValue_MenuLabel);
         column.setDescription(Messages.ColumnPurchaseValue_Description);
         labelProvider = new ReportingPeriodLabelProvider(
@@ -551,6 +553,7 @@ public class StatementOfAssetsViewer
 
         // cost value - moving average
         column = new Column("pvmvavg", Messages.ColumnPurchaseValueMovingAverage, SWT.RIGHT, 80); //$NON-NLS-1$
+        column.setGroupLabel(Messages.ColumnPurchaseValue);
         column.setMenuLabel(Messages.ColumnPurchaseValueMovingAverage_MenuLabel);
         column.setDescription(Messages.ColumnPurchaseValueMovingAverage_Description);
         labelProvider = new ReportingPeriodLabelProvider(


### PR DESCRIPTION
Hello, 

This is a little proposition to group under a common menu the Purchase Value (FIFO) and Purchase Value (moving average) in Statement of Assets and Performance/Securities

**Before :**
![2025-06-19 23_16_59-](https://github.com/user-attachments/assets/72a89521-f38c-4be8-b246-709d3898bc61)

**After :**
![2025-06-19 23_19_17-](https://github.com/user-attachments/assets/4a8d65f8-1fb0-4219-971e-ed3008c71979)