### PR TITLE
SecuritiesChart: Factor out addPurchasePrice()

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -51,6 +51,7 @@ import com.google.common.primitives.Doubles;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.AttributeType;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.LimitPrice;
 import name.abuchen.portfolio.model.Named;
 import name.abuchen.portfolio.model.PortfolioTransaction;
@@ -995,28 +996,22 @@ public class SecuritiesChart
                 boolean showAreaRelativeToFirstQuote = chartConfigPainting.contains(ChartDetails.CLOSING)
                                 || chartConfigPainting.contains(ChartDetails.PURCHASEPRICE)
                                 || chartConfigPainting.contains(ChartDetails.PURCHASEPRICE_MA);
-                if (!chartConfigPainting.contains(ChartDetails.PURCHASEPRICE)
-                                && !chartConfigPainting.contains(ChartDetails.PURCHASEPRICE_MA))
+
+                if (chartConfigPainting.contains(ChartDetails.PURCHASEPRICE)
+                                || chartConfigPainting.contains(ChartDetails.PURCHASEPRICE_MA))
+                {
+                    Optional<Double> purchasePrice = chartConfigPainting.contains(ChartDetails.PURCHASEPRICE)
+                                    ? getLatestPurchasePrice(security, CostMethod.FIFO)
+                                    : getLatestPurchasePrice(security, CostMethod.MOVING_AVERAGE);
+
+                    if (purchasePrice.isPresent())
+                        firstQuote = purchasePrice.get();
+                    else
+                        showAreaRelativeToFirstQuote = false;
+                }
+                else
                 {
                     firstQuote = referenceQuote;
-                }
-                else if (chartConfigPainting.contains(ChartDetails.PURCHASEPRICE))
-                {
-                    Optional<Double> purchasePrice = getLatestPurchasePrice(security);
-
-                    if (purchasePrice.isPresent())
-                        firstQuote = purchasePrice.get();
-                    else
-                        showAreaRelativeToFirstQuote = false;
-                }
-                else if (chartConfigPainting.contains(ChartDetails.PURCHASEPRICE_MA))
-                {
-                    Optional<Double> purchasePrice = getLatestMovingAveragePurchasePrice(security);
-
-                    if (purchasePrice.isPresent())
-                        firstQuote = purchasePrice.get();
-                    else
-                        showAreaRelativeToFirstQuote = false;
                 }
 
                 addChartMarkerBackground(chartInterval, range, security, chartConfigPainting);
@@ -1231,10 +1226,10 @@ public class SecuritiesChart
             return;
 
         if (chartConfig.contains(ChartDetails.FIFOPURCHASE))
-            addFIFOPurchasePrice(chartInterval, security);
+            addPurchasePrice(chartInterval, security, CostMethod.FIFO);
 
         if (chartConfig.contains(ChartDetails.FLOATINGAVGPURCHASE))
-            addMovingAveragePurchasePrice(chartInterval, security);
+            addPurchasePrice(chartInterval, security, CostMethod.MOVING_AVERAGE);
 
         if (chartConfig.contains(ChartDetails.INVESTMENT))
             addInvestmentMarkerLines(chartInterval, security, chartConfig);
@@ -1808,14 +1803,14 @@ public class SecuritiesChart
         }
     }
 
-    private void addFIFOPurchasePrice(ChartInterval chartInterval, Security security)
+    private void addPurchasePrice(ChartInterval chartInterval, Security security, CostMethod costMethod)
     {
         // securities w/o currency (e.g. index) cannot be bought and hence have
         // no purchase price
         if (security.getCurrencyCode() == null)
             return;
 
-        // create a list of dates that are relevant for FIFO purchase price
+        // create a list of dates that are relevant for FIFO or moving average purchase price
         // changes (i.e. all purchase and sell events)
 
         Client filteredClient = new ClientSecurityFilter(security).filter(client);
@@ -1833,7 +1828,11 @@ public class SecuritiesChart
                         .sorted() //
                         .toList();
 
-        // calculate FIFO purchase price for each event - separate lineSeries
+        var color = costMethod == CostMethod.FIFO ? colorFifoPurchasePrice : colorMovingAveragePurchasePrice;
+        var costMethodLabel = costMethod == CostMethod.FIFO ? Messages.LabelCapitalGainsMethodFIFO
+                        : Messages.LabelCapitalGainsMethodMovingAverage;
+
+        // calculate FIFO or moving average purchase price for each event - separate lineSeries
         // per holding period
 
         List<Double> values = new ArrayList<>();
@@ -1842,7 +1841,8 @@ public class SecuritiesChart
 
         for (LocalDate eventDate : candidates)
         {
-            Optional<Double> purchasePrice = getPurchasePrice(filteredClient, securityCurrency, eventDate, security);
+            Optional<Double> purchasePrice = getPurchasePrice(filteredClient, securityCurrency, eventDate, security,
+                            costMethod);
 
             if (purchasePrice.isPresent())
             {
@@ -1859,10 +1859,9 @@ public class SecuritiesChart
                     dates.add(eventDate);
                     values.add(values.get(values.size() - 1));
 
-                    createPriceLineSeries(values, dates, seriesCounter++, colorFifoPurchasePrice,
+                    createPriceLineSeries(values, dates, seriesCounter++, color,
                                     MessageFormat.format(Messages.LabelWithQualifier, Messages.ColumnPurchasePrice,
-                                                    Messages.LabelCapitalGainsMethodFIFO));
-
+                                                    costMethodLabel));
                     values.clear();
                     dates.clear();
                 }
@@ -1875,99 +1874,16 @@ public class SecuritiesChart
         }
 
         // add today if needed
-
-        getPurchasePrice(filteredClient, securityCurrency, chartInterval.getEnd(), security).ifPresent(price -> {
+        getPurchasePrice(filteredClient, securityCurrency, chartInterval.getEnd(), security, costMethod)
+                        .ifPresent(price -> {
             dates.add(chartInterval.getEnd());
             values.add(price);
         });
 
         if (!dates.isEmpty())
-            createPriceLineSeries(values, dates, seriesCounter, colorFifoPurchasePrice,
+            createPriceLineSeries(values, dates, seriesCounter, color,
                             MessageFormat.format(Messages.LabelWithQualifier, Messages.ColumnPurchasePrice,
-                                            Messages.LabelCapitalGainsMethodFIFO));
-    }
-
-    private void addMovingAveragePurchasePrice(ChartInterval chartInterval, Security security)
-    {
-        // securities w/o currency (e.g. index) cannot be bought and hence have
-        // no purchase price
-        if (security.getCurrencyCode() == null)
-            return;
-
-        // create a list of dates that are relevant for floating avg purchase
-        // price
-        // changes (i.e. all purchase and sell events)
-
-        Client filteredClient = new ClientSecurityFilter(security).filter(client);
-        CurrencyConverter securityCurrency = converter.with(security.getCurrencyCode());
-
-        List<LocalDate> candidates = client.getPortfolios().stream() //
-                        .flatMap(p -> p.getTransactions().stream()) //
-                        .filter(t -> t.getSecurity().equals(security))
-                        .filter(t -> !(t.getType() == PortfolioTransaction.Type.TRANSFER_IN
-                                        || t.getType() == PortfolioTransaction.Type.TRANSFER_OUT))
-                        .filter(t -> !t.getDateTime().toLocalDate().isAfter(chartInterval.getEnd()))
-                        .map(t -> chartInterval.contains(t.getDateTime()) ? t.getDateTime().toLocalDate()
-                                        : chartInterval.getStart())
-                        .distinct() //
-                        .sorted() //
-                        .toList();
-
-        // calculate floating avg purchase price for each event - separate
-        // lineSeries
-        // per holding period
-
-        List<Double> values = new ArrayList<>();
-        List<LocalDate> dates = new ArrayList<>();
-        int seriesCounter = 0;
-
-        for (LocalDate eventDate : candidates)
-        {
-            Optional<Double> purchasePrice = getMovingAveragePurchasePrice(filteredClient, securityCurrency, eventDate,
-                            security);
-
-            if (purchasePrice.isPresent())
-            {
-                dates.add(eventDate);
-                values.add(purchasePrice.get());
-            }
-            else
-            {
-                if (!dates.isEmpty())
-                {
-                    // add previous value if the data series ends here (no more
-                    // future events)
-
-                    dates.add(eventDate);
-                    values.add(values.get(values.size() - 1));
-
-                    createPriceLineSeries(values, dates, seriesCounter++, colorMovingAveragePurchasePrice,
-                                    MessageFormat.format(Messages.LabelWithQualifier, Messages.ColumnPurchasePrice,
-                                                    Messages.LabelCapitalGainsMethodMovingAverage));
-
-                    values.clear();
-                    dates.clear();
-                }
-                else if (dates.isEmpty())
-                {
-                    // if no holding period exists, then do not add the event at
-                    // all
-                }
-            }
-        }
-
-        // add today if needed
-
-        getMovingAveragePurchasePrice(filteredClient, securityCurrency, chartInterval.getEnd(), security)
-                        .ifPresent(price -> {
-                            dates.add(chartInterval.getEnd());
-                            values.add(price);
-                        });
-
-        if (!dates.isEmpty())
-            createPriceLineSeries(values, dates, seriesCounter, colorMovingAveragePurchasePrice,
-                            MessageFormat.format(Messages.LabelWithQualifier, Messages.ColumnPurchasePrice,
-                                            Messages.LabelCapitalGainsMethodMovingAverage));
+                                            costMethodLabel));
     }
 
     private void createPriceLineSeries(List<Double> values, List<LocalDate> dates, int seriesCounter, Color color,
@@ -1990,7 +1906,7 @@ public class SecuritiesChart
         setupTooltipDisplayCalculatedQuote(label);
     }
 
-    private Optional<Double> getLatestPurchasePrice(Security security)
+    private Optional<Double> getLatestPurchasePrice(Security security, CostMethod costMethod)
     {
         // securities w/o currency (e.g. index) cannot be bought and hence have
         // no purchase price
@@ -1998,22 +1914,11 @@ public class SecuritiesChart
             return Optional.empty();
 
         return getPurchasePrice(new ClientSecurityFilter(security).filter(client),
-                        converter.with(security.getCurrencyCode()), LocalDate.now(), security);
-    }
-
-    private Optional<Double> getLatestMovingAveragePurchasePrice(Security security)
-    {
-        // securities w/o currency (e.g. index) cannot be bought and hence have
-        // no purchase price
-        if (security.getCurrencyCode() == null)
-            return Optional.empty();
-
-        return getMovingAveragePurchasePrice(new ClientSecurityFilter(security).filter(client),
-                        converter.with(security.getCurrencyCode()), LocalDate.now(), security);
+                        converter.with(security.getCurrencyCode()), LocalDate.now(), security, costMethod);
     }
 
     private Optional<Double> getPurchasePrice(Client filteredClient, CurrencyConverter currencyConverter,
-                    LocalDate date, Security security)
+                    LocalDate date, Security security, CostMethod costMethod)
     {
         var r = LazySecurityPerformanceSnapshot
                         .create(filteredClient, currencyConverter, Interval.of(LocalDate.MIN, date))
@@ -2022,26 +1927,12 @@ public class SecuritiesChart
         if (r.isEmpty())
             return Optional.empty();
 
-        var fifoPerShare = r.get().getFifoCostPerSharesHeld().get();
+        var purchasePricePerShare = costMethod == CostMethod.FIFO //
+                        ? r.get().getFifoCostPerSharesHeld().get()
+                        : r.get().getMovingAverageCostPerSharesHeld().get();
 
-        return fifoPerShare.isZero() ? Optional.empty()
-                        : Optional.of(fifoPerShare.getAmount() / Values.Quote.divider());
-    }
-
-    private Optional<Double> getMovingAveragePurchasePrice(Client filteredClient, CurrencyConverter currencyConverter,
-                    LocalDate date, Security security)
-    {
-        var r = LazySecurityPerformanceSnapshot
-                        .create(filteredClient, currencyConverter, Interval.of(LocalDate.MIN, date))
-                        .getRecord(security);
-
-        if (r.isEmpty())
-            return Optional.empty();
-
-        var movingAveragePerShare = r.get().getMovingAverageCostPerSharesHeld().get();
-
-        return movingAveragePerShare.isZero() ? Optional.empty()
-                        : Optional.of(movingAveragePerShare.getAmount() / Values.Quote.divider());
+        return purchasePricePerShare.isZero() ? Optional.empty()
+                        : Optional.of(purchasePricePerShare.getAmount() / Values.Quote.divider());
     }
 
     private static class MessagePainter implements PaintListener, DisposeListener

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/CostMethod.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/CostMethod.java
@@ -1,0 +1,6 @@
+package name.abuchen.portfolio.model;
+
+public enum CostMethod
+{
+    FIFO, MOVING_AVERAGE;
+}


### PR DESCRIPTION
Closes https://github.com/portfolio-performance/portfolio/issues/4507

Hello,
This is a proposition to factor out some methods in SecuritiesChart to avoid duplication.
I followed your approach of an Enum file in model, same TaxesAndFees as https://github.com/portfolio-performance/portfolio/commit/e1b515bfc01559bbabf9af778d234c7d9d2b2a35
To be noted that I am also adding a CostMethod enum in PR https://github.com/portfolio-performance/portfolio/pull/4830, but at a different place, if both PR are merged as it is I wonder if this could cause issue