### PR TITLE
Fix: Div%/year calculated incorrectly

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendCalculationTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendCalculationTest.java
@@ -16,7 +16,9 @@ import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.PortfolioTransaction.Type;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.SecurityPrice;
 import name.abuchen.portfolio.money.CurrencyConverter;
+import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.security.BaseSecurityPerformanceRecord.Periodicity;
 
 @SuppressWarnings("nls")
@@ -195,5 +197,62 @@ public class DividendCalculationTest
                         transactions);
 
         assertEquals(0.1, dividends.getRateOfReturnPerYear(), 0.0);
+    }
+
+    @Test
+    public void rateOfReturnWithCurrencyMismatchBugTest()
+    {
+        // Test case that catches the currency mismatch bug:
+        // When transaction currency (USD) differs from term currency (EUR),
+        // the bug divides raw USD amount by converted EUR cost without proper conversion.
+        // 
+        // Purchase: 10 shares at 100 USD per share = 1000 USD total
+        // Dividend: 50 USD (5 USD per share) on 2015-01-15
+        // 
+        // Using TestCurrencyConverter with EUR term currency:
+        // Exchange rate on 2015-01-15: ~1.1708 EUR per USD (from test data)
+        // - Purchase cost in EUR: 1000 USD * 1.1708 = 1170.8 EUR
+        // - Dividend in EUR: 50 USD * 1.1708 = 58.54 EUR
+        // - Correct rate: 58.54 / 1170.8 = 0.05 (5%)
+        //
+        // BUG: Code uses raw dividend amount (5000 in stored format, USD) divided by
+        //      converted cost (in EUR), which gives wrong result
+        //      With buggy code: ~0.0588 (wrong - dividing USD by EUR)
+        //      With fixed code: ~0.05 (correct - both in EUR)
+
+        Security testSecurity = new Security("Test Security", "USD");
+        testSecurity.addPrice(new SecurityPrice(LocalDateTime.of(2015, 1, 15, 0, 0).toLocalDate(),
+                        Values.Quote.factorize(100)));
+
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        // Purchase: 10 shares at 100 USD = 1000 USD
+        transactions.add(CalculationLineItem.of(new Portfolio(), new PortfolioTransaction(
+                        LocalDateTime.of(2015, 1, 14, 12, 0), testSecurity.getCurrencyCode(),
+                        Values.Amount.factorize(1000), testSecurity, Values.Share.factorize(10), Type.BUY, 0L, 0L)));
+
+        // Dividend: 50 USD (5 USD per share)
+        AccountTransaction dividend = new AccountTransaction();
+        dividend.setType(AccountTransaction.Type.DIVIDENDS);
+        dividend.setSecurity(testSecurity);
+        dividend.setDateTime(LocalDateTime.of(2015, 1, 15, 12, 0));
+        dividend.setAmount(Values.Amount.factorize(50));
+        dividend.setShares(Values.Share.factorize(10));
+        dividend.setCurrencyCode(testSecurity.getCurrencyCode());
+
+        transactions.add(CalculationLineItem.of(new Account(), dividend));
+
+        @SuppressWarnings("unused")
+        CostCalculation cost = Calculation.perform(CostCalculation.class, converter, testSecurity, transactions);
+        DividendCalculation dividends = Calculation.perform(DividendCalculation.class, converter, testSecurity,
+                        transactions);
+
+        // Expected: 50 USD / 1000 USD = 0.05 (5%)
+        // After currency conversion to EUR: ~58.54 EUR / ~1170.8 EUR = 0.05
+        // With bug: Uses raw USD amount / converted EUR cost = ~0.0588 (wrong!)
+        // With fix: Uses converted dividend / converted cost = ~0.05 (correct)
+        // This test will FAIL with the buggy code (~0.0588) and PASS with the fix (~0.05)
+        // Tolerance is tight (0.005) to catch the bug: 0.0588 - 0.05 = 0.0088 > 0.005
+        assertEquals(0.05, dividends.getRateOfReturnPerYear(), 0.005);
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
@@ -74,7 +74,11 @@ import name.abuchen.portfolio.util.Dates;
 
                 Money movingAverageCost = t.getMovingAverageCost();
                 if (movingAverageCost != null && !movingAverageCost.isZero())
-                    rr = t.getGrossValueAmount() / (double) movingAverageCost.getAmount();
+                {
+                    // Use converted amount (in term currency) instead of raw amount (in transaction currency)
+                    // to ensure both values are in the same currency for correct calculation
+                    rr = this.amount.getAmount() / (double) movingAverageCost.getAmount();
+                }
 
                 // check if it is valid (non 0)
                 if (rr == 0)


### PR DESCRIPTION
Looking at Reports -> Performance -> Securities, as far as I can see, Div%/year is calculated wrongly when:
- The dividend currency differs from the portfolio's base currency (term currency)
AND
- The moving average cost path is used

I had a case with a JPY dividend in a EUR portfolio and Div%/year showed >800% instead of around 5% !

I believe this PR fixes the issue.

PR includes a test for the bug, however the margin of error is much smaller than the case I encountered. This is because all of the currencies in TestCurrencyConverter (CHF/EUR/USD) are actually quite close in value, which doesn't seem ideal? However I didn't want to mess with that, in case the change was not wanted.