### PR TITLE
fix kommer MSCI World feed from onvista

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/parts/kommer.xml
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/parts/kommer.xml
@@ -68,15 +68,17 @@
     <security>
       <uuid>dfd4a396-34fe-484c-8130-4fecde91039d</uuid>
       <name>MSCI World</name>
-      <tickerSymbol></tickerSymbol>
-      <feed>GENERIC_HTML_TABLE</feed>
-      <feedURL>http://www.onvista.de/index/MSCI-WORLD-Index-3194141</feedURL>
+      <tickerSymbol>3193857</tickerSymbol>
+      <feed>GENERIC-JSON</feed>
+      <feedURL>https://api.onvista.de/api/v1/instruments/FUND/{TICKER}/eod_history?idNotation=7070261&amp;range=Y5&amp;startDate={TODAY:yyyy-MM-dd:-P5Y}</feedURL>
       <prices/>
       <latestFeed>MANUAL</latestFeed>
       <attributes>
         <map/>
       </attributes>
       <events/>
+      <property type="FEED" name="GENERIC-JSON-DATE">$.datetimeLast[*]</property>
+      <property type="FEED" name="GENERIC-JSON-CLOSE">$.last[*]</property>
       <isRetired>false</isRetired>
       <updatedAt>2024-02-16T07:17:00.710442Z</updatedAt>
     </security>


### PR DESCRIPTION
Hello,

This is a proposition to fix the historical price feed for "MSCI WORLD" of kommer, table on website does not seem to work anymore for onvista, but JSON does.

![Capture d’écran 2025-06-29 235721](https://github.com/user-attachments/assets/37b17279-b05d-49dc-baca-007a41c118c1)
 
https://forum.portfolio-performance.info/t/historische-kurse-von-onvista-nicht-mehr-lesbar/14794/78
https://forum.portfolio-performance.info/t/historische-kurse-von-onvista-nicht-mehr-lesbar/14794/136
Maybe 5 years of historical data is a bit too much to query ? Would the built-in price provider be better ?

This is MSCI Worl in EUR. For MSCI World in USD, idNotation=3193857