### PR TITLE
Accept trailing whitespace in bank statement from Deutsche Bank

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
@@ -2791,4 +2791,22 @@ public class DeutscheBankPDFExtractorTest
                         "Deutsche Bank Privat- und Geschäftskunden AG", "GiroKontoauszug07.txt");
         assertEquals(expectedErrorMessage, firstError.getMessage());
     }
+
+    @Test
+    public void testGiroKontoauszug08()
+    {
+        var extractor = new DeutscheBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        // A trailing whitespace in "Kontoauszug vom 19.09.2025 bis 02.10.2025 "
+        // caused a mismatch of the pattern meant to extract the year of the
+        // bank statement. It was anchored strictly to the end of the line.
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "GiroKontoauszug08.txt"), errors);
+
+        assertThat(errors, empty());
+
+        // just a single (skipped) transaction
+        assertThat(results.size(), is(1));
+    }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/GiroKontoauszug08.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/GiroKontoauszug08.txt
@@ -1,0 +1,38 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.80.5.qualifier
+System: linux | x86_64 | 21.0.8+9-LTS | Eclipse Adoptium
+-----------------------------------------
+Deutsche Bank AG
+Filiale
+Musterhausen
+Paul-Muster-Platz 1
+Herrn 22222 Hamburg
+Max Mustermann Frau Ronja Musterfrau
+Musterstr. 1 A Telefon (010) 3333-2222
+22222 Musterhausen
+24h-Kundenservice (069) 910-10000
+2. Oktober 2025
+Kontoauszug vom 19.09.2025 bis 02.10.2025
+Kontoinhaber: Max Mustermann
+Auszug Seite von IBAN Alter Saldo per 18.09.2025
+3 1 1 DE12 3456 7890 1234 5678 90 USD + 1.284,05
+Buchung Valuta Vorgang Soll Haben
+02.10. 01.10. Verwendungszweck/ Kundenreferenz + 7,87
+2025 2025 ZINSEN/DIVIDENDEN/ERTRAEGE STK/NOM:
+60 NIKE INC.REGISTERED SHARES CLASS B O.N
+.
+Filialnummer Kontonummer Neuer Saldo
+111 2345678 90 USD + 1.291,92
+BIC (SWIFT)
+DEUTDEDBHAM
+Wichtige Hinweise
+Bitte erheben Sie Einwendungen gegen einzelne Buchungen unverzüglich. Schecks, Wechsel und sonstige Lastschriften schreiben wir unter dem Vorbehalt
+des Eingangs gut. Der angegebene Kontostand berücksichtigt nicht die Wertstellung der Buchungen (siehe oben unter "Valuta").
+Somit können bei Verfügungen1)
+ möglicherweise Zinsen für die Inanspruchnahme einer eingeräumten oder geduldeten Kontoüberziehung anfallen.
+Die abgerechneten Leistungen sind als Bank- oder Finanzdienstleistungen von der Umsatzsteuer befreit, sofern Umsatzsteuer nicht gesondert
+ausgewiesen ist. Umsatzsteuer ID Nr.: Deutsche Bank AG, 60262 Frankfurt DE114103379
+Guthaben sind als Einlagen nach Maßgabe des Einlagensicherungsgesetzes entschädigungsfähig. Nähere Informationen können dem "Informationsbogen
+für den Einleger" entnommen werden.
+1) Der Begriff umfasst unter anderem die relevanten Zahlungskontendienste "Bargeldauszahlung" und "Überweisung".
+0000000003 / 06500900 / 20251002

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
@@ -426,7 +426,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
                                         .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency"))))
 
                                         .section("year") //
-                                        .match("^Kontoauszug vom [\\d]{2}\\.[\\d]{2}\\.(?<year>[\\d]{4}) bis [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}$")
+                                        .match("^Kontoauszug vom [\\d]{2}\\.[\\d]{2}\\.(?<year>[\\d]{4}) bis [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}\\s*$")
                                         .assign(Map::putAll));
 
         this.addDocumentTyp(type);


### PR DESCRIPTION
The statement year got extracted via a pattern that has strictly been anchored to the end of line so far. This is now relaxed to accept trailing whitespace.

QUESTION: is there an easier way? Like an option to strip trailing whitespace altogether? This could be a convenient
pre-processing.