### PR TITLE
Fix discreet mode for grouped account list

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/GroupedAccountsListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/GroupedAccountsListView.java
@@ -223,7 +223,6 @@ public class GroupedAccountsListView extends AbstractFinanceView implements Modi
                                             groupedAccounts.setExpandedState(newItem, true);
                                             // select the newly created account
                                             groupedAccounts.setSelection(new StructuredSelection(newItem));
-
                                         })))));
     }
 
@@ -474,10 +473,7 @@ public class GroupedAccountsListView extends AbstractFinanceView implements Modi
         String message = MessageFormat.format(Messages.MenuReportingPeriodDeleteConfirm, filterItem.getLabel());
         if (MessageDialog.openConfirm(Display.getDefault().getActiveShell(), Messages.MenuReportingPeriodDelete,
                         message))
-        {
             items.remove(filterItem);
-            groupedAccounts.refresh();
-        }
     }
 
     private void deleteElementInFilter(Object element, ClientFilterMenu.Item filterItem)
@@ -488,7 +484,6 @@ public class GroupedAccountsListView extends AbstractFinanceView implements Modi
             // important step: update UUIDs because this is basic
             // information in settings
             filterItem.setUUIDs(ClientFilterMenu.buildUUIDs(filter.getAllElements()));
-            groupedAccounts.refresh();
         }
     }
 
@@ -534,7 +529,6 @@ public class GroupedAccountsListView extends AbstractFinanceView implements Modi
                 // important step: update UUIDs because this is
                 // basic information in settings
                 selectedFilterElement.setUUIDs(ClientFilterMenu.buildUUIDs(filter.getAllElements()));
-                groupedAccounts.refresh();
             }
         }
     }


### PR DESCRIPTION
Issue : https://forum.portfolio-performance.info/t/group-accounts-does-not-update/38300

Hello, I can reproduce the issue mentionned above : when on the Grouped account view, if you switch the Discreet Mode, the values of the top table does not immediatly follow the change. It applies if you switch view then go back to grouped account view.
I understand that the change of discreet mode calls `notifyModelUpdated()` and therefore this method is added. 
I think `notifyModelUpdated `is now called also from other actions such as add/delete an element to a grouped account, so in the second commit I am assuming it can be simplified.