### PR TITLE
Modify Deutsche Bank PDF-Importer to support new transaction

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
@@ -545,6 +545,39 @@ public class DeutscheBankPDFExtractorTest
     }
 
     @Test
+    public void testKupon01()
+    {
+        var extractor = new DeutscheBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kupon01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("XS2722190795"), hasWkn("A3511H"), hasTicker(null), //
+                        hasName("4% DEUTSCHE BAHN AG MTN.23 23.11. 43"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends (here: interest) transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-11-24T00:00"), hasShares(10.00), //
+                        hasSource("Kupon01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 33.46), hasGrossValue("EUR", 40.00), //
+                        hasTaxes("EUR", 6.20 + 0.34), hasFees("EUR", 0.00))));
+    }
+
+    @Test
     public void testWertpapierKauf01()
     {
         var extractor = new DeutscheBankPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/Kupon01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/Kupon01.txt
@@ -1,0 +1,38 @@
+PDFBox Version: 3.0.5
+Portfolio Performance Version: 0.80.4
+System: linux | x86_64 | 21.0.9+10-Ubuntu-124.04 | Ubuntu
+-----------------------------------------
+Deutsche Bank AG
+24/7-Kundenservice (069) 910-10000
+Max Mustermann 
+Musterstr. 1 A 
+22222 Musterstadt
+24. November 2025
+Ihr Depot Nr. 100 1234567 01 
+Kupongutschrift
+CorpID: IPP0000000829024
+Nominal Währung WKN ISIN
+1.000,000000 EUR A3511H XS2722190795
+4% DEUTSCHE BAHN AG MTN.23 23.11. 43
+Zinsen in % 4,0000000000 Zahlbar 24.11.2025
+Ursprungsland DEUTSCHLAND Ex-Tag 24.11.2025
+Bruttoertrag 40,00 EUR 
+Kapitalertragsteuer (KESt) - 6,20 EUR 
+Solidaritätszuschlag auf KESt - 0,34 EUR
+Gutschrift mit Wert 24.11.2025 33,46 EUR
+Steuerliche Bemessungsgrundlagen zur Kupongutschrift - keine Steuerbescheinigung
+Angerechneter Verlusttopf "Sonstige" 14,28 EUR 
+KESt-pflichtiger Kapitalertrag 25,72 EUR
+Auf die KESt angerechnete ausländische 22,80 EUR
+Quellensteuer
+Vorsitzender des Aufsichtsrats: Alexander R. Wynaendts
+Vorstand: Christian Sewing (Vorsitzender), James von Moltke, Fabrizio Campelli, Marcus Chromik, Bernd Leukert, Alexander von zur Mühlen, Laura Padovani, Claudio de Sanctis, 
+Rebecca Short
+Deutsche Bank Aktiengesellschaft mit Sitz in Frankfurt am Main; Amtsgericht Frankfurt am Main, HRB Nr. 30 000; Umsatzsteuer-Id.-Nr. DE114103379; www.db.com/de 1/2
+TRINCM0001 KUPO 20251122 99999999
+  
+ 
+Wir überweisen den Betrag von 33,45 EUR auf Ihr Konto 1234567 00.
+Kapitalerträge sind einkommensteuerpflichtig!
+Diese Mitteilung wurde maschinell erstellt und wird nicht unterschrieben.
+2/2

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
@@ -300,10 +300,10 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("(Dividendengutschrift|Ertragsgutschrift)");
+        var type = new DocumentType("(Dividendengutschrift|Ertragsgutschrift|Kupongutschrift)");
         this.addDocumentTyp(type);
 
-        var firstRelevantLine = new Block("^^(Dividendengutschrift|Ertragsgutschrift)$");
+        var firstRelevantLine = new Block("^^(Dividendengutschrift|Ertragsgutschrift|Kupongutschrift)$");
         type.addBlock(firstRelevantLine);
 
         var pdfTransaction = new Transaction<AccountTransaction>();


### PR DESCRIPTION
Due to lack of native support for cupons, the payment will be recorded as a "dividend". Same way as done for Onvista and Postbank.