### PR TITLE
Fix CSV import rounding errors with exchange rates (#5069)

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/actions/CheckForexGrossValueAction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/actions/CheckForexGrossValueAction.java
@@ -70,7 +70,10 @@ public class CheckForexGrossValueAction implements ImportAction
         Money unitValue = grossValueUnit.get().getAmount();
         Money calculatedValue = transaction.getGrossValue();
 
-        if (!unitValue.equals(calculatedValue))
+        // Allow tolerance of ±2 (0.02 in currency) to account for rounding errors
+        // when Money values are limited to 2 decimal places. This addresses issue #5069.
+        long difference = Math.abs(unitValue.getAmount() - calculatedValue.getAmount());
+        if (difference > 2)
             return new Status(Status.Code.ERROR,
                             MessageFormat.format(Messages.MsgCheckConfiguredAndCalculatedGrossValueDoNotMatch,
                                             Values.Money.format(unitValue), Values.Money.format(calculatedValue)));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/BaseCSVExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/BaseCSVExtractor.java
@@ -205,7 +205,8 @@ import name.abuchen.portfolio.money.Money;
 
         Money forex = Money.of(currencyCode, Math.abs(grossAmount.longValue()));
         BigDecimal grossAmountConverted = exchangeRate.multiply(BigDecimal.valueOf(grossAmount));
-        Money converted = Money.of(amount.getCurrencyCode(), Math.round(grossAmountConverted.doubleValue()));
+        Money converted = Money.of(amount.getCurrencyCode(),
+                        grossAmountConverted.setScale(0, RoundingMode.HALF_UP).longValue());
 
         return Optional.of(new Unit(Unit.Type.GROSS_VALUE, converted, forex, exchangeRate));
     }
@@ -220,8 +221,9 @@ import name.abuchen.portfolio.money.Money;
         if (exchangeRate != null && exchangeRate.compareTo(BigDecimal.ZERO) != 0)
         {
             var grossValue = transaction.getGrossValue();
-            var forex = Money.of(transaction.getSecurity().getCurrencyCode(), Math
-                            .round(exchangeRate.multiply(BigDecimal.valueOf(grossValue.getAmount())).doubleValue()));
+            var forex = Money.of(transaction.getSecurity().getCurrencyCode(),
+                            exchangeRate.multiply(BigDecimal.valueOf(grossValue.getAmount()))
+                                    .setScale(0, RoundingMode.HALF_UP).longValue());
             exchangeRate = BigDecimal.ONE.divide(exchangeRate, 10, RoundingMode.HALF_DOWN);
             transaction.addUnit(new Unit(Unit.Type.GROSS_VALUE, grossValue, forex, exchangeRate));
         }


### PR DESCRIPTION
This commit addresses issue #5069 where CSV imports fail validation due to rounding errors when dealing with foreign exchange rates.

Changes made:

1. BaseCSVExtractor.java:
   - Replaced Math.round(BigDecimal.doubleValue()) with BigDecimal.setScale(0, RoundingMode.HALF_UP).longValue()
   - This avoids precision loss from converting BigDecimal to double
   - Applies to both extractGrossAmount() and createGrossValueIfNecessary()

2. CheckForexGrossValueAction.java:
   - Added tolerance of ±2 (±0.02 in currency) to validation
   - This accounts for unavoidable rounding when Money values are limited to 2 decimal places
   - Prevents false positives while still catching actual errors

Root cause: Money stores amounts as longs with 2 decimal precision (factor of 100). When gross amounts are calculated with exchange rates, rounding to 2 decimals can cause small discrepancies that fail strict equality checks.

Example from issue:
- Value: 95.26 CAD, FX Rate: 1.3795
- Calculated: 95.26 / 1.3795 = 69.0540... → rounded to 69.05
- Recalculated: 69.05 × 1.3795 = 95.254... → 95.25 ≠ 95.26

The fix improves calculation precision and adds reasonable tolerance.