### PR TITLE
add Security Edit shortcut in views

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
@@ -28,6 +28,8 @@ import org.eclipse.jface.window.ToolTip;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
@@ -417,6 +419,7 @@ public class PerformanceView extends AbstractHistoricView
         item.setImage(Images.VIEW_TABLE.image());
 
         hookContextMenu(calculation.getTree(), this::fillContextMenu);
+        hookKeyListener();
     }
 
     private void fillContextMenu(IMenuManager manager) // NOSONAR
@@ -430,6 +433,20 @@ public class PerformanceView extends AbstractHistoricView
 
         Security security = ((ClientPerformanceSnapshot.Position) selection).getSecurity();
         new SecurityContextMenu(this).menuAboutToShow(manager, security);
+    }
+
+    private void hookKeyListener()
+    {
+        calculation.getControl().addKeyListener(new KeyAdapter()
+        {
+            @Override
+            public void keyPressed(KeyEvent e)
+            {
+                Object selection = ((IStructuredSelection) calculation.getSelection()).getFirstElement();
+                if (selection instanceof ClientPerformanceSnapshot.Position position)
+                    new SecurityContextMenu(PerformanceView.this).handleEditKey(e, position.getSecurity());
+            }
+        });
     }
 
     private void addTreeActionsContextMenu(IMenuManager manager, Object obj)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -45,6 +45,8 @@ import org.eclipse.jface.window.ToolTip;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.dnd.Transfer;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
@@ -778,6 +780,7 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                         new SecurityDragListener(records));
 
         hookContextMenu(records.getTable(), this::fillContextMenu);
+        hookKeyListener();
 
         records.addSelectionChangedListener(event -> {
             var selection = event.getStructuredSelection();
@@ -1867,5 +1870,22 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
 
         Security security = row.performanceRecord.getSecurity();
         new SecurityContextMenu(this).menuAboutToShow(manager, security);
+    }
+
+    private void hookKeyListener()
+    {
+        records.getControl().addKeyListener(new KeyAdapter()
+        {
+            @Override
+            public void keyPressed(KeyEvent e)
+            {
+                RowElement row = (RowElement) ((IStructuredSelection) records.getSelection()).getFirstElement();
+                if (row == null || !row.isRecord())
+                    return;
+
+                Security security = row.performanceRecord.getSecurity();
+                new SecurityContextMenu(SecuritiesPerformanceView.this).handleEditKey(e, security);
+            }
+        });
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
@@ -150,6 +150,7 @@ public class StatementOfAssetsView extends AbstractFinanceView
 
         hookContextMenu(assetViewer.getTableViewer().getControl(),
                         manager -> assetViewer.hookMenuListener(manager, StatementOfAssetsView.this));
+        assetViewer.hookKeyListener();
 
         assetViewer.getTableViewer().addSelectionChangedListener(e -> {
             var selection = e.getStructuredSelection();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -40,6 +40,8 @@ import org.eclipse.jface.window.ToolTip;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.dnd.Transfer;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
@@ -1063,6 +1065,20 @@ public class StatementOfAssetsViewer
 
             new SecurityContextMenu(view).menuAboutToShow(manager, element.getSecurity(), reference);
         }
+    }
+
+    public void hookKeyListener()
+    {
+        assets.getControl().addKeyListener(new KeyAdapter()
+        {
+            @Override
+            public void keyPressed(KeyEvent e)
+            {
+                Element element = (Element) assets.getStructuredSelection().getFirstElement();
+                if (element != null && element.isSecurity())
+                    new SecurityContextMenu(owner).handleEditKey(e, element.getSecurity());
+            }
+        });
     }
 
     public TableViewer getTableViewer()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TransactionContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TransactionContextMenu.java
@@ -46,7 +46,7 @@ public class TransactionContextMenu
     {
         if (selection.isEmpty() && fullContextMenu)
         {
-            new SecurityContextMenu(owner).menuAboutToShow(manager, null, null);
+            new SecurityContextMenu(owner, fullContextMenu).menuAboutToShow(manager, null, null);
         }
 
         if (selection.size() == 1)
@@ -203,7 +203,8 @@ public class TransactionContextMenu
         manager.add(new Separator());
 
         if (fullContextMenu)
-            new SecurityContextMenu(owner).menuAboutToShow(manager, ptx.getSecurity(), (Portfolio) tx.getOwner());
+            new SecurityContextMenu(owner, fullContextMenu).menuAboutToShow(manager, ptx.getSecurity(),
+                            (Portfolio) tx.getOwner());
         else
             manager.add(new BookmarkMenu(owner.getPart(), ptx.getSecurity()));
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsMatrixTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsMatrixTab.java
@@ -29,6 +29,8 @@ import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.jface.window.ToolTip;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
@@ -178,6 +180,7 @@ public abstract class PaymentsMatrixTab implements PaymentsTab
         model.addUpdateListener(() -> updateColumns(tableViewer, tableLayout));
 
         new ContextMenu(tableViewer.getControl(), this::fillContextMenu).hook();
+        hookKeyListener();
 
         return container;
     }
@@ -356,5 +359,26 @@ public abstract class PaymentsMatrixTab implements PaymentsTab
         {
             new SecurityContextMenu(view).menuAboutToShow(manager, security);
         }
+    }
+
+    private void hookKeyListener()
+    {
+        tableViewer.getControl().addKeyListener(new KeyAdapter()
+        {
+            @Override
+            public void keyPressed(KeyEvent e)
+            {
+                IStructuredSelection selection = tableViewer.getStructuredSelection();
+                if (selection.isEmpty() || selection.size() > 1)
+                    return;
+
+                Line line = (Line) selection.getFirstElement();
+                InvestmentVehicle vehicle = line.getVehicle();
+                if (vehicle instanceof Security security)
+                {
+                    new SecurityContextMenu(view).handleEditKey(e, security);
+                }
+            }
+        });
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
@@ -39,6 +39,8 @@ import org.eclipse.swt.dnd.DragSourceAdapter;
 import org.eclipse.swt.dnd.DragSourceEvent;
 import org.eclipse.swt.dnd.Transfer;
 import org.eclipse.swt.dnd.TransferData;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Composite;
@@ -455,6 +457,7 @@ import name.abuchen.portfolio.util.TextUtil;
         nodeViewer.setInput(getModel());
 
         new ContextMenu(nodeViewer.getControl(), this::fillContextMenu).hook();
+        hookKeyListener();
 
         return container;
     }
@@ -907,6 +910,24 @@ import name.abuchen.portfolio.util.TextUtil;
                 new SecurityContextMenu(this.view).menuAboutToShow(manager, security);
             }
         }
+    }
+
+    private void hookKeyListener()
+    {
+        nodeViewer.getControl().addKeyListener(new KeyAdapter()
+        {
+            @Override
+            public void keyPressed(KeyEvent e)
+            {
+                IStructuredSelection selection = nodeViewer.getStructuredSelection();
+                if (selection.isEmpty() || selection.size() > 1)
+                    return;
+
+                TaxonomyNode node = (TaxonomyNode) selection.getFirstElement();
+                if (!node.isClassification())
+                    new SecurityContextMenu(view).handleEditKey(e, node.getBackingSecurity());
+            }
+        });
     }
 
     private void addAvailableAssignments(MenuManager manager, TaxonomyNode targetNode)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
@@ -23,6 +23,8 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.KeyAdapter;
+import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
@@ -428,6 +430,7 @@ public class TradeDetailsView extends AbstractFinanceView
         update();
 
         new ContextMenu(table.getTableViewer().getControl(), this::fillContextMenu).hook();
+        hookKeyListener();
 
         return control;
     }
@@ -451,6 +454,23 @@ public class TradeDetailsView extends AbstractFinanceView
 
         Trade trade = (Trade) selection.getFirstElement();
         new SecurityContextMenu(this).menuAboutToShow(manager, trade.getSecurity(), trade.getPortfolio());
+    }
+
+    private void hookKeyListener()
+    {
+        table.getTableViewer().getControl().addKeyListener(new KeyAdapter()
+        {
+            @Override
+            public void keyPressed(KeyEvent e)
+            {
+                IStructuredSelection selection = table.getTableViewer().getStructuredSelection();
+                if (selection.isEmpty() || selection.size() > 1)
+                    return;
+
+                Trade trade = (Trade) selection.getFirstElement();
+                new SecurityContextMenu(TradeDetailsView.this).handleEditKey(e, trade.getSecurity());
+            }
+        });
     }
 
     private void update()


### PR DESCRIPTION
Closes https://github.com/portfolio-performance/portfolio/issues/4091
Closes https://github.com/portfolio-performance/portfolio/issues/4999

Hello, 
This is a proposition to add the Ctrl+E shortcut to the action "Edit Security". This is already available in the Security List View, but only there. So the proposition is to add it to the other views where a Security Context Menu exists. The exception is for transactions, where the Ctrl+E shortcut is already related to the "Edit transaction" action.

One detail, on Tree (Performance/Calculation and Taxonomy), Windows gives me a "beep" sound when closing the Edit window. But it is actually already (before the PR change) giving me the beep if press a Ctrl+E or else with a Tree row selected.

**Before**
<img width="390" height="418" alt="2025-09-25 21_06_41-Portfolio Performance" src="https://github.com/user-attachments/assets/1d574cad-0ad7-4d4c-8db3-9e1ca12ae3e0" />

**After**
<img width="433" height="412" alt="2025-09-25 21_10_33-Portfolio Performance" src="https://github.com/user-attachments/assets/867fac63-4423-4a6a-a035-4b54ec6fb039" />
