### PR TITLE
fix ClientClassificationFilter when client is already a filtered client

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientClassificationFilter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientClassificationFilter.java
@@ -66,12 +66,14 @@ public class ClientClassificationFilter implements ClientFilter
 
         public boolean isCategorized(Account account)
         {
-            return categorizedAccounts.contains(account);
+            return categorizedAccounts
+                            .contains((account instanceof ReadOnlyAccount readOnly) ? readOnly.unwrap() : account);
         }
 
         public BigDecimal getWeight(InvestmentVehicle vehicle)
         {
-            BigDecimal w = vehicle2weight.get(vehicle);
+            BigDecimal w = vehicle2weight
+                            .get((vehicle instanceof ReadOnlyAccount readOnly) ? readOnly.unwrap() : vehicle);
             return w == null ? BigDecimal.ZERO : w;
         }
 


### PR DESCRIPTION
Hello,
This is a proposition of fix of the following topic :
From https://github.com/portfolio-performance/portfolio/pull/4217 and https://github.com/portfolio-performance/portfolio/commit/0f7eb387d416f556cef9a4429a82cde5f4373db7, the possibility to see the TWR and IRR at classification levels was added in the statement of asset.
But there is a strange behavior when the classification node contains Account while a grouped account filtering the whole client portfolio is used : example with kommer, add the TWR column over 10y, add a filtered grouped account containing all of the cash and securities account (so equal to the full portfolio). Similar results are expected with and without the portfolio filter, but this is not the case.

**Before :** 
![2025-07-08 20_04_41-Paramètres](https://github.com/user-attachments/assets/24ccd411-29df-464e-bc96-4af9d7903f44)
![2025-07-08 20_05_54-Portfolio Performance](https://github.com/user-attachments/assets/9c41c890-f8cf-4c2e-96a2-5a8dcd86054c)
while the grouped account is actually composed of all accounts, no different than Total Portfolio

**After :** 
![2025-07-08 20_09_42-Paramètres](https://github.com/user-attachments/assets/4d5f5c6d-f7d9-4299-8dde-d76c1d62af07)

Regarding the fix itself : I think this is because a filtered client's accounts are already ReadOnlyAccount and no longer the original accounts, while the `CalculationState state `(`categorizedAccounts `and `vehicle2weight`) are only made of the original accounts. So when they are compared for example at `if (state.isCategorized(account))`, it return false in this filter case, it sees a mismatch.
Not sure if unwrap is necessary, getSource was working too in this kommer example, or if the methods should take care of the fix vs the input account of the methods should be "sanizited unwrap" beforehand instead.
Maybe a test case would be good here ?