### PR TITLE
Fix ComDirect to include foreign withholding tax in the calculation of gross tax treatment

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
@@ -1956,8 +1956,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2025-04-09T00:00"), hasShares(1.708), //
                         hasSource("VerkaufMitSteuerbehandlung20.txt"), //
                         hasNote("Ord.-Nr.: 099011756580 | R.-Nr.: 671305787389DC15"), //
-                        hasAmount("EUR", 250.01), hasGrossValue("EUR", 250.01), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+                        hasAmount("EUR", 243.26), hasGrossValue("EUR", 250.01), //
+                        hasTaxes("EUR", 6.75), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -2982,7 +2982,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2020-05-19T00:00"), hasShares(7.499), //
                         hasSource("SteuerbehandlungVonDividende11.txt"), //
                         hasNote(null), //
-                        hasAmount("EUR", (5.47 - 4.65) + 0.58), hasGrossValue("EUR", (5.47 - 4.65) + 0.58), //
+                        hasAmount("EUR", (5.47 + 0.82 - 4.65) + 0.58),
+                        hasGrossValue("EUR", (5.47 + 0.82 - 4.65) + 0.58), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
@@ -3016,9 +3017,9 @@ public class ComdirectPDFExtractorTest
                         hasDate("2020-05-19T00:00"), hasShares(7.499), //
                         hasSource("Dividende11.txt; SteuerbehandlungVonDividende11.txt"), //
                         hasNote("Ref.-Nr.: 0IIFTGGFCJV002JX | Quartalsdividende"), //
-                        hasAmount("EUR", 4.07), hasGrossValue("EUR", 5.47), //
-                        hasForexGrossValue("USD", 5.93), //
-                        hasTaxes("EUR", (5.47 - 4.65) + 0.58), hasFees("EUR", 0.00))));
+                        hasAmount("EUR", 4.07), hasGrossValue("EUR", 5.47 + 0.82), //
+                        hasForexGrossValue("USD", 6.82), //
+                        hasTaxes("EUR", (5.47 + 0.82 - 4.65) + 0.58), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -3052,8 +3053,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2020-05-19T00:00"), hasShares(7.499), //
                         hasSource("Dividende11.txt; SteuerbehandlungVonDividende11.txt"), //
                         hasNote("Ref.-Nr.: 0IIFTGGFCJV002JX | Quartalsdividende"), //
-                        hasAmount("EUR", 4.07), hasGrossValue("EUR", 5.47), //
-                        hasTaxes("EUR", (5.47 - 4.65) + 0.58), hasFees("EUR", 0.00), //
+                        hasAmount("EUR", 4.07), hasGrossValue("EUR", 5.47 + 0.82), //
+                        hasTaxes("EUR", (5.47 + 0.82 - 4.65) + 0.58), hasFees("EUR", 0.00), //
                         check(tx -> {
                             var c = new CheckCurrenciesAction();
                             var account = new Account();
@@ -3093,8 +3094,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2020-05-19T00:00"), hasShares(7.499), //
                         hasSource("Dividende11.txt; SteuerbehandlungVonDividende11.txt"), //
                         hasNote("Ref.-Nr.: 0IIFTGGFCJV002JX | Quartalsdividende"), //
-                        hasAmount("EUR", 4.07), hasGrossValue("EUR", 5.47), //
-                        hasTaxes("EUR", (5.47 - 4.65) + 0.58), hasFees("EUR", 0.00))));
+                        hasAmount("EUR", 4.07), hasGrossValue("EUR", 5.47 + 0.82), //
+                        hasTaxes("EUR", (5.47 + 0.82 - 4.65) + 0.58), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -3128,8 +3129,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2020-05-19T00:00"), hasShares(7.499), //
                         hasSource("Dividende11.txt; SteuerbehandlungVonDividende11.txt"), //
                         hasNote("Ref.-Nr.: 0IIFTGGFCJV002JX | Quartalsdividende"), //
-                        hasAmount("EUR", 4.07), hasGrossValue("EUR", 5.47), //
-                        hasTaxes("EUR", (5.47 - 4.65) + 0.58), hasFees("EUR", 0.00), //
+                        hasAmount("EUR", 4.07), hasGrossValue("EUR", 5.47 + 0.82), //
+                        hasTaxes("EUR", (5.47 + 0.82 - 4.65) + 0.58), hasFees("EUR", 0.00), //
                         check(tx -> {
                             var c = new CheckCurrenciesAction();
                             var account = new Account();
@@ -3460,15 +3461,13 @@ public class ComdirectPDFExtractorTest
                         hasName("ALLIANZ SE NA O.N."), //
                         hasCurrencyCode("EUR"))));
 
-        // check cancellation transaction
-        assertThat(results, hasItem(withFailureMessage( //
-                        Messages.MsgErrorTransactionTypeNotSupported, //
-                        taxes( //
-                                        hasDate("2018-05-14T00:00"), hasShares(16.00), //
-                                        hasSource("SteuerbehandlungVonDividende13.txt"), //
-                                        hasNote(null), //
-                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
-                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
+        // check taxes transaction
+        assertThat(results, hasItem(taxes( //
+                        hasDate("2018-05-14T00:00"), hasShares(16.00), //
+                        hasSource("SteuerbehandlungVonDividende13.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 4.40), hasGrossValue("EUR", 4.40), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -3501,8 +3500,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2018-05-14T00:00"), hasShares(16.00), //
                         hasSource("Dividende13.txt; SteuerbehandlungVonDividende13.txt"), //
                         hasNote("Ref.-Nr.: 1234567890"), //
-                        hasAmount("EUR", 128.00), hasGrossValue("EUR", 128.00), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+                        hasAmount("EUR", 128.00), hasGrossValue("EUR", 128.00 + 4.40), //
+                        hasTaxes("EUR", 4.40), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -3535,8 +3534,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2018-05-14T00:00"), hasShares(16.00), //
                         hasSource("Dividende13.txt; SteuerbehandlungVonDividende13.txt"), //
                         hasNote("Ref.-Nr.: 1234567890"), //
-                        hasAmount("EUR", 128.00), hasGrossValue("EUR", 128.00), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+                        hasAmount("EUR", 128.00), hasGrossValue("EUR", 128.00 + 4.40), //
+                        hasTaxes("EUR", 4.40), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -3641,8 +3640,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2020-11-04T00:00"), hasShares(32.000), //
                         hasSource("SteuerbehandlungVonDividende14.txt"), //
                         hasNote(null), //
-                        hasAmount("EUR", (13.70 - 11.64) + 1.38 + 0.07),
-                        hasGrossValue("EUR", (13.70 - 11.64) + 1.38 + 0.07), //
+                        hasAmount("EUR", (13.70 + 2.05 - 11.64) + 1.38 + 0.07),
+                        hasGrossValue("EUR", (13.70 + 2.05 - 11.64) + 1.38 + 0.07), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
@@ -3676,9 +3675,9 @@ public class ComdirectPDFExtractorTest
                         hasDate("2020-11-04T00:00"), hasShares(32.000), //
                         hasSource("Dividende14.txt; SteuerbehandlungVonDividende14.txt"), //
                         hasNote("Ref.-Nr.: XXX1234567899ABC | Quartalsdividende"), //
-                        hasAmount("EUR", 10.19), hasGrossValue("EUR", 13.70), //
-                        hasForexGrossValue("USD", 16.00), //
-                        hasTaxes("EUR", (13.70 - 11.64) + 1.38 + 0.07), hasFees("EUR", 0.00))));
+                        hasAmount("EUR", 10.19), hasGrossValue("EUR", 13.70 + 2.05), //
+                        hasForexGrossValue("USD", 18.40), //
+                        hasTaxes("EUR", (13.70 + 2.05 - 11.64) + 1.38 + 0.07), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -3712,8 +3711,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2020-11-04T00:00"), hasShares(32.000), //
                         hasSource("Dividende14.txt; SteuerbehandlungVonDividende14.txt"), //
                         hasNote("Ref.-Nr.: XXX1234567899ABC | Quartalsdividende"), //
-                        hasAmount("EUR", 10.19), hasGrossValue("EUR", 13.70), //
-                        hasTaxes("EUR", (13.70 - 11.64) + 1.38 + 0.07), hasFees("EUR", 0.00), //
+                        hasAmount("EUR", 10.19), hasGrossValue("EUR", 13.70 + 2.05), //
+                        hasTaxes("EUR", (13.70 + 2.05 - 11.64) + 1.38 + 0.07), hasFees("EUR", 0.00), //
                         check(tx -> {
                             var c = new CheckCurrenciesAction();
                             var account = new Account();
@@ -3753,8 +3752,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2020-11-04T00:00"), hasShares(32.000), //
                         hasSource("Dividende14.txt; SteuerbehandlungVonDividende14.txt"), //
                         hasNote("Ref.-Nr.: XXX1234567899ABC | Quartalsdividende"), //
-                        hasAmount("EUR", 10.19), hasGrossValue("EUR", 13.70), //
-                        hasTaxes("EUR", (13.70 - 11.64) + 1.38 + 0.07), hasFees("EUR", 0.00))));
+                        hasAmount("EUR", 10.19), hasGrossValue("EUR", 13.70 + 2.05), //
+                        hasTaxes("EUR", (13.70 + 2.05 - 11.64) + 1.38 + 0.07), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -3788,8 +3787,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2020-11-04T00:00"), hasShares(32.000), //
                         hasSource("Dividende14.txt; SteuerbehandlungVonDividende14.txt"), //
                         hasNote("Ref.-Nr.: XXX1234567899ABC | Quartalsdividende"), //
-                        hasAmount("EUR", 10.19), hasGrossValue("EUR", 13.70), //
-                        hasTaxes("EUR", (13.70 - 11.64) + 1.38 + 0.07), hasFees("EUR", 0.00), //
+                        hasAmount("EUR", 10.19), hasGrossValue("EUR", 13.70 + 2.05), //
+                        hasTaxes("EUR", (13.70 + 2.05 - 11.64) + 1.38 + 0.07), hasFees("EUR", 0.00), //
                         check(tx -> {
                             var c = new CheckCurrenciesAction();
                             var account = new Account();
@@ -4465,8 +4464,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2023-09-07T00:00"), hasShares(300.000), //
                         hasSource("SteuerbehandlungVonDividende21.txt"), //
                         hasNote(null), //
-                        hasAmount("EUR", (114.21 - 97.08) + 11.42 + 0.62),
-                        hasGrossValue("EUR", (114.21 - 97.08) + 11.42 + 0.62), //
+                        hasAmount("EUR", (114.21 + 17.13 - 97.08) + 11.42 + 0.62),
+                        hasGrossValue("EUR", (114.21 + 17.13 - 97.08) + 11.42 + 0.62), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
@@ -4500,9 +4499,9 @@ public class ComdirectPDFExtractorTest
                         hasDate("2023-09-07T00:00"), hasShares(300.000), //
                         hasSource("Dividende21.txt; SteuerbehandlungVonDividende21.txt"), //
                         hasNote("Ref.-Nr.: 22IJUON6JHE000NY | Quartalsdividende"), //
-                        hasAmount("EUR", 85.04), hasGrossValue("EUR", 114.21), //
-                        hasForexGrossValue("USD", 123.00), //
-                        hasTaxes("EUR", (114.21 - 97.08) + 11.42 + 0.62), hasFees("EUR", 0.00))));
+                        hasAmount("EUR", 85.04), hasGrossValue("EUR", 114.21 + 17.13), //
+                        hasForexGrossValue("USD", 141.45), //
+                        hasTaxes("EUR", (114.21 + 17.13 - 97.08) + 11.42 + 0.62), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -4536,8 +4535,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2023-09-07T00:00"), hasShares(300.000), //
                         hasSource("Dividende21.txt; SteuerbehandlungVonDividende21.txt"), //
                         hasNote("Ref.-Nr.: 22IJUON6JHE000NY | Quartalsdividende"), //
-                        hasAmount("EUR", 85.04), hasGrossValue("EUR", 114.21), //
-                        hasTaxes("EUR", (114.21 - 97.08) + 11.42 + 0.62), hasFees("EUR", 0.00), //
+                        hasAmount("EUR", 85.04), hasGrossValue("EUR", 114.21 + 17.13), //
+                        hasTaxes("EUR", (114.21 + 17.13 - 97.08) + 11.42 + 0.62), hasFees("EUR", 0.00), //
                         check(tx -> {
                             var c = new CheckCurrenciesAction();
                             var account = new Account();
@@ -4577,8 +4576,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2023-09-07T00:00"), hasShares(300.000), //
                         hasSource("Dividende21.txt; SteuerbehandlungVonDividende21.txt"), //
                         hasNote("Ref.-Nr.: 22IJUON6JHE000NY | Quartalsdividende"), //
-                        hasAmount("EUR", 85.04), hasGrossValue("EUR", 114.21), //
-                        hasTaxes("EUR", (114.21 - 97.08) + 11.42 + 0.62), hasFees("EUR", 0.00))));
+                        hasAmount("EUR", 85.04), hasGrossValue("EUR", 114.21 + 17.13), //
+                        hasTaxes("EUR", (114.21 + 17.13 - 97.08) + 11.42 + 0.62), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -4612,8 +4611,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2023-09-07T00:00"), hasShares(300.000), //
                         hasSource("Dividende21.txt; SteuerbehandlungVonDividende21.txt"), //
                         hasNote("Ref.-Nr.: 22IJUON6JHE000NY | Quartalsdividende"), //
-                        hasAmount("EUR", 85.04), hasGrossValue("EUR", 114.21), //
-                        hasTaxes("EUR", (114.21 - 97.08) + 11.42 + 0.62), hasFees("EUR", 0.00), //
+                        hasAmount("EUR", 85.04), hasGrossValue("EUR", 114.21 + 17.13), //
+                        hasTaxes("EUR", (114.21 + 17.13 - 97.08) + 11.42 + 0.62), hasFees("EUR", 0.00), //
                         check(tx -> {
                             var c = new CheckCurrenciesAction();
                             var account = new Account();
@@ -4924,7 +4923,7 @@ public class ComdirectPDFExtractorTest
                         hasDate("2023-11-03T00:00"), hasShares(0.516), //
                         hasSource("SteuerbehandlungVonDividende28.txt"), //
                         hasNote(null), //
-                        hasAmount("EUR", 0.03 + 0.04), hasGrossValue("EUR", 0.03 + 0.04), //
+                        hasAmount("EUR", 0.03 + 0.04 + 0.04), hasGrossValue("EUR", 0.03 + 0.04 + 0.04), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
@@ -4958,9 +4957,9 @@ public class ComdirectPDFExtractorTest
                         hasDate("2023-11-03T00:00"), hasShares(0.516), //
                         hasSource("Dividende28.txt; SteuerbehandlungVonDividende28.txt"), //
                         hasNote("Ref.-Nr.: 19IJYGE75X60021N | Quartalsdividende"), //
-                        hasAmount("EUR", 0.21), hasGrossValue("EUR", 0.28), //
-                        hasForexGrossValue("USD", 0.30), //
-                        hasTaxes("EUR", 0.03 + 0.04), hasFees("EUR", 0.00))));
+                        hasAmount("EUR", 0.21), hasGrossValue("EUR", 0.28 + 0.04), //
+                        hasForexGrossValue("USD", 0.34), //
+                        hasTaxes("EUR", 0.03 + 0.04 + 0.04), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -4994,8 +4993,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2023-11-03T00:00"), hasShares(0.516), //
                         hasSource("Dividende28.txt; SteuerbehandlungVonDividende28.txt"), //
                         hasNote("Ref.-Nr.: 19IJYGE75X60021N | Quartalsdividende"), //
-                        hasAmount("EUR", 0.21), hasGrossValue("EUR", 0.28), //
-                        hasTaxes("EUR", 0.03 + 0.04), hasFees("EUR", 0.00), //
+                        hasAmount("EUR", 0.21), hasGrossValue("EUR", 0.28 + 0.04), //
+                        hasTaxes("EUR", 0.03 + 0.04 + 0.04), hasFees("EUR", 0.00), //
                         check(tx -> {
                             var c = new CheckCurrenciesAction();
                             var account = new Account();
@@ -5035,8 +5034,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2023-11-03T00:00"), hasShares(0.516), //
                         hasSource("Dividende28.txt; SteuerbehandlungVonDividende28.txt"), //
                         hasNote("Ref.-Nr.: 19IJYGE75X60021N | Quartalsdividende"), //
-                        hasAmount("EUR", 0.21), hasGrossValue("EUR", 0.28), //
-                        hasTaxes("EUR", 0.07), hasFees("EUR", 0.00))));
+                        hasAmount("EUR", 0.21), hasGrossValue("EUR", 0.28 + 0.04), //
+                        hasTaxes("EUR", 0.07 + 0.04), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -5070,8 +5069,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2023-11-03T00:00"), hasShares(0.516), //
                         hasSource("Dividende28.txt; SteuerbehandlungVonDividende28.txt"), //
                         hasNote("Ref.-Nr.: 19IJYGE75X60021N | Quartalsdividende"), //
-                        hasAmount("EUR", 0.21), hasGrossValue("EUR", 0.28), //
-                        hasTaxes("EUR", 0.03 + 0.04), hasFees("EUR", 0.00), //
+                        hasAmount("EUR", 0.21), hasGrossValue("EUR", 0.28 + 0.04), //
+                        hasTaxes("EUR", 0.03 + 0.04 + 0.04), hasFees("EUR", 0.00), //
                         check(tx -> {
                             var c = new CheckCurrenciesAction();
                             var account = new Account();
@@ -5682,7 +5681,7 @@ public class ComdirectPDFExtractorTest
                         hasDate("2025-09-10T00:00"), hasShares(5920.000), //
                         hasSource("SteuerbehandlungVonDividende33.txt"), //
                         hasNote(null), //
-                        hasAmount("EUR", 59.65), hasGrossValue("EUR", 59.65), //
+                        hasAmount("EUR", 319.68 + 59.65), hasGrossValue("EUR", 319.68 + 59.65), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
@@ -5716,8 +5715,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2025-09-10T00:00"), hasShares(5920.000), //
                         hasSource("Dividende33.txt; SteuerbehandlungVonDividende33.txt"), //
                         hasNote("Ref.-Nr.: 29IMEUAZ6PN001NC"), //
-                        hasAmount("EUR", 1751.87), hasGrossValue("EUR", 1811.52), //
-                        hasTaxes("EUR", 59.65), hasFees("EUR", 0.00))));
+                        hasAmount("EUR", 1751.87), hasGrossValue("EUR", 2131.20), //
+                        hasTaxes("EUR", 319.68 + 59.65), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -5750,8 +5749,8 @@ public class ComdirectPDFExtractorTest
                         hasDate("2025-09-10T00:00"), hasShares(5920.000), //
                         hasSource("Dividende33.txt; SteuerbehandlungVonDividende33.txt"), //
                         hasNote("Ref.-Nr.: 29IMEUAZ6PN001NC"), //
-                        hasAmount("EUR", 1751.87), hasGrossValue("EUR", 1811.52), //
-                        hasTaxes("EUR", 59.65), hasFees("EUR", 0.00))));
+                        hasAmount("EUR", 1751.87), hasGrossValue("EUR", 2131.20), //
+                        hasTaxes("EUR", 319.68 + 59.65), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -6556,8 +6555,8 @@ public class ComdirectPDFExtractorTest
         assertTrue(firstError instanceof UnsupportedOperationException);
 
         // Check the error message of the first error
-        var expectedErrorMessage = MessageFormat.format(Messages.PDFdbMsgCannotDetermineFileType,
-                        "Comdirect Bank AG", "Finanzreport13.txt");
+        var expectedErrorMessage = MessageFormat.format(Messages.PDFdbMsgCannotDetermineFileType, "Comdirect Bank AG",
+                        "Finanzreport13.txt");
         assertEquals(expectedErrorMessage, firstError.getMessage());
     }
 
@@ -6654,7 +6653,7 @@ public class ComdirectPDFExtractorTest
                         hasDate("2023-07-18T00:00"), hasShares(70), //
                         hasSource("SteuerbehandlungOhneDividende01.txt"), //
                         hasNote(null), //
-                        hasAmount("EUR", 15.90 - 11.84), hasGrossValue("EUR", 15.90 - 11.84), //
+                        hasAmount("EUR", 15.90 + 2.38 - 11.84), hasGrossValue("EUR", 15.90 + 2.38 - 11.84), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
@@ -1126,6 +1126,48 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
                         .oneOf( //
                                         // @formatter:off
+                                        // Z u  Ih r e n G u n s t e n v o r S te u e r n :                                                                                                    E U R               0,2 4
+                                        //  S te u e rb e m  e ss u n g s g r u n d la g e                                                            E  U   R                                  0 , 2 8
+                                        // (angerechnete ausländische Quellensteuer:       EUR               0,04  )
+                                        // a b g e f ü h rt e S t e u er n                                                                                                                    _E _U R_ _ _ _ _ _ _ _ _ _ _  _ __ -__0,_0_ _3
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("currencyBeforeTaxes", "grossBeforeTaxes", "currencyAssessmentBasis", "currencyForeignWithholdingTax", "foreignWithholdingTax", "grossAssessmentBasis", "currencyDeductedTaxes", "deductedTaxes") //
+                                                        .match("^[\\s]*Z[\\s]*u[\\s]*I[\\s]*h[\\s]*r[\\s]*e[\\s]*n[\\s]*G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?<currencyBeforeTaxes>(?:[A-Z][\\s]*){3})[\\s\\-]+(?<grossBeforeTaxes>[\\.,\\d\\s]+).*$") //
+                                                        .match("^[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*b[\\s]*e[\\s]*m[\\s]*e[\\s]*s[\\s]*s[\\s]*u[\\s]*n[\\s]*g[\\s]*s[\\s]*g[\\s]*r[\\s]*u[\\s]*n[\\s]*d[\\s]*l[\\s]*a[\\s]*g[\\s]*e[\\s]*.*(?<currencyAssessmentBasis>(?:[A-Z][\\s]*){3})[\\s\\-]+(?<grossAssessmentBasis>[\\.,\\d\\s]+).*$") //
+                                                        .match("^\\(angerechnete ausl.ndische Quellensteuer:[\\s]*(?<currencyForeignWithholdingTax>[A-Z]{3})[\\s]+(?<foreignWithholdingTax>[\\.,\\d\\s]+)\\).*$") //
+                                                        .match("^[\\s]*a[\\s]*b[\\s]*g[\\s]*e[\\s]*f[\\s]*.[\\s]*h[\\s]*r[\\s]*t[\\s]*e[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]+(?<currencyDeductedTaxes>[A-Z_\\s]+)[\\-_\\s]+(?<deductedTaxes>[\\.,\\d_\\s]+).*$") //
+                                                        .assign((t, v) -> {
+                                                            var grossBeforeTaxes = Money.of(asCurrencyCode(stripBlanks(v.get("currencyBeforeTaxes"))), asAmount(stripBlanks(v.get("grossBeforeTaxes"))));
+                                                            var grossAssessmentBasis = Money.of(asCurrencyCode(stripBlanks(v.get("currencyAssessmentBasis"))), asAmount(stripBlanks(v.get("grossAssessmentBasis"))));
+                                                            var foreignWithholdingTax = Money.of(asCurrencyCode(stripBlanks(v.get("currencyForeignWithholdingTax"))), asAmount(stripBlanks(v.get("foreignWithholdingTax"))));
+                                                            var deductedTaxes = Money.of(asCurrencyCode(stripBlanksAndUnderscores(v.get("currencyDeductedTaxes"))), asAmount(stripBlanksAndUnderscores(v.get("deductedTaxes"))));
+
+                                                            // Combine deducted taxes with foreign withholding tax
+                                                            var totalDeductedTaxes = deductedTaxes.add(foreignWithholdingTax);
+
+                                                            // Decide whether to use assessment basis or gross before taxes
+                                                            var useAssessmentBasis = !grossBeforeTaxes.isZero() && grossAssessmentBasis.isGreaterThan(grossBeforeTaxes);
+
+                                                            if (useAssessmentBasis)
+                                                                t.setMonetaryAmount(grossAssessmentBasis.subtract(grossBeforeTaxes).add(totalDeductedTaxes));
+                                                            else
+                                                                t.setMonetaryAmount(totalDeductedTaxes);
+
+                                                            // Store gross tax treatment including foreign withholding tax (if same currency)
+                                                            var grossTreatmentBase = useAssessmentBasis ? grossAssessmentBasis : grossBeforeTaxes;
+                                                            if (foreignWithholdingTax.getCurrencyCode().equals(grossTreatmentBase.getCurrencyCode()))
+                                                            {
+                                                                v.getTransactionContext().put(ATTRIBUTE_GROSS_TAXES_TREATMENT, grossTreatmentBase.add(foreignWithholdingTax));
+                                                            }
+                                                            else
+                                                            {
+                                                                // Fallback: store base amount, keep foreign tax separately
+                                                                v.getTransactionContext().put(ATTRIBUTE_GROSS_TAXES_TREATMENT, grossTreatmentBase);
+                                                                v.getTransactionContext().put("ATTRIBUTE_FOREIGN_WITHHOLDING_TAX", foreignWithholdingTax);
+                                                            }
+                                                        }),
+                                        // @formatter:off
                                         //  Zu  Ih r e n G u n s t e n v o r S te u e r n :                                                                                                    E U R               5,0 3
                                         // S  te u e rb e m  e ss u n g s g r u n d la g e v o r V e r lu s tv e r re c h n u n g                  E  U   R                                  6 , 7 1
                                         // a b g e f ü h rt e S t e u er n                                                                                                                    E_ U_ _R _ _ _ _ _ _ _  __ _  _ __ _ _0_,_0 0_
@@ -1163,46 +1205,47 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                                                 t.setMonetaryAmount(deductedTaxes);
                                                             }
                                                         }),
-                                    // @formatter:off
-                                    //  Zu  Ih r e n G u n s t e n v o r S te u e r n :                                                        E  U   R                         9  .  1   1  0 , 3 5  U S D          1  0.  86 1 , 3  6
-                                    // S  te u e rb e m  e ss u n g s g r u n d la g e ( 1 )                                                     E  U   R                         3  .  0   4  7 , 7 1
-                                    //  ab g e f ü h rt e S t e u er n                                                                        E  U   R                           -  8   0  3 , 8 3  U_ _S D_ _ _ _ _ _ _ _  _ _ _ _- _9_ 5_  8__,  3_ 4_
-                                    // @formatter:on
-                                    section -> section //
-                                                    .attributes("currencyBeforeTaxes", "grossBeforeTaxes", "fxCurrencyAssessmentBasis", "fxGrossAssessmentBasis", "currencyDeductedTaxes", "deductedTaxes", "exchangeRate") //
-                                                    .match("^[\\s]*Z[\\s]*u[\\s]*I[\\s]*h[\\s]*r[\\s]*e[\\s]*n[\\s]*" //
-                                                                    + "(G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n|L[\\s]*a[\\s]*s[\\s]*t[\\s]*e[\\s]*n)" //
-                                                                    + "[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?:[A-Z][\\s]*){3}[\\s]{1,}[\\.,\\d\\s]+[\\s]{1,}(?<currencyBeforeTaxes>(?:[A-Z][\\s]*){3})[\\-\\s]{1,}(?<grossBeforeTaxes>[\\.,\\d\\s]+).*$") //
-                                                    .match("^[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*b[\\s]*e[\\s]*m[\\s]*e[\\s]*s[\\s]*s[\\s]*u[\\s]*n[\\s]*g[\\s]*s[\\s]*g[\\s]*r[\\s]*u[\\s]*n[\\s]*d[\\s]*l[\\s]*a[\\s]*g[\\s]*e[\\s]{1,}([\\(\\s\\d\\)]+)?(?<fxCurrencyAssessmentBasis>(?:[A-Z][\\s]*){3})[\\s]{1,}(?<fxGrossAssessmentBasis>[\\.,\\d\\s]+).*$") //
-                                                    .match("^[\\s]*a[\\s]*b[\\s]*g[\\s]*e[\\s]*f[\\s]*.[\\s]*h[\\s]*r[\\s]*t[\\s]*e[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]{1,}[A-Z_\\s]+[\\-_\\s]{1,}[\\.,\\d_\\s]+[\\s]{1,}(?<currencyDeductedTaxes>[A-Z_\\s]+)[\\-_\\s]{1,}(?<deductedTaxes>[\\.,\\d_\\s]+).*$") //
-                                                    .match("^Umrechnungen zum Devisenkurs [\\s]*(?<exchangeRate>[\\.,\\d]+).*$") //
-                                                    .assign((t, v) -> {
-                                                        var grossBeforeTaxes = Money.of(asCurrencyCode(stripBlanks(v.get("currencyBeforeTaxes"))), asAmount(stripBlanks(v.get("grossBeforeTaxes"))));
-                                                        var fxGrossAssessmentBasis = Money.of(asCurrencyCode(stripBlanks(v.get("fxCurrencyAssessmentBasis"))), asAmount(stripBlanks(v.get("fxGrossAssessmentBasis"))));
-                                                        var deductedTaxes = Money.of(asCurrencyCode(stripBlanksAndUnderscores(v.get("currencyDeductedTaxes"))), asAmount(stripBlanksAndUnderscores(v.get("deductedTaxes"))));
+                                        // @formatter:off
+                                        //  Zu  Ih r e n G u n s t e n v o r S te u e r n :                                                        E  U   R                         9  .  1   1  0 , 3 5  U S D          1  0.  86 1 , 3  6
+                                        // S  te u e rb e m  e ss u n g s g r u n d la g e ( 1 )                                                     E  U   R                         3  .  0   4  7 , 7 1
+                                        //  ab g e f ü h rt e S t e u er n                                                                        E  U   R                           -  8   0  3 , 8 3  U_ _S D_ _ _ _ _ _ _ _  _ _ _ _- _9_ 5_  8__,  3_ 4_
+                                        // Umrechnungen zum Devisenkurs       1,192200
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("currencyBeforeTaxes", "grossBeforeTaxes", "fxCurrencyAssessmentBasis", "fxGrossAssessmentBasis", "currencyDeductedTaxes", "deductedTaxes", "exchangeRate") //
+                                                        .match("^[\\s]*Z[\\s]*u[\\s]*I[\\s]*h[\\s]*r[\\s]*e[\\s]*n[\\s]*" //
+                                                                        + "(G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n|L[\\s]*a[\\s]*s[\\s]*t[\\s]*e[\\s]*n)" //
+                                                                        + "[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?:[A-Z][\\s]*){3}[\\s]{1,}[\\.,\\d\\s]+[\\s]{1,}(?<currencyBeforeTaxes>(?:[A-Z][\\s]*){3})[\\-\\s]{1,}(?<grossBeforeTaxes>[\\.,\\d\\s]+).*$") //
+                                                        .match("^[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*b[\\s]*e[\\s]*m[\\s]*e[\\s]*s[\\s]*s[\\s]*u[\\s]*n[\\s]*g[\\s]*s[\\s]*g[\\s]*r[\\s]*u[\\s]*n[\\s]*d[\\s]*l[\\s]*a[\\s]*g[\\s]*e[\\s]{1,}([\\(\\s\\d\\)]+)?(?<fxCurrencyAssessmentBasis>(?:[A-Z][\\s]*){3})[\\s]{1,}(?<fxGrossAssessmentBasis>[\\.,\\d\\s]+).*$") //
+                                                        .match("^[\\s]*a[\\s]*b[\\s]*g[\\s]*e[\\s]*f[\\s]*.[\\s]*h[\\s]*r[\\s]*t[\\s]*e[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]{1,}[A-Z_\\s]+[\\-_\\s]{1,}[\\.,\\d_\\s]+[\\s]{1,}(?<currencyDeductedTaxes>[A-Z_\\s]+)[\\-_\\s]{1,}(?<deductedTaxes>[\\.,\\d_\\s]+).*$") //
+                                                        .match("^Umrechnungen zum Devisenkurs [\\s]*(?<exchangeRate>[\\.,\\d]+).*$") //
+                                                        .assign((t, v) -> {
+                                                            var grossBeforeTaxes = Money.of(asCurrencyCode(stripBlanks(v.get("currencyBeforeTaxes"))), asAmount(stripBlanks(v.get("grossBeforeTaxes"))));
+                                                            var fxGrossAssessmentBasis = Money.of(asCurrencyCode(stripBlanks(v.get("fxCurrencyAssessmentBasis"))), asAmount(stripBlanks(v.get("fxGrossAssessmentBasis"))));
+                                                            var deductedTaxes = Money.of(asCurrencyCode(stripBlanksAndUnderscores(v.get("currencyDeductedTaxes"))), asAmount(stripBlanksAndUnderscores(v.get("deductedTaxes"))));
 
-                                                        var exchangeRate = asExchangeRate(v.get("exchangeRate"));
-                                                        var inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
+                                                            var exchangeRate = asExchangeRate(v.get("exchangeRate"));
+                                                            var inverseRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
 
-                                                        var grossAssessmentBasis = Money.of(grossBeforeTaxes.getCurrencyCode(), BigDecimal.valueOf(fxGrossAssessmentBasis.getAmount())
-                                                                        .multiply(inverseRate).setScale(0, RoundingMode.HALF_UP).longValue());
+                                                            var grossAssessmentBasis = Money.of(grossBeforeTaxes.getCurrencyCode(), BigDecimal.valueOf(fxGrossAssessmentBasis.getAmount())
+                                                                            .multiply(inverseRate).setScale(0, RoundingMode.HALF_UP).longValue());
 
-                                                        // Calculate the taxes and store gross amount
-                                                        if (!grossBeforeTaxes.isZero() && grossAssessmentBasis.isGreaterThan(grossBeforeTaxes))
-                                                        {
-                                                            t.setMonetaryAmount(grossAssessmentBasis.subtract(grossBeforeTaxes).add(deductedTaxes));
+                                                            // Calculate the taxes and store gross amount
+                                                            if (!grossBeforeTaxes.isZero() && grossAssessmentBasis.isGreaterThan(grossBeforeTaxes))
+                                                            {
+                                                                t.setMonetaryAmount(grossAssessmentBasis.subtract(grossBeforeTaxes).add(deductedTaxes));
 
-                                                            // Store in transaction context
-                                                            v.getTransactionContext().put(ATTRIBUTE_GROSS_TAXES_TREATMENT, grossAssessmentBasis);
-                                                        }
-                                                        else
-                                                        {
-                                                            // Store in transaction context
-                                                            v.getTransactionContext().put(ATTRIBUTE_GROSS_TAXES_TREATMENT, grossBeforeTaxes);
+                                                                // Store in transaction context
+                                                                v.getTransactionContext().put(ATTRIBUTE_GROSS_TAXES_TREATMENT, grossAssessmentBasis);
+                                                            }
+                                                            else
+                                                            {
+                                                                // Store in transaction context
+                                                                v.getTransactionContext().put(ATTRIBUTE_GROSS_TAXES_TREATMENT, grossBeforeTaxes);
 
-                                                            t.setMonetaryAmount(deductedTaxes);
-                                                        }
-                                                    }),
+                                                                t.setMonetaryAmount(deductedTaxes);
+                                                            }
+                                                        }),
                                         // @formatter:off
                                         //  Zu  Ih r e n G u n s t e n v o r S te u e r n :                                                                                                    E U R               4,6 5
                                         // S  te u e rb e m  e ss u n g s g r u n d la g e                                                            E  U   R                                  5 , 4 7
@@ -1244,26 +1287,26 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                                                 t.setMonetaryAmount(deductedTaxes);
                                                             }
                                                         }),
-                                            // @formatter:off
-                                            // Z u  Ih r e n G u n s t e n v o r S te u e r n :                                                                                                    E U R           1.263,0 5
-                                            // S  te u e rb e m  e ss u n g s g r u n d la g e                                                            E  U   R                             -   3  8 , 7 2
-                                            //  er s ta t te t e S t e ue r n                                                                                                                     E_ U_ R_ _ _ _ _ _ _ _ _  __  _ __ _10_,_8_ 4_
-                                            //
-                                            // Z  u     I h  r e   n    G  u   n   s  t e   n   v  o  r    S  t e  u   e   r n  :                                                         E  U   R                      1   0  .  5   8  3 , 9 9  U S D           11  .9 5 8 ,  8 5
-                                            // S  te u e rb e m  e ss u n g s g r u n d la g e                                                            E  U   R                    -  1   2  .  6   4  4 , 1 7
-                                            // e r s ta t te t e S t e ue r n                                                                         E  U   R                         3  .  5   3  9 , 5 8  U_ S_ D_ _ _ _ _ _ _ _  _ __ 3_ ._ _ 9_9 _ 9, _3 _ 7_
-                                            // @formatter:on
-                                            section -> section //
-                                                            .attributes("currencyRefundedTaxes", "refundedTaxes") //
-                                                            .match("^[\\s]*Z[\\s]*u[\\s]*I[\\s]*h[\\s]*r[\\s]*e[\\s]*n[\\s]*G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?:[A-Z][\\s]*){3}[\\-\\s]{1,}[\\.,\\d\\s]+.*$") //
-                                                            .match("^[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*b[\\s]*e[\\s]*m[\\s]*e[\\s]*s[\\s]*s[\\s]*u[\\s]*n[\\s]*g[\\s]*s[\\s]*g[\\s]*r[\\s]*u[\\s]*n[\\s]*d[\\s]*l[\\s]*a[\\s]*g[\\s]*e[\\s]{1,}([\\(\\s\\d\\)]+)?(?:[A-Z][\\s]*){3}[\\-\\s]{1,}[\\.,\\d\\s]+.*$") //
-                                                            .match("^[\\s]*e[\\s]*r[\\s]*s[\\s]*t[\\s]*a[\\s]*t[\\s]*t[\\s]*e[\\s]*t[\\s]*e[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n [\\s]{1,}[A-Z_\\s]+[\\-_\\s]{1,}[\\.,\\d_\\s]+[\\s]{1,}(?<currencyRefundedTaxes>[A-Z_\\s]+)[\\-_\\s]{1,}(?<refundedTaxes>[\\.,\\d_\\s]+)$") //
-                                                            .assign((t, v) -> {
-                                                                t.setType(AccountTransaction.Type.TAX_REFUND);
+                                        // @formatter:off
+                                        // Z u  Ih r e n G u n s t e n v o r S te u e r n :                                                                                                    E U R           1.263,0 5
+                                        // S  te u e rb e m  e ss u n g s g r u n d la g e                                                            E  U   R                             -   3  8 , 7 2
+                                        //  er s ta t te t e S t e ue r n                                                                                                                     E_ U_ R_ _ _ _ _ _ _ _ _  __  _ __ _10_,_8_ 4_
+                                        //
+                                        // Z  u     I h  r e   n    G  u   n   s  t e   n   v  o  r    S  t e  u   e   r n  :                                                         E  U   R                      1   0  .  5   8  3 , 9 9  U S D           11  .9 5 8 ,  8 5
+                                        // S  te u e rb e m  e ss u n g s g r u n d la g e                                                            E  U   R                    -  1   2  .  6   4  4 , 1 7
+                                        // e r s ta t te t e S t e ue r n                                                                         E  U   R                         3  .  5   3  9 , 5 8  U_ S_ D_ _ _ _ _ _ _ _  _ __ 3_ ._ _ 9_9 _ 9, _3 _ 7_
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("currencyRefundedTaxes", "refundedTaxes") //
+                                                        .match("^[\\s]*Z[\\s]*u[\\s]*I[\\s]*h[\\s]*r[\\s]*e[\\s]*n[\\s]*G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?:[A-Z][\\s]*){3}[\\-\\s]{1,}[\\.,\\d\\s]+.*$") //
+                                                        .match("^[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*b[\\s]*e[\\s]*m[\\s]*e[\\s]*s[\\s]*s[\\s]*u[\\s]*n[\\s]*g[\\s]*s[\\s]*g[\\s]*r[\\s]*u[\\s]*n[\\s]*d[\\s]*l[\\s]*a[\\s]*g[\\s]*e[\\s]{1,}([\\(\\s\\d\\)]+)?(?:[A-Z][\\s]*){3}[\\-\\s]{1,}[\\.,\\d\\s]+.*$") //
+                                                        .match("^[\\s]*e[\\s]*r[\\s]*s[\\s]*t[\\s]*a[\\s]*t[\\s]*t[\\s]*e[\\s]*t[\\s]*e[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n [\\s]{1,}[A-Z_\\s]+[\\-_\\s]{1,}[\\.,\\d_\\s]+[\\s]{1,}(?<currencyRefundedTaxes>[A-Z_\\s]+)[\\-_\\s]{1,}(?<refundedTaxes>[\\.,\\d_\\s]+)$") //
+                                                        .assign((t, v) -> {
+                                                            t.setType(AccountTransaction.Type.TAX_REFUND);
 
-                                                                t.setCurrencyCode(asCurrencyCode(stripBlanksAndUnderscores(v.get("currencyRefundedTaxes"))));
-                                                                t.setAmount(asAmount(stripBlanksAndUnderscores(v.get("refundedTaxes"))));
-                                                        }),
+                                                            t.setCurrencyCode(asCurrencyCode(stripBlanksAndUnderscores(v.get("currencyRefundedTaxes"))));
+                                                            t.setAmount(asAmount(stripBlanksAndUnderscores(v.get("refundedTaxes"))));
+                                                    }),
                                         // @formatter:off
                                         // Z u  Ih r e n G u n s t e n v o r S te u e r n :                                                                                                    E U R               1,4 0
                                         // S  te u e rb e m  e ss u n g s g r u n d la g e n a c h V e r lu s t ve r r ec h n u n g  (8 )         E  U  R                                 -  0 , 1 0


### PR DESCRIPTION
This change updates the tax parsing logic to correctly account for foreign withholding tax.

- Added parsing of angerechnete ausländische Quellensteuer.
- Deducted taxes now include both domestic and foreign withholding tax.
- ATTRIBUTE_GROSS_TAXES_TREATMENT is calculated as gross base + foreign withholding tax, if currencies match.
- In case of different currencies, the base is stored as before and the foreign tax is saved separately.

This ensures that reported tax amounts reflect both domestic and foreign withholding components.

https://forum.portfolio-performance.info/t/pdf-import-von-comdirect/1647/429