### PR TITLE
The SonarLint plug-in is called SonarQube for IDE now.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ Optionally, install via the Eclipse Marketplace (drag and drop the *Install* but
 * [Infinitest](https://marketplace.eclipse.org/content/infinitest)
 * [ResourceBundle Editor](https://marketplace.eclipse.org/content/resourcebundle-editor)
 * [Checkstyle Plug-In](https://marketplace.eclipse.org/content/checkstyle-plug)
-* [SonarLint](https://marketplace.eclipse.org/content/sonarlint)
+* [SonarQube for IDE](https://marketplace.eclipse.org/content/sonarqube-ide)
 * [Launch Configuration DSL](https://marketplace.eclipse.org/content/launch-configuration-dsl)
 * [Darkest Dark Theme with DevStyle](https://marketplace.eclipse.org/content/darkest-dark-theme-devstyle) (Programming and chilling in DarkMode :sunglasses:)
 


### PR DESCRIPTION
The old URL forwards to the new one.