### PR TITLE
re-add missing logo of securities in Trades view

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
@@ -38,6 +38,7 @@ import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
 import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.LogoManager;
 import name.abuchen.portfolio.ui.util.TabularDataSource;
 import name.abuchen.portfolio.ui.util.viewers.Column;
 import name.abuchen.portfolio.ui.util.viewers.ColumnEditingSupport;
@@ -293,7 +294,8 @@ public class TradesTableViewer
                 {
                     Trade trade = asTrade(e);
                     if (trade != null)
-                        return Images.SECURITY.image();
+                        return LogoManager.instance().getDefaultColumnImage(trade.getSecurity(),
+                                        view.getClient().getSettings());
                     return null;
                 }
             }));


### PR DESCRIPTION
Hello,

In a recent change, the possiblity to group Trades by Taxonomy was added. For this change, the default `getImage() `method of a `NameColumn` was overriden to include the possibility of empty image for taxonomy rows, but the dedicated logo of each security was then lost.

This is a proposition to have them back.