### PR TITLE
allow information pane for Transaction to be filtered by accounts

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/TransactionsPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/TransactionsPane.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.action.ToolBarManager;
@@ -25,6 +26,7 @@ import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.TransactionPair;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
 import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.SimpleAction;
@@ -37,6 +39,7 @@ public class TransactionsPane implements InformationPanePage
 {
 
     @Inject
+    @Named(UIConstants.Context.ACTIVE_CLIENT)
     private Client client;
 
     @Inject


### PR DESCRIPTION
Closes https://github.com/portfolio-performance/portfolio/issues/2371

Hello, this is a proposition to filter the transactions in the bottom Transactions pane of a security based on the accounts selected. This is the current behavior for the Chart pane and the Trades panes, so I guess we can apply it also for Transaction pane ? And this is also the current behavior of the "uneditable transactions pane" of Performance Securities view.
