### PR TITLE
Correct CostCalculation to show negative held shares

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CostCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CostCalculation.java
@@ -116,14 +116,14 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
                 {
                     movingRelativeCost = 0;
                     movingRelativeNetCost = 0;
-                    heldShares = 0;
                 }
                 else
                 {
                     movingRelativeCost = Math.round(movingRelativeCost / (double) heldShares * remaining);
                     movingRelativeNetCost = Math.round(movingRelativeNetCost / (double) heldShares * remaining);
-                    heldShares = remaining;
                 }
+
+                heldShares = remaining;
 
                 for (LineItem entry : fifo)
                 {
@@ -151,6 +151,16 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
                     PortfolioLog.warning(MessageFormat.format(Messages.MsgNegativeHoldingsDuringFIFOCostCalculation,
                                     Values.Share.format(sold), t.getSecurity().getName(),
                                     Values.DateTime.format(t.getDateTime())));
+
+                    grossAmount = t.getMonetaryAmount(converter).getAmount();
+                    netAmount = t.getGrossValue(converter).getAmount();
+
+                    trail = TrailRecord.ofTransaction(t);
+                    if (!getTermCurrency().equals(t.getCurrencyCode()))
+                        trail = trail.convert(Money.of(getTermCurrency(), grossAmount),
+                                        converter.getRate(t.getDateTime(), t.getCurrencyCode()));
+
+                    fifo.add(new LineItem(item.getOwner(), -sold, grossAmount, netAmount, trail));
                 }
 
                 break;


### PR DESCRIPTION
under per-security performance in case of short selling.

## Tests

* Szenario wie in https://github.com/portfolio-performance/portfolio/issues/353#issuecomment-3015850599

### Ohne diesen PR

Wertpapiere haben scheinbar einen Bestand von 0, in Wirklichkeit -12. :-1:

### Mit diesem PR

Wertpapiere haben einen Bestand von -12. :white_check_mark: