### PR TITLE
fix CSV importer of Buy/Sell account transaction with exchange rate

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportCSVHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportCSVHandler.java
@@ -87,8 +87,10 @@ public class ImportCSVHandler
         if (account != null)
             wizard.setTarget(account);
         if (portfolio != null)
+        {
             wizard.setTarget(portfolio);
-
+            wizard.setExtractor("portfolio-transaction"); //$NON-NLS-1$
+        }
         if (index != null)
         {
             // see comment CSVConfigurationsMenuContribution#aboutToShow

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/BaseCSVExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/BaseCSVExtractor.java
@@ -4,6 +4,7 @@ import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.MessageFormat;
 import java.text.ParseException;
 import java.time.LocalDate;
@@ -22,6 +23,7 @@ import name.abuchen.portfolio.datatransfer.SecurityCache;
 import name.abuchen.portfolio.datatransfer.csv.CSVImporter.Column;
 import name.abuchen.portfolio.datatransfer.csv.CSVImporter.Field;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.SecurityPrice;
 import name.abuchen.portfolio.model.Transaction.Unit;
@@ -206,5 +208,22 @@ import name.abuchen.portfolio.money.Money;
         Money converted = Money.of(amount.getCurrencyCode(), Math.round(grossAmountConverted.doubleValue()));
 
         return Optional.of(new Unit(Unit.Type.GROSS_VALUE, converted, forex, exchangeRate));
+    }
+
+    protected void createGrossValueIfNecessary(String[] rawValues, Map<String, Column> field2column,
+                    PortfolioTransaction transaction) throws ParseException
+    {
+        if (transaction.getSecurity().getCurrencyCode().equals(transaction.getCurrencyCode()))
+            return;
+
+        BigDecimal exchangeRate = getBigDecimal(Messages.CSVColumn_ExchangeRate, rawValues, field2column);
+        if (exchangeRate != null && exchangeRate.compareTo(BigDecimal.ZERO) != 0)
+        {
+            Money grossValue = transaction.getGrossValue();
+            Money forex = Money.of(transaction.getSecurity().getCurrencyCode(), Math
+                            .round(exchangeRate.multiply(BigDecimal.valueOf(grossValue.getAmount())).doubleValue()));
+            exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+            transaction.addUnit(new Unit(Unit.Type.GROSS_VALUE, grossValue, forex, exchangeRate));
+        }
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVAccountTransactionExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVAccountTransactionExtractor.java
@@ -10,6 +10,7 @@ import java.util.StringJoiner;
 
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.datatransfer.Extractor;
+import name.abuchen.portfolio.datatransfer.ExtractorUtils;
 import name.abuchen.portfolio.datatransfer.csv.CSVImporter.AmountField;
 import name.abuchen.portfolio.datatransfer.csv.CSVImporter.Column;
 import name.abuchen.portfolio.datatransfer.csv.CSVImporter.DateField;
@@ -136,6 +137,9 @@ import name.abuchen.portfolio.money.Money;
                 buySellEntry.setDate(date);
                 buySellEntry.setNote(note);
 
+                if (grossAmount.isPresent())
+                    buySellEntry.getPortfolioTransaction().addUnit(grossAmount.get());
+
                 if (taxes != null && taxes.longValue() != 0)
                     buySellEntry.getPortfolioTransaction().addUnit(new Unit(Unit.Type.TAX, Money
                                     .of(buySellEntry.getPortfolioTransaction().getCurrencyCode(), Math.abs(taxes))));
@@ -143,6 +147,11 @@ import name.abuchen.portfolio.money.Money;
                 if (fees != null && fees.longValue() != 0)
                     buySellEntry.getPortfolioTransaction().addUnit(new Unit(Unit.Type.FEE, Money
                                     .of(buySellEntry.getPortfolioTransaction().getCurrencyCode(), Math.abs(fees))));
+
+                if (!grossAmount.isPresent())
+                    createGrossValueIfNecessary(rawValues, field2column, buySellEntry.getPortfolioTransaction());
+
+                ExtractorUtils.fixGrossValueBuySell().accept(buySellEntry);
 
                 if (buySellEntry.getPortfolioTransaction().getAmount() == 0L
                                 && buySellEntry.getPortfolioTransaction().getType() == PortfolioTransaction.Type.SELL)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVExporter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVExporter.java
@@ -46,6 +46,9 @@ public class CSVExporter
                             Messages.CSVColumn_Type, //
                             Messages.CSVColumn_Value, //
                             Messages.CSVColumn_TransactionCurrency, //
+                            Messages.CSVColumn_GrossAmount, //
+                            Messages.CSVColumn_CurrencyGrossAmount, //
+                            Messages.CSVColumn_ExchangeRate, //
                             Messages.CSVColumn_Fees, //
                             Messages.CSVColumn_Taxes, //
                             Messages.CSVColumn_Shares, //
@@ -65,6 +68,21 @@ public class CSVExporter
                 printer.print(Values.Amount.format(t.getType().isDebit() ? -t.getAmount() : t.getAmount()));
                 printer.print(t.getCurrencyCode());
                 var transaction = t.getCrossEntry() instanceof BuySellEntry entry ? entry.getPortfolioTransaction() : t;
+                // gross amount
+                Optional<Unit> grossAmount = transaction.getUnit(Unit.Type.GROSS_VALUE);
+                if (grossAmount.isPresent())
+                {
+                    Money forex = grossAmount.get().getForex();
+                    printer.print(Values.Amount.format(forex.getAmount()));
+                    printer.print(forex.getCurrencyCode());
+                    printer.print(Values.ExchangeRate.format(grossAmount.get().getExchangeRate()));
+                }
+                else
+                {
+                    printer.print(""); //$NON-NLS-1$
+                    printer.print(""); //$NON-NLS-1$
+                    printer.print(""); //$NON-NLS-1$
+                }
                 printer.print(Values.Amount.formatNonZero(transaction.getUnitSum(Unit.Type.FEE).getAmount()));
                 printer.print(Values.Amount.formatNonZero(transaction.getUnitSum(Unit.Type.TAX).getAmount()));
                 printer.print(Values.Share.formatNonZero(transaction.getShares()));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVPortfolioTransactionExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVPortfolioTransactionExtractor.java
@@ -1,7 +1,5 @@
 package name.abuchen.portfolio.datatransfer.csv;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.text.MessageFormat;
 import java.text.ParseException;
 import java.time.LocalDateTime;
@@ -173,27 +171,6 @@ import name.abuchen.portfolio.money.Money;
         ExtractorUtils.fixGrossValueBuySell().accept(entry);
         
         return new BuySellEntryItem(entry);
-    }
-
-    private void createGrossValueIfNecessary(String[] rawValues, Map<String, Column> field2column,
-                    PortfolioTransaction transaction) throws ParseException
-    {
-        if (transaction.getSecurity().getCurrencyCode().equals(transaction.getCurrencyCode()))
-            return;
-
-        BigDecimal exchangeRate = getBigDecimal(Messages.CSVColumn_ExchangeRate, rawValues, field2column);
-        if (exchangeRate != null && exchangeRate.compareTo(BigDecimal.ZERO) != 0)
-        {
-            Money grossValue = transaction.getGrossValue();
-
-            Money forex = Money.of(transaction.getSecurity().getCurrencyCode(), Math
-                            .round(exchangeRate.multiply(BigDecimal.valueOf(grossValue.getAmount())).doubleValue()));
-
-            exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
-
-            transaction.addUnit(new Unit(Unit.Type.GROSS_VALUE, grossValue, forex, exchangeRate));
-
-        }
     }
 
     private Item createTransfer(Security security, Money amount, LocalDateTime date, String note, Long shares)


### PR DESCRIPTION
Closes https://github.com/portfolio-performance/portfolio/issues/3000
Closes https://github.com/portfolio-performance/portfolio/issues/4586
Issue https://forum.portfolio-performance.info/t/import-csv-when-currency-conversions-include/34306
Issue https://forum.portfolio-performance.info/t/csv-import-wahrungproblem/37349

Hello,

This is a proposition to fix the following topic :

In CSV importer, when using the Account Transaction (which is default mode of the CSV importer), it is not possible to create buy/sell transactions when a exchange rate is required. While it is possible in Portfolio Transaction mode. So far, the workaround has been to recommend to use this Portfolio Transaction mode instead.
But, it is a workaround only, and since Account Transaction allows to create Buy/Sell and its CSV importer already accepts an exchange rate, I assume for foreign dividends or transfer, I think they should also allow the creation of those foreign buy/sell too.

Some notes :
- In the first commit, one little modification to have Portfolio Transaction as the default importer when the wizard is coming from PortfolioListView right click "import csv", so when we have a default portfolio account selected (but unsure if this is really necessary now).

- I also proposed that the CSV export of Account Transactions include the exchange/gross amount/currency, to be able to have compatibility with between Export-Import csv files.
- Two tests added, those are mostly the same as in CSVPortfolioTransactionExtractorTest.

To be noted that now CSVPortfolioTransactionImporter/Exporter and CSVAccountTransactionImporter/Exporter are quite similar.