### PR TITLE
Fix: unescaped tooltip labels

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BookmarkMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BookmarkMenu.java
@@ -13,6 +13,7 @@ import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.editor.PortfolioPart;
 import name.abuchen.portfolio.ui.views.settings.SettingsView;
+import name.abuchen.portfolio.util.TextUtil;
 
 public class BookmarkMenu extends MenuManager
 {
@@ -46,7 +47,7 @@ public class BookmarkMenu extends MenuManager
             }
             else
             {
-                add(new SimpleAction(bookmark.getLabel(), a -> securities.stream().limit(10)
+                add(new SimpleAction(TextUtil.tooltip(bookmark.getLabel()), a -> securities.stream().limit(10)
                                 .forEach(s -> DesktopAPI.browse(bookmark.constructURL(client, s)))));
             }
         }
@@ -57,7 +58,7 @@ public class BookmarkMenu extends MenuManager
         {
             add(new Separator());
             securities.forEach(s -> s.getCustomBookmarks().forEach(
-                            bm -> add(new SimpleAction(bm.getLabel(), a -> DesktopAPI.browse(bm.getPattern())))));
+                            bm -> add(new SimpleAction(TextUtil.tooltip(bm.getLabel()), a -> DesktopAPI.browse(bm.getPattern())))));
         }
 
         add(new Separator());
@@ -67,7 +68,7 @@ public class BookmarkMenu extends MenuManager
 
         List<Bookmark> templates = ClientSettings.getDefaultBookmarks();
         Collections.sort(templates, (r, l) -> r.getLabel().compareTo(l.getLabel()));
-        templates.forEach(bookmark -> templatesMenu.add(new SimpleAction(bookmark.getLabel(),
+        templates.forEach(bookmark -> templatesMenu.add(new SimpleAction(TextUtil.tooltip(bookmark.getLabel()),
                         a -> securities.stream().limit(10)
                                         .forEach(s -> DesktopAPI.browse(bookmark.constructURL(client, s))))));
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
@@ -37,6 +37,7 @@ import name.abuchen.portfolio.snapshot.filter.PortfolioClientFilter;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.dialogs.EditClientFilterDialog;
 import name.abuchen.portfolio.ui.dialogs.ListSelectionDialog;
+import name.abuchen.portfolio.util.TextUtil;
 
 public final class ClientFilterMenu implements IMenuListener
 {
@@ -148,7 +149,7 @@ public final class ClientFilterMenu implements IMenuListener
     public void menuAboutToShow(IMenuManager manager)
     {
         defaultItems.forEach(item -> {
-            Action action = new SimpleAction(item.label, a -> {
+            Action action = new SimpleAction(TextUtil.tooltip(item.label), a -> {
                 selectedItem = item;
                 listeners.forEach(l -> l.accept(item.filter));
             });
@@ -158,7 +159,7 @@ public final class ClientFilterMenu implements IMenuListener
 
         manager.add(new Separator());
         customItems.forEach(item -> {
-            Action action = new SimpleAction(item.label, a -> {
+            Action action = new SimpleAction(TextUtil.tooltip(item.label), a -> {
                 selectedItem = item;
                 listeners.forEach(l -> l.accept(item.filter));
             });

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ShowHideColumnHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ShowHideColumnHelper.java
@@ -613,25 +613,25 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
             if (column.getGroupLabel() != null)
             {
                 managerToAdd = groups.computeIfAbsent(column.getGroupLabel(), l -> {
-                    MenuManager m = new MenuManager(l);
+                    MenuManager m = new MenuManager(TextUtil.tooltip(l));
                     manager.add(m);
                     return m;
                 });
                 if (column.hasHeading())
-                    managerToAdd.add(new LabelOnly(column.getHeading()));
+                    managerToAdd.add(new LabelOnly(TextUtil.tooltip(column.getHeading())));
             }
 
             if (column.hasOptions())
             {
                 List<Object> options = visible.getOrDefault(column, Collections.emptyList());
 
-                MenuManager subMenu = new MenuManager(column.getMenuLabel());
+                MenuManager subMenu = new MenuManager(TextUtil.tooltip(column.getMenuLabel()));
 
                 for (Object option : column.getOptions().getOptions())
                 {
                     boolean isVisible = options.contains(option);
                     String label = column.getOptions().getMenuLabel(option);
-                    addShowHideAction(subMenu, column, label, isVisible, option);
+                    addShowHideAction(subMenu, column, TextUtil.tooltip(label), isVisible, option);
 
                     if (isVisible)
                         options.remove(option);
@@ -640,7 +640,7 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
                 for (Object option : options)
                 {
                     String label = column.getOptions().getMenuLabel(option);
-                    addShowHideAction(subMenu, column, label, true, option);
+                    addShowHideAction(subMenu, column, TextUtil.tooltip(label), true, option);
                 }
 
                 if (column.getOptions().canCreateNewOptions())
@@ -650,7 +650,7 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
             }
             else
             {
-                addShowHideAction(managerToAdd, column, column.getMenuLabel(), visible.containsKey(column), null);
+                addShowHideAction(managerToAdd, column, TextUtil.tooltip(column.getMenuLabel()), visible.containsKey(column), null);
             }
         }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TaxonomyConfig.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TaxonomyConfig.java
@@ -8,6 +8,7 @@ import name.abuchen.portfolio.model.Taxonomy;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.LabelOnly;
 import name.abuchen.portfolio.ui.util.SimpleAction;
+import name.abuchen.portfolio.util.TextUtil;
 
 public class TaxonomyConfig implements WidgetConfig
 {
@@ -32,12 +33,12 @@ public class TaxonomyConfig implements WidgetConfig
     public void menuAboutToShow(IMenuManager manager)
     {
         manager.appendToGroup(DashboardView.INFO_MENU_GROUP_NAME,
-                        new LabelOnly(taxonomy != null ? taxonomy.getName() : Messages.LabelNoName));
+                        new LabelOnly(TextUtil.tooltip(taxonomy != null ? taxonomy.getName() : Messages.LabelNoName)));
 
         MenuManager subMenu = new MenuManager(Messages.LabelTaxonomies);
 
         delegate.getClient().getTaxonomies().forEach(t -> {
-            SimpleAction action = new SimpleAction(t.getName(), a -> {
+            SimpleAction action = new SimpleAction(TextUtil.tooltip(t.getName()), a -> {
                 taxonomy = t;
                 delegate.getWidget().getConfiguration().put(Dashboard.Config.TAXONOMY.name(), t.getId());
 


### PR DESCRIPTION
I created a taxonomy whose name contains an ampersand and noticed it wasn’t displayed in the column dropdown when selecting taxonomy. I believe this is because the ampersand has a special meaning in this context, but was being passed unescaped.

Here is a PR to address that. I took the opportunity to add defensive escaping in all the places I could identify where I believe this problem could – in principle – occur.