### PR TITLE
Fix NPE when switching view of securities if new table is sorted by a column with ParameterizedColumnLabelProvider

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ShowHideColumnHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ShowHideColumnHelper.java
@@ -292,13 +292,13 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
             CellLabelProvider labelProvider = column.getLabelProvider().get();
             col.setLabelProvider(labelProvider);
 
-            setCommonParameters(column, col, direction);
-
             if (labelProvider instanceof CellItemImageClickedListener listener)
                 setupImageClickedListener(col, listener);
 
             if (labelProvider instanceof ParameterizedColumnLabelProvider parametrized)
                 parametrized.setTableColumn(tableColumn);
+
+            setCommonParameters(column, col, direction);
 
             return tableColumn;
         }


### PR DESCRIPTION
Fixes NPE when switching view of securities if new table is sorted by a column with ParameterizedColumnLabelProvider.

```
Exception occurred
java.lang.NullPointerException: Cannot invoke "org.eclipse.swt.widgets.TableColumn.getData(String)" because "this.tableColumn" is null
	at name.abuchen.portfolio.ui.util.viewers.ParameterizedColumnLabelProvider.getOption(ParameterizedColumnLabelProvider.java:32)
	at name.abuchen.portfolio.ui.views.SecuritiesTable$QuoteReportingPeriodLabelProvider.getText(SecuritiesTable.java:1224)
	at org.eclipse.jface.viewers.ColumnLabelProvider.update(ColumnLabelProvider.java:39)
	at org.eclipse.jface.viewers.ViewerColumn.refresh(ViewerColumn.java:149)
	at org.eclipse.jface.viewers.AbstractTableViewer.doUpdateItem(AbstractTableViewer.java:390)
	at org.eclipse.jface.viewers.StructuredViewer$UpdateItemSafeRunnable.run(StructuredViewer.java:426)
	at org.eclipse.jface.util.SafeRunnable$1.run(SafeRunnable.java:129)
	at org.eclipse.jface.util.SafeRunnable.run(SafeRunnable.java:174)
	at org.eclipse.jface.viewers.StructuredViewer.updateItem(StructuredViewer.java:2111)
	at org.eclipse.jface.viewers.AbstractTableViewer.internalRefreshAll(AbstractTableViewer.java:680)
	at org.eclipse.jface.viewers.AbstractTableViewer.internalRefresh(AbstractTableViewer.java:616)
	at org.eclipse.jface.viewers.AbstractTableViewer.internalRefresh(AbstractTableViewer.java:608)
	at org.eclipse.jface.viewers.StructuredViewer.lambda$2(StructuredViewer.java:1463)
	at org.eclipse.jface.viewers.StructuredViewer.preservingSelection(StructuredViewer.java:1392)
	at org.eclipse.jface.viewers.StructuredViewer.preservingSelection(StructuredViewer.java:1353)
	at org.eclipse.jface.viewers.StructuredViewer.refresh(StructuredViewer.java:1463)
	at org.eclipse.jface.viewers.ColumnViewer.refresh(ColumnViewer.java:521)
	at org.eclipse.jface.viewers.StructuredViewer.refresh(StructuredViewer.java:1417)
	at org.eclipse.jface.viewers.StructuredViewer.setComparator(StructuredViewer.java:1747)
	at name.abuchen.portfolio.ui.util.viewers.ColumnViewerSorter$ViewerSorter.setSorter(ColumnViewerSorter.java:346)
	at name.abuchen.portfolio.ui.util.viewers.ColumnViewerSorter.attachTo(ColumnViewerSorter.java:463)
	at name.abuchen.portfolio.ui.util.viewers.ShowHideColumnHelper$ViewerPolicy.setCommonParameters(ShowHideColumnHelper.java:101)
	at name.abuchen.portfolio.ui.util.viewers.ShowHideColumnHelper$TableViewerPolicy.create(ShowHideColumnHelper.java:295)
	at name.abuchen.portfolio.ui.util.viewers.ShowHideColumnHelper.lambda$8(ShowHideColumnHelper.java:918)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
	at name.abuchen.portfolio.ui.util.viewers.ShowHideColumnHelper.createFromColumnConfig(ShowHideColumnHelper.java:902)
	at name.abuchen.portfolio.ui.util.viewers.ShowHideColumnHelper.onConfigurationPicked(ShowHideColumnHelper.java:1011)
	at name.abuchen.portfolio.ui.util.ConfigurationStore.lambda$19(ConfigurationStore.java:220)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at name.abuchen.portfolio.ui.util.ConfigurationStore.activate(ConfigurationStore.java:220)
	at name.abuchen.portfolio.ui.util.ConfigurationStore.lambda$9(ConfigurationStore.java:147)
	at name.abuchen.portfolio.ui.util.SimpleAction.run(SimpleAction.java:69)
	at name.abuchen.portfolio.ui.util.DropDown.lambda$0(DropDown.java:206)
	at org.eclipse.swt.events.SelectionListener$1.widgetSelected(SelectionListener.java:84)
	at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:265)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4404)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1173)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:4202)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3790)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1151)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1042)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Application.start(E4Application.java:165)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:208)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:143)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:109)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:439)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:271)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:668)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:605)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1481)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1454)
```