### PR TITLE
fix automatic quote and total in foreign currency in Sell and Outbound delivery transaction dialog

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/AbstractSecurityTransactionModel.java
@@ -276,8 +276,8 @@ public abstract class AbstractSecurityTransactionModel extends AbstractModel
         firePropertyChange(Properties.inverseExchangeRateCurrencies.name(), oldInverseExchangeRateCurrencies,
                         getInverseExchangeRateCurrencies());
 
-        updateSharesAndQuote();
         updateExchangeRate();
+        updateSharesAndQuote();
     }
 
     protected void updateSharesAndQuote()
@@ -302,6 +302,8 @@ public abstract class AbstractSecurityTransactionModel extends AbstractModel
                 if (position != null)
                 {
                     setShares(position.getShares());
+                    // position.calculateValue().getAmount() is in the security
+                    // currency
                     setTotal(position.calculateValue().getAmount());
                     hasPosition = true;
                 }
@@ -564,13 +566,10 @@ public abstract class AbstractSecurityTransactionModel extends AbstractModel
 
     public void setTotal(long total)
     {
-        triggerTotal(total);
-
+        firePropertyChange(Properties.grossValue.name(), this.grossValue, this.grossValue = total);
         firePropertyChange(Properties.convertedGrossValue.name(), this.convertedGrossValue,
-                        this.convertedGrossValue = calculateConvertedGrossValue());
-
-        firePropertyChange(Properties.grossValue.name(), this.grossValue,
-                        this.grossValue = Math.round(convertedGrossValue / exchangeRate.doubleValue()));
+                        this.convertedGrossValue = Math.round(exchangeRate.doubleValue() * grossValue));
+        triggerTotal(calculateTotal());
 
         if (shares != 0)
             firePropertyChange(Properties.quote.name(), this.quote, this.quote = BigDecimal


### PR DESCRIPTION
Closes https://github.com/portfolio-performance/portfolio/issues/2543
Closes https://github.com/portfolio-performance/portfolio/issues/4322
Closes https://github.com/portfolio-performance/portfolio/issues/4889

Hello,
This is a proposition to fix the above issues. They all mention GBX/GBP but the issue applied to any currency exchange.
The problem is easy to reproduce from the detailed steps of #2543. And was also existing with a time change or a date change or security change. 

In `updateSharesAndQuote`, at `setTotal(position.calculateValue().getAmount())`,  `position.calculateValue().getAmount` is in the security currency, but `setTotal` was using it directly to set the total value of the transaction, which is in the portfolio currency.

`setTotal` logic is slightly changed to first setup the `this.grossValue` (which is in the security currency), then all the rest are computed. I think it actually makes a bit more sense, before the logic was to estimate first the total final sell value from the market value and then deduced all the other value and quote from it  (market value->total->converted gross value->gross value-> quote), but with taxe & fees, the final total value will be different than market value, while `this.grossValue` is the one equivalent to market value.

Additionaly, I think the `updateExchangeRate` should be called before `updateSharesAndQuote` in `setSecurity`.

Edit : maybe the setTotal method name should be modified to better reflect the new Logic ? Also, I quickly check, I do not think this method is called elsewhere,  but if it is it could be an issue. 