### PR TITLE
Less Java-style spelling in German translation.

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -2201,7 +2201,7 @@ MsgHintNoAttributesConfigured = Keine Attribute vom Typ ''{0}'' konfiguriert.\n<
 
 MsgHintNoEvents = Keine Ereignisse.
 
-MsgHintUseOutboundDeliveryForZeroTotal = Hinweis: Verk\u00E4ufe mit einem Wert von null werden nicht unterst\u00FCtzt. Bitte erstelle stattdessen eine Buchung vom Typ Auslieferung.
+MsgHintUseOutboundDeliveryForZeroTotal = Hinweis: Verk\u00E4ufe mit einem Wert von Null werden nicht unterst\u00FCtzt. Bitte erstelle stattdessen eine Buchung vom Typ Auslieferung.
 
 MsgHistoricalPricesRequireSignIn = Um auf historische Preise aus dem integrierten Feed zugreifen zu k\u00F6nnen, musst du dich anmelden oder eine Portfolio Performance ID erstellen.
 


### PR DESCRIPTION
Null vs. null.