### PR TITLE
add Time Machine in Statement of Assets/Holdings view

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TimeMachineDropDown.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TimeMachineDropDown.java
@@ -1,0 +1,108 @@
+package name.abuchen.portfolio.ui.util;
+
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.eclipse.jface.action.IMenuListener;
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.action.Separator;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Display;
+
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.Images;
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.dialogs.DateSelectionDialog;
+import name.abuchen.portfolio.util.TradeCalendar;
+import name.abuchen.portfolio.util.TradeCalendarManager;
+
+public final class TimeMachineDropDown extends DropDown implements IMenuListener
+{
+    /**
+     * The date for which to calculate the statement of assets. If the date is
+     * empty, it means using the current date. We do not save the current date
+     * here, because some users have the view open more than 24 hours.
+     */
+    private Optional<LocalDate> snapshotDate = Optional.empty();
+    private Consumer<Optional<LocalDate>> notifyModelUpdated;
+
+    public TimeMachineDropDown(Consumer<Optional<LocalDate>> notifyModelUpdated)
+    {
+        super(Messages.LabelPortfolioTimeMachine, Images.CALENDAR_OFF, SWT.NONE);
+        this.notifyModelUpdated = Objects.requireNonNull(notifyModelUpdated);
+
+        setMenuListener(this);
+    }
+
+    @Override
+    public void menuAboutToShow(IMenuManager manager)
+    {   
+        manager.add(new LabelOnly(Values.Date.format(snapshotDate.orElse(LocalDate.now()))));
+        manager.add(new Separator());
+
+        addTodayAction(manager);
+        addPreviousTradingDayAction(manager);
+        addDateSelectionAction(manager);
+    }
+
+    private void addTodayAction(IMenuManager manager)
+    {
+        SimpleAction action = new SimpleAction(Messages.LabelToday, a -> {
+            snapshotDate = Optional.empty();
+            notifyModelUpdated.accept(snapshotDate);
+            setImage(Images.CALENDAR_OFF);
+        });
+        action.setEnabled(snapshotDate.isPresent());
+        manager.add(action);
+    }
+
+    private void addPreviousTradingDayAction(IMenuManager manager)
+    {
+        LocalDate actionDate = findPreviousTradingDay();
+
+        SimpleAction action = new SimpleAction(Messages.LabelPreviousTradingDay, a -> {
+            snapshotDate = Optional.of(actionDate);
+            notifyModelUpdated.accept(snapshotDate);
+            setImage(Images.CALENDAR_ON);
+        });
+
+        snapshotDate.ifPresent(date -> action.setEnabled(!date.equals(actionDate)));
+        manager.add(action);
+    }
+
+    private void addDateSelectionAction(IMenuManager manager)
+    {
+        manager.add(new SimpleAction(Messages.MenuPickOtherDate, a -> {
+            DateSelectionDialog dialog = new DateSelectionDialog(Display.getDefault().getActiveShell());
+            dialog.setSelection(snapshotDate.orElse(LocalDate.now()));
+            if (dialog.open() != DateSelectionDialog.OK)
+                return;
+            if (snapshotDate.isPresent() && snapshotDate.get().equals(dialog.getSelection()))
+                return;
+            snapshotDate = LocalDate.now().equals(dialog.getSelection()) ? Optional.empty()
+                            : Optional.of(dialog.getSelection());
+            notifyModelUpdated.accept(snapshotDate);
+            setImage(snapshotDate.isPresent() ? Images.CALENDAR_ON : Images.CALENDAR_OFF);
+        }));
+    }
+
+    private LocalDate findPreviousTradingDay()
+    {
+        LocalDate date = LocalDate.now().minusDays(1);
+
+        TradeCalendar calendar = TradeCalendarManager.getDefaultInstance();
+        while (calendar.isHoliday(date))
+        {
+            date = date.minusDays(1);
+        }
+
+        return date;
+    }
+
+    public Optional<LocalDate> getTimeMachineDate()
+    {
+        return snapshotDate;
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
@@ -10,7 +10,6 @@ import jakarta.inject.Inject;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.action.Action;
-import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.action.ToolBarManager;
@@ -23,18 +22,16 @@ import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyConverterImpl;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
-import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.UIConstants;
-import name.abuchen.portfolio.ui.dialogs.DateSelectionDialog;
 import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
 import name.abuchen.portfolio.ui.selection.SecuritySelection;
 import name.abuchen.portfolio.ui.util.ClientFilterDropDown;
 import name.abuchen.portfolio.ui.util.DropDown;
-import name.abuchen.portfolio.ui.util.LabelOnly;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.TableViewerCSVExporter;
+import name.abuchen.portfolio.ui.util.TimeMachineDropDown;
 import name.abuchen.portfolio.ui.views.panes.ChartPane;
 import name.abuchen.portfolio.ui.views.panes.HistoricalPricesDataQualityPane;
 import name.abuchen.portfolio.ui.views.panes.HistoricalPricesPane;
@@ -43,21 +40,13 @@ import name.abuchen.portfolio.ui.views.panes.SecurityEventsPane;
 import name.abuchen.portfolio.ui.views.panes.TradesPane;
 import name.abuchen.portfolio.ui.views.panes.TransactionsPane;
 import name.abuchen.portfolio.util.Pair;
-import name.abuchen.portfolio.util.TradeCalendar;
-import name.abuchen.portfolio.util.TradeCalendarManager;
 
 public class StatementOfAssetsView extends AbstractFinanceView
 {
     private StatementOfAssetsViewer assetViewer;
     private PropertyChangeListener currencyChangeListener;
     private ClientFilterDropDown clientFilter;
-
-    /**
-     * The date for which to calculate the statement of assets. If the date is
-     * empty, it means using the current date. We do not save the current date
-     * here, because some users have the view open more than 24 hours.
-     */
-    private Optional<LocalDate> snapshotDate = Optional.empty();
+    private TimeMachineDropDown timeMachineDropDown;
 
     @Inject
     private ExchangeRateProviderFactory factory;
@@ -78,6 +67,7 @@ public class StatementOfAssetsView extends AbstractFinanceView
         Client filteredClient = clientFilter.getSelectedFilter().filter(getClient());
         setToContext(UIConstants.Context.FILTERED_CLIENT, filteredClient);
 
+        Optional<LocalDate> snapshotDate = timeMachineDropDown.getTimeMachineDate();
         CurrencyConverter converter = new CurrencyConverterImpl(factory, getClient().getBaseCurrency());
         assetViewer.setInput(clientFilter.getSelectedFilter(), snapshotDate.orElse(LocalDate.now()), converter);
         updateTitle(getDefaultTitle());
@@ -126,7 +116,8 @@ public class StatementOfAssetsView extends AbstractFinanceView
         currencyChangeListener = e -> dropDown.setLabel(e.getNewValue().toString());
         getClient().addPropertyChangeListener("baseCurrency", currencyChangeListener); //$NON-NLS-1$
 
-        addCalendarButton(toolBar);
+        timeMachineDropDown = new TimeMachineDropDown(date -> notifyModelUpdated());
+        toolBar.add(timeMachineDropDown);
 
         this.clientFilter = new ClientFilterDropDown(getClient(), getPreferenceStore(),
                         StatementOfAssetsView.class.getSimpleName(), filter -> notifyModelUpdated());
@@ -140,63 +131,6 @@ public class StatementOfAssetsView extends AbstractFinanceView
 
         toolBar.add(new DropDown(Messages.MenuShowHideColumns, Images.CONFIG, SWT.NONE,
                         manager -> assetViewer.menuAboutToShow(manager)));
-    }
-
-    private void addCalendarButton(ToolBarManager toolBar)
-    {
-        DropDown dropDown = new DropDown(Messages.LabelPortfolioTimeMachine, Images.CALENDAR_OFF, SWT.NONE);
-        dropDown.setMenuListener(manager -> {
-            manager.add(new LabelOnly(Values.Date.format(snapshotDate.orElse(LocalDate.now()))));
-            manager.add(new Separator());
-
-            addTodayAction(dropDown, manager);
-            addPreviousTradingDayAction(dropDown, manager);
-            addDateSelectionAction(dropDown, manager);
-        });
-
-        toolBar.add(dropDown);
-    }
-
-    private void addTodayAction(DropDown dropDown, IMenuManager manager)
-    {
-        SimpleAction action = new SimpleAction(Messages.LabelToday, a -> {
-            snapshotDate = Optional.empty();
-            notifyModelUpdated();
-            dropDown.setImage(Images.CALENDAR_OFF);
-        });
-        action.setEnabled(snapshotDate.isPresent());
-        manager.add(action);
-    }
-
-    private void addPreviousTradingDayAction(DropDown dropDown, IMenuManager manager)
-    {
-        LocalDate actionDate = findPreviousTradingDay();
-
-        SimpleAction action = new SimpleAction(Messages.LabelPreviousTradingDay, a -> {
-            snapshotDate = Optional.of(actionDate);
-            notifyModelUpdated();
-            dropDown.setImage(Images.CALENDAR_ON);
-        });
-
-        snapshotDate.ifPresent(date -> action.setEnabled(!date.equals(actionDate)));
-        manager.add(action);
-    }
-
-    private void addDateSelectionAction(DropDown dropDown, IMenuManager manager)
-    {
-        manager.add(new SimpleAction(Messages.MenuPickOtherDate, a -> {
-            DateSelectionDialog dialog = new DateSelectionDialog(getActiveShell());
-            dialog.setSelection(snapshotDate.orElse(LocalDate.now()));
-            if (dialog.open() != DateSelectionDialog.OK)
-                return;
-            if (snapshotDate.isPresent() && snapshotDate.get().equals(dialog.getSelection()))
-                return;
-
-            snapshotDate = LocalDate.now().equals(dialog.getSelection()) ? Optional.empty()
-                            : Optional.of(dialog.getSelection());
-            notifyModelUpdated();
-            dropDown.setImage(snapshotDate.isPresent() ? Images.CALENDAR_ON : Images.CALENDAR_OFF);
-        }));
     }
 
     @Override
@@ -251,18 +185,5 @@ public class StatementOfAssetsView extends AbstractFinanceView
     {
         if (currencyChangeListener != null)
             getClient().removePropertyChangeListener("baseCurrency", currencyChangeListener); //$NON-NLS-1$
-    }
-
-    private LocalDate findPreviousTradingDay()
-    {
-        LocalDate date = LocalDate.now().minusDays(1);
-
-        TradeCalendar calendar = TradeCalendarManager.getDefaultInstance();
-        while (calendar.isHoliday(date))
-        {
-            date = date.minusDays(1);
-        }
-
-        return date;
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/holdings/HoldingsPieChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/holdings/HoldingsPieChartView.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.ui.views.holdings;
 import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import jakarta.annotation.PostConstruct;
@@ -30,6 +31,7 @@ import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
 import name.abuchen.portfolio.ui.util.ClientFilterDropDown;
 import name.abuchen.portfolio.ui.util.EmbeddedBrowser;
 import name.abuchen.portfolio.ui.util.SimpleAction;
+import name.abuchen.portfolio.ui.util.TimeMachineDropDown;
 import name.abuchen.portfolio.ui.views.IPieChart;
 import name.abuchen.portfolio.ui.views.panes.HistoricalPricesPane;
 import name.abuchen.portfolio.ui.views.panes.InformationPanePage;
@@ -46,6 +48,7 @@ public class HoldingsPieChartView extends AbstractFinanceView
     private IPieChart chart;
     private ClientFilterDropDown clientFilter;
     private ClientSnapshot snapshot;
+    private TimeMachineDropDown timeMachineDropDown;
 
     @Inject
     @Preference(UIConstants.Preferences.ENABLE_SWTCHART_PIECHARTS)
@@ -58,6 +61,8 @@ public class HoldingsPieChartView extends AbstractFinanceView
 
         clientFilter = new ClientFilterDropDown(getClient(), getPreferenceStore(),
                         HoldingsPieChartView.class.getSimpleName(), filter -> notifyModelUpdated());
+
+        timeMachineDropDown = new TimeMachineDropDown(date -> notifyModelUpdated());
 
         Client filteredClient = clientFilter.getSelectedFilter().filter(getClient());
         setToContext(UIConstants.Context.FILTERED_CLIENT, filteredClient);
@@ -78,11 +83,12 @@ public class HoldingsPieChartView extends AbstractFinanceView
     {
         Client filteredClient = clientFilter.getSelectedFilter().filter(getClient());
         setToContext(UIConstants.Context.FILTERED_CLIENT, filteredClient);
-        snapshot = ClientSnapshot.create(filteredClient, converter, LocalDate.now(),
+        Optional<LocalDate> snapshotDate = timeMachineDropDown.getTimeMachineDate();
+        snapshot = ClientSnapshot.create(filteredClient, converter, snapshotDate.orElse(LocalDate.now()),
                         clientFilter.getClientFilterMenu().getSelectedItem().getLabel());
 
         chart.refresh(snapshot);
-        
+
         updateWarningInToolBar();
         updateTitle(getDefaultTitle());
 
@@ -92,6 +98,7 @@ public class HoldingsPieChartView extends AbstractFinanceView
     @Override
     protected void addButtons(ToolBarManager toolBar)
     {
+        toolBar.add(timeMachineDropDown);
         toolBar.add(clientFilter);
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/holdings/HoldingsPieChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/holdings/HoldingsPieChartView.java
@@ -84,13 +84,15 @@ public class HoldingsPieChartView extends AbstractFinanceView
         Client filteredClient = clientFilter.getSelectedFilter().filter(getClient());
         setToContext(UIConstants.Context.FILTERED_CLIENT, filteredClient);
         Optional<LocalDate> snapshotDate = timeMachineDropDown.getTimeMachineDate();
+        var snapshotDateLabel = snapshotDate.map(date -> " | " + Values.Date.format(date)) //$NON-NLS-1$
+                        .orElse(""); //$NON-NLS-1$
         snapshot = ClientSnapshot.create(filteredClient, converter, snapshotDate.orElse(LocalDate.now()),
                         clientFilter.getClientFilterMenu().getSelectedItem().getLabel());
 
         chart.refresh(snapshot);
 
         updateWarningInToolBar();
-        updateTitle(getDefaultTitle());
+        updateTitle(getDefaultTitle() + snapshotDateLabel);
 
         setInformationPaneInput(null);
     }


### PR DESCRIPTION
Partially Closes https://github.com/portfolio-performance/portfolio/issues/4965
Issue : https://forum.portfolio-performance.info/t/portfolio-time-machine-auch-fuer-bestaende-gewuenscht/10261

Hello,

This is a proposition to add the time machine in the holdings view.
The methods already present in the `StatementofAssetsView` are moved in a separate class to be reusable. Some of those methods are very slighty modified (`getActiveShell() `that I could not access anymore -> `Display.getDefault().getActiveShell() `)
When a date other than today is selected, I added it to the title of the Holdings view.

(By the way about the title of the different views, with the addition of selected filter name in the titles, users that do not name their filter/grouped account and therefore have the very long name ("account 1 + account 2 + ...") can have the issue that the title is longer than the window, making the different icons no longer reachable. I did not manage to implement a truncate method in those case.)

**Results :** 
<img width="1732" height="876" alt="2025-09-10 20_21_39-Portfolio Performance" src="https://github.com/user-attachments/assets/8067eb3b-5f92-4f52-b45c-735a2cd8e0f2" />


<img width="1736" height="922" alt="Capture d’écran 2025-09-09 235938" src="https://github.com/user-attachments/assets/eef6c882-2ed7-483d-bca8-2972e5df6363" />