### PR TITLE
Remove most currency conversions from IBFlex importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
@@ -679,7 +679,7 @@ public class IBFlexStatementExtractorTest
         assertThat(buySellTransactions.size(), is(9));
         assertThat(accountTransactions.size(), is(3));
         assertThat(results.size(), is(20));
-        new AssertImportActions().check(results, CurrencyUnit.EUR);
+        new AssertImportActions().check(results, CurrencyUnit.EUR, CurrencyUnit.USD);
 
         // check security
         Security security1 = results.stream().filter(SecurityItem.class::isInstance).findFirst()
@@ -767,19 +767,17 @@ public class IBFlexStatementExtractorTest
         assertThat(entry.getNote(), is("Trade-ID: 1908991475"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4185.05))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(5000.00))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4183.38))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(4998.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.67))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(2.00))));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(41.8338))));
+                        is(Quote.of(CurrencyUnit.USD, Values.Quote.factorize(49.98))));
 
-        Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(5000.00))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 2nd buy sell transaction
         entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
@@ -794,19 +792,17 @@ public class IBFlexStatementExtractorTest
         assertThat(entry.getNote(), is("Trade-ID: 1902533101"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(41.17))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(49.50))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(44.08))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(53.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.91))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(3.50))));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(0.4408))));
+                        is(Quote.of(CurrencyUnit.USD, Values.Quote.factorize(0.53))));
 
-        grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(53.00))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 3th buy sell (Amount = 0,00) transaction
         entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
@@ -821,19 +817,17 @@ public class IBFlexStatementExtractorTest
         assertThat(entry.getNote(), is("Trade-ID: 1908991474"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(0.00))));
+                        is(Quote.of(CurrencyUnit.USD, Values.Quote.factorize(0.00))));
 
-        grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check cancellation (Storno) 3rd buy sell transaction
         BuySellEntry cancellation = (BuySellEntry) results.stream() //
@@ -854,19 +848,17 @@ public class IBFlexStatementExtractorTest
         assertThat(cancellation.getNote(), is("Trade-ID: 1908991474"));
 
         assertThat(cancellation.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(cancellation.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(cancellation.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(cancellation.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(cancellation.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(0.00))));
+                        is(Quote.of(CurrencyUnit.USD, Values.Quote.factorize(0.00))));
 
-        grossValueUnit = cancellation.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 4th buy sell transaction
         entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
@@ -881,19 +873,17 @@ public class IBFlexStatementExtractorTest
         assertThat(entry.getNote(), is("Trade-ID: 1910911677"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(42.94))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(51.50))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(45.86))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(55.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.92))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(3.50))));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(0.4586))));
+                        is(Quote.of(CurrencyUnit.USD, Values.Quote.factorize(0.55))));
 
-        grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(55.01))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 5th buy sell transaction
         entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(4).findFirst()
@@ -908,19 +898,18 @@ public class IBFlexStatementExtractorTest
         assertThat(entry.getNote(), is("Trade-ID: 2107408815 | Transaction-ID: 9004815263"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(578.32))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(690.64))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(577.78))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(690.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.54))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.64))));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(5.7778))));
+                        is(Quote.of(CurrencyUnit.USD, Values.Quote.factorize(6.90))));
 
-        grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(690.64))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 6th buy sell transaction
         entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
@@ -1025,15 +1014,14 @@ public class IBFlexStatementExtractorTest
         assertNull(transaction.getSource());
         assertThat(transaction.getNote(), is("ORCL(US68389X1054) CASH DIVIDEND 0.19000000 USD PER SHARE - US TAX"));
 
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(13.67))));
-        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(16.08))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(16.15))));
+        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(19.00))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.41))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(2.85))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
 
-        grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(19.00))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check transaction
         // get transactions
@@ -1128,7 +1116,7 @@ public class IBFlexStatementExtractorTest
         assertThat(buySellTransactions.size(), is(1));
         assertThat(accountTransactions.size(), is(0));
         assertThat(results.size(), is(2));
-        new AssertImportActions().check(results, "CHF");
+        new AssertImportActions().check(results, "CHF", CurrencyUnit.USD);
 
         // check security
         Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
@@ -1153,19 +1141,17 @@ public class IBFlexStatementExtractorTest
         assertThat(entry.getNote(), is("Trade-ID: 1111111111"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("CHF", Values.Amount.factorize(775.80))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(844.95))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("CHF", Values.Amount.factorize(775.50))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(844.62))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("CHF", Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("CHF", Values.Amount.factorize(0.30))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.33))));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of("CHF", Values.Quote.factorize(55.39285714))));
+                        is(Quote.of(CurrencyUnit.USD, Values.Quote.factorize(60.33))));
 
-        Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(844.95))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
     }
 
     @Test
@@ -1319,7 +1305,7 @@ public class IBFlexStatementExtractorTest
         assertThat(buySellTransactions.size(), is(2));
         assertThat(accountTransactions.size(), is(2));
         assertThat(results.size(), is(6));
-        new AssertImportActions().check(results, CurrencyUnit.EUR);
+        new AssertImportActions().check(results, CurrencyUnit.EUR, CurrencyUnit.USD);
 
         // check security
         Security security1 = results.stream().filter(SecurityItem.class::isInstance).findFirst()
@@ -1376,19 +1362,17 @@ public class IBFlexStatementExtractorTest
         assertThat(entry.getNote(), is("Trade-ID: 3004185992 | Transaction-ID: 13346288726"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2433.96))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(2870.00))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2429.72))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(2865.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.24))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(5.00))));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(97.1888))));
+                        is(Quote.of(CurrencyUnit.USD, Values.Quote.factorize(114.60))));
 
-        Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(2870.00))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 1st dividends transaction
         AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
@@ -1401,12 +1385,12 @@ public class IBFlexStatementExtractorTest
         assertNull(transaction.getSource());
         assertThat(transaction.getNote(), is("Transaction-ID: 8765764573"));
 
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.74))));
-        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.74))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(9.52))));
+        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(9.52))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
 
         // check 2nd dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(1)
@@ -1419,15 +1403,15 @@ public class IBFlexStatementExtractorTest
         assertNull(transaction.getSource());
         assertThat(transaction.getNote(), is("Transaction-ID: 13713058125"));
 
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(8.04))));
-        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(8.04))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(9.50))));
+        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(9.50))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
 
-        grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(9.50))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
+
     }
 
     @Test
@@ -1676,7 +1660,7 @@ public class IBFlexStatementExtractorTest
         assertThat(buySellTransactions.size(), is(1));
         assertThat(accountTransactions.size(), is(0));
         assertThat(results.size(), is(3));
-        new AssertImportActions().check(results, "EUR", "USD");
+        new AssertImportActions().check(results, CurrencyUnit.EUR, CurrencyUnit.USD);
 
         // check security
         Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
@@ -1701,19 +1685,17 @@ public class IBFlexStatementExtractorTest
         assertThat(entry.getNote(), is("Trade-ID: 116815359 | Transaction-ID: 415451625"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(132.81))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(140.83))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(132.50))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(140.50))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.31))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.33))));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(13.25))));
+                        is(Quote.of(CurrencyUnit.USD, Values.Quote.factorize(14.05))));
 
-        Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(140.83))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 1st account transfer
         assertThat(results, hasItem(outboundCash( //
@@ -1752,7 +1734,7 @@ public class IBFlexStatementExtractorTest
         assertThat(buySellTransactions.size(), is(1));
         assertThat(accountTransactions.size(), is(0));
         assertThat(results.size(), is(2));
-        new AssertImportActions().check(results, CurrencyUnit.EUR);
+        new AssertImportActions().check(results, CurrencyUnit.USD);
 
         // check security
         Security security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
@@ -1777,19 +1759,17 @@ public class IBFlexStatementExtractorTest
         assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(344.56))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(350.17))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(344.39))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(350.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.17))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.17))));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(24.59928571))));
+                        is(Quote.of(CurrencyUnit.USD, Values.Quote.factorize(25.00))));
 
-        Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(350.17))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
     }
 
     @Test
@@ -1816,7 +1796,7 @@ public class IBFlexStatementExtractorTest
         assertThat(buySellTransactions.size(), is(4));
         assertThat(accountTransactions.size(), is(11));
         assertThat(results.size(), is(17));
-        new AssertImportActions().check(results, CurrencyUnit.EUR);
+        new AssertImportActions().check(results, CurrencyUnit.EUR, CurrencyUnit.USD, "CAD");
 
         // check security
         Security security1 = results.stream().filter(SecurityItem.class::isInstance).findFirst()
@@ -1850,19 +1830,17 @@ public class IBFlexStatementExtractorTest
         assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(848.65))));
+                        is(Money.of("CAD", Values.Amount.factorize(1234.00))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(845.90))));
+                        is(Money.of("CAD", Values.Amount.factorize(1230.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of("CAD", Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2.75))));
+                        is(Money.of("CAD", Values.Amount.factorize(4.00))));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(2.11475))));
+                        is(Quote.of("CAD", Values.Quote.factorize(3.075))));
 
-        Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of("CAD", Values.Amount.factorize(1234.00))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 2nd buy sell transaction
         entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
@@ -1877,19 +1855,18 @@ public class IBFlexStatementExtractorTest
         assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5203.94))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(5814.00))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5202.15))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(5812.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.79))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(2.00))));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(26.01075))));
+                        is(Quote.of(CurrencyUnit.USD, Values.Quote.factorize(29.06))));
 
-        grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(5814.00))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
+
 
         // check 3rd buy sell transaction
         entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
@@ -1904,19 +1881,17 @@ public class IBFlexStatementExtractorTest
         assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4093.22))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(4545.50))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4091.42))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(4543.50))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.80))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(2.00))));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(116.8977143))));
+                        is(Quote.of(CurrencyUnit.USD, Values.Quote.factorize(129.8142857))));
 
-        grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(4545.50))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 4th buy sell transaction
         entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
@@ -1931,19 +1906,18 @@ public class IBFlexStatementExtractorTest
         assertNull(entry.getNote());
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1349.34))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(1504.50))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1347.55))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(1502.50))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.79))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(2.00))));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(26.951))));
+                        is(Quote.of(CurrencyUnit.USD, Values.Quote.factorize(30.05))));
 
-        grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(1504.50))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
+
 
         // check transaction
         // get transactions
@@ -1956,12 +1930,11 @@ public class IBFlexStatementExtractorTest
         AccountTransaction transaction = (AccountTransaction) item.getSubject();
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-01-31T20:20")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.81))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(1.99))));
         assertNull(transaction.getSource());
         assertThat(transaction.getNote(), is("XXXXXUSD"));
 
-        grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(1.99))));
+        assertThat(transaction.getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         item = iter.next();
 
@@ -1969,12 +1942,11 @@ public class IBFlexStatementExtractorTest
         transaction = (AccountTransaction) item.getSubject();
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAXES));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-01-31T20:20")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.49))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.54))));
         assertNull(transaction.getSource());
         assertThat(transaction.getNote(), is("XXXXXUSD"));
 
-        grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.54))));
+        assertThat(transaction.getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         item = iter.next();
 
@@ -1982,12 +1954,11 @@ public class IBFlexStatementExtractorTest
         transaction = (AccountTransaction) item.getSubject();
         assertThat(transaction.getType(), is(AccountTransaction.Type.TAXES));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-01-02T20:20")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3.55))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(3.97))));
         assertNull(transaction.getSource());
         assertThat(transaction.getNote(), is("XXXXXUSD"));
 
-        grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(3.97))));
+        assertThat(transaction.getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 1st dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(3)
@@ -2000,15 +1971,14 @@ public class IBFlexStatementExtractorTest
         assertNull(transaction.getSource());
         assertThat(transaction.getNote(), is("XXXXXCAD"));
 
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(26.95))));
-        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(31.71))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of("CAD", Values.Amount.factorize(39.10))));
+        assertThat(transaction.getGrossValue(), is(Money.of("CAD", Values.Amount.factorize(46.00))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.76))));
+                        is(Money.of("CAD", Values.Amount.factorize(6.90))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of("CAD", Values.Amount.factorize(0.00))));
 
-        grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of("CAD", Values.Amount.factorize(46.00))));
+        assertThat(transaction.getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 2nd dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(4)
@@ -2021,15 +1991,14 @@ public class IBFlexStatementExtractorTest
         assertNull(transaction.getSource());
         assertThat(transaction.getNote(), is("XXXXXCAD"));
 
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(23.24))));
-        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(29.44))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of("CAD", Values.Amount.factorize(33.75))));
+        assertThat(transaction.getGrossValue(), is(Money.of("CAD", Values.Amount.factorize(42.75))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(6.20))));
+                        is(Money.of("CAD", Values.Amount.factorize(9.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of("CAD", Values.Amount.factorize(0.00))));
 
-        grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of("CAD", Values.Amount.factorize(42.75))));
+        assertThat(transaction.getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 3rd dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(5)
@@ -2042,15 +2011,14 @@ public class IBFlexStatementExtractorTest
         assertNull(transaction.getSource());
         assertThat(transaction.getNote(), is("XXXXXUSD"));
 
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(43.51))));
-        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(51.19))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(48.61))));
+        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(57.19))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(7.68))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(8.58))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
 
-        grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(57.19))));
+        assertThat(transaction.getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 4th dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(6)
@@ -2063,15 +2031,14 @@ public class IBFlexStatementExtractorTest
         assertNull(transaction.getSource());
         assertNull(transaction.getNote());
 
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(23.72))));
-        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(23.72))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(26.50))));
+        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(26.50))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
 
-        grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(26.50))));
+        assertThat(transaction.getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check transaction
         // get transactions
@@ -2113,7 +2080,7 @@ public class IBFlexStatementExtractorTest
         transaction = (AccountTransaction) item.getSubject();
         assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
         assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-01-06T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(8.92))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(9.99))));
         assertNull(transaction.getSource());
         assertThat(transaction.getNote(), is("USD DEBIT INT FOR DEC-2019"));
     }
@@ -2976,6 +2943,7 @@ public class IBFlexStatementExtractorTest
         assertThat(buySellTransactions.size(), is(1));
         assertThat(accountTransactions.size(), is(2));
         assertThat(results.size(), is(5));
+        new AssertImportActions().check(results, CurrencyUnit.USD, "CAD");
 
         // check security
         Security security1 = results.stream().filter(SecurityItem.class::isInstance).findFirst()
@@ -3009,19 +2977,17 @@ public class IBFlexStatementExtractorTest
         assertThat(entry.getNote(), is("Trade-ID: 486028469 | Transaction-ID: 1619968617"));
 
         assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2754.96))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(2995.20))));
         assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2753.12))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(2993.20))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1.84))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(2.00))));
         assertThat(entry.getPortfolioTransaction().getGrossPricePerShare(),
-                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(17.53579618))));
+                        is(Quote.of(CurrencyUnit.USD, Values.Quote.factorize(19.06496815))));
 
-        Unit grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(2995.20))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 1st tax refund transaction
         AccountTransaction transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance)
@@ -3034,15 +3000,14 @@ public class IBFlexStatementExtractorTest
         assertNull(transaction.getSource());
         assertThat(entry.getNote(), is("Trade-ID: 486028469 | Transaction-ID: 1619968617"));
 
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(21.02))));
-        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(21.02))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of("CAD", Values.Amount.factorize(28.50))));
+        assertThat(transaction.getGrossValue(), is(Money.of("CAD", Values.Amount.factorize(28.50))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of("CAD", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of("CAD", Values.Amount.factorize(0.00))));
 
-        grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of("CAD", Values.Amount.factorize(28.50))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 1st tax refund transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(1)
@@ -3055,15 +3020,15 @@ public class IBFlexStatementExtractorTest
         assertNull(transaction.getSource());
         assertThat(entry.getNote(), is("Trade-ID: 486028469 | Transaction-ID: 1619968617"));
 
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(21.02))));
-        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(21.02))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of("CAD", Values.Amount.factorize(28.50))));
+        assertThat(transaction.getGrossValue(), is(Money.of("CAD", Values.Amount.factorize(28.50))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of("CAD", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of("CAD", Values.Amount.factorize(0.00))));
 
-        grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of("CAD", Values.Amount.factorize(28.50))));
+        assertThat(entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
+
     }
 
     @Test
@@ -3252,15 +3217,14 @@ public class IBFlexStatementExtractorTest
         assertThat(transaction.getShares(), is(Values.Share.factorize(0)));
         assertNull(transaction.getSource());
 
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(8.28))));
-        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(8.28))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(8.97))));
+        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(8.97))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
 
-        Unit grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of("USD", Values.Amount.factorize(8.97))));
+        assertThat(transaction.getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 1st dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(1)
@@ -3273,15 +3237,14 @@ public class IBFlexStatementExtractorTest
         assertNull(transaction.getSource());
         assertThat(transaction.getNote(), is("Transaction-ID: 11136056417"));
 
-        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(55.03))));
-        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(55.03))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(61.13))));
+        assertThat(transaction.getGrossValue(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(61.13))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE),
-                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(0.00))));
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0.00))));
 
-        grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(61.13))));
+        assertThat(transaction.getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
 
         // check 1st buy sell transaction
         BuySellEntry entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
@@ -3338,5 +3301,94 @@ public class IBFlexStatementExtractorTest
                         hasNote("Transaction-ID: 34211209522 | FinAdvisor Fee: Percent of Equity, Posted Monthly"),
                         hasAmount("USD", 245.92), hasGrossValue("USD", 245.92), //
                         hasTaxes("USD", 0.00), hasFees("USD", 0.00))));
+    }
+
+    @Test
+    public void testIBFlexStatementFile25() throws IOException
+    {
+        var client = new Client();
+
+        var vwrl = new Security("Vanguard MSCI World", "EUR");
+        vwrl.setTickerSymbol("VWRL");
+        client.addSecurity(vwrl);
+
+        var euns = new Security("EUNS", "EUR");
+        euns.setTickerSymbol("EUNS");
+        client.addSecurity(vwrl);
+
+        var test = new Security("TEST", "GBP");
+        test.setTickerSymbol("TEST");
+        client.addSecurity(test);
+
+        var test2 = new Security("TEST2", "EUR");
+        test2.setTickerSymbol("TEST2");
+        client.addSecurity(test2);
+
+        var extractor = new IBFlexStatementExtractor(client);
+
+        var activityStatement = getClass().getResourceAsStream("testIBFlexStatementFile25.xml");
+        var tempFile = createTempFile(activityStatement);
+
+        var errors = new ArrayList<Exception>();
+
+        var results = extractor.extract(Collections.singletonList(tempFile), errors);
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(4L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(4L));
+        new AssertImportActions().check(results, CurrencyUnit.USD, CurrencyUnit.EUR, "GBP");
+
+        // Check first two cash transactions (dividends)
+        var iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
+
+        // EUNS dividend, no GROSS_VALUE.
+        var item1 = iter.next();
+        var transaction1 = (AccountTransaction) item1.getSubject();
+        assertThat(transaction1.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(transaction1.getDateTime(), is(LocalDateTime.parse("2025-01-29T00:00")));
+        // assertThat(transaction1.getDateTime(),
+        // is(LocalDateTime.parse("2025-01-29T20:20")));
+        assertThat(transaction1.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(13.51))));
+        assertThat(transaction1.getSecurity().getTickerSymbol(), is("EUNS"));
+
+        assertThat(transaction1.getUnit(Unit.Type.GROSS_VALUE).isPresent(), is(false));
+
+        // TEST dividend (EUR converted to GBP)
+        var item2 = iter.next();
+        var transaction2 = (AccountTransaction) item2.getSubject();
+        assertThat(transaction2.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(transaction2.getDateTime(), is(LocalDateTime.parse("2025-01-29T00:00")));
+        // assertThat(transaction1.getDateTime(),
+        // is(LocalDateTime.parse("2025-01-29T20:20")));
+        assertThat(transaction2.getMonetaryAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(13.51))));
+        assertThat(transaction2.getSecurity().getTickerSymbol(), is("TEST"));
+
+        var grossValue2 = transaction2.getUnit(Unit.Type.GROSS_VALUE).orElseThrow();
+        assertThat(grossValue2.getAmount(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(13.51))));
+        assertThat(grossValue2.getForex(), is(Money.of("GBP", Values.Amount.factorize(11.31))));
+
+        // VWRL dividend (USD converted to EUR via cross rate)
+        var item3 = iter.next();
+        var transaction3 = (AccountTransaction) item3.getSubject();
+        assertThat(transaction3.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(transaction3.getDateTime(), is(LocalDateTime.parse("2024-12-30T00:00")));
+        assertThat(transaction3.getMonetaryAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(4.46619))));
+        assertThat(transaction3.getSecurity().getTickerSymbol(), is("VWRL"));
+
+        var grossValue3 = transaction3.getUnit(Unit.Type.GROSS_VALUE).orElseThrow();
+        assertThat(grossValue3.getAmount(), is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(4.47))));
+        assertThat(grossValue3.getForex(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4.30))));
+
+        // TEST2 dividend (GBP converted to EUR)
+        var item4 = iter.next();
+        var transaction4 = (AccountTransaction) item4.getSubject();
+        assertThat(transaction4.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(transaction4.getDateTime(), is(LocalDateTime.parse("2024-12-30T00:00")));
+        assertThat(transaction4.getMonetaryAmount(), is(Money.of("GBP", Values.Amount.factorize(4.46619))));
+        assertThat(transaction4.getSecurity().getTickerSymbol(), is("TEST2"));
+
+        var grossValue4 = transaction4.getUnit(Unit.Type.GROSS_VALUE).orElseThrow();
+        assertThat(grossValue4.getAmount(), is(Money.of("GBP", Values.Amount.factorize(4.47))));
+        assertThat(grossValue4.getForex(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5.39))));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/testIBFlexStatementFile25.xml
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/testIBFlexStatementFile25.xml
@@ -1,0 +1,1232 @@
+<FlexQueryResponse queryName="PP" type="AF">
+    <FlexStatements count="1">
+        <FlexStatement accountId="U1234560" fromDate="20241010" toDate="20250911" period=""
+            whenGenerated="20250912;050533">
+            <AccountInformation accountId="U1234560" acctAlias="Account A" model=""
+                currency="GBP" name="John Doe" accountType="Individual"
+                customerType="Individual" accountCapabilities="Cash"
+                tradingPermissions="Stocks,Warrants,Forex" accountRepName="" accountRepPhone=""
+                dateOpened="20240626" dateFunded="20240726" dateClosed="" lastTradedDate="20241220"
+                street="REDACTED" street2="" city="REDACTED" state="GB"
+                country="United Kingdom" postalCode="REDACTED"
+                streetResidentialAddress="REDACTED" street2ResidentialAddress=""
+                cityResidentialAddress="REDACTED" stateResidentialAddress="GB"
+                countryResidentialAddress="United Kingdom" postalCodeResidentialAddress="REDACTED"
+                masterName="" ibEntity="IB-UK" primaryEmail="mail@example.org" />
+            <CashTransactions>
+                <CashTransaction accountId="U1234560" acctAlias="Account A" model=""
+                    currency="EUR" fxRateToBase="0.83697" assetCategory="STK" subCategory="ETF"
+                    symbol="EUNS"
+                    description="EUNS(IE00B4L5ZY03) CASH DIVIDEND EUR 1.351 PER SHARE (Mixed Income)"
+                    conid="78999745" securityID="IE00B4L5ZY03" securityIDType="ISIN" cusip=""
+                    isin="IE00B4L5ZY03" figi="BBG000Q0SCD9" listingExchange="IBIS2"
+                    underlyingConid="" underlyingSymbol="EUNS" underlyingSecurityID=""
+                    underlyingListingExchange="" issuer="" issuerCountryCode="IE" multiplier="1"
+                    strike="" expiry="" putCall="" principalAdjustFactor=""
+                    dateTime="20250129;202000" settleDate="20250129" availableForTradingDate=""
+                    amount="13.51" type="Dividends" tradeID="" code="" transactionID="REDACTED"
+                    reportDate="20250129" clientReference="" actionID="REDACTED"
+                    levelOfDetail="DETAIL" serialNumber="" deliveryType="" commodityType=""
+                    fineness="0.0" weight="0.0" />
+                <CashTransaction accountId="U1234560" acctAlias="Account A" model=""
+                    currency="EUR" fxRateToBase="0.83697" assetCategory="STK" subCategory="ETF"
+                    symbol="TEST"
+                    description="TEST(IE000000000) CASH DIVIDEND EUR 1.351 PER SHARE (Mixed Income)"
+                    conid="78999745" securityID="IE000000000" securityIDType="ISIN" cusip=""
+                    isin="IE000000000" figi="BBG000Q0SCD9" listingExchange="IBIS2"
+                    underlyingConid="" underlyingSymbol="TEST" underlyingSecurityID=""
+                    underlyingListingExchange="" issuer="" issuerCountryCode="IE" multiplier="1"
+                    strike="" expiry="" putCall="" principalAdjustFactor=""
+                    dateTime="20250129;202000" settleDate="20250129" availableForTradingDate=""
+                    amount="13.51" type="Dividends" tradeID="" code="" transactionID="REDACTED"
+                    reportDate="20250129" clientReference="" actionID="REDACTED"
+                    levelOfDetail="DETAIL" serialNumber="" deliveryType="" commodityType=""
+                    fineness="0.0" weight="0.0" />
+                <CashTransaction accountId="U1234560" acctAlias="Account A" model=""
+                    currency="USD" fxRateToBase="0.79672" assetCategory="STK" subCategory="ETF"
+                    symbol="VWRL"
+                    description="VWRL(IE00B3RBWM25) CASH DIVIDEND USD 0.446619 PER SHARE (Mixed Income)"
+                    conid="128831206" securityID="IE00B3RBWM25" securityIDType="ISIN" cusip=""
+                    isin="IE00B3RBWM25" figi="BBG004N6GFZ3" listingExchange="AEB" underlyingConid=""
+                    underlyingSymbol="VWRL" underlyingSecurityID="" underlyingListingExchange=""
+                    issuer="" issuerCountryCode="IE" multiplier="1" strike="" expiry="" putCall=""
+                    principalAdjustFactor="" dateTime="20241227;202000" settleDate="20241227"
+                    availableForTradingDate="" amount="4.46619" type="Dividends" tradeID="" code=""
+                    transactionID="REDACTED" reportDate="20241230" clientReference=""
+                    actionID="REDACTED" levelOfDetail="DETAIL" serialNumber="" deliveryType=""
+                    commodityType="" fineness="0.0" weight="0.0" />
+                <CashTransaction accountId="U1234560" acctAlias="Account A" model=""
+                    currency="GBP" assetCategory="STK" subCategory="ETF"
+                    symbol="TEST2"
+                    description="TEST2(IE0000000001) CASH DIVIDEND GBP 0.446619 PER SHARE (Mixed Income)"
+                    conid="128831206" securityID="IE0000000001" securityIDType="ISIN" cusip=""
+                    isin="IE0000000001" figi="BBG004N6GFZ3" listingExchange="AEB" underlyingConid=""
+                    underlyingSymbol="TEST2" underlyingSecurityID="" underlyingListingExchange=""
+                    issuer="" issuerCountryCode="IE" multiplier="1" strike="" expiry="" putCall=""
+                    principalAdjustFactor="" dateTime="20241227;202000" settleDate="20241227"
+                    availableForTradingDate="" amount="4.46619" type="Dividends" tradeID="" code=""
+                    transactionID="REDACTED" reportDate="20241230" clientReference=""
+                    actionID="REDACTED" levelOfDetail="DETAIL" serialNumber="" deliveryType=""
+                    commodityType="" fineness="0.0" weight="0.0" />
+            </CashTransactions>
+            <ConversionRates>
+                <ConversionRate reportDate="20241010" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83747" />
+                <ConversionRate reportDate="20241011" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83703" />
+                <ConversionRate reportDate="20241013" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83666" />
+                <ConversionRate reportDate="20241014" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83532" />
+                <ConversionRate reportDate="20241015" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83306" />
+                <ConversionRate reportDate="20241016" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8362" />
+                <ConversionRate reportDate="20241017" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83243" />
+                <ConversionRate reportDate="20241018" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83268" />
+                <ConversionRate reportDate="20241020" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83268" />
+                <ConversionRate reportDate="20241021" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83288" />
+                <ConversionRate reportDate="20241022" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83164" />
+                <ConversionRate reportDate="20241023" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83448" />
+                <ConversionRate reportDate="20241024" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83441" />
+                <ConversionRate reportDate="20241025" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83287" />
+                <ConversionRate reportDate="20241027" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83258" />
+                <ConversionRate reportDate="20241028" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83354" />
+                <ConversionRate reportDate="20241029" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83114" />
+                <ConversionRate reportDate="20241030" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83749" />
+                <ConversionRate reportDate="20241031" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84375" />
+                <ConversionRate reportDate="20241101" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83833" />
+                <ConversionRate reportDate="20241103" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83877" />
+                <ConversionRate reportDate="20241104" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83948" />
+                <ConversionRate reportDate="20241105" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83811" />
+                <ConversionRate reportDate="20241106" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83302" />
+                <ConversionRate reportDate="20241107" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83182" />
+                <ConversionRate reportDate="20241108" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82954" />
+                <ConversionRate reportDate="20241110" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82967" />
+                <ConversionRate reportDate="20241111" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82804" />
+                <ConversionRate reportDate="20241112" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83335" />
+                <ConversionRate reportDate="20241113" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83131" />
+                <ConversionRate reportDate="20241114" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83134" />
+                <ConversionRate reportDate="20241115" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83519" />
+                <ConversionRate reportDate="20241117" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8353" />
+                <ConversionRate reportDate="20241118" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83598" />
+                <ConversionRate reportDate="20241119" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83553" />
+                <ConversionRate reportDate="20241120" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8333" />
+                <ConversionRate reportDate="20241121" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83199" />
+                <ConversionRate reportDate="20241122" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83154" />
+                <ConversionRate reportDate="20241124" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82709" />
+                <ConversionRate reportDate="20241125" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8351" />
+                <ConversionRate reportDate="20241126" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83451" />
+                <ConversionRate reportDate="20241127" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83333" />
+                <ConversionRate reportDate="20241128" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83192" />
+                <ConversionRate reportDate="20241129" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83051" />
+                <ConversionRate reportDate="20241201" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82982" />
+                <ConversionRate reportDate="20241202" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82954" />
+                <ConversionRate reportDate="20241203" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82928" />
+                <ConversionRate reportDate="20241204" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82757" />
+                <ConversionRate reportDate="20241205" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82971" />
+                <ConversionRate reportDate="20241206" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82933" />
+                <ConversionRate reportDate="20241208" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82931" />
+                <ConversionRate reportDate="20241209" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82765" />
+                <ConversionRate reportDate="20241210" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82432" />
+                <ConversionRate reportDate="20241211" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82319" />
+                <ConversionRate reportDate="20241212" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82587" />
+                <ConversionRate reportDate="20241213" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8323" />
+                <ConversionRate reportDate="20241215" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83127" />
+                <ConversionRate reportDate="20241216" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82877" />
+                <ConversionRate reportDate="20241217" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82536" />
+                <ConversionRate reportDate="20241218" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82336" />
+                <ConversionRate reportDate="20241219" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8289" />
+                <ConversionRate reportDate="20241220" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8298" />
+                <ConversionRate reportDate="20241222" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83001" />
+                <ConversionRate reportDate="20241223" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83008" />
+                <ConversionRate reportDate="20241224" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8292" />
+                <ConversionRate reportDate="20241225" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82876" />
+                <ConversionRate reportDate="20241226" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83207" />
+                <ConversionRate reportDate="20241227" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82877" />
+                <ConversionRate reportDate="20241229" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82932" />
+                <ConversionRate reportDate="20241230" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82909" />
+                <ConversionRate reportDate="20241231" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82739" />
+                <ConversionRate reportDate="20250101" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82735" />
+                <ConversionRate reportDate="20250102" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82928" />
+                <ConversionRate reportDate="20250103" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82983" />
+                <ConversionRate reportDate="20250105" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82945" />
+                <ConversionRate reportDate="20250106" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82986" />
+                <ConversionRate reportDate="20250107" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82869" />
+                <ConversionRate reportDate="20250108" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83463" />
+                <ConversionRate reportDate="20250109" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83689" />
+                <ConversionRate reportDate="20250110" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83926" />
+                <ConversionRate reportDate="20250112" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83918" />
+                <ConversionRate reportDate="20250113" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83907" />
+                <ConversionRate reportDate="20250114" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84384" />
+                <ConversionRate reportDate="20250115" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84051" />
+                <ConversionRate reportDate="20250116" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84166" />
+                <ConversionRate reportDate="20250117" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84425" />
+                <ConversionRate reportDate="20250119" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84421" />
+                <ConversionRate reportDate="20250120" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84508" />
+                <ConversionRate reportDate="20250121" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84408" />
+                <ConversionRate reportDate="20250122" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84528" />
+                <ConversionRate reportDate="20250123" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84321" />
+                <ConversionRate reportDate="20250124" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84073" />
+                <ConversionRate reportDate="20250126" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8402" />
+                <ConversionRate reportDate="20250127" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83938" />
+                <ConversionRate reportDate="20250128" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83832" />
+                <ConversionRate reportDate="20250129" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83697" />
+                <ConversionRate reportDate="20250130" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83688" />
+                <ConversionRate reportDate="20250131" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8361" />
+                <ConversionRate reportDate="20250202" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83502" />
+                <ConversionRate reportDate="20250203" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83079" />
+                <ConversionRate reportDate="20250204" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83152" />
+                <ConversionRate reportDate="20250205" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83191" />
+                <ConversionRate reportDate="20250206" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83503" />
+                <ConversionRate reportDate="20250207" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83243" />
+                <ConversionRate reportDate="20250209" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83013" />
+                <ConversionRate reportDate="20250210" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83346" />
+                <ConversionRate reportDate="20250211" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83249" />
+                <ConversionRate reportDate="20250212" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83439" />
+                <ConversionRate reportDate="20250213" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83278" />
+                <ConversionRate reportDate="20250214" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83358" />
+                <ConversionRate reportDate="20250216" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83306" />
+                <ConversionRate reportDate="20250217" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8304" />
+                <ConversionRate reportDate="20250218" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82811" />
+                <ConversionRate reportDate="20250219" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82809" />
+                <ConversionRate reportDate="20250220" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82886" />
+                <ConversionRate reportDate="20250221" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82795" />
+                <ConversionRate reportDate="20250223" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82752" />
+                <ConversionRate reportDate="20250224" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82913" />
+                <ConversionRate reportDate="20250225" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83013" />
+                <ConversionRate reportDate="20250226" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82716" />
+                <ConversionRate reportDate="20250227" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82523" />
+                <ConversionRate reportDate="20250228" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82497" />
+                <ConversionRate reportDate="20250302" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82668" />
+                <ConversionRate reportDate="20250303" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.82574" />
+                <ConversionRate reportDate="20250304" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8305" />
+                <ConversionRate reportDate="20250305" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83662" />
+                <ConversionRate reportDate="20250306" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8372" />
+                <ConversionRate reportDate="20250307" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83844" />
+                <ConversionRate reportDate="20250309" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83941" />
+                <ConversionRate reportDate="20250310" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84135" />
+                <ConversionRate reportDate="20250311" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84316" />
+                <ConversionRate reportDate="20250312" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83985" />
+                <ConversionRate reportDate="20250313" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83792" />
+                <ConversionRate reportDate="20250314" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84107" />
+                <ConversionRate reportDate="20250316" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84118" />
+                <ConversionRate reportDate="20250317" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84075" />
+                <ConversionRate reportDate="20250318" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84175" />
+                <ConversionRate reportDate="20250319" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8384" />
+                <ConversionRate reportDate="20250320" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.837" />
+                <ConversionRate reportDate="20250321" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83729" />
+                <ConversionRate reportDate="20250323" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83837" />
+                <ConversionRate reportDate="20250324" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83578" />
+                <ConversionRate reportDate="20250325" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8337" />
+                <ConversionRate reportDate="20250326" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83435" />
+                <ConversionRate reportDate="20250327" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8342" />
+                <ConversionRate reportDate="20250328" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83699" />
+                <ConversionRate reportDate="20250330" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83668" />
+                <ConversionRate reportDate="20250331" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83725" />
+                <ConversionRate reportDate="20250401" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83511" />
+                <ConversionRate reportDate="20250402" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83464" />
+                <ConversionRate reportDate="20250403" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84359" />
+                <ConversionRate reportDate="20250404" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85021" />
+                <ConversionRate reportDate="20250406" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85437" />
+                <ConversionRate reportDate="20250407" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85713" />
+                <ConversionRate reportDate="20250408" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85842" />
+                <ConversionRate reportDate="20250409" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85399" />
+                <ConversionRate reportDate="20250410" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86354" />
+                <ConversionRate reportDate="20250411" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86829" />
+                <ConversionRate reportDate="20250413" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86505" />
+                <ConversionRate reportDate="20250414" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86051" />
+                <ConversionRate reportDate="20250415" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85263" />
+                <ConversionRate reportDate="20250416" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86092" />
+                <ConversionRate reportDate="20250417" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85659" />
+                <ConversionRate reportDate="20250418" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85682" />
+                <ConversionRate reportDate="20250420" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85845" />
+                <ConversionRate reportDate="20250421" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86046" />
+                <ConversionRate reportDate="20250422" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85672" />
+                <ConversionRate reportDate="20250423" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85368" />
+                <ConversionRate reportDate="20250424" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85382" />
+                <ConversionRate reportDate="20250425" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85367" />
+                <ConversionRate reportDate="20250427" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85421" />
+                <ConversionRate reportDate="20250428" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84964" />
+                <ConversionRate reportDate="20250429" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84908" />
+                <ConversionRate reportDate="20250430" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84981" />
+                <ConversionRate reportDate="20250501" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85033" />
+                <ConversionRate reportDate="20250502" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85148" />
+                <ConversionRate reportDate="20250504" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85237" />
+                <ConversionRate reportDate="20250505" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85096" />
+                <ConversionRate reportDate="20250506" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85048" />
+                <ConversionRate reportDate="20250507" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85035" />
+                <ConversionRate reportDate="20250508" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84768" />
+                <ConversionRate reportDate="20250509" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84545" />
+                <ConversionRate reportDate="20250511" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84382" />
+                <ConversionRate reportDate="20250512" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84146" />
+                <ConversionRate reportDate="20250513" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8406" />
+                <ConversionRate reportDate="20250514" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8426" />
+                <ConversionRate reportDate="20250515" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84076" />
+                <ConversionRate reportDate="20250516" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84071" />
+                <ConversionRate reportDate="20250518" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84218" />
+                <ConversionRate reportDate="20250519" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84148" />
+                <ConversionRate reportDate="20250520" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84253" />
+                <ConversionRate reportDate="20250521" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84433" />
+                <ConversionRate reportDate="20250522" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84066" />
+                <ConversionRate reportDate="20250523" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83943" />
+                <ConversionRate reportDate="20250525" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84026" />
+                <ConversionRate reportDate="20250526" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83958" />
+                <ConversionRate reportDate="20250527" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83872" />
+                <ConversionRate reportDate="20250528" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.83835" />
+                <ConversionRate reportDate="20250529" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84258" />
+                <ConversionRate reportDate="20250530" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84341" />
+                <ConversionRate reportDate="20250601" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84326" />
+                <ConversionRate reportDate="20250602" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84483" />
+                <ConversionRate reportDate="20250603" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84117" />
+                <ConversionRate reportDate="20250604" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84244" />
+                <ConversionRate reportDate="20250605" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84331" />
+                <ConversionRate reportDate="20250606" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84254" />
+                <ConversionRate reportDate="20250608" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84269" />
+                <ConversionRate reportDate="20250609" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84276" />
+                <ConversionRate reportDate="20250610" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84642" />
+                <ConversionRate reportDate="20250611" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.84803" />
+                <ConversionRate reportDate="20250612" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85102" />
+                <ConversionRate reportDate="20250613" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85112" />
+                <ConversionRate reportDate="20250615" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85006" />
+                <ConversionRate reportDate="20250616" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85159" />
+                <ConversionRate reportDate="20250617" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85491" />
+                <ConversionRate reportDate="20250618" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85552" />
+                <ConversionRate reportDate="20250619" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85366" />
+                <ConversionRate reportDate="20250620" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85667" />
+                <ConversionRate reportDate="20250622" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85472" />
+                <ConversionRate reportDate="20250623" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85609" />
+                <ConversionRate reportDate="20250624" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85269" />
+                <ConversionRate reportDate="20250625" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85332" />
+                <ConversionRate reportDate="20250626" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85239" />
+                <ConversionRate reportDate="20250627" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85426" />
+                <ConversionRate reportDate="20250629" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85515" />
+                <ConversionRate reportDate="20250630" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85831" />
+                <ConversionRate reportDate="20250701" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.85887" />
+                <ConversionRate reportDate="20250702" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86536" />
+                <ConversionRate reportDate="20250703" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86103" />
+                <ConversionRate reportDate="20250704" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86258" />
+                <ConversionRate reportDate="20250706" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86389" />
+                <ConversionRate reportDate="20250707" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86086" />
+                <ConversionRate reportDate="20250708" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86259" />
+                <ConversionRate reportDate="20250709" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86279" />
+                <ConversionRate reportDate="20250710" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86164" />
+                <ConversionRate reportDate="20250711" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86632" />
+                <ConversionRate reportDate="20250713" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86502" />
+                <ConversionRate reportDate="20250714" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86879" />
+                <ConversionRate reportDate="20250715" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86688" />
+                <ConversionRate reportDate="20250716" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86735" />
+                <ConversionRate reportDate="20250717" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86437" />
+                <ConversionRate reportDate="20250718" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86707" />
+                <ConversionRate reportDate="20250720" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86638" />
+                <ConversionRate reportDate="20250721" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86681" />
+                <ConversionRate reportDate="20250722" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86855" />
+                <ConversionRate reportDate="20250723" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86678" />
+                <ConversionRate reportDate="20250724" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86967" />
+                <ConversionRate reportDate="20250725" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.87376" />
+                <ConversionRate reportDate="20250727" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.87556" />
+                <ConversionRate reportDate="20250728" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86774" />
+                <ConversionRate reportDate="20250729" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86475" />
+                <ConversionRate reportDate="20250730" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86156" />
+                <ConversionRate reportDate="20250731" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86439" />
+                <ConversionRate reportDate="20250801" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.87264" />
+                <ConversionRate reportDate="20250803" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.873" />
+                <ConversionRate reportDate="20250804" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.87113" />
+                <ConversionRate reportDate="20250805" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.87036" />
+                <ConversionRate reportDate="20250806" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.87295" />
+                <ConversionRate reportDate="20250807" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86765" />
+                <ConversionRate reportDate="20250808" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86547" />
+                <ConversionRate reportDate="20250810" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86613" />
+                <ConversionRate reportDate="20250811" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86477" />
+                <ConversionRate reportDate="20250812" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86474" />
+                <ConversionRate reportDate="20250813" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86218" />
+                <ConversionRate reportDate="20250814" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86089" />
+                <ConversionRate reportDate="20250815" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86357" />
+                <ConversionRate reportDate="20250817" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86416" />
+                <ConversionRate reportDate="20250818" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86352" />
+                <ConversionRate reportDate="20250819" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86322" />
+                <ConversionRate reportDate="20250820" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86582" />
+                <ConversionRate reportDate="20250821" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86526" />
+                <ConversionRate reportDate="20250822" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86644" />
+                <ConversionRate reportDate="20250824" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86717" />
+                <ConversionRate reportDate="20250825" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86361" />
+                <ConversionRate reportDate="20250826" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86369" />
+                <ConversionRate reportDate="20250827" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86219" />
+                <ConversionRate reportDate="20250828" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86454" />
+                <ConversionRate reportDate="20250829" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86535" />
+                <ConversionRate reportDate="20250831" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86656" />
+                <ConversionRate reportDate="20250901" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86464" />
+                <ConversionRate reportDate="20250902" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86913" />
+                <ConversionRate reportDate="20250903" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86731" />
+                <ConversionRate reportDate="20250904" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86712" />
+                <ConversionRate reportDate="20250905" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86745" />
+                <ConversionRate reportDate="20250907" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86747" />
+                <ConversionRate reportDate="20250908" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86847" />
+                <ConversionRate reportDate="20250909" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86562" />
+                <ConversionRate reportDate="20250910" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.8643" />
+                <ConversionRate reportDate="20250911" fromCurrency="EUR" toCurrency="GBP"
+                    rate="0.86452" />
+                <ConversionRate reportDate="20241010" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7657" />
+                <ConversionRate reportDate="20241011" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.76534" />
+                <ConversionRate reportDate="20241013" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.76526" />
+                <ConversionRate reportDate="20241014" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7657" />
+                <ConversionRate reportDate="20241015" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.76487" />
+                <ConversionRate reportDate="20241016" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.76981" />
+                <ConversionRate reportDate="20241017" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.76854" />
+                <ConversionRate reportDate="20241018" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.76623" />
+                <ConversionRate reportDate="20241020" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.76655" />
+                <ConversionRate reportDate="20241021" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77013" />
+                <ConversionRate reportDate="20241022" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77013" />
+                <ConversionRate reportDate="20241023" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77392" />
+                <ConversionRate reportDate="20241024" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77063" />
+                <ConversionRate reportDate="20241025" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77148" />
+                <ConversionRate reportDate="20241027" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7708" />
+                <ConversionRate reportDate="20241028" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77091" />
+                <ConversionRate reportDate="20241029" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.76826" />
+                <ConversionRate reportDate="20241030" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77146" />
+                <ConversionRate reportDate="20241031" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77526" />
+                <ConversionRate reportDate="20241101" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7738" />
+                <ConversionRate reportDate="20241103" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77089" />
+                <ConversionRate reportDate="20241104" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77175" />
+                <ConversionRate reportDate="20241105" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7668" />
+                <ConversionRate reportDate="20241106" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77644" />
+                <ConversionRate reportDate="20241107" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.76999" />
+                <ConversionRate reportDate="20241108" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7739" />
+                <ConversionRate reportDate="20241110" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77459" />
+                <ConversionRate reportDate="20241111" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77709" />
+                <ConversionRate reportDate="20241112" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78444" />
+                <ConversionRate reportDate="20241113" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78694" />
+                <ConversionRate reportDate="20241114" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78947" />
+                <ConversionRate reportDate="20241115" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79239" />
+                <ConversionRate reportDate="20241117" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79239" />
+                <ConversionRate reportDate="20241118" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78874" />
+                <ConversionRate reportDate="20241119" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78852" />
+                <ConversionRate reportDate="20241120" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79034" />
+                <ConversionRate reportDate="20241121" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7943" />
+                <ConversionRate reportDate="20241122" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79797" />
+                <ConversionRate reportDate="20241124" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7939" />
+                <ConversionRate reportDate="20241125" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79563" />
+                <ConversionRate reportDate="20241126" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7956" />
+                <ConversionRate reportDate="20241127" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78864" />
+                <ConversionRate reportDate="20241128" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78817" />
+                <ConversionRate reportDate="20241129" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78514" />
+                <ConversionRate reportDate="20241201" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78515" />
+                <ConversionRate reportDate="20241202" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79018" />
+                <ConversionRate reportDate="20241203" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78908" />
+                <ConversionRate reportDate="20241204" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78736" />
+                <ConversionRate reportDate="20241205" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78366" />
+                <ConversionRate reportDate="20241206" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78475" />
+                <ConversionRate reportDate="20241208" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78525" />
+                <ConversionRate reportDate="20241209" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78426" />
+                <ConversionRate reportDate="20241210" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78302" />
+                <ConversionRate reportDate="20241211" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78426" />
+                <ConversionRate reportDate="20241212" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78903" />
+                <ConversionRate reportDate="20241213" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79242" />
+                <ConversionRate reportDate="20241215" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79269" />
+                <ConversionRate reportDate="20241216" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78842" />
+                <ConversionRate reportDate="20241217" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7867" />
+                <ConversionRate reportDate="20241218" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79533" />
+                <ConversionRate reportDate="20241219" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79987" />
+                <ConversionRate reportDate="20241220" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79562" />
+                <ConversionRate reportDate="20241222" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79564" />
+                <ConversionRate reportDate="20241223" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79765" />
+                <ConversionRate reportDate="20241224" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79704" />
+                <ConversionRate reportDate="20241225" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79646" />
+                <ConversionRate reportDate="20241226" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79831" />
+                <ConversionRate reportDate="20241227" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79502" />
+                <ConversionRate reportDate="20241229" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79532" />
+                <ConversionRate reportDate="20241230" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79672" />
+                <ConversionRate reportDate="20241231" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79914" />
+                <ConversionRate reportDate="20250101" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79887" />
+                <ConversionRate reportDate="20250102" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80771" />
+                <ConversionRate reportDate="20250103" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80499" />
+                <ConversionRate reportDate="20250105" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80506" />
+                <ConversionRate reportDate="20250106" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7987" />
+                <ConversionRate reportDate="20250107" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80144" />
+                <ConversionRate reportDate="20250108" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80886" />
+                <ConversionRate reportDate="20250109" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.81254" />
+                <ConversionRate reportDate="20250110" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.81915" />
+                <ConversionRate reportDate="20250112" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.81967" />
+                <ConversionRate reportDate="20250113" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.82135" />
+                <ConversionRate reportDate="20250114" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.81859" />
+                <ConversionRate reportDate="20250115" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.81678" />
+                <ConversionRate reportDate="20250116" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.81707" />
+                <ConversionRate reportDate="20250117" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.8219" />
+                <ConversionRate reportDate="20250119" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.8219" />
+                <ConversionRate reportDate="20250120" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.81126" />
+                <ConversionRate reportDate="20250121" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80932" />
+                <ConversionRate reportDate="20250122" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.81198" />
+                <ConversionRate reportDate="20250123" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80957" />
+                <ConversionRate reportDate="20250124" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80116" />
+                <ConversionRate reportDate="20250126" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80189" />
+                <ConversionRate reportDate="20250127" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80003" />
+                <ConversionRate reportDate="20250128" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.8037" />
+                <ConversionRate reportDate="20250129" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80318" />
+                <ConversionRate reportDate="20250130" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80535" />
+                <ConversionRate reportDate="20250131" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80687" />
+                <ConversionRate reportDate="20250202" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.8137" />
+                <ConversionRate reportDate="20250203" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80321" />
+                <ConversionRate reportDate="20250204" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80117" />
+                <ConversionRate reportDate="20250205" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7997" />
+                <ConversionRate reportDate="20250206" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80423" />
+                <ConversionRate reportDate="20250207" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80607" />
+                <ConversionRate reportDate="20250209" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80661" />
+                <ConversionRate reportDate="20250210" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80861" />
+                <ConversionRate reportDate="20250211" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80344" />
+                <ConversionRate reportDate="20250212" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.80362" />
+                <ConversionRate reportDate="20250213" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79577" />
+                <ConversionRate reportDate="20250214" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79447" />
+                <ConversionRate reportDate="20250216" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79438" />
+                <ConversionRate reportDate="20250217" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79206" />
+                <ConversionRate reportDate="20250218" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79277" />
+                <ConversionRate reportDate="20250219" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79452" />
+                <ConversionRate reportDate="20250220" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78928" />
+                <ConversionRate reportDate="20250221" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79153" />
+                <ConversionRate reportDate="20250223" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78967" />
+                <ConversionRate reportDate="20250224" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79205" />
+                <ConversionRate reportDate="20250225" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78949" />
+                <ConversionRate reportDate="20250226" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78892" />
+                <ConversionRate reportDate="20250227" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79361" />
+                <ConversionRate reportDate="20250228" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.79507" />
+                <ConversionRate reportDate="20250302" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7945" />
+                <ConversionRate reportDate="20250303" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78731" />
+                <ConversionRate reportDate="20250304" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78154" />
+                <ConversionRate reportDate="20250305" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77546" />
+                <ConversionRate reportDate="20250306" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77628" />
+                <ConversionRate reportDate="20250307" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77391" />
+                <ConversionRate reportDate="20250309" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77492" />
+                <ConversionRate reportDate="20250310" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77652" />
+                <ConversionRate reportDate="20250311" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77218" />
+                <ConversionRate reportDate="20250312" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7714" />
+                <ConversionRate reportDate="20250313" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77213" />
+                <ConversionRate reportDate="20250314" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77311" />
+                <ConversionRate reportDate="20250316" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77325" />
+                <ConversionRate reportDate="20250317" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.76975" />
+                <ConversionRate reportDate="20250318" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.76914" />
+                <ConversionRate reportDate="20250319" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.76899" />
+                <ConversionRate reportDate="20250320" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77118" />
+                <ConversionRate reportDate="20250321" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7742" />
+                <ConversionRate reportDate="20250323" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77523" />
+                <ConversionRate reportDate="20250324" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7738" />
+                <ConversionRate reportDate="20250325" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77253" />
+                <ConversionRate reportDate="20250326" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7759" />
+                <ConversionRate reportDate="20250327" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77228" />
+                <ConversionRate reportDate="20250328" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77287" />
+                <ConversionRate reportDate="20250330" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77319" />
+                <ConversionRate reportDate="20250331" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77414" />
+                <ConversionRate reportDate="20250401" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77383" />
+                <ConversionRate reportDate="20250402" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7688" />
+                <ConversionRate reportDate="20250403" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.76331" />
+                <ConversionRate reportDate="20250404" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77552" />
+                <ConversionRate reportDate="20250406" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77982" />
+                <ConversionRate reportDate="20250407" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78589" />
+                <ConversionRate reportDate="20250408" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.78337" />
+                <ConversionRate reportDate="20250409" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77993" />
+                <ConversionRate reportDate="20250410" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.77101" />
+                <ConversionRate reportDate="20250411" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.76431" />
+                <ConversionRate reportDate="20250413" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.76374" />
+                <ConversionRate reportDate="20250414" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75817" />
+                <ConversionRate reportDate="20250415" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75576" />
+                <ConversionRate reportDate="20250416" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75528" />
+                <ConversionRate reportDate="20250417" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75378" />
+                <ConversionRate reportDate="20250418" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75209" />
+                <ConversionRate reportDate="20250420" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75322" />
+                <ConversionRate reportDate="20250421" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74738" />
+                <ConversionRate reportDate="20250422" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75012" />
+                <ConversionRate reportDate="20250423" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75446" />
+                <ConversionRate reportDate="20250424" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74967" />
+                <ConversionRate reportDate="20250425" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75121" />
+                <ConversionRate reportDate="20250427" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75151" />
+                <ConversionRate reportDate="20250428" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74387" />
+                <ConversionRate reportDate="20250429" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7458" />
+                <ConversionRate reportDate="20250430" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75015" />
+                <ConversionRate reportDate="20250501" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75311" />
+                <ConversionRate reportDate="20250502" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75358" />
+                <ConversionRate reportDate="20250504" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75401" />
+                <ConversionRate reportDate="20250505" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75207" />
+                <ConversionRate reportDate="20250506" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.748" />
+                <ConversionRate reportDate="20250507" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75235" />
+                <ConversionRate reportDate="20250508" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75491" />
+                <ConversionRate reportDate="20250509" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75162" />
+                <ConversionRate reportDate="20250511" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75389" />
+                <ConversionRate reportDate="20250512" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75893" />
+                <ConversionRate reportDate="20250513" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75157" />
+                <ConversionRate reportDate="20250514" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75405" />
+                <ConversionRate reportDate="20250515" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75169" />
+                <ConversionRate reportDate="20250516" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7531" />
+                <ConversionRate reportDate="20250518" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75339" />
+                <ConversionRate reportDate="20250519" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74844" />
+                <ConversionRate reportDate="20250520" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74663" />
+                <ConversionRate reportDate="20250521" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74517" />
+                <ConversionRate reportDate="20250522" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7452" />
+                <ConversionRate reportDate="20250523" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73862" />
+                <ConversionRate reportDate="20250525" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7393" />
+                <ConversionRate reportDate="20250526" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73728" />
+                <ConversionRate reportDate="20250527" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74038" />
+                <ConversionRate reportDate="20250528" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7424" />
+                <ConversionRate reportDate="20250529" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74125" />
+                <ConversionRate reportDate="20250530" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74323" />
+                <ConversionRate reportDate="20250601" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74267" />
+                <ConversionRate reportDate="20250602" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73829" />
+                <ConversionRate reportDate="20250603" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73979" />
+                <ConversionRate reportDate="20250604" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73778" />
+                <ConversionRate reportDate="20250605" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73687" />
+                <ConversionRate reportDate="20250606" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73937" />
+                <ConversionRate reportDate="20250608" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73923" />
+                <ConversionRate reportDate="20250609" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73792" />
+                <ConversionRate reportDate="20250610" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74079" />
+                <ConversionRate reportDate="20250611" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73821" />
+                <ConversionRate reportDate="20250612" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73459" />
+                <ConversionRate reportDate="20250613" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7368" />
+                <ConversionRate reportDate="20250615" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73733" />
+                <ConversionRate reportDate="20250616" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73656" />
+                <ConversionRate reportDate="20250617" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74467" />
+                <ConversionRate reportDate="20250618" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7451" />
+                <ConversionRate reportDate="20250619" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74251" />
+                <ConversionRate reportDate="20250620" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74349" />
+                <ConversionRate reportDate="20250622" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74591" />
+                <ConversionRate reportDate="20250623" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73941" />
+                <ConversionRate reportDate="20250624" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73449" />
+                <ConversionRate reportDate="20250625" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73185" />
+                <ConversionRate reportDate="20250626" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.72848" />
+                <ConversionRate reportDate="20250627" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.72889" />
+                <ConversionRate reportDate="20250629" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.729" />
+                <ConversionRate reportDate="20250630" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.72814" />
+                <ConversionRate reportDate="20250701" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.72747" />
+                <ConversionRate reportDate="20250702" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73338" />
+                <ConversionRate reportDate="20250703" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73232" />
+                <ConversionRate reportDate="20250704" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73241" />
+                <ConversionRate reportDate="20250706" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73307" />
+                <ConversionRate reportDate="20250707" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73524" />
+                <ConversionRate reportDate="20250708" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73567" />
+                <ConversionRate reportDate="20250709" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73606" />
+                <ConversionRate reportDate="20250710" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7364" />
+                <ConversionRate reportDate="20250711" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74104" />
+                <ConversionRate reportDate="20250713" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74114" />
+                <ConversionRate reportDate="20250714" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7448" />
+                <ConversionRate reportDate="20250715" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74718" />
+                <ConversionRate reportDate="20250716" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74514" />
+                <ConversionRate reportDate="20250717" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74532" />
+                <ConversionRate reportDate="20250718" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7458" />
+                <ConversionRate reportDate="20250720" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74468" />
+                <ConversionRate reportDate="20250721" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7412" />
+                <ConversionRate reportDate="20250722" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73891" />
+                <ConversionRate reportDate="20250723" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73636" />
+                <ConversionRate reportDate="20250724" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74022" />
+                <ConversionRate reportDate="20250725" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74415" />
+                <ConversionRate reportDate="20250727" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74461" />
+                <ConversionRate reportDate="20250728" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74879" />
+                <ConversionRate reportDate="20250729" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74901" />
+                <ConversionRate reportDate="20250730" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75539" />
+                <ConversionRate reportDate="20250731" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75721" />
+                <ConversionRate reportDate="20250801" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75308" />
+                <ConversionRate reportDate="20250803" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75304" />
+                <ConversionRate reportDate="20250804" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75276" />
+                <ConversionRate reportDate="20250805" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.75193" />
+                <ConversionRate reportDate="20250806" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74867" />
+                <ConversionRate reportDate="20250807" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74376" />
+                <ConversionRate reportDate="20250808" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74341" />
+                <ConversionRate reportDate="20250810" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74372" />
+                <ConversionRate reportDate="20250811" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74449" />
+                <ConversionRate reportDate="20250812" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74074" />
+                <ConversionRate reportDate="20250813" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73657" />
+                <ConversionRate reportDate="20250814" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73911" />
+                <ConversionRate reportDate="20250815" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73788" />
+                <ConversionRate reportDate="20250817" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73776" />
+                <ConversionRate reportDate="20250818" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74053" />
+                <ConversionRate reportDate="20250819" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74119" />
+                <ConversionRate reportDate="20250820" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7432" />
+                <ConversionRate reportDate="20250821" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74553" />
+                <ConversionRate reportDate="20250822" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73925" />
+                <ConversionRate reportDate="20250824" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7397" />
+                <ConversionRate reportDate="20250825" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74325" />
+                <ConversionRate reportDate="20250826" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74193" />
+                <ConversionRate reportDate="20250827" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74081" />
+                <ConversionRate reportDate="20250828" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74002" />
+                <ConversionRate reportDate="20250829" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74049" />
+                <ConversionRate reportDate="20250831" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74089" />
+                <ConversionRate reportDate="20250901" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73829" />
+                <ConversionRate reportDate="20250902" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7466" />
+                <ConversionRate reportDate="20250903" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74376" />
+                <ConversionRate reportDate="20250904" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7443" />
+                <ConversionRate reportDate="20250905" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74022" />
+                <ConversionRate reportDate="20250907" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.74058" />
+                <ConversionRate reportDate="20250908" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73827" />
+                <ConversionRate reportDate="20250909" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73923" />
+                <ConversionRate reportDate="20250910" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.7391" />
+                <ConversionRate reportDate="20250911" fromCurrency="USD" toCurrency="GBP"
+                    rate="0.73673" />
+            </ConversionRates>
+        </FlexStatement>
+    </FlexStatements>
+</FlexQueryResponse>


### PR DESCRIPTION
IBFlex: Refactor extractDate to work on all transaction types

    Use a single method to extract a LocalDateTime from a transaction element.
    This improves the result of some imports by adding LocalTime when there
    previously wasn't one.

IBFlex: Improve handling of currency conversions

    The existing exchange rate calculations are spread all over the place and
    are not entirely consistent. For example, fxRateToBase can only safely be
    used if the accountCurrency is known.

    Improve this by using fxRateToBase correctly and by parsing ConversionRate
    elements contained in the IB XML. This allows doing cross currency
    conversions even if the accountCurrency is not known.

IBFlex: Remove most currency conversions

    The IBFlex importer currently has a set of historically grown heuristics 
    around currency conversions:

    1. DIVIDEND and TAX transactions are converted to account base currency
      in buildAccountTransaction() 2. BUY and SELL transactions are converted to
    account base currency
      in buildPortfolioTransaction()

    As far as I can tell, Interactive Brokers doesn't actually work the way that
    these heuristics assume.

    - There are no automatic currency conversions, the platform creates
     forex balances on the fly.
    - Performing a trade in a foreign currency requires a balance in
     that currency.
    - Dividends are distributed in the "base" currency of a security.
    - fxRateToBase attributes give the exchange rate to the base currency
     of the account.

    It is possible to get into a situation where the internal currency of a
    security doesn't match the listed currency. For example by buying a security
    denominated in USD on a German exchange and then transferring this to
    Interactive Brokers. The current heuristics make it impossible to import
    transactions in this case.

    Fix this by removing most currency conversions outright. Users will have to
    maintain additional deposit accounts in the correct currency and then
    manually track forex conversions.

    We still create GROSS_VALUE units with forex amounts for securities where
    the internal currency doesn't match the listed currency.

Closes https://github.com/portfolio-performance/portfolio/issues/4978
