### PR TITLE
Linux Pie Charts

### DIFF
--- a/name.abuchen.portfolio.ui/META-INF/html/flare.html
+++ b/name.abuchen.portfolio.ui/META-INF/html/flare.html
@@ -1,11 +1,14 @@
 <!DOCTYPE html>
+<html>
 <meta charset="utf-8">
 <link rel="stylesheet" type="text/css" href="${/META-INF/css/THEME.css}">
 <body>
 <script src="${/META-INF/js/d3.min.js}"></script>
 <script src="${/META-INF/js/pp.js}"></script>
 <script>
+window.addEventListener('load', createFlare);
 
+function createFlare(){	
 pp.onResizeEnd(function() {
   width = pp.getInnerWidth();
   height = pp.getInnerHeight();
@@ -239,4 +242,7 @@ function brightness(rgb) {
 }
 
 flare.setContent(loadData());
+}
 </script>
+</body>
+</html>

--- a/name.abuchen.portfolio.ui/META-INF/html/pie.html
+++ b/name.abuchen.portfolio.ui/META-INF/html/pie.html
@@ -6,9 +6,11 @@
 <script src="${/META-INF/js/d3.min.js}"></script>
 <script src="${/META-INF/js/pp.js}"></script>
 <script>
+window.addEventListener('load', createPie)
 var data = JSON.parse(loadData());
 var total = d3.sum(data, function(d) {return d.value;} );
 
+function createPie() {
 pp.onResizeEnd(function() {
     thePieChart.resize();
 });
@@ -245,4 +247,7 @@ thePieChart.update(data);
 function brightness(rgb) {
   return rgb.r * .299 + rgb.g * .587 + rgb.b * .114;
 }
+}
 </script>
+</body>
+</html>

--- a/name.abuchen.portfolio.ui/META-INF/js/pp.js
+++ b/name.abuchen.portfolio.ui/META-INF/js/pp.js
@@ -31,18 +31,26 @@
 
 	pp.getInitialHeight = function() {
 		if (typeof (document.height) == 'number') {
-			return document.height;
+			height = document.height;
 		} else {
-			return window.innerHeight - 4;
+			height = window.innerHeight - 4;
 		}
+		if (height <=0){
+			height = 50;
+		}		
+		return height;
 	}
 	
 	pp.getInitialWidth = function() {
 		if (typeof (document.width) == 'number') {
-			return document.width;
+			width = document.width;
 		} else {
-			return window.innerWidth - 4;
+			width = window.innerWidth - 4;
 		}
+		if (width <=0){
+			width = 50;
+		}		
+		return width;
 	}
 	
 	pp.getInnerHeight = function() {


### PR DESCRIPTION
Hello, this is just a draft POC from @hendrikm78 proposition here : https://github.com/portfolio-performance/portfolio/issues/2719#issuecomment-3005852373

> I figured out the following:
> 
> - `pp.getInitialHeight `& `pp.getInitialWidth `return -4, seems the dimensions can not be determined when the script is called
> 
> To avoid this problem I did two workarounds:
> 
>  1. Limit the output of these two functions to >= 50
>  2. add a EventListener "load" to the flare and pie chart
> 
> For details see attachment. (I am not familar with git, so I would do it this way)
> The Flare-Chart works fine, but the Pie-Chart is a little bit tricky. Sometimes you have to switch to another Taxonomy and go back.
> 

I do not have Linux myself, but as per the comments in the linked discussion, **it seems this is fixing the "sunburst" pie chart**, but not fixing the "donut" pie chart.
So this seems promising, I think this is worth a bit of visibility, in case Linux contributors want to further investigate.
On my side, both "sunburst" and "donut" pie chart keep functioning as intended on Windows 11.

If this goes somewhere, the contributor is hendrikm78, not me.