### PR TITLE
Update SecuritiesChart.java

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -917,7 +917,7 @@ public class SecuritiesChart
         chart.setRedraw(false);
         chart.suspendUpdate(true);
 
-        ColorWheel colorWheel = new ColorWheel(securities.length);
+        ColorWheel colorWheel = new ColorWheel(MAX_SECURITIES_BENCHMARK);
 
         try
         {


### PR DESCRIPTION
Chart colors remain unchanged for benchmark, as proposed here: https://forum.portfolio-performance.info/t/farben-von-chart-grafiken-unverandert-lassen/37593. But only when user is marking securities in same order as displayed in the list (see my comment in forum).
