### PR TITLE
Re-added trailing whitespace lost in a testcase. Oops!

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/GiroKontoauszug08.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/GiroKontoauszug08.txt
@@ -2,7 +2,7 @@ PDFBox Version: 3.0.6
 Portfolio Performance Version: 0.80.5.qualifier
 System: linux | x86_64 | 21.0.8+9-LTS | Eclipse Adoptium
 -----------------------------------------
-Deutsche Bank AG
+Deutsche Bank AG 
 Filiale
 Musterhausen
 Paul-Muster-Platz 1
@@ -12,7 +12,7 @@ Musterstr. 1 A Telefon (010) 3333-2222
 22222 Musterhausen
 24h-Kundenservice (069) 910-10000
 2. Oktober 2025
-Kontoauszug vom 19.09.2025 bis 02.10.2025
+Kontoauszug vom 19.09.2025 bis 02.10.2025 
 Kontoinhaber: Max Mustermann
 Auszug Seite von IBAN Alter Saldo per 18.09.2025
 3 1 1 DE12 3456 7890 1234 5678 90 USD + 1.284,05


### PR DESCRIPTION
One of my editors is configured to automatically remove the trailing whitespace. Embarassing! I manually ensured that testGiroKontoauszug08 fails if the \\s* expression in addAccountStatementTransaction() is missing.

This fixes the test that came with pull request https://github.com/portfolio-performance/portfolio/pull/5156
