### PR TITLE
Fixed spelling of "separator" in Danish translation.

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_da.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_da.properties
@@ -65,7 +65,7 @@ BookmarksListView_LabelReplaceFirstAvailable = Brug den f\u00F8rste tilg\u00E6ng
 
 BookmarksListView_NewBookmark = Nyt bogm\u00E6rke
 
-BookmarksListView_addSeparator = Tilf\u00F8j seperator
+BookmarksListView_addSeparator = Tilf\u00F8j separator
 
 BookmarksListView_bookmark = Bogm\u00E6rke
 


### PR DESCRIPTION
Found by accident. When searching for the term with the typo in it...