### PR TITLE
fix Original Size action for SecuritiesChart

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/PriceTimelineChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/PriceTimelineChart.java
@@ -1,0 +1,78 @@
+package name.abuchen.portfolio.ui.util.chart;
+
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swtchart.IAxis;
+import org.eclipse.swtchart.IAxis.Position;
+import org.eclipse.swtchart.LineStyle;
+import org.eclipse.swtchart.Range;
+
+import name.abuchen.portfolio.ui.util.format.AxisTickPercentNumberFormat;
+
+public class PriceTimelineChart extends TimelineChart
+{
+    private Double firstQuote;
+
+    public PriceTimelineChart(Composite parent)
+    {
+        super(parent);
+
+        // 2nd y axis
+        int axisId = getAxisSet().createYAxis();
+        IAxis y2Axis = getAxisSet().getYAxis(axisId);
+        y2Axis.getTitle().setVisible(false);
+        y2Axis.getTick().setVisible(false);
+        y2Axis.getGrid().setStyle(LineStyle.NONE);
+        y2Axis.setPosition(Position.Primary);
+
+        // 3rd y axis (percentage)
+        int axisId3rd = getAxisSet().createYAxis();
+        IAxis y3Axis = getAxisSet().getYAxis(axisId3rd);
+        y3Axis.getTitle().setVisible(false);
+        y3Axis.getTick().setVisible(false);
+        y3Axis.getTick().setFormat(new AxisTickPercentNumberFormat("+#.##%;-#.##%")); //$NON-NLS-1$
+        y3Axis.getGrid().setStyle(LineStyle.NONE);
+        y3Axis.setPosition(Position.Primary);
+    }
+
+    @Override
+    public void adjustRange()
+    {
+        // custom implementation because the 2nd and 3rd y axis must follow
+        // exactly the first one
+        try
+        {
+            setRedraw(false);
+
+            getAxisSet().adjustRange();
+
+            var yAxis1st = getAxisSet().getYAxis(0);
+            var yAxis2nd = getAxisSet().getYAxis(1);
+            var yAxis3rd = getAxisSet().getYAxis(2);
+
+            if (firstQuote != null)
+            {
+                yAxis2nd.setRange(new Range(yAxis1st.getRange().lower - firstQuote,
+                                yAxis1st.getRange().upper - firstQuote));
+
+                if (firstQuote != 0)
+                {
+                    yAxis3rd.setRange(new Range(yAxis1st.getRange().lower / firstQuote - 1,
+                                    yAxis1st.getRange().upper / firstQuote - 1));
+                }
+            }
+
+            ChartUtil.addYMargins(this, 0.08);
+
+        }
+        finally
+        {
+            setRedraw(true);
+        }
+    }
+
+    public void setFirstQuote(Double firstQuote)
+    {
+        this.firstQuote = firstQuote;
+    }
+
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChart.java
@@ -30,8 +30,6 @@ import org.eclipse.swtchart.internal.PlotArea;
 
 import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.util.Colors;
-import name.abuchen.portfolio.ui.util.format.AxisTickPercentNumberFormat;
-import name.abuchen.portfolio.ui.views.SecuritiesChart;
 
 public class TimelineChart extends Chart // NOSONAR
 {
@@ -82,8 +80,6 @@ public class TimelineChart extends Chart // NOSONAR
     private TimelineChartToolTip toolTip;
     private ChartContextMenu contextMenu;
 
-    private SecuritiesChart securitiesChart;
-
     @SuppressWarnings("restriction")
     public TimelineChart(Composite parent)
     {
@@ -109,23 +105,6 @@ public class TimelineChart extends Chart // NOSONAR
         IAxis yAxis = getAxisSet().getYAxis(0);
         yAxis.getTitle().setVisible(false);
         yAxis.setPosition(Position.Secondary);
-
-        // 2nd y axis
-        int axisId = getAxisSet().createYAxis();
-        IAxis y2Axis = getAxisSet().getYAxis(axisId);
-        y2Axis.getTitle().setVisible(false);
-        y2Axis.getTick().setVisible(false);
-        y2Axis.getGrid().setStyle(LineStyle.NONE);
-        y2Axis.setPosition(Position.Primary);
-
-        // 3rd y axis (percentage)
-        int axisId3rd = getAxisSet().createYAxis();
-        IAxis y3Axis = getAxisSet().getYAxis(axisId3rd);
-        y3Axis.getTitle().setVisible(false);
-        y3Axis.getTick().setVisible(false);
-        y3Axis.getTick().setFormat(new AxisTickPercentNumberFormat("+#.##%;-#.##%")); //$NON-NLS-1$
-        y3Axis.getGrid().setStyle(LineStyle.NONE);
-        y3Axis.setPosition(Position.Primary);
 
         getPlotArea().addCustomPaintListener(new ICustomPaintListener()
         {
@@ -155,12 +134,6 @@ public class TimelineChart extends Chart // NOSONAR
         getPlotArea().getControl().addTraverseListener(event -> event.doit = true);
 
         this.contextMenu = new ChartContextMenu(this);
-    }
-
-    public TimelineChart(Composite parent, SecuritiesChart securitiesChart)
-    {
-        this(parent);
-        this.securitiesChart = securitiesChart;
     }
 
     public void addMarkerLine(LocalDate date, Color color, String label)
@@ -381,9 +354,6 @@ public class TimelineChart extends Chart // NOSONAR
         {
             setRedraw(true);
         }
-
-        if (securitiesChart != null)
-            securitiesChart.updateChart();
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -44,7 +44,6 @@ import org.eclipse.swtchart.ILineSeries.PlotSymbolType;
 import org.eclipse.swtchart.ISeries;
 import org.eclipse.swtchart.ISeries.SeriesType;
 import org.eclipse.swtchart.LineStyle;
-import org.eclipse.swtchart.Range;
 
 import com.google.common.primitives.Doubles;
 
@@ -75,8 +74,7 @@ import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.chart.ChartColorWheel;
-import name.abuchen.portfolio.ui.util.chart.ChartUtil;
-import name.abuchen.portfolio.ui.util.chart.TimelineChart;
+import name.abuchen.portfolio.ui.util.chart.PriceTimelineChart;
 import name.abuchen.portfolio.ui.util.chart.TimelineChartToolTip;
 import name.abuchen.portfolio.ui.util.chart.TimelineSeriesModel;
 import name.abuchen.portfolio.ui.util.format.AxisTickPercentNumberFormat;
@@ -402,7 +400,7 @@ public class SecuritiesChart
     private CurrencyConverter converter;
     private Security[] securities = new Security[0];
 
-    private TimelineChart chart;
+    private PriceTimelineChart chart;
 
     /**
      * Calculates dynamically for each security the interval of security prices
@@ -446,7 +444,7 @@ public class SecuritiesChart
         container = new Composite(parent, SWT.NONE);
         container.setLayout(new FillLayout());
 
-        chart = new TimelineChart(container, this);
+        chart = new PriceTimelineChart(container);
         chart.getTitle().setText("..."); //$NON-NLS-1$
         chart.getTitle().setVisible(false);
 
@@ -910,7 +908,7 @@ public class SecuritiesChart
         return Arrays.stream(securities).map(Named::getName).collect(Collectors.joining(", ")); //$NON-NLS-1$
     }
 
-    public void updateChart()
+    private void updateChart()
     {
         boolean isSingleSecurityMode = securities.length == 1;
 
@@ -1077,27 +1075,16 @@ public class SecuritiesChart
                 configureSeriesPainter(lineSeries, dates, values, color, 2, LineStyle.SOLID, enableArea,
                                 !isSingleSecurityMode);
 
-                adjustRange();
+                chart.adjustRange();
 
                 addChartMarkerForeground(chartInterval, security, chartConfigPainting);
 
-                adjustRange();
+                chart.setFirstQuote(firstQuote);
+                chart.adjustRange();
 
                 IAxis yAxis1st = chart.getAxisSet().getYAxis(0);
                 IAxis yAxis2nd = chart.getAxisSet().getYAxis(1);
                 IAxis yAxis3rd = chart.getAxisSet().getYAxis(2);
-
-                if (firstQuote == null)
-                    firstQuote = (prices.get(range.start).getValue() / Values.Quote.divider());
-
-                yAxis2nd.setRange(new Range(yAxis1st.getRange().lower - firstQuote,
-                                yAxis1st.getRange().upper - firstQuote));
-
-                if (firstQuote != 0)
-                {
-                    yAxis3rd.setRange(new Range(yAxis1st.getRange().lower / firstQuote - 1,
-                                    yAxis1st.getRange().upper / firstQuote - 1));
-                }
 
                 yAxis1st.enableLogScale(chartConfigPainting.contains(ChartDetails.SCALING_LOG));
                 yAxis2nd.enableLogScale(chartConfigPainting.contains(ChartDetails.SCALING_LOG));
@@ -1997,20 +1984,4 @@ public class SecuritiesChart
                 font.dispose();
         }
     }
-
-    private void adjustRange()
-    {
-        try
-        {
-            chart.setRedraw(false);
-
-            chart.getAxisSet().adjustRange();
-            ChartUtil.addYMargins(chart, 0.08);
-        }
-        finally
-        {
-            chart.setRedraw(true);
-        }
-    }
-
 }


### PR DESCRIPTION
Closes https://github.com/portfolio-performance/portfolio/issues/2490
Closes https://github.com/portfolio-performance/portfolio/issues/4063

Hello, on the Securities Chart, when you hit the '0' accelerator key or trigger the 'reset to Original size' action, the graph becomes incorrect when there are the positive/négative area on it.
What I understand : 
* SecuritiesChart is a TimelineChart and therefore the adjustRange of Timelinechart is used for those actions
* However In the updateChart of SecuritiesCharts, dedicated ranges are used for yAxis2nd and yAxis3rd, so if adjustRange is called after, the particular settings is lost.

So what I propose is to call updateChart at the end of the adjustRange method of timelinechart. But this means changing from private to public. I think this works. Otherwise, at first I was thinking we could get an override adjustRange method for SecuritiesCharts, but this was not so straightforward.

~~While I write this, I note that I did not check the behaviour when multiple securities are selected, I will check.~~
-> OK, no problem seen with multi securities selection.