### PR TITLE
adding support ISO 4217 currency codes in account statements

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Kontoauszug33.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Kontoauszug33.txt
@@ -1,0 +1,56 @@
+```
+PDFBox Version: 3.0.5 != 1.8.17
+Portfolio Performance Version: 0.77.3
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+VORNAME NACHNAME SEITE 1 von 4
+Straße 1, 12345 DATUM 01 Juni 2025 - 30 Juni 2025
+Ort, DE IBAN DE00000000000000000000
+BIC TRBKDEBBXXX
+KONTOÜBERSICHT
+PRODUKT ANFANGSSALDO ZAHLUNGSEINGANG ZAHLUNGSAUSGANG ENDSALDO
+Cashkonto 3.805,83 € 0,00 € 91,84 € 3.713,99 €
+UMSATZÜBERSICHT
+DATUM TYP BESCHREIBUNG ZAHLUNGSEINGANG ZAHLUNGSAUSGANG SALDO
+07 Juni _BAZG VIA WebShop, 40,00 CHF, exchange rate: 1,07225, ECB rate: 
+Kartentransaktion 42,89 € 3.762,94 €
+2025 1,0657572205, markup: 0,6092175 %
+07 Juni 
+Kartentransaktion GENVOICE.COM 0,93 € 3.762,01 €
+2025
+08 Juni Schloss Laufen Rheinfall, 24,50 CHF, exchange rate: 1,0685714, ECB rate: 
+Kartentransaktion 26,18 € 3.735,83 €
+2025 1,0657572205, markup: 0,26405446 %
+11 Juni 
+Kartentransaktion Lidl sagt Danke 21,84 € 3.713,99 €
+2025
+BARMITTELÜBERSICHT
+Zum 30 Juni 2025
+TREUHANDKONTEN SALDO
+Deutsche Bank 3.713,99 €
+GELDMARKTFONDS ISIN STK. / NOMINALE KURS PRO STÜCK KURSWERT IN EUR
+BlackRock ICS Euro Liquidity Fund IE000GWTNRJ7 0,00 1,00 € 0,00 €
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Vorname Hecker
+Thomas Pischke
+Erstellt am 01 Juli 2025 Seite 3 von 4
+HINWEISE ZUM KONTOAUSZUG
+Bitte überprüfe deinen Kontoauszug, da Einwendungen unverzüglich geltend gemacht/erhoben werden müssen. Bitte beachte, dass der angegebene 
+Kontostand nicht die Wertstellung der einzelnen Buchungen bzw. Transaktionen berücksichtigt, der genannte Betrag bzw. Nennbetrag also nicht dem für 
+die Zinsrechnung maßgeblichen Kontostand entsprechen muss. Ein Rechnungsabschluss gilt als genehmigt, sofern du innerhalb von 6 Wochen keine 
+Einwendungen erhebst. Zur Fristwahrung genügt die rechtzeitige Absendung an den Bereich Internal Audit von Trade Republic. Dieser Kontoauszug gilt 
+im Zusammenhang mit den zugrundeliegenden Verträgen laut angegebener Kontonummer als Rechnung i.S.d. UStG.  Die Guthaben, die bei 
+Treuhandbanken verwahrt werden, sind jeweils bis zu 100.000 € von der Einlagensicherung der Treuhandbank gesichert. Die Anteile an qualifizierten 
+Geldmarktfonds (QMMF) sind für den unwahrscheinlichen Fall einer Insolvenz von Trade Republic geschützt. Weitere Informationen zur Sicherung deiner 
+Gelder findest du unter https://support.traderepublic.com/de-de/3070-How-is-my-money-protected.
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Vorname Hecker
+Thomas Pischke
+Erstellt am 01 Juli 2025 Seite 4 von 4
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Kontoauszug34.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Kontoauszug34.txt
@@ -4,39 +4,62 @@ Portfolio Performance Version: 0.77.3
 System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
 -----------------------------------------
 TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
-VORNAME NACHNAME SEITE 1 von 4
+VORNAME NACHNAME SEITE 1 von 5
 Straße 1, 12345 DATUM 01 Juni 2025 - 30 Juni 2025
 Ort, DE IBAN DE00000000000000000000
 BIC TRBKDEBBXXX
 KONTOÜBERSICHT
 PRODUKT ANFANGSSALDO ZAHLUNGSEINGANG ZAHLUNGSAUSGANG ENDSALDO
-Cashkonto 3.805,83 € 0,00 € 91,84 € 3.713,99 €
+Cashkonto 1.000,00 € 313,42 € 33,20 € 1.280,22 €
 UMSATZÜBERSICHT
 DATUM TYP BESCHREIBUNG ZAHLUNGSEINGANG ZAHLUNGSAUSGANG SALDO
-07 Juni _BAZG VIA WebShop, 40,00 CHF, exchange rate: 1,07225, ECB rate: 
-Kartentransaktion 42,89 € 3.762,94 €
-2025 1,0657572205, markup: 0,6092175 %
-07 Juni 
-Kartentransaktion GENVOICE.COM 0,93 € 3.762,01 €
+08 
+SEPA 
+Juni Incoming transfer from Vorname Nachname 313,42 € 1.313,42 €
+Echtzeitüberweisung
 2025
-08 Juni Schloss Laufen Rheinfall, 24,50 CHF, exchange rate: 1,0685714, ECB rate: 
-Kartentransaktion 26,18 € 3.735,83 €
-2025 1,0657572205, markup: 0,26405446 %
-11 Juni 
-Kartentransaktion Lidl sagt Danke 21,84 € 3.713,99 €
+08 
+Schloss Laufen Rheinfall, 10,00 CHF, exchange rate: 1,068, ECB rate: 
+Juni Kartentransaktion 10,68 € 1.302,74 €
+1,0657572205, markup: 0,21044 %
+2025
+08 
+Schloss Laufen Rheinfall, 9,00 CHF, exchange rate: 1,0688889, ECB rate: 
+Juni Kartentransaktion 9,62 € 1.293,12 €
+1,0657572205, markup: 0,29384549 %
+2025
+29 
+Juni Kartentransaktion TROELSCH GMBH BAECKERE 12,90 € 1.280,22 €
 2025
 BARMITTELÜBERSICHT
 Zum 30 Juni 2025
 TREUHANDKONTEN SALDO
-Deutsche Bank 3.713,99 €
+Deutsche Bank 15.000,00 €
 GELDMARKTFONDS ISIN STK. / NOMINALE KURS PRO STÜCK KURSWERT IN EUR
-BlackRock ICS Euro Liquidity Fund IE000GWTNRJ7 0,00 1,00 € 0,00 €
+BlackRock ICS Euro Liquidity Fund IE000GWTNRJ7 1.614,26 1,00 € 1.614,26 €
 Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
 Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
 10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
 Christian Hecker
 Thomas Pischke
-Erstellt am 01 Juli 2025 Seite 3 von 4
+Erstellt am 01 Juli 2025 Seite 3 von 5
+TRANSAKTIONSÜBERSICHT
+DATUM ZAHLUNGSART GELDMARKTFONDS STÜCK KURS PRO STÜCK BETRAG
+BlackRock ICS Euro Liquidity Fund
+25 Juni 2025 Kauf 1.741,74 1,00 € 1.741,74 €
+IE000GWTNRJ7
+BlackRock ICS Euro Liquidity Fund
+26 Juni 2025 Verkauf 18,48 1,00 € 18,48 €
+IE000GWTNRJ7
+BlackRock ICS Euro Liquidity Fund
+30 Juni 2025 Verkauf 55,71 1,00 € 55,71 €
+IE000GWTNRJ7
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke
+Erstellt am 01 Juli 2025 Seite 4 von 5
 HINWEISE ZUM KONTOAUSZUG
 Bitte überprüfe deinen Kontoauszug, da Einwendungen unverzüglich geltend gemacht/erhoben werden müssen. Bitte beachte, dass der angegebene 
 Kontostand nicht die Wertstellung der einzelnen Buchungen bzw. Transaktionen berücksichtigt, der genannte Betrag bzw. Nennbetrag also nicht dem für 
@@ -51,6 +74,6 @@ Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
 10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
 Christian Hecker
 Thomas Pischke
-Erstellt am 01 Juli 2025 Seite 4 von 4
+Erstellt am 01 Juli 2025 Seite 5 von 5
 
 ```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -3448,6 +3448,36 @@ public class TradeRepublicPDFExtractorTest
     }
 
     @Test
+    public void testKontoauszug33()
+    {
+        var extractor = new TradeRepublicPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kontoauszug33.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(4L));
+        assertThat(results.size(), is(4));
+        new AssertImportActions().check(results, "EUR");
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2025-06-07"), hasAmount("EUR", 42.89),
+                        hasSource("Kontoauszug33.txt"), hasNote("_BAZG VIA WebShop"))));
+        
+        assertThat(results, hasItem(removal(hasDate("2025-06-07"), hasAmount("EUR", 0.93),
+                        hasSource("Kontoauszug33.txt"), hasNote("GENVOICE.COM"))));
+        
+        assertThat(results, hasItem(removal(hasDate("2025-06-08"), hasAmount("EUR", 26.18),
+                        hasSource("Kontoauszug33.txt"), hasNote("Schloss Laufen Rheinfall"))));
+        
+        assertThat(results, hasItem(removal(hasDate("2025-06-11"), hasAmount("EUR", 21.84),
+                        hasSource("Kontoauszug33.txt"), hasNote("Lidl sagt Danke"))));
+    }
+
+    @Test
     public void testReleveDeCompte01()
     {
         var extractor = new TradeRepublicPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -3478,6 +3478,36 @@ public class TradeRepublicPDFExtractorTest
     }
 
     @Test
+    public void testKontoauszug34()
+    {
+        var extractor = new TradeRepublicPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kontoauszug34.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(4L));
+        assertThat(results.size(), is(4));
+        new AssertImportActions().check(results, "EUR");
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2025-06-08"), hasAmount("EUR", 313.42),
+                        hasSource("Kontoauszug34.txt"), hasNote("Vorname Nachname"))));
+
+        assertThat(results, hasItem(removal(hasDate("2025-06-08"), hasAmount("EUR", 10.680),
+                        hasSource("Kontoauszug34.txt"), hasNote("Schloss Laufen Rheinfall"))));
+
+        assertThat(results, hasItem(removal(hasDate("2025-06-08"), hasAmount("EUR", 9.62),
+                        hasSource("Kontoauszug34.txt"), hasNote("Schloss Laufen Rheinfall"))));
+
+        assertThat(results, hasItem(removal(hasDate("2025-06-29"), hasAmount("EUR", 12.90),
+                        hasSource("Kontoauszug34.txt"), hasNote("TROELSCH GMBH BAECKERE"))));
+    }
+
+    @Test
     public void testReleveDeCompte01()
     {
         var extractor = new TradeRepublicPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -3497,7 +3497,7 @@ public class TradeRepublicPDFExtractorTest
         assertThat(results, hasItem(deposit(hasDate("2025-06-08"), hasAmount("EUR", 313.42),
                         hasSource("Kontoauszug34.txt"), hasNote("Vorname Nachname"))));
 
-        assertThat(results, hasItem(removal(hasDate("2025-06-08"), hasAmount("EUR", 10.680),
+        assertThat(results, hasItem(removal(hasDate("2025-06-08"), hasAmount("EUR", 10.68),
                         hasSource("Kontoauszug34.txt"), hasNote("Schloss Laufen Rheinfall"))));
 
         assertThat(results, hasItem(removal(hasDate("2025-06-08"), hasAmount("EUR", 9.62),

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -2165,7 +2165,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date", "note", "year", "amount", "currency", "amountAfter", "currencyAfter") //
-                                                        .match("^(?<date>[\\d]{2} [\\p{L}]{3,4}([\\.]{1})?)[\\s]Transacci.n (?<note>.*), [\\.,\\d]+ \\p{Sc}.*$") //
+                                                        .match("^(?<date>[\\d]{2} [\\p{L}]{3,4}([\\.]{1})?)[\\s]Transacci.n (?<note>.*), [\\.,\\d]+ (\\p{Sc}|[A-Z]{3}).*$") //
                                                         .match("^(?<year>[\\d]{4}) con tarjeta .* (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) (?<amountAfter>[\\.,\\d]+) (?<currencyAfter>\\p{Sc})$") //
                                                         .assign((t, v) -> {
                                                             var context = type.getCurrentContext();
@@ -2191,10 +2191,14 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // 26 Dez. BACKBLAZE INC, 5,34 $, exchange rate: 0,9625468, ECB rate:
                                         // Kartentransaktion 5,14 € 5.969,04 €
                                         // 2024 0,962000962, markup: 0,05673986 %
+                                        //                
+                                        // 07 Juni _BAZG VIA WebShop, 40,00 CHF, exchange rate: 1,07225, ECB rate: 
+                                        // Kartentransaktion 42,89 € 3.762,94 €
+                                        // 2025 1,0657572205, markup: 0,6092175 %                
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date", "note", "year", "amount", "currency", "amountAfter", "currencyAfter") //
-                                                        .match("^(?<date>[\\d]{2} [\\p{L}]{3,4}([\\.]{1})?)[\\s](?<note>.*), [\\.,\\d]+ \\p{Sc}.*$") //
+                                                        .match("^(?<date>[\\d]{2} [\\p{L}]{3,4}([\\.]{1})?)[\\s](?<note>.*), [\\.,\\d]+ (\\p{Sc}|[A-Z]{3}).*$") //
                                                         .match("^Kartentransaktion (?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}) (?<amountAfter>[\\.,\\d]+) (?<currencyAfter>\\p{Sc})$") //
                                                         .match("^(?<year>[\\d]{4}) [\\.,\\d]+, .*$") //
                                                         .assign((t, v) -> {


### PR DESCRIPTION
adding support for CHF and other ISO 4217 currency codes for account statements (credit card payments)