### PR TITLE
Update Flatex documents to format generated by PDFBox 3

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatExDegiroKauf05.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatExDegiroKauf05.txt
@@ -12,11 +12,12 @@ E-Mail: info@flatex.de
 flatexDEGIRO Bank AG -  Hammfelddamm 4 - 41460 Neuss, Deutschland
         Frankfurt, 16.01.2025
 5018893443676558698451
-Herr Auftragsdatum      16.01.2025n
-ePgx FpSgMQ mgYwLhl Handelstag         16.01.2025
-WR ZbgYYdcYug Ausführungszeit    21:57 Uhr
-zHwdt ByVKEXzQqG 26 Valuta             20.01.2025
-62541 mNPJUisVJ Auftragsnummer     826637070/1
+Auftragsdatum      16.01.2025
+Herrn Handelstag         16.01.2025
+Vorname Nachname
+WR Stadt Ausführungszeit    21:57 Uhr
+Musterstrasse 26 Valuta             20.01.2025
+62541 Stadt Auftragsnummer     826637070/1
 Ausf.platz/-art    Société Général
 Wertpapierabrechnung Kauf Fonds/Zertifikate
 Ihre Depotnummer: 2943276222


### PR DESCRIPTION
This is a "companion" pull request to #4803

This is how the document would be generated if the user would have had PDFBox 3.
It is retrofitting the document to how it - most likely would have been created.

This sample files will not be generated anymore - also not for old documents - because PDFBox 1.8 is gone.

Here you can see how PDFBox 1.8 generated the document diffed against how PDFBox 3.0 generates the same document.

```diff
--- 1.8.17
+++ 3.0.3
@@ -11,2 +11,3 @@
-F Auftragsdatum      16.06.2025rau
-Vorname N hna e Handelstag         16.06.2025ac me
+Auftragsdatum      16.06.2025
+Frau Handelstag         16.06.2025
+Vorname Nachname
```

What do you say? Retrofit? Or keep in mind, that these documents will not be created this way anymore?

Because this is a fairly small change, I think both ways are possible.

(The pull request fails because I did it on the master which does not have the adapted code)