### PR TITLE
add moving average option to Trades ProfitLoss Widget

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/CostMethod.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/CostMethod.java
@@ -1,0 +1,29 @@
+package name.abuchen.portfolio.ui.views.dashboard;
+
+import name.abuchen.portfolio.ui.Messages;
+
+public enum CostMethod
+{
+    FIFO(Messages.LabelCapitalGainsMethodFIFO, true), //
+    MOVING_AVERAGE(Messages.LabelCapitalGainsMethodMovingAverage, false);
+
+    private String label;
+    private boolean useFifo;
+
+    private CostMethod(String label, boolean useFifo)
+    {
+        this.label = label;
+        this.useFifo = useFifo;
+    }
+
+    @Override
+    public String toString()
+    {
+        return label;
+    }
+
+    public boolean useFifo()
+    {
+        return useFifo;
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/CostMethodConfig.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/CostMethodConfig.java
@@ -1,0 +1,14 @@
+package name.abuchen.portfolio.ui.views.dashboard;
+
+import name.abuchen.portfolio.model.Dashboard;
+import name.abuchen.portfolio.ui.Messages;
+
+public class CostMethodConfig extends EnumBasedConfig<CostMethod>
+{
+    public CostMethodConfig(WidgetDelegate<?> delegate)
+    {
+        super(delegate, Messages.LabelCapitalGainsMethod, CostMethod.class, Dashboard.Config.COST_METHOD,
+                        Policy.EXACTLY_ONE);
+    }
+}
+

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
@@ -62,41 +62,6 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
         }
     }
 
-    enum CostMethod
-    {
-        FIFO(Messages.LabelCapitalGainsMethodFIFO, true), //
-        MOVING_AVERAGE(Messages.LabelCapitalGainsMethodMovingAverage, false);
-
-        private String label;
-        private boolean useFifo;
-
-        private CostMethod(String label, boolean useFifo)
-        {
-            this.label = label;
-            this.useFifo = useFifo;
-        }
-
-        @Override
-        public String toString()
-        {
-            return label;
-        }
-
-        public boolean useFifo()
-        {
-            return useFifo;
-        }
-    }
-
-    static class CostMethodConfig extends EnumBasedConfig<CostMethod>
-    {
-        public CostMethodConfig(WidgetDelegate<?> delegate)
-        {
-            super(delegate, Messages.LabelCapitalGainsMethod, CostMethod.class, Dashboard.Config.COST_METHOD,
-                            Policy.EXACTLY_ONE);
-        }
-    }
-
     static class PositionToolTip extends ToolTip
     {
         private static final int MAX_NO_OF_ROWS = 10;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TradesProfitLossWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TradesProfitLossWidget.java
@@ -16,6 +16,7 @@ public class TradesProfitLossWidget extends AbstractTradesWidget
     public TradesProfitLossWidget(Widget widget, DashboardData dashboardData)
     {
         super(widget, dashboardData);
+        addConfig(new CostMethodConfig(this));
     }
 
     @Override
@@ -24,8 +25,13 @@ public class TradesProfitLossWidget extends AbstractTradesWidget
         this.title.setText(TextUtil.tooltip(getWidget().getLabel()));
 
         List<Trade> trades = input.getTrades();
+        boolean useFifo = get(CostMethodConfig.class).getValue().useFifo();
 
-        Money profitLoss = trades.stream().map(Trade::getProfitLoss)
+        Money profitLoss = useFifo
+                        ? trades.stream().map(Trade::getProfitLoss)
+                                        .collect(MoneyCollectors.sum(
+                                                        getDashboardData().getCurrencyConverter().getTermCurrency()))
+                        : trades.stream().map(Trade::getProfitLossMovingAverage)
                         .collect(MoneyCollectors.sum(getDashboardData().getCurrencyConverter().getTermCurrency()));
 
         this.indicator.setText(


### PR DESCRIPTION
in addition to the existing FIFO method

Hello,

This is a proposition to add the moving average option in the Trade Profit/Loss Widget  :

![2025-07-05 11_23_36-Portfolio Performance](https://github.com/user-attachments/assets/23bfbc43-bdc2-46dd-bf17-530dfbe91b80)
