### PR TITLE
Handle RuntimeExceptions from PDFBox1 gracefully

### DIFF
--- a/name.abuchen.portfolio.pdfbox1/src/name/abuchen/portfolio/pdfbox1/PDFBox1Adapter.java
+++ b/name.abuchen.portfolio.pdfbox1/src/name/abuchen/portfolio/pdfbox1/PDFBox1Adapter.java
@@ -25,7 +25,7 @@ public class PDFBox1Adapter
             textStripper.setSortByPosition(true);
             return textStripper.getText(document);
         }
-        catch (CryptographyException e)
+        catch (RuntimeException | CryptographyException e)
         {
             throw new IOException(e);
         }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/CreateTextFromPDFHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/CreateTextFromPDFHandler.java
@@ -2,9 +2,7 @@ package name.abuchen.portfolio.ui.handlers;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Random;
-import java.util.stream.Collectors;
 
 import jakarta.inject.Named;
 
@@ -19,9 +17,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-
-import com.github.difflib.DiffUtils;
-import com.github.difflib.UnifiedDiffUtils;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
 import name.abuchen.portfolio.money.CurrencyUnit;
@@ -56,26 +51,9 @@ public class CreateTextFromPDFHandler
             var extractedText = inputFile.getText();
             var pdfBoxVersion = inputFile.getPDFBoxVersion();
 
-            // check if the extracted text changed with the PDFBox version
-            inputFile.convertLegacyPDFtoText();
-            var legacyText = inputFile.getText();
-            var legacyPdfBoxVersion = inputFile.getPDFBoxVersion();
-            var isDifferent = !extractedText.equals(legacyText);
-
-            if (isDifferent)
-            {
-                var patch = DiffUtils.diff(legacyText, extractedText, null);
-                var unifiedDiff = UnifiedDiffUtils.generateUnifiedDiff(legacyPdfBoxVersion, pdfBoxVersion,
-                                Arrays.asList(legacyText.split("\n")), patch, 0);
-                PortfolioPlugin.info(
-                                inputFile.getName() + "\n\n" + unifiedDiff.stream().collect(Collectors.joining("\n")));
-            }
-
             StringBuilder textBuilder = new StringBuilder();
             textBuilder.append("```").append("\n");
-            textBuilder.append("PDFBox Version: ").append(pdfBoxVersion)
-                            .append(isDifferent ? " != " + legacyPdfBoxVersion : "") //
-                            .append("\n");
+            textBuilder.append("PDFBox Version: ").append(pdfBoxVersion).append("\n");
             textBuilder.append("Portfolio Performance Version: ")
                             .append(PortfolioPlugin.getDefault().getBundle().getVersion().toString()) //
                             .append("\n");

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFImportAssistant.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFImportAssistant.java
@@ -181,22 +181,30 @@ public class PDFImportAssistant
 
                 if (!extracted)
                 {
-                    inputFile.convertLegacyPDFtoText();
-                    for (Extractor extractor : extractors)
+                    try
                     {
-                        var items = extractor.extract(securityCache, inputFile, warnings);
-
-                        if (!items.isEmpty())
+                        inputFile.convertLegacyPDFtoText();
+                        for (Extractor extractor : extractors)
                         {
-                            extracted = true;
-                            itemsByExtractor.computeIfAbsent(extractor, e -> new ArrayList<Item>()).addAll(items);
-                            break;
+                            var items = extractor.extract(securityCache, inputFile, warnings);
+
+                            if (!items.isEmpty())
+                            {
+                                extracted = true;
+                                itemsByExtractor.computeIfAbsent(extractor, e -> new ArrayList<Item>()).addAll(items);
+                                break;
+                            }
+                        }
+
+                        if (extracted)
+                        {
+                            PortfolioLog.info("PDF successfully imported with PDFBox 1.8.x " + inputFile.getName()); //$NON-NLS-1$
                         }
                     }
-
-                    if (extracted)
+                    catch (IOException ignore)
                     {
-                        PortfolioLog.info("PDF successfully imported with PDFBox 1.8.x " + inputFile.getName()); //$NON-NLS-1$
+                        // ignore if the file cannot be read by PDFBox Version 1
+                        PortfolioLog.error(ignore);
                     }
                 }
 


### PR DESCRIPTION
If PDFBox version 1 is failing to convert the document to text, ignore the error during import of PDF documents.

As the error would also prevent the user from creating a PDF debug text, this change removes the diff between version 1 and version 3 of PDFBox from the debug output.

Closes #5083