### PR TITLE
Update KBCGroupNVPDFExtractor.java

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KBCGroupNVPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KBCGroupNVPDFExtractor.java
@@ -305,7 +305,7 @@ public class KBCGroupNVPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
                                         // Uw Uitbetaling dividenden van 2.130 FIRST MAJESTIC SILVER CORP aan 0,0057 USD 12,14 USD
-                                        // Waardecode ES0000012I08
+                                        // Cash Dividend CA32076V1031ex 2025-02-28 pd 2025-03-14
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "currency", "isin") //


### PR DESCRIPTION
Hi,
I noticed pdf extraction wouldn't work for my example pdf. On closer inspection one of the latest updates (https://github.com/portfolio-performance/portfolio/commit/9f48cca1bcefcdb67329dfa0f5f3a04b35805b04) comes closes, but is a bit too specific for the ISIN extraction. I believe my proposal works more generally.
The "waardecode" value isn't necessarily always an ISIN. (may depend on market or someth if it is)
Works with https://github.com/Nirus2000/portfolio/blob/904a65387d25dafca41d768aa2cee42b6524d13c/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/kbcgroupnv/Dividende02.txt