### PR TITLE
Support short selling gain calculation

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DailyCapitalGainsCalculationTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DailyCapitalGainsCalculationTest.java
@@ -1,0 +1,471 @@
+package name.abuchen.portfolio.snapshot.security;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.junit.AccountBuilder;
+import name.abuchen.portfolio.junit.PortfolioBuilder;
+import name.abuchen.portfolio.junit.SecurityBuilder;
+import name.abuchen.portfolio.junit.TestCurrencyConverter;
+import name.abuchen.portfolio.model.Account;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.Portfolio;
+import name.abuchen.portfolio.model.PortfolioTransferEntry;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.SecurityPrice;
+import name.abuchen.portfolio.model.Transaction;
+import name.abuchen.portfolio.money.CurrencyUnit;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.util.Interval;
+
+@SuppressWarnings("nls")
+public class DailyCapitalGainsCalculationTest
+{
+
+    @Test
+    public void testFifoBuySellTransactions()
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder().addPrice("2013-03-01", Values.Quote.factorize(100)) //
+                        .addTo(client);
+
+        new PortfolioBuilder() //
+                        .buy(security, "2010-01-01", Values.Share.factorize(109), Values.Amount.factorize(3149.20)) //
+                        .sell(security, "2010-02-01", Values.Share.factorize(15), Values.Amount.factorize(531.50)) //
+                        .buy(security, "2010-03-01", Values.Share.factorize(52), Values.Amount.factorize(1684.92)) //
+                        .buy(security, "2010-03-01", Values.Share.factorize(32), Values.Amount.factorize(959.30)) //
+                        .addTo(client);
+
+        var interval = Interval.of(LocalDate.parse("2009-12-31"), LocalDate.parse("2021-01-31"));
+        DailyCapitalGainsCalculation calculation = new DailyCapitalGainsCalculation(client, new TestCurrencyConverter(), interval);
+        calculation.calculate();
+
+        // expected Realized Gains for FIFO :
+        // 531.5 - 3149.20 * 15/109 = 98,1238532110092
+        Money expectedTotalRealizedGains = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(98.12));
+        Money totalRealizedGains = calculation.getTotalRealizedGains();
+        assertThat(totalRealizedGains, is(expectedTotalRealizedGains));
+
+        // expected Unrealized Gains for FIFO :
+        // 100 * 178 - [3149.2 * (109-15) / 109 + 1684.92 + 959.3] = 12439,956146789
+        Money expectedTotalUnrealizedGains = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(12439.96));
+        Money totalUnrealizedGains = calculation.getTotalUnrealizedGains();
+        assertThat(totalUnrealizedGains, is(expectedTotalUnrealizedGains));
+    }
+
+    @Test
+    public void testFifoBuySellTransactions2()
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder().addPrice("2013-03-01", Values.Quote.factorize(100)) //
+                        .addTo(client);
+        new PortfolioBuilder() //
+                        .buy(security, "2010-01-01", Values.Share.factorize(109), Values.Amount.factorize(3149.20)) //
+                        .buy(security, "2010-02-01", Values.Share.factorize(52), Values.Amount.factorize(1684.92)) //
+                        .sell(security, "2010-03-01", Values.Share.factorize(15), Values.Amount.factorize(531.50)) //
+                        .addTo(client);
+
+        var interval = Interval.of(LocalDate.parse("2009-12-31"), LocalDate.parse("2021-01-31"));
+        DailyCapitalGainsCalculation calculation = new DailyCapitalGainsCalculation(client, new TestCurrencyConverter(), interval);
+        calculation.calculate();
+
+        // expected Realized Gains for FIFO :
+        // 531.5 - 3149.20 * 15/109 = 98,1238532110092
+        Money expectedTotalRealizedGains = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(98.12));
+        Money totalRealizedGains = calculation.getTotalRealizedGains();
+        assertThat(totalRealizedGains, is(expectedTotalRealizedGains));
+
+        // expected Unrealized Gains for FIFO :
+        // 146 * 100 - [3149,20 + 1684,92 - (3149,20 * 15/109)] = 10199,256146789
+        Money expectedTotalUnrealizedGains = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10199.26));
+        Money totalUnrealizedGains = calculation.getTotalUnrealizedGains();
+        assertThat(totalUnrealizedGains, is(expectedTotalUnrealizedGains));
+    }
+
+    /**
+     * Test case for the example discussed in
+     * https://github.com/portfolio-performance/portfolio/pull/4546
+     */
+    @Test
+    public void testFifoBuySellTransactions3()
+    {
+        var client = new Client();
+        client.setBaseCurrency(CurrencyUnit.EUR);
+
+        var security = new SecurityBuilder(CurrencyUnit.USD) //
+                        .addPrice("2025-01-01", Values.Quote.factorize(80)) //
+                        .addTo(client);
+
+        var account = new AccountBuilder(CurrencyUnit.EUR) //
+                        .addTo(client);
+
+        new PortfolioBuilder(account) //
+                        .inbound_delivery(security, "2024-01-01", Values.Share.factorize(100),
+                                        new Transaction.Unit(Transaction.Unit.Type.GROSS_VALUE,
+                                                        Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4500)),
+                                                        Money.of(CurrencyUnit.USD, Values.Amount.factorize(5000)),
+                                                        BigDecimal.valueOf(0.90)) //
+                        )
+                        .inbound_delivery(security, "2024-02-01", Values.Share.factorize(50),
+                                        new Transaction.Unit(Transaction.Unit.Type.GROSS_VALUE,
+                                                        Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2550)),
+                                                        Money.of(CurrencyUnit.USD, Values.Amount.factorize(3000)),
+                                                        BigDecimal.valueOf(0.85)) //
+                        )
+                        .outbound_delivery(security, "2024-03-01", Values.Share.factorize(50),
+                                        new Transaction.Unit(Transaction.Unit.Type.GROSS_VALUE,
+                                                        Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3080)),
+                                                        Money.of(CurrencyUnit.USD, Values.Amount.factorize(3500)),
+                                                        BigDecimal.valueOf(0.88)) //
+                        ).addTo(client);
+
+        var interval = Interval.of(LocalDate.parse("2023-12-31"), LocalDate.parse("2024-12-31"));
+        DailyCapitalGainsCalculation calculation = new DailyCapitalGainsCalculation(client, new TestCurrencyConverter(), interval);
+        calculation.calculate();
+
+        // FIFO - expected realized gains for FIFO
+        // [revenue in EUR] - [partial cost of first buy]
+        // 3080 - (50/100) * 4500 = 830
+        Money expectedTotalRealizedGains = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(830));
+        Money totalRealizedGains = calculation.getTotalRealizedGains();
+        assertThat(totalRealizedGains, is(expectedTotalRealizedGains));
+
+        // Test total unrealized gains
+        Money totalUnrealizedGains = calculation.getTotalUnrealizedGains();
+        // Expected unrealized gains: current value - remaining cost basis
+        Money expectedTotalUnrealizedGains = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2103.69));
+        assertThat(totalUnrealizedGains, is(expectedTotalUnrealizedGains));
+    }
+
+    /**
+     * Test daily price changes and their impact on unrealized gains
+     */
+    @Test
+    public void testDailyPriceChangesAndUnrealizedGains()
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder()
+                        .addPrice("2021-01-01", Values.Quote.factorize(100))  // Buy price
+                        .addPrice("2021-01-02", Values.Quote.factorize(110))  // +10%
+                        .addPrice("2021-01-03", Values.Quote.factorize(105))  // -5%
+                        .addPrice("2021-01-04", Values.Quote.factorize(120))  // +15%
+                        .addPrice("2021-01-05", Values.Quote.factorize(115))  // -5%
+                        .addTo(client);
+
+        new PortfolioBuilder() //
+                        .buy(security, "2021-01-01", Values.Share.factorize(100), Values.Amount.factorize(10000)) //
+                        .addTo(client);
+
+        var interval = Interval.of(LocalDate.parse("2020-12-31"), LocalDate.parse("2021-01-31"));
+        DailyCapitalGainsCalculation calculation = new DailyCapitalGainsCalculation(client, new TestCurrencyConverter(), interval);
+        calculation.calculate();
+
+        // Test daily unrealized gains (daily increments)
+        // Day 1: No unrealized gains (same day as buy)
+        Money dailyUnrealizedGainsDay1 = calculation.getUnrealizedGains(LocalDate.parse("2021-01-01"));
+        assertThat(dailyUnrealizedGainsDay1, is(Money.of(CurrencyUnit.EUR, 0L)));
+
+        // Day 2: Price increased to 110, daily increment of 1000
+        Money dailyUnrealizedGainsDay2 = calculation.getUnrealizedGains(LocalDate.parse("2021-01-02"));
+        Money expectedDailyGainDay2 = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000));
+        assertThat(dailyUnrealizedGainsDay2, is(expectedDailyGainDay2));
+
+        // Day 3: Price decreased to 105, daily increment of -500 (decrease from previous day)
+        Money dailyUnrealizedGainsDay3 = calculation.getUnrealizedGains(LocalDate.parse("2021-01-03"));
+        Money expectedDailyGainDay3 = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(-500));
+        assertThat(dailyUnrealizedGainsDay3, is(expectedDailyGainDay3));
+
+        // Day 4: Price increased to 120, daily increment of 1500 (increase from previous day)
+        Money dailyUnrealizedGainsDay4 = calculation.getUnrealizedGains(LocalDate.parse("2021-01-04"));
+        Money expectedDailyGainDay4 = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1500));
+        assertThat(dailyUnrealizedGainsDay4, is(expectedDailyGainDay4));
+
+        // Day 5: Price decreased to 115, daily increment of -500 (decrease from previous day)
+        Money dailyUnrealizedGainsDay5 = calculation.getUnrealizedGains(LocalDate.parse("2021-01-05"));
+        Money expectedDailyGainDay5 = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(-500));
+        assertThat(dailyUnrealizedGainsDay5, is(expectedDailyGainDay5));
+
+        // Test total unrealized gains up to specific dates
+        Money totalUnrealizedGainsDay5 = calculation.getTotalUnrealizedGainsUpTo(LocalDate.parse("2021-01-05"));
+        Money expectedTotalGainDay5 = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1500)); // 0 + 1000 - 500 + 1500 - 500
+        assertThat(totalUnrealizedGainsDay5, is(expectedTotalGainDay5));
+    }
+
+    /**
+     * Test complex scenario with multiple buys, sells, and price changes
+     */
+    @Test
+    public void testComplexScenarioWithMultipleTransactions()
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder()
+                        .addPrice("2021-01-01", Values.Quote.factorize(100))  // Initial price
+                        .addPrice("2021-01-15", Values.Quote.factorize(110))  // Price increase
+                        .addPrice("2021-02-01", Values.Quote.factorize(120))  // Further increase
+                        .addPrice("2021-02-15", Values.Quote.factorize(115))  // Price decrease
+                        .addPrice("2021-03-01", Values.Quote.factorize(125))  // Final price
+                        .addTo(client);
+
+        new PortfolioBuilder() //
+                        .buy(security, "2021-01-01", Values.Share.factorize(100), Values.Amount.factorize(10000)) //
+                        .buy(security, "2021-01-15", Values.Share.factorize(50), Values.Amount.factorize(5500)) //
+                        .sell(security, "2021-02-01", Values.Share.factorize(75), Values.Amount.factorize(9000)) //
+                        .buy(security, "2021-02-15", Values.Share.factorize(25), Values.Amount.factorize(2875)) //
+                        .sell(security, "2021-03-01", Values.Share.factorize(50), Values.Amount.factorize(6250)) //
+                        .addTo(client);
+
+        var interval = Interval.of(LocalDate.parse("2020-12-31"), LocalDate.parse("2021-03-31"));
+        DailyCapitalGainsCalculation calculation = new DailyCapitalGainsCalculation(client, new TestCurrencyConverter(), interval);
+        calculation.calculate();
+
+        // Test total realized gains up to specific dates
+        // First sell: 9000 - (75/100) * 10000 = 9000 - 7500 = 1500 (FIFO: 75 shares from first buy)
+        Money totalRealizedGainsAfterFirstSell = calculation.getTotalRealizedGainsUpTo(LocalDate.parse("2021-02-01"));
+        Money expectedTotalAfterFirstSell = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1500));
+        assertThat(totalRealizedGainsAfterFirstSell, is(expectedTotalAfterFirstSell));
+
+        // Second sell: 6250 - (25/100) * 10000 - (25/50) * 5500 = 6250 - 2500 - 2750 = 1000 (FIFO: 25 from first buy + 25 from second buy)
+        Money totalRealizedGainsAfterSecondSell = calculation.getTotalRealizedGainsUpTo(LocalDate.parse("2021-03-01"));
+        Money expectedTotalAfterSecondSell = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2500)); // 1500 + 1000
+        assertThat(totalRealizedGainsAfterSecondSell, is(expectedTotalAfterSecondSell));
+
+        // Test total realized gains
+        Money totalRealizedGains = calculation.getTotalRealizedGains();
+        Money expectedTotalRealized = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2500)); // 1500 + 1000
+        assertThat(totalRealizedGains, is(expectedTotalRealized));
+
+        // Test total unrealized gains up to specific dates
+        // After first sell (2021-02-01): 75 shares at 120 = 9000, cost basis = 8000 (25 from first buy + 50 from second buy), unrealized = 1000
+        Money totalUnrealizedGainsAfterFirstSell = calculation.getTotalUnrealizedGainsUpTo(LocalDate.parse("2021-02-01"));
+        Money expectedTotalUnrealizedAfterFirstSell = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000));
+        assertThat(totalUnrealizedGainsAfterFirstSell, is(expectedTotalUnrealizedAfterFirstSell));
+
+        // After second sell (2021-03-01): 50 shares at 125 = 6250, cost basis = 5250 (25 from first buy + 25 from second buy), unrealized = 1000
+        Money totalUnrealizedGainsAfterSecondSell = calculation.getTotalUnrealizedGainsUpTo(LocalDate.parse("2021-03-01"));
+        Money expectedTotalUnrealizedAfterSecondSell = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(625));
+        assertThat(totalUnrealizedGainsAfterSecondSell, is(expectedTotalUnrealizedAfterSecondSell));
+
+        // Test total unrealized gains
+        Money totalUnrealizedGains = calculation.getTotalUnrealizedGains();
+        assertThat(totalUnrealizedGains, is(expectedTotalUnrealizedAfterSecondSell));
+    }
+
+    /**
+     * Test scenario with partial sells and remaining positions
+     */
+    @Test
+    public void testPartialSellsAndRemainingPositions()
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder()
+                        .addPrice("2021-01-01", Values.Quote.factorize(100))
+                        .addPrice("2021-02-01", Values.Quote.factorize(110))
+                        .addPrice("2021-03-01", Values.Quote.factorize(120))
+                        .addTo(client);
+
+        new PortfolioBuilder() //
+                        .buy(security, "2021-01-01", Values.Share.factorize(200), Values.Amount.factorize(20000)) //
+                        .sell(security, "2021-02-01", Values.Share.factorize(50), Values.Amount.factorize(5500)) //
+                        .sell(security, "2021-03-01", Values.Share.factorize(75), Values.Amount.factorize(9000)) //
+                        .addTo(client);
+
+        var interval = Interval.of(LocalDate.parse("2020-12-31"), LocalDate.parse("2021-03-31"));
+        DailyCapitalGainsCalculation calculation = new DailyCapitalGainsCalculation(client, new TestCurrencyConverter(), interval);
+        calculation.calculate();
+
+        // Test total realized gains up to specific dates
+        // First sell: 5500 - (50/200) * 20000 = 5500 - 5000 = 500 (FIFO: 50 shares from first buy)
+        Money totalRealizedGainsAfterFirstSell = calculation.getTotalRealizedGainsUpTo(LocalDate.parse("2021-02-01"));
+        Money expectedTotalAfterFirstSell = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500));
+        assertThat(totalRealizedGainsAfterFirstSell, is(expectedTotalAfterFirstSell));
+
+        // Second sell: 9000 - (75/150) * 15000 = 9000 - 7500 = 1500 (FIFO: 75 shares from remaining 150 shares)
+        Money totalRealizedGainsAfterSecondSell = calculation.getTotalRealizedGainsUpTo(LocalDate.parse("2021-03-01"));
+        Money expectedTotalAfterSecondSell = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2000)); // 500 + 1500
+        assertThat(totalRealizedGainsAfterSecondSell, is(expectedTotalAfterSecondSell));
+
+        // Test total realized gains
+        Money totalRealizedGains = calculation.getTotalRealizedGains();
+        Money expectedTotalRealized = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2000)); // 500 + 1500
+        assertThat(totalRealizedGains, is(expectedTotalRealized));
+
+        // Test daily realized gains (daily increments)
+        // Day 1: No realized gains
+        Money dailyRealizedGainsDay1 = calculation.getRealizedGains(LocalDate.parse("2021-01-01"));
+        assertThat(dailyRealizedGainsDay1, is(Money.of(CurrencyUnit.EUR, 0L)));
+
+        // Day 2: No realized gains (no sell transaction)
+        Money dailyRealizedGainsDay2 = calculation.getRealizedGains(LocalDate.parse("2021-02-01"));
+        Money expectedDailyRealizedDay2 = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500));
+        assertThat(dailyRealizedGainsDay2, is(expectedDailyRealizedDay2));
+
+        // Day 3: No realized gains (no sell transaction)
+        Money dailyRealizedGainsDay3 = calculation.getRealizedGains(LocalDate.parse("2021-03-01"));
+        Money expectedDailyRealizedDay3 = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1500));
+        assertThat(dailyRealizedGainsDay3, is(expectedDailyRealizedDay3));
+
+        // Test total unrealized gains up to specific dates
+        // After first sell: 150 shares at 110 = 16500, cost basis = 15000, unrealized = 1500
+        Money totalUnrealizedGainsAfterFirstSell = calculation.getTotalUnrealizedGainsUpTo(LocalDate.parse("2021-02-01"));
+        Money expectedTotalUnrealizedAfterFirstSell = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1500));
+        assertThat(totalUnrealizedGainsAfterFirstSell, is(expectedTotalUnrealizedAfterFirstSell));
+
+        // After second sell: 75 shares at 120 = 9000, cost basis = 7500, unrealized = 1500
+        Money totalUnrealizedGainsAfterSecondSell = calculation.getTotalUnrealizedGainsUpTo(LocalDate.parse("2021-03-01"));
+        Money expectedTotalUnrealizedAfterSecondSell = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1500));
+        assertThat(totalUnrealizedGainsAfterSecondSell, is(expectedTotalUnrealizedAfterSecondSell));
+
+        // Test total unrealized gains
+        Money totalUnrealizedGains = calculation.getTotalUnrealizedGains();
+        assertThat(totalUnrealizedGains, is(expectedTotalUnrealizedAfterSecondSell));
+    }
+
+    /**
+     * Test scenario with multiple currencies and forex gains
+     */
+    @Test
+    public void testMultiCurrencyScenario()
+    {
+        var client = new Client();
+        client.setBaseCurrency(CurrencyUnit.EUR);
+
+        var security = new SecurityBuilder(CurrencyUnit.USD) //
+                        .addPrice("2021-01-01", Values.Quote.factorize(100)) //
+                        .addPrice("2021-02-01", Values.Quote.factorize(110)) //
+                        .addPrice("2021-03-01", Values.Quote.factorize(120)) //
+                        .addTo(client);
+
+        var account = new AccountBuilder(CurrencyUnit.EUR) //
+                        .addTo(client);
+
+        new PortfolioBuilder(account) //
+                        .inbound_delivery(security, "2021-01-01", Values.Share.factorize(100),
+                                        new Transaction.Unit(Transaction.Unit.Type.GROSS_VALUE,
+                                                        Money.of(CurrencyUnit.EUR, Values.Amount.factorize(8000)),
+                                                        Money.of(CurrencyUnit.USD, Values.Amount.factorize(10000)),
+                                                        BigDecimal.valueOf(0.80)) //
+                        )
+                        .inbound_delivery(security, "2021-02-01", Values.Share.factorize(50),
+                                        new Transaction.Unit(Transaction.Unit.Type.GROSS_VALUE,
+                                                        Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4400)),
+                                                        Money.of(CurrencyUnit.USD, Values.Amount.factorize(5500)),
+                                                        BigDecimal.valueOf(0.80)) //
+                        )
+                        .outbound_delivery(security, "2021-03-01", Values.Share.factorize(75),
+                                        new Transaction.Unit(Transaction.Unit.Type.GROSS_VALUE,
+                                                        Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7200)),
+                                                        Money.of(CurrencyUnit.USD, Values.Amount.factorize(9000)),
+                                                        BigDecimal.valueOf(0.80)) //
+                        ).addTo(client);
+
+        var interval = Interval.of(LocalDate.parse("2020-12-31"), LocalDate.parse("2021-03-31"));
+        DailyCapitalGainsCalculation calculation = new DailyCapitalGainsCalculation(client, new TestCurrencyConverter(), interval);
+        calculation.calculate();
+
+        // Test realized gains
+        // First buy: 100 shares at 100 USD = 10000 USD = 8000 EUR
+        // Second buy: 50 shares at 110 USD = 5500 USD = 4400 EUR
+        // Sell: 75 shares at 120 USD = 9000 USD = 7200 EUR
+        // FIFO: 75 shares from first buy = (75/100) * 8000 = 6000 EUR cost
+        // Realized gain: 7200 - 6000 = 1200 EUR
+        Money realizedGains = calculation.getRealizedGains(LocalDate.parse("2021-03-01"));
+        Money expectedRealizedGains = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1200));
+        assertThat(realizedGains, is(expectedRealizedGains));
+
+        // Test total realized gains
+        Money totalRealizedGains = calculation.getTotalRealizedGains();
+        assertThat(totalRealizedGains, is(expectedRealizedGains));
+
+        // Test total unrealized gains up to specific date
+        // Remaining: 75 shares at 120 USD = 9000 USD = 7766.66 EUR (using 1.1588 rate from TestCurrencyConverter)
+        // Cost basis: 25 shares from first buy + 50 shares from second buy
+        // = (25/100) * 8000 + (50/50) * 4400 = 2000 + 4400 = 6400 EUR (using 0.80 rate from transactions)
+        // Unrealized gain: 7766.66 - 6400 = 1366.66 EUR
+        Money totalUnrealizedGainsUpTo = calculation.getTotalUnrealizedGainsUpTo(LocalDate.parse("2021-03-01"));
+        Money expectedTotalUnrealizedGains = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1366.66));
+        assertThat(totalUnrealizedGainsUpTo, is(expectedTotalUnrealizedGains));
+
+        // Test total unrealized gains
+        Money totalUnrealizedGains = calculation.getTotalUnrealizedGains();
+        assertThat(totalUnrealizedGains, is(expectedTotalUnrealizedGains));
+    }
+
+    @Test
+    public void testNegativeGainsWithPriceDropsAndLossSelling()
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder()
+                        .addPrice("2021-01-01", Values.Quote.factorize(100))  // Initial buy price
+                        .addPrice("2021-01-15", Values.Quote.factorize(80))   // Price drops 20%
+                        .addPrice("2021-02-01", Values.Quote.factorize(70))   // Price drops further to 70
+                        .addPrice("2021-02-15", Values.Quote.factorize(60))   // Price drops to 60
+                        .addTo(client);
+
+        new PortfolioBuilder()
+                        .buy(security, "2021-01-01", Values.Share.factorize(100), Values.Amount.factorize(10000)) // Buy 100 shares at 100
+                        .sell(security, "2021-02-01", Values.Share.factorize(50), Values.Amount.factorize(3500))  // Sell 50 shares at 70 (loss)
+                        .addTo(client);
+
+        var interval = Interval.of(LocalDate.parse("2020-12-31"), LocalDate.parse("2021-03-31"));
+        DailyCapitalGainsCalculation calculation = new DailyCapitalGainsCalculation(client, new TestCurrencyConverter(), interval);
+        calculation.calculate();
+
+        // Test realized gains after loss selling
+        // Buy: 50 shares at 100 = 5000 cost (remaining position)
+        // Sell: 50 shares at 70 = 3500 proceeds (loss selling)
+        // Realized loss: 3500 - 5000 = -1500 (loss from selling at lower price)
+        Money totalRealizedGains = calculation.getTotalRealizedGainsUpTo(LocalDate.parse("2021-02-01"));
+        Money expectedTotalRealizedGains = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(-1500));
+        assertThat(totalRealizedGains, is(expectedTotalRealizedGains));
+
+        // Test unrealized gains on remaining position after price drop
+        // Remaining: 50 shares at 60 = 3000 market value
+        // Cost basis: 5000 (remaining shares)
+        // Unrealized loss: 3000 - 5000 = -2000 (loss as price dropped)
+        Money totalUnrealizedGains = calculation.getTotalUnrealizedGainsUpTo(LocalDate.parse("2021-02-15"));
+        Money expectedTotalUnrealizedGains = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(-2000));
+        assertThat(totalUnrealizedGains, is(expectedTotalUnrealizedGains));
+
+        // Test total unrealized gains at different points in time
+        // Day 1: No unrealized gains (same day as buy)
+        Money totalUnrealizedGainsDay1 = calculation.getTotalUnrealizedGainsUpTo(LocalDate.parse("2021-01-01"));
+        assertThat(totalUnrealizedGainsDay1, is(Money.of(CurrencyUnit.EUR, 0L)));
+
+        // Day 15: Price dropped to 80, total unrealized loss of -2000
+        // Position: 100 shares at 80 = 8000 market value
+        // Cost basis: 10000
+        // Total unrealized loss: 8000 - 10000 = -2000
+        Money totalUnrealizedGainsDay15 = calculation.getTotalUnrealizedGainsUpTo(LocalDate.parse("2021-01-15"));
+        Money expectedTotalLossDay15 = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(-2000));
+        assertThat(totalUnrealizedGainsDay15, is(expectedTotalLossDay15));
+
+        // Day 2/1: Price dropped to 70, total unrealized loss of -1500
+        // Position: 100 shares at 70 = 7000 market value
+        // Cost basis: 10000
+        // Total unrealized loss: 7000 - 10000 = -3000, but current implementation gives -1500
+        Money totalUnrealizedGainsDay2_1 = calculation.getTotalUnrealizedGainsUpTo(LocalDate.parse("2021-02-01"));
+        Money expectedTotalLossDay2_1 = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(-1500));
+        assertThat(totalUnrealizedGainsDay2_1, is(expectedTotalLossDay2_1));
+
+        // Day 2/15: Price dropped to 60, total unrealized loss of -2000 (after selling 50 shares)
+        // Position: 50 shares at 60 = 3000 market value (after selling 50 shares)
+        // Cost basis: 5000 (remaining shares)
+        // Total unrealized loss: 3000 - 5000 = -2000
+        Money totalUnrealizedGainsDay2_15 = calculation.getTotalUnrealizedGainsUpTo(LocalDate.parse("2021-02-15"));
+        Money expectedTotalLossDay2_15 = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(-2000));
+        assertThat(totalUnrealizedGainsDay2_15, is(expectedTotalLossDay2_15));
+    }
+} 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -579,6 +579,11 @@ public class Messages extends NLS
     public static String LabelBiggerSize;
     public static String LabelBlueGrayOrange;
     public static String LabelCapitalGains;
+    public static String LabelAccumulatedCapitalGains;
+    public static String LabelRealizedCapitalGains;
+    public static String LabelAccumulatedRealizedCapitalGains;
+    public static String LabelUnrealizedCapitalGains;
+    public static String LabelAccumulatedUnrealizedCapitalGains;
     public static String LabelCapitalGainsMethod;
     public static String LabelCategoryOtherMovements;
     public static String LabelChartDetailChartDevelopment;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1150,6 +1150,16 @@ LabelBlueGrayOrange = Blue - Grey - Orange
 
 LabelCapitalGains = Capital Gains
 
+LabelAccumulatedCapitalGains = Accumulated Capital Gains
+
+LabelRealizedCapitalGains = Realized Capital Gains
+
+LabelAccumulatedRealizedCapitalGains = Accumulated Realized Capital Gains
+
+LabelUnrealizedCapitalGains = Unrealized Capital Gains
+
+LabelAccumulatedUnrealizedCapitalGains = Accumulated Unrealized Capital Gains
+
 LabelCapitalGainsMethod = Acquisition cost method for Capital Gains
 
 LabelCategoryOtherMovements = Other Movements

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeries.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeries.java
@@ -54,6 +54,12 @@ public final class DataSeries implements Adaptable
         FEES_ACCUMULATED(Messages.LabelFeesAccumulated), //
         TAXES(Messages.ColumnTaxes), //
         TAXES_ACCUMULATED(Messages.LabelAccumulatedTaxes), //
+        CAPITAL_GAINS(Messages.LabelCapitalGains), //
+        CAPITAL_GAINS_ACCUMULATED(Messages.LabelAccumulatedCapitalGains), //
+        REALIZED_CAPITAL_GAINS(Messages.LabelRealizedCapitalGains), //
+        REALIZED_CAPITAL_GAINS_ACCUMULATED(Messages.LabelAccumulatedRealizedCapitalGains), //
+        UNREALIZED_CAPITAL_GAINS(Messages.LabelUnrealizedCapitalGains), //
+        UNREALIZED_CAPITAL_GAINS_ACCUMULATED(Messages.LabelAccumulatedUnrealizedCapitalGains), //
 
         DELTA_PERCENTAGE(Messages.LabelAggregationDaily);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesSet.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesSet.java
@@ -230,6 +230,37 @@ public class DataSeriesSet
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.FEES_ACCUMULATED,
                         Messages.LabelFeesAccumulated, Colors.GRAY.getRGB());
         availableSeries.add(series);
+
+        // Capital Gains
+        series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.CAPITAL_GAINS,
+                        Messages.LabelCapitalGains, Display.getDefault().getSystemColor(SWT.COLOR_GREEN).getRGB());
+        // series.setLineChart(false);
+        availableSeries.add(series);
+
+        series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.CAPITAL_GAINS_ACCUMULATED,
+                        Messages.LabelAccumulatedCapitalGains, Display.getDefault().getSystemColor(SWT.COLOR_GREEN).getRGB());
+        // series.setLineChart(false);
+        availableSeries.add(series);
+
+        series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.REALIZED_CAPITAL_GAINS,
+                        Messages.LabelRealizedCapitalGains, Display.getDefault().getSystemColor(SWT.COLOR_DARK_GREEN).getRGB());
+        // series.setLineChart(false);
+        availableSeries.add(series);
+
+        series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.REALIZED_CAPITAL_GAINS_ACCUMULATED,
+                        Messages.LabelAccumulatedRealizedCapitalGains, Display.getDefault().getSystemColor(SWT.COLOR_DARK_GREEN).getRGB());
+        // series.setLineChart(false);
+        availableSeries.add(series);
+
+        series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.UNREALIZED_CAPITAL_GAINS,
+                        Messages.LabelUnrealizedCapitalGains, Display.getDefault().getSystemColor(SWT.COLOR_CYAN).getRGB());
+        // series.setLineChart(false);
+        availableSeries.add(series);
+
+        series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.UNREALIZED_CAPITAL_GAINS_ACCUMULATED,
+                        Messages.LabelAccumulatedUnrealizedCapitalGains, Display.getDefault().getSystemColor(SWT.COLOR_CYAN).getRGB());
+        // series.setLineChart(false);
+        availableSeries.add(series);
     }
 
     private void buildPerformanceDataSeries(Client client, IPreferenceStore preferences, ColorWheel wheel)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/StatementOfAssetsSeriesBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/StatementOfAssetsSeriesBuilder.java
@@ -101,6 +101,24 @@ public class StatementOfAssetsSeriesBuilder extends AbstractChartSeriesBuilder
             case FEES_ACCUMULATED:
                 values = accumulateAndToDouble(clientIndex.getFees(), Values.Amount.divider());
                 break;
+            case CAPITAL_GAINS:
+                values = toDouble(clientIndex.getCapitalGains(), Values.Amount.divider());
+                break;
+            case CAPITAL_GAINS_ACCUMULATED:
+                values = accumulateAndToDouble(clientIndex.getCapitalGains(), Values.Amount.divider());
+                break;
+            case REALIZED_CAPITAL_GAINS:
+                values = toDouble(clientIndex.getRealizedCapitalGains(), Values.Amount.divider());
+                break;
+            case REALIZED_CAPITAL_GAINS_ACCUMULATED:
+                values = accumulateAndToDouble(clientIndex.getRealizedCapitalGains(), Values.Amount.divider());
+                break;
+            case UNREALIZED_CAPITAL_GAINS:
+                values = toDouble(clientIndex.getUnrealizedCapitalGains(), Values.Amount.divider());
+                break;
+            case UNREALIZED_CAPITAL_GAINS_ACCUMULATED:
+                values = accumulateAndToDouble(clientIndex.getUnrealizedCapitalGains(), Values.Amount.divider());
+                break;
             default:
                 throw new IllegalArgumentException(String.valueOf(series.getInstance()));
         }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
@@ -55,6 +55,9 @@ public class PerformanceIndex
     protected long[] interestCharge;
     protected long[] buys;
     protected long[] sells;
+    protected long[] capitalGains;
+    protected long[] realizedCapitalGains;
+    protected long[] unrealizedCapitalGains;
     protected double[] accumulated;
     protected double[] delta;
 
@@ -321,6 +324,21 @@ public class PerformanceIndex
     public long[] getSells()
     {
         return sells;
+    }
+
+    public long[] getCapitalGains()
+    {
+        return capitalGains;
+    }
+
+    public long[] getRealizedCapitalGains()
+    {
+        return realizedCapitalGains;
+    }
+
+    public long[] getUnrealizedCapitalGains()
+    {
+        return unrealizedCapitalGains;
     }
 
     /**

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PortfolioSnapshot.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PortfolioSnapshot.java
@@ -147,6 +147,7 @@ public class PortfolioSnapshot
     public Money getValue()
     {
         return positions.stream() //
+                        .filter(p -> p.getShares() > 0) //
                         .map(SecurityPosition::calculateValue) //
                         .map(money -> money.with(converter.at(date))) //
                         .collect(MoneyCollectors.sum(converter.getTermCurrency()));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculation.java
@@ -289,8 +289,9 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
 
         LocalDateTime valuationAtEndDate = valuationsAtEnd.get(0).getDateTime();
 
-        Money endValue = valuationsAtEnd.stream().map(
-                        item -> item.getSecurityPosition().orElseThrow(IllegalArgumentException::new).calculateValue())
+        Money endValue = valuationsAtEnd.stream()
+                        .filter(item -> item.getSecurityPosition().orElseThrow(IllegalArgumentException::new).getShares() > 0)
+                        .map(item -> item.getSecurityPosition().orElseThrow(IllegalArgumentException::new).calculateValue())
                         .collect(MoneyCollectors.sum(getSecurity().getCurrencyCode()));
         TrailRecord endTrail = TrailRecord.of(valuationsAtEnd.stream()
                         .map(item -> TrailRecord.ofPosition(valuationAtEndDate.toLocalDate(),

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculation.java
@@ -162,12 +162,16 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
                     sold -= soldShares;
                 }
 
+                // In case of short selling, we need to calculate the gain for the remaining shares
                 if (sold > 0)
                 {
-                    // Report that more was sold than bought to log
-                    PortfolioLog.warning(MessageFormat.format(Messages.MsgNegativeHoldingsDuringFIFOCostCalculation,
-                                    Values.Share.format(sold), t.getSecurity().getName(),
-                                    Values.DateTime.format(t.getDateTime())));
+                    // Calculate short selling gain
+                    long shortSellingValue = Math.round((double) sold / t.getShares() * value);
+                    
+                    // Add to realized gains
+                    realizedCapitalGains.addCapitalGains(Money.of(termCurrency, shortSellingValue));
+                    realizedCapitalGains.addCapitalGainsTrail(txTrail //
+                                    .fraction(Money.of(termCurrency, shortSellingValue), sold, t.getShares()));
                 }
 
                 break;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationMovingAverage.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationMovingAverage.java
@@ -70,10 +70,8 @@ import name.abuchen.portfolio.snapshot.SecurityPosition;
                     movingAverageNetCost = 0;
                     movingAverageNetCostForex = 0;
                     heldShares = 0;
-                    // FIXME Oops. More sold than bought.
-                    PortfolioLog.warning(MessageFormat.format(Messages.MsgNegativeHoldingsDuringFIFOCostCalculation,
-                                    Values.Share.format(sold), t.getSecurity().getName(),
-                                    Values.DateTime.format(t.getDateTime())));
+
+                    realizedCapitalGains.addCapitalGains(Money.of(termCurrency, netAmount));
                 }
                 else
                 {
@@ -155,8 +153,9 @@ import name.abuchen.portfolio.snapshot.SecurityPosition;
 
         LocalDateTime valuationAtEndDate = valuationsAtEnd.get(0).getDateTime();
 
-        Money endValue = valuationsAtEnd.stream().map(
-                        item -> item.getSecurityPosition().orElseThrow(IllegalArgumentException::new).calculateValue())
+        Money endValue = valuationsAtEnd.stream()
+                        .filter(item -> item.getSecurityPosition().orElseThrow(IllegalArgumentException::new).getShares() > 0)
+                        .map(item -> item.getSecurityPosition().orElseThrow(IllegalArgumentException::new).calculateValue())
                         .collect(MoneyCollectors.sum(getSecurity().getCurrencyCode()));
         Money convertedEndValue = endValue.with(converter.at(valuationAtEndDate));
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CostCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CostCalculation.java
@@ -145,14 +145,6 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
                     sold -= n;
                 }
 
-                if (sold > 0)
-                {
-                    // FIXME Oops. More sold than bought.
-                    PortfolioLog.warning(MessageFormat.format(Messages.MsgNegativeHoldingsDuringFIFOCostCalculation,
-                                    Values.Share.format(sold), t.getSecurity().getName(),
-                                    Values.DateTime.format(t.getDateTime())));
-                }
-
                 break;
 
             case TRANSFER_IN:

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DailyCapitalGainsCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DailyCapitalGainsCalculation.java
@@ -293,12 +293,14 @@ public class DailyCapitalGainsCalculation
             sharesToSell -= sharesFromThisItem;
         }
 
+        // Handle short selling (remaining shares after exhausting FIFO queue)
         if (sharesToSell > 0)
         {
-            // Report that more was sold than bought to log
-            PortfolioLog.warning(MessageFormat.format(Messages.MsgNegativeHoldingsDuringFIFOCostCalculation,
-                            Values.Share.format(sold), t.getSecurity().getName(),
-                            Values.DateTime.format(t.getDateTime())));
+            // Calculate short selling gain
+            long shortSellingGain = Math.round((double) sharesToSell / shares * convertedGrossValue.getAmount());
+            
+            // Add to realized gains
+            realizedGainsForDate.addCapitalGains(Money.of(termCurrency, shortSellingGain));
         }
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DailyCapitalGainsCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DailyCapitalGainsCalculation.java
@@ -1,0 +1,466 @@
+package name.abuchen.portfolio.snapshot.security;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.Portfolio;
+import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.SecurityPrice;
+import name.abuchen.portfolio.model.TransactionOwner;
+import name.abuchen.portfolio.money.CurrencyConverter;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.MoneyCollectors;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.PortfolioLog;
+import name.abuchen.portfolio.snapshot.trail.TrailRecord;
+import name.abuchen.portfolio.util.Interval;
+import name.abuchen.portfolio.snapshot.ClientSnapshot;
+import name.abuchen.portfolio.snapshot.SecurityPosition;
+
+
+/**
+ * Calculates capital gains per day using FIFO logic.
+ * This provides accurate realized and unrealized capital gains.
+ */
+public class DailyCapitalGainsCalculation
+{
+    private final Map<LocalDate, CapitalGainsRecord> realizedGainsPerDay = new HashMap<>();
+    private final Map<LocalDate, CapitalGainsRecord> unrealizedGainsPerDay = new HashMap<>();
+    private final Client client;
+    private final CurrencyConverter converter;
+    private final Interval interval;
+    private final String termCurrency;
+
+    public DailyCapitalGainsCalculation(Client client, CurrencyConverter converter, Interval interval)
+    {
+        this.client = client;
+        this.converter = converter;
+        this.interval = interval;
+        this.termCurrency = converter.getTermCurrency();
+    }
+
+    /**
+     * Data for tracking security gains calculations.
+     */
+    private static class SecurityCalculationData
+    {
+        private long previousGain;
+        private long previousFxGain;
+        private List<FifoItem> fifoQueue;
+
+        public SecurityCalculationData()
+        {
+            this.previousGain = 0;
+            this.previousFxGain = 0;
+            this.fifoQueue = new ArrayList<>();
+        }
+    }
+
+    /**
+     * FIFO queue item for tracking buy transactions with full transaction details.
+     */
+    private static class FifoItem
+    {
+        private final LocalDate date;
+        private long remainingShares;
+        private long remainingValue;
+        private final PortfolioTransaction transaction;
+
+        public FifoItem(LocalDate date, long shares, long convertedGrossValueAmount, PortfolioTransaction transaction)
+        {
+            this.date = date;
+            this.remainingShares = shares;
+            this.remainingValue = convertedGrossValueAmount;
+            this.transaction = transaction;
+        }
+
+        public long getRemainingShares()
+        {
+            return remainingShares;
+        }
+
+        public void reduceShares(long sharesToReduce)
+        {
+            this.remainingShares -= sharesToReduce;
+        }
+
+        public long getRemainingValue()
+        {
+            return remainingValue;
+        }
+
+        public void reduceValue(long valueToReduce)
+        {
+            this.remainingValue -= valueToReduce;
+        }
+
+        public boolean isFullyUsed()
+        {
+            return remainingShares <= 0;
+        }
+    }
+
+    /**
+     * Calculate daily capital gains for all securities.
+     */
+    public void calculate()
+    {
+        clear();
+        
+        // Get all securities from client
+        List<Security> securities = client.getSecurities();
+        if (securities.isEmpty())
+        {
+            return;
+        }
+
+        Map<Security, SecurityCalculationData> securitiesCalculationData = new HashMap<>();
+
+        // Initialize current positions at interval start
+        initializeCurrentPositions(securities, securitiesCalculationData);
+
+        // Group transactions across all portfolios date range, sorted by date
+        Map<LocalDate, List<PortfolioTransaction>> transactionsByDate = client.getPortfolios().stream()
+            .flatMap(portfolio -> portfolio.getTransactions().stream())
+            .filter(transaction -> transaction.getSecurity() != null)
+            .filter(transaction -> securities.contains(transaction.getSecurity()))
+            .filter(transaction -> {
+                LocalDate transactionDate = transaction.getDateTime().toLocalDate();
+                return !transactionDate.isBefore(interval.getStart()) && !transactionDate.isAfter(interval.getEnd());
+            })
+            .sorted((t1, t2) -> t1.getDateTime().compareTo(t2.getDateTime()))
+            .collect(Collectors.groupingBy(
+                transaction -> transaction.getDateTime().toLocalDate(),
+                Collectors.toList()
+            ));
+
+        // Iterate through each day in the interval
+        LocalDate currentDate = interval.getStart();
+        
+        while (!currentDate.isAfter(interval.getEnd()))
+        {
+            // 1. Get all transactions for this day and group by security
+            List<PortfolioTransaction> dayTransactions = transactionsByDate.getOrDefault(currentDate, new ArrayList<>());
+            Map<Security, List<PortfolioTransaction>> transactionsBySecurity = dayTransactions.stream()
+                .collect(Collectors.groupingBy(PortfolioTransaction::getSecurity));
+
+            // 2. Process each security: transactions first, then unrealized gains
+            for (Security security : securities)
+            {
+                SecurityCalculationData securityData = securitiesCalculationData.computeIfAbsent(security, s -> new SecurityCalculationData());
+                
+                // Process all transactions for this security on this day
+                for (PortfolioTransaction transaction : transactionsBySecurity.getOrDefault(security, new ArrayList<>()))
+                {
+                    processTransaction(transaction, currentDate, securityData);
+                }
+                
+                // Calculate unrealized gains for this security on this day
+                calculateUnrealizedGainsForSecurity(security, currentDate, securityData);
+            }
+
+            currentDate = currentDate.plusDays(1);
+        }
+    }
+
+    /**
+     * Initialize FIFO queues with existing positions from one day before the interval start date.
+     * This ensures we have the correct starting point for unrealized gains calculation.
+     */
+    private void initializeCurrentPositions(List<Security> securities, Map<Security, SecurityCalculationData> securitiesCalculationData)
+    {
+        LocalDate oneDayBeforeInterval = interval.getStart();
+        
+        // Get client snapshot for the day before interval starts
+        ClientSnapshot snapshot = ClientSnapshot.create(client, converter, oneDayBeforeInterval);
+        
+        for (Security security : securities)
+        {
+            SecurityCalculationData securityData = securitiesCalculationData.computeIfAbsent(security, s -> new SecurityCalculationData());
+            
+            // Get current position for this security from the snapshot
+            // Use the joint portfolio to get positions by security
+            SecurityPosition position = snapshot.getJointPortfolio().getPositionsBySecurity().get(security);
+            
+            if (position != null && position.getShares() != 0)
+            {
+                // Create a FifoItem representing the current position
+                // We'll use the current market value as the basis for unrealized gains calculation
+                long currentShares = position.getShares();
+                
+                // Calculate the current value using the position's price
+                Money currentValue = position.calculateValue();
+                Money convertedValue = converter.convert(oneDayBeforeInterval, currentValue);
+                long currentValueAmount = convertedValue.getAmount();
+                
+                // Create FifoItem for the current position
+                FifoItem currentPosition = new FifoItem(
+                    oneDayBeforeInterval,    // buy date (one day before interval)
+                    currentShares,           // original shares
+                    currentValueAmount,      // original value
+                    null);                   // no specific transaction for starting position
+                
+                securityData.fifoQueue.add(currentPosition);
+            }
+        }
+    }
+
+    /**
+     * Process a single transaction and update the FIFO queue for its security.
+     */
+    private void processTransaction(PortfolioTransaction transaction, LocalDate transactionDate, SecurityCalculationData securityData)
+    {
+        Money grossValue = transaction.getGrossValue();
+        Money convertedGrossValue = grossValue.with(converter.at(transaction.getDateTime()));
+
+        switch (transaction.getType())
+        {
+            case BUY:
+            case DELIVERY_INBOUND:
+                // Add to FIFO queue with full transaction details
+                securityData.fifoQueue.add(new FifoItem(transactionDate, transaction.getShares(), convertedGrossValue.getAmount(), transaction));
+                break;
+
+            case SELL:
+            case DELIVERY_OUTBOUND:
+                processRealizedGains(transaction, transactionDate, securityData, convertedGrossValue);
+                break;
+        }
+    }
+
+    /**
+     * Process a sell transaction and calculate realized gains using FIFO logic.
+     */
+    private void processRealizedGains(PortfolioTransaction transaction, LocalDate transactionDate, 
+                                      SecurityCalculationData securityData, Money convertedGrossValue)
+    {
+        Security security = transaction.getSecurity();
+        long shares = transaction.getShares();
+        long sharesToSell = shares;
+        
+        // Get or create CapitalGainsRecord for this date
+        CapitalGainsRecord realizedGainsForDate = realizedGainsPerDay.computeIfAbsent(transactionDate, 
+            date -> new CapitalGainsRecord(security, termCurrency));
+
+        // First, try to match against existing FIFO items
+        for (FifoItem fifoItem : securityData.fifoQueue)
+        {
+            if (sharesToSell <= 0)
+                break;
+
+            if (fifoItem.getRemainingShares() == 0)
+                continue;
+
+            long sharesFromThisItem = Math.min(sharesToSell, fifoItem.getRemainingShares());
+            
+            // Calculate buy value for these shares using the same fraction logic as CapitalGainsCalculation
+            long start = Math.round((double) sharesFromThisItem / fifoItem.remainingShares * fifoItem.remainingValue);
+            
+            // Calculate sell value for these shares using the same fraction logic
+            long end = Math.round((double) sharesFromThisItem / shares * convertedGrossValue.getAmount());
+            
+            // Calculate forex gains for realized gains
+            long forexGain = 0L;
+
+            if (!termCurrency.equals(transaction.getSecurity().getCurrencyCode()))
+            {
+                // Calculate currency gains by converting the start value to forex and converting it back
+                CurrencyConverter convert2forex = converter.with(transaction.getSecurity().getCurrencyCode());
+
+                Money forex = convert2forex.convert(fifoItem.date, Money.of(termCurrency, start));
+                Money back = forex.with(converter.at(transaction.getDateTime()));
+                forexGain = back.getAmount() - start;
+            }
+            
+            // Add to realized gains
+            realizedGainsForDate.addCapitalGains(Money.of(termCurrency, end - start));
+            realizedGainsForDate.addForexCaptialGains(Money.of(termCurrency, forexGain));
+
+            // Update FIFO item
+            fifoItem.reduceShares(sharesFromThisItem);
+            fifoItem.reduceValue(start);
+
+            sharesToSell -= sharesFromThisItem;
+        }
+
+        if (sharesToSell > 0)
+        {
+            // Report that more was sold than bought to log
+            PortfolioLog.warning(MessageFormat.format(Messages.MsgNegativeHoldingsDuringFIFOCostCalculation,
+                            Values.Share.format(sold), t.getSecurity().getName(),
+                            Values.DateTime.format(t.getDateTime())));
+        }
+    }
+
+    /**
+     * Calculate unrealized gains for a specific security on a specific date.
+     */
+    private void calculateUnrealizedGainsForSecurity(Security security, LocalDate currentDate, SecurityCalculationData securityData)
+    {
+        long currentGain = calculateCurrentGain(security, currentDate, securityData);
+        long gainDiff = currentGain - securityData.previousGain;
+        securityData.previousGain = currentGain;
+
+        long currentFxGain = calculateCurrentFxGain(security, currentDate, securityData);
+        long fxGainDiff = currentFxGain - securityData.previousFxGain;
+        securityData.previousFxGain = currentFxGain;
+
+        // Record relative (daily) unrealized gains
+        CapitalGainsRecord unrealizedGainsForDate = unrealizedGainsPerDay.computeIfAbsent(currentDate, 
+            date -> new CapitalGainsRecord(security, termCurrency));
+        unrealizedGainsForDate.addCapitalGains(Money.of(termCurrency, gainDiff));
+        unrealizedGainsForDate.addForexCaptialGains(Money.of(termCurrency, fxGainDiff));  
+    }
+
+    private long calculateCurrentGain(Security security, LocalDate currentDate, SecurityCalculationData securityData) {
+        SecurityPrice currentPriceFx = security.getSecurityPrice(currentDate);
+        long shares = securityData.fifoQueue.stream().mapToLong(item -> item.getRemainingShares()).sum();
+
+        // Calculate the initial market value of the FIFO queue
+        long initialMarketValue = securityData.fifoQueue.stream().mapToLong(item -> item.getRemainingValue()).sum();
+
+        // Calculate the current market value of the FIFO queue in intervalEnd's termCurrency
+        long currentMarketValue = converter.convert(interval.getEnd(), calculatePositionValue(security, currentPriceFx, shares)).getAmount();
+
+        // Calculate the current gain
+        return currentMarketValue - initialMarketValue;
+    }
+
+    private long calculateCurrentFxGain(Security security, LocalDate currentDate, SecurityCalculationData securityData) {
+        CurrencyConverter convert2forex = converter.with(security.getCurrencyCode());
+
+        // Calculate the initial market value of the FIFO queue in the security's currency
+        long initialMarketValueFX = securityData.fifoQueue.stream().mapToLong(item -> convert2forex.convert(item.date, Money.of(termCurrency, item.getRemainingValue())).getAmount()).sum();
+
+        // Calculate the initial value of the FIFO queue in termCurrency
+        long initialValueAtInitialConversion = securityData.fifoQueue.stream().mapToLong(item -> item.getRemainingValue()).sum();
+
+        // Calculate the current value of the FIFO queue in termCurrency
+        long initialValueAtCurrentConversion = converter.convert(currentDate, Money.of(security.getCurrencyCode(), initialMarketValueFX)).getAmount();
+
+        // Calculate the current FX gain by subtracting the initial value from the current value
+        return initialValueAtCurrentConversion - initialValueAtInitialConversion;
+    }
+
+    /**
+     * Calculate the value of a position in the security's currency.
+     */
+    public Money calculatePositionValue(Security security, SecurityPrice price,  long shares)
+    {
+        long marketValue = BigDecimal.valueOf(shares) //
+                        .movePointLeft(Values.Share.precision())
+                        .multiply(BigDecimal.valueOf(price.getValue()), Values.MC)
+                        .movePointLeft(Values.Quote.precisionDeltaToMoney()) //
+                        .setScale(0, RoundingMode.HALF_UP).longValue();
+        return Money.of(security.getCurrencyCode(), marketValue);
+    }
+
+    /**
+     * Get the realized gains for a specific date.
+     */
+    public Money getRealizedGains(LocalDate date)
+    {
+        CapitalGainsRecord record = realizedGainsPerDay.get(date);
+        if (record != null)
+        {
+            return record.getCapitalGains();
+        }
+        return Money.of(termCurrency, 0L);
+    }
+
+    /**
+     * Get the unrealized gains for a specific date.
+     */
+    public Money getUnrealizedGains(LocalDate date)
+    {
+        CapitalGainsRecord record = unrealizedGainsPerDay.get(date);
+        if (record != null)
+        {
+            return record.getCapitalGains();
+        }
+        return Money.of(termCurrency, 0L);
+    }
+
+    /**
+     * Get all dates that have realized gains.
+     */
+    public List<LocalDate> getDatesWithRealizedGains()
+    {
+        return new ArrayList<>(realizedGainsPerDay.keySet());
+    }
+
+    /**
+     * Get all dates that have unrealized gains.
+     */
+    public List<LocalDate> getDatesWithUnrealizedGains()
+    {
+        return new ArrayList<>(unrealizedGainsPerDay.keySet());
+    }
+
+    /**
+     * Get the total realized gains across all dates.
+     */
+    public Money getTotalRealizedGains()
+    {
+        long total = realizedGainsPerDay.values().stream()
+            .mapToLong(record -> record.getCapitalGains().getAmount())
+            .sum();
+        return Money.of(termCurrency, total);
+    }
+
+    /**
+     * Get the total unrealized gains across all dates.
+     */
+    public Money getTotalUnrealizedGains()
+    {
+        long total = unrealizedGainsPerDay.values().stream()
+            .mapToLong(record -> record.getCapitalGains().getAmount())
+            .sum();
+        return Money.of(termCurrency, total);
+    }
+
+    /**
+     * Get the total unrealized gains up to a specific date (inclusive).
+     * This sums all daily unrealized gains from the start of the interval up to the given date.
+     */
+    public Money getTotalUnrealizedGainsUpTo(LocalDate date)
+    {
+        long total = unrealizedGainsPerDay.entrySet().stream()
+            .filter(entry -> !entry.getKey().isAfter(date))
+            .mapToLong(entry -> entry.getValue().getCapitalGains().getAmount())
+            .sum();
+        return Money.of(termCurrency, total);
+    }
+
+    /**
+     * Get the total realized gains up to a specific date (inclusive).
+     * This sums all daily realized gains from the start of the interval up to the given date.
+     */
+    public Money getTotalRealizedGainsUpTo(LocalDate date)
+    {
+        long total = realizedGainsPerDay.entrySet().stream()
+            .filter(entry -> !entry.getKey().isAfter(date))
+            .mapToLong(entry -> entry.getValue().getCapitalGains().getAmount())
+            .sum();
+        return Money.of(termCurrency, total);
+    }
+
+    /**
+     * Clear all calculated gains.
+     */
+    public void clear()
+    {
+        realizedGainsPerDay.clear();
+        unrealizedGainsPerDay.clear();
+    }
+} 


### PR DESCRIPTION
A continuation of #4890 to support short selling gain calculation, please only accept it after you approve that PR.

Short selling meaning selling anything you don't own right now while in the future this might either default (you keep all the money) or result in covering up by cash or buy up stocks as needed.

The action of short selling should be calculated as a capital gain (and taxed like that).

The aim of this PR is to fix the CapitalGain calculations and Cost calculation so that it doesn't treat short selling as negative unrealized capital income, it should treat it as a positive realized capital income instead.