### PR TITLE
Feature: add taxonomy selection to Securities Accounts view

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -1078,6 +1078,11 @@ public class StatementOfAssetsViewer
         return assets;
     }
 
+    public boolean hasModel()
+    {
+        return model != null;
+    }
+
     public void showConfigMenu(Shell shell)
     {
         if (contextMenu == null)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/StatementOfAssetsPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/StatementOfAssetsPane.java
@@ -46,6 +46,8 @@ public class StatementOfAssetsPane implements InformationPanePage
 
     private StatementOfAssetsViewer viewer;
 
+    private DropDown configurationMenu;
+
     @Override
     public String getLabel()
     {
@@ -71,8 +73,11 @@ public class StatementOfAssetsPane implements InformationPanePage
                         a -> new TableViewerCSVExporter(viewer.getTableViewer()).export(getLabel(),
                                         genericAccount)));
 
-        toolBar.add(new DropDown(Messages.MenuShowHideColumns, Images.CONFIG, SWT.NONE,
-                        manager -> viewer.getColumnHelper().menuAboutToShow(manager)));
+        configurationMenu = new DropDown(Messages.MenuShowHideColumns, Images.CONFIG, SWT.NONE,
+                        manager -> viewer.menuAboutToShow(manager));
+        configurationMenu.setEnabled(false); // disabled until the viewer has data to build the menu safely
+        toolBar.add(configurationMenu);
+        updateConfigurationMenuState();
     }
 
     @Override
@@ -129,6 +134,14 @@ public class StatementOfAssetsPane implements InformationPanePage
             }
 
         }
+
+        updateConfigurationMenuState();
+    }
+
+    private void updateConfigurationMenuState()
+    {
+        if (configurationMenu != null)
+            configurationMenu.setEnabled(genericAccount != null && viewer != null && viewer.hasModel());
     }
 
     @Override


### PR DESCRIPTION
@buchen here is a PR for the change mentioned here https://github.com/portfolio-performance/portfolio/pull/5106#issuecomment-3475940289, adding taxonomy selection to the Securities Accounts dropdown, in line with Statement of Assets.