### PR TITLE
add local-sensitive viewer comparator to data series selection

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
@@ -22,6 +22,8 @@ import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Display;
@@ -228,6 +230,31 @@ public final class ClientFilterMenu implements IMenuListener
         dialog.setTitle(Messages.LabelClientFilterDialogTitle);
         dialog.setMessage(Messages.LabelClientFilterDialogMessage);
         dialog.setPropertyLabel(Messages.ColumnName);
+        dialog.setViewerComparator(new ViewerComparator()
+        {
+            @Override
+            public int compare(Viewer viewer, Object o1, Object o2)
+            {
+                if (o1 == null && o2 == null)
+                    return 0;
+                else if (o1 == null)
+                    return -1;
+                else if (o2 == null)
+                    return 1;
+
+                String s1 = labelProvider.getText(o1);
+                String s2 = labelProvider.getText(o2);
+
+                if (s1 == null && s2 == null)
+                    return 0;
+                else if (s1 == null)
+                    return -1;
+                else if (s2 == null)
+                    return 1;
+
+                return TextUtil.compare(s1, s2);
+            }
+        });
 
         List<Object> elements = new ArrayList<>();
         elements.addAll(client.getPortfolios());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/GroupedAccountsListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/GroupedAccountsListView.java
@@ -28,6 +28,8 @@ import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TreeSelection;
 import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.jface.viewers.ViewerDropAdapter;
 import org.eclipse.jface.window.ToolTip;
 import org.eclipse.jface.window.Window;
@@ -81,6 +83,7 @@ import name.abuchen.portfolio.ui.views.panes.GroupedAccountBalancePane;
 import name.abuchen.portfolio.ui.views.panes.InformationPanePage;
 import name.abuchen.portfolio.ui.views.panes.PortfolioHoldingsPane;
 import name.abuchen.portfolio.ui.views.panes.StatementOfAssetsPane;
+import name.abuchen.portfolio.util.TextUtil;
 
 public class GroupedAccountsListView extends AbstractFinanceView implements ModificationListener
 {
@@ -506,6 +509,31 @@ public class GroupedAccountsListView extends AbstractFinanceView implements Modi
 
         dialog.setTitle(Messages.LabelClientFilterDialogTitle);
         dialog.setMessage(Messages.LabelClientFilterDialogMessage);
+        dialog.setViewerComparator(new ViewerComparator()
+        {
+            @Override
+            public int compare(Viewer viewer, Object o1, Object o2)
+            {
+                if (o1 == null && o2 == null)
+                    return 0;
+                else if (o1 == null)
+                    return -1;
+                else if (o2 == null)
+                    return 1;
+
+                String s1 = labelProvider.getText(o1);
+                String s2 = labelProvider.getText(o2);
+
+                if (s1 == null && s2 == null)
+                    return 0;
+                else if (s1 == null)
+                    return -1;
+                else if (s2 == null)
+                    return 1;
+
+                return TextUtil.compare(s1, s2);
+            }
+        });
 
         List<Object> elements = new ArrayList<>();
         elements.addAll(getClient().getPortfolios());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesSelectionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesSelectionDialog.java
@@ -35,6 +35,7 @@ import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.LogoManager;
 import name.abuchen.portfolio.ui.util.viewers.CopyPasteSupport;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeries.Type;
+import name.abuchen.portfolio.util.TextUtil;
 
 public class DataSeriesSelectionDialog extends Dialog
 {
@@ -302,7 +303,7 @@ public class DataSeriesSelectionDialog extends Dialog
         TreeViewerColumn column = new TreeViewerColumn(treeViewer, SWT.None);
         layout.setColumnData(column.getColumn(), new ColumnWeightData(100));
 
-        treeViewer.setLabelProvider(new LabelProvider()
+        LabelProvider labelProvider = new LabelProvider()
         {
             @Override
             public Image getImage(Object element)
@@ -334,12 +335,37 @@ public class DataSeriesSelectionDialog extends Dialog
             {
                 return ((Node) element).label;
             }
-        });
+        };
+
+        treeViewer.setLabelProvider(labelProvider);
         treeViewer.setContentProvider(new NodeContentProvider());
         treeViewer.addFilter(elementFilter);
         treeViewer.setInput(elements);
-        treeViewer.setComparator(new ViewerComparator());
+        treeViewer.setComparator(new ViewerComparator()
+        {
+            @Override
+            public int compare(Viewer viewer, Object o1, Object o2)
+            {
+                if (o1 == null && o2 == null)
+                    return 0;
+                else if (o1 == null)
+                    return -1;
+                else if (o2 == null)
+                    return 1;
 
+                String s1 = labelProvider.getText(o1);
+                String s2 = labelProvider.getText(o2);
+
+                if (s1 == null && s2 == null)
+                    return 0;
+                else if (s1 == null)
+                    return -1;
+                else if (s2 == null)
+                    return 1;
+
+                return TextUtil.compare(s1, s2);
+            }
+        });
         hookListener();
 
         if (isTreeExpanded)


### PR DESCRIPTION
Closes https://github.com/portfolio-performance/portfolio/issues/4529

Hello, on some locations there is a case sensitive sorting, on some location not. And more than a case sensitive sorting, I understand it is local sorting for special letter.
I reused what is done in ColumnViewerSorter, https://github.com/portfolio-performance/portfolio/commit/f61269ac8954f50fb36133c49dff75cce8d87e22, I understand the goal is to use `TextUtil.compare` in the different `ViewerComparator`.

the location where the locale-sensitive sorting is now applied too : 

- when selecting data series to plot on graph
- when selecting accounts for creating grouped account and add new accounts to them

**Expected behavior :** 
<img width="352" height="282" alt="Capture d’écran 2025-12-07 131410" src="https://github.com/user-attachments/assets/b6624c09-f2b6-42c0-8d62-c71336dbbb6e" />
OK

**Before :**  different behavior elsewhere :
<img width="268" height="250" alt="Capture d’écran 2025-12-07 132645" src="https://github.com/user-attachments/assets/c71605d9-909c-4628-ba47-15cf4271bb94" />

<img width="335" height="347" alt="Capture d’écran 2025-12-07 131459" src="https://github.com/user-attachments/assets/c15c3de4-77d4-461e-a0d9-5be1cbf76ddd" />



**After :** 
<img width="318" height="438" alt="Capture d’écran 2025-12-07 131746" src="https://github.com/user-attachments/assets/d4b31a96-e574-43aa-bc61-4840d362ddfa" />
<img width="157" height="261" alt="Capture d’écran 2025-12-07 131813" src="https://github.com/user-attachments/assets/db0bfc0e-2941-436f-90ca-afbd2573367b" />
