### PR TITLE
Modify Bourse Direct PDF-Importer to support new transaction

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursedirect/BourseDirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursedirect/BourseDirectPDFExtractorTest.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf.boursedirect;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
@@ -180,5 +181,36 @@ public class BourseDirectPDFExtractorTest
                         hasNote(null), //
                         hasAmount("EUR", 174.18), hasGrossValue("EUR", 173.31), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.87))));
+    }
+
+    @Test
+    public void testDividende01()
+    {
+        var extractor = new BourseDirectPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("NL0010273215"), hasWkn(null), hasTicker(null), //
+                        hasName("ASML HOLDING"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-08-06T00:00"), hasShares(3.00), //
+                        hasSource("Dividende01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 4.08), hasGrossValue("EUR", 4.80), //
+                        hasTaxes("EUR", 0.72), hasFees("EUR", 0.00))));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursedirect/Dividende01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursedirect/Dividende01.txt
@@ -1,0 +1,21 @@
+PDFBox Version: 3.0.5
+Portfolio Performance Version: 0.78.1
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+1/1
+Nous vous prions de trouver ci-dessous votre relevé d'opérations. Sans observation de votre part au
+sujet du présent relevé, nous le considérerons comme ayant obtenu votre accord. Veuillez agréer nos
+salutations distinguées.
+Le 06/08/2025
+Avis d'Opération
+COMPTE N° XXX PEA MR XXX  XXX
+XXX
+MR XXX XXX 12000 RODEZ RODEZ
+Date Désignation Débit (€) Crédit (€)
+ 06/08/2025  COUPONS  NL0010273215  ASML HOLDING  4,08
+ QUANTITE :  -3
+ PX UN.BRUT :  +1,60072  BRUT :  +4,80
+ COMMISSION :  +0,00
+Sous réserve de bonne fin / Ce relevé ne constitue pas une facture
+Les montants des colonnes Débit et Crédit sont stipulés TVA Comprise
+Bourse Direct ,  SA au capital de 13.988.845,75 €, R.C.S Paris B 408 790 608, Siège Social : 374 rue Saint-Honoré, 75001 Paris -  Groupe VIEL et Cie

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursedirect/ReleveDeCompte02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursedirect/ReleveDeCompte02.txt
@@ -42,26 +42,3 @@ Date Désignation Débit (€) Crédit (€)
 Sous réserve de bonne fin / Ce relevé ne constitue pas une facture
 Les montants des colonnes Débit et Crédit sont stipulés TVA Comprise
 Bourse Direct ,  SA au capital de 13.988.845,75 €, R.C.S Paris B 408 790 608, Siège Social : 374 rue Saint-Honoré, 75001 Paris -  Groupe VIEL et Cie
-
-```
-PDFBox Version: 3.0.5
-Portfolio Performance Version: 0.78.1
-System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
------------------------------------------
-1/1
-Nous vous prions de trouver ci-dessous votre relevé d'opérations. Sans observation de votre part au
-sujet du présent relevé, nous le considérerons comme ayant obtenu votre accord. Veuillez agréer nos
-salutations distinguées.
-Le 06/08/2025
-Avis d'Opération
-COMPTE N° XXX PEA MR XXX  XXX
-XXX
-MR XXX XXX 12000 RODEZ RODEZ
-Date Désignation Débit (€) Crédit (€)
- 06/08/2025  COUPONS  NL0010273215  ASML HOLDING  4,08
- QUANTITE :  -3
- PX UN.BRUT :  +1,60072  BRUT :  +4,80
- COMMISSION :  +0,00
-Sous réserve de bonne fin / Ce relevé ne constitue pas une facture
-Les montants des colonnes Débit et Crédit sont stipulés TVA Comprise
-Bourse Direct ,  SA au capital de 13.988.845,75 €, R.C.S Paris B 408 790 608, Siège Social : 374 rue Saint-Honoré, 75001 Paris -  Groupe VIEL et Cie

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BourseDirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BourseDirectPDFExtractor.java
@@ -4,9 +4,12 @@ import name.abuchen.portfolio.datatransfer.ExtractorUtils;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
+import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.Transaction.Unit;
+import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 
 @SuppressWarnings("nls")
@@ -19,6 +22,7 @@ public class BourseDirectPDFExtractor extends AbstractPDFExtractor
         addBankIdentifier("Bourse Direct");
 
         addBuySellTransaction();
+        addDividendeTransaction();
     }
 
     @Override
@@ -60,7 +64,7 @@ public class BourseDirectPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("isin", "name") //
                         .documentContext("currency") //
-                        .match("^.*[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}[\\s]{1,}ACHAT .*[\\s]{1,}(?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])[\\s]{1,}(?<name>.*)[\\s]{2,}[\\d\\s]+,[\\d]{2}$") //
+                        .match("^.*[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}[\\s]{1,}ACHAT.*[\\s]{1,}(?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])[\\s]{1,}(?<name>.*)[\\s]{2,}[\\d\\s]+,[\\d]{2}$") //
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                         // @formatter:off
@@ -91,6 +95,90 @@ public class BourseDirectPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .wrap(BuySellEntryItem::new);
+
+        addFeesSectionsTransaction(pdfTransaction, type);
+    }
+
+    private void addDividendeTransaction()
+    {
+        final var type = new DocumentType("Avis d.Op.ration", //
+                        documentContext -> documentContext //
+                        // @formatter:off
+                        // Date Désignation Débit (€) Crédit (€)
+                        // @formatter:on
+                                        .section("currency") //
+                                        .match("^Date D.signation D.bit \\((?<currency>\\p{Sc})\\).*$") //
+                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency")))));
+
+        this.addDocumentTyp(type);
+
+        var pdfTransaction = new Transaction<AccountTransaction>();
+
+        var firstRelevantLine = new Block("^.*[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}[\\s]{1,}COUPONS.*$");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
+
+        pdfTransaction //
+
+                        .subject(() -> {
+                            var accountTransaction = new AccountTransaction();
+                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
+                            return accountTransaction;
+                        })
+
+                        // @formatter:off
+                        //   06/08/2025  COUPONS  NL0010273215  ASML HOLDING  4,08
+                        // @formatter:on
+                        .section("isin", "name") //
+                        .documentContext("currency") //
+                        .match("^.*[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}[\\s]{1,}COUPONS[\\s]{1,}(?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])[\\s]{1,}(?<name>.*)[\\s]{2,}[\\d\\s]+,[\\d]{2}$") //
+                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+
+                        // @formatter:off
+                        //  QUANTITE :  -3
+                        // @formatter:on
+                        .section("shares") //
+                        .match("^.*QUANTITE :[\\s]{1,}\\-(?<shares>[\\d\\s]+(,[\\d]{2})?)$") //
+                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+
+                        // @formatter:off
+                        //  06/08/2025  COUPONS  NL0010273215  ASML HOLDING  4,08
+                        // Heure Execution: 09:04:28       Lieu: EURONEXT - EURONEXT PARIS
+                        // @formatter:on
+                        .section("date") //
+                        .match("^.*(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4})[\\s]{1,}COUPONS.*$") //
+                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
+
+                        // @formatter:off
+                        //  06/08/2025  COUPONS  NL0010273215  ASML HOLDING  4,08
+                        // @formatter:on
+                        .section("amount") //
+                        .documentContext("currency") //
+                        .match("^.*[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}[\\s]{1,}COUPONS.*[\\s]{2,}(?<amount>[\\d\\s]+,[\\d]{2})$") //
+                        .assign((t, v) -> {
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setAmount(asAmount(v.get("amount")));
+                        })
+
+                        // @formatter:off
+                        //  06/08/2025  COUPONS  NL0010273215  ASML HOLDING  4,08
+                        //  PX UN.BRUT :  +1,60072  BRUT :  +4,80
+                        // @formatter:on
+                        .section("amount", "gross").optional() //
+                        .documentContext("currency") //
+                        .match("^.*[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}[\\s]{1,}COUPONS.*[\\s]{2,}(?<amount>[\\d\\s]+,[\\d]{2})$") //
+                        .match("^.*PX UN.BRUT :[\\s]{1,}\\+[\\d\\s]+,[\\d]+[\\s]{1,}BRUT :[\\s]{1,}\\+(?<gross>[\\d\\s]+,[\\d]{2})$") //
+                        .assign((t, v) -> {
+                            var amount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
+                            var gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
+
+                            // @formatter:off
+                            // we assume that the difference between gross and amount is tax
+                            // @formatter:on
+                            t.addUnit(new Unit(Unit.Type.TAX, gross.subtract(amount)));
+                        })
+
+                        .wrap(TransactionItem::new);
 
         addFeesSectionsTransaction(pdfTransaction, type);
     }


### PR DESCRIPTION
Fixes the error that there are two PDF documents in the PDF Debug https://forum.portfolio-performance.info/t/pdf-import-from-boursedirect/31291/5.
 These have been separated and the dividend entry has been added.