### PR TITLE
Minor refactorings inside csv-classes

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVExporter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVExporter.java
@@ -164,7 +164,7 @@ public class CSVExporter
 
     private void printSecurityInfo(CSVPrinter printer, Transaction t) throws IOException
     {
-        Security security = t.getSecurity();
+        var security = t.getSecurity();
         if (security != null)
         {
             printer.print(escapeNull(security.getIsin()));
@@ -260,12 +260,12 @@ public class CSVExporter
 
         for (Security s : securities)
         {
-            List<SecurityPrice> prices = s.getPrices();
+            var prices = s.getPrices();
             if (!prices.isEmpty())
             {
                 export.add(s);
 
-                LocalDate quoteDate = prices.get(0).getDate();
+                var quoteDate = prices.get(0).getDate();
                 if (earliestDate == null)
                     earliestDate = quoteDate;
                 else
@@ -287,8 +287,8 @@ public class CSVExporter
                 return;
 
             // write quotes
-            LocalDate pointer = earliestDate;
-            LocalDate today = LocalDate.now();
+            var pointer = earliestDate;
+            var today = LocalDate.now();
 
             while (pointer.compareTo(today) <= 0)
             {
@@ -298,7 +298,7 @@ public class CSVExporter
                 int ii = 0;
                 for (Security security : export)
                 {
-                    SecurityPrice p = new SecurityPrice(pointer, 0);
+                    var p = new SecurityPrice(pointer, 0);
                     indices[ii] = Collections.binarySearch(security.getPrices(), p);
                     ii++;
                 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVExtractor.java
@@ -9,7 +9,6 @@ import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import name.abuchen.portfolio.Messages;
@@ -46,7 +45,7 @@ public abstract class CSVExtractor implements Extractor
 
     protected final String getText(String name, String[] rawValues, Map<String, Column> field2column)
     {
-        Column column = field2column.get(name);
+        var column = field2column.get(name);
         if (column == null)
             return null;
 
@@ -56,12 +55,12 @@ public abstract class CSVExtractor implements Extractor
             return null;
 
         String value = rawValues[columnIndex];
-        return value != null && value.trim().length() == 0 ? null : value;
+        return value != null && value.trim().isEmpty() ? null : value;
     }
 
     protected final String getISIN(String name, String[] rawValues, Map<String, Column> field2column)
     {
-        Column column = field2column.get(name);
+        var column = field2column.get(name);
         if (column == null)
             return null;
 
@@ -76,12 +75,12 @@ public abstract class CSVExtractor implements Extractor
 
         value = value.trim().toUpperCase();
 
-        Pattern pattern = Pattern.compile("\\b(" + Isin.PATTERN + ")\\b"); //$NON-NLS-1$ //$NON-NLS-2$
-        Matcher matcher = pattern.matcher(value);
+        var pattern = Pattern.compile("\\b(" + Isin.PATTERN + ")\\b"); //$NON-NLS-1$ //$NON-NLS-2$
+        var matcher = pattern.matcher(value);
         if (matcher.find())
             value = matcher.group(1);
 
-        return value.length() == 0 ? null : value;
+        return value.isEmpty() ? null : value;
     }
 
     protected final Long getAmount(String name, String[] rawValues, Map<String, Column> field2column)
@@ -99,13 +98,13 @@ public abstract class CSVExtractor implements Extractor
     protected final Long getValue(String name, String[] rawValues, Map<String, Column> field2column,
                     Values<Long> values) throws ParseException
     {
-        String value = getText(name, rawValues, field2column);
+        var value = getText(name, rawValues, field2column);
         if (value == null)
             return null;
 
         try
         {
-            Number num = (Number) field2column.get(name).getFormat().getFormat().parseObject(value);
+            var num = (Number) field2column.get(name).getFormat().getFormat().parseObject(value);
             return Long.valueOf(Math.round(num.doubleValue() * values.factor()));
         }
         catch (ParseException e)
@@ -120,14 +119,14 @@ public abstract class CSVExtractor implements Extractor
     protected final LocalDateTime getDate(String dateColumn, String timeColumn, String[] rawValues,
                     Map<String, Column> field2column) throws ParseException
     {
-        String dateValue = getText(dateColumn, rawValues, field2column);
+        var dateValue = getText(dateColumn, rawValues, field2column);
         if (dateValue == null)
             return null;
 
         LocalDateTime result;
         try
         {
-            Date date = (Date) field2column.get(dateColumn).getFormat().getFormat().parseObject(dateValue);
+            var date = (Date) field2column.get(dateColumn).getFormat().getFormat().parseObject(dateValue);
             result = LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
         }
         catch (ParseException e)
@@ -140,7 +139,7 @@ public abstract class CSVExtractor implements Extractor
         if (timeColumn == null)
             return result;
 
-        String timeValue = getText(timeColumn, rawValues, field2column);
+        var timeValue = getText(timeColumn, rawValues, field2column);
         if (timeValue != null)
         {
             String[] timeToks = timeValue.split(":"); //$NON-NLS-1$
@@ -166,13 +165,13 @@ public abstract class CSVExtractor implements Extractor
     protected final BigDecimal getBigDecimal(String name, String[] rawValues, Map<String, Column> field2column)
                     throws ParseException
     {
-        String value = getText(name, rawValues, field2column);
+        var value = getText(name, rawValues, field2column);
         if (value == null)
             return null;
 
         try
         {
-            Number num = (Number) field2column.get(name).getFormat().getFormat().parseObject(value);
+            var num = (Number) field2column.get(name).getFormat().getFormat().parseObject(value);
             return BigDecimal.valueOf(num.doubleValue());
         }
         catch (ParseException e)
@@ -186,7 +185,7 @@ public abstract class CSVExtractor implements Extractor
     protected final Long getShares(String name, String[] rawValues, Map<String, Column> field2column)
                     throws ParseException
     {
-        Long value = getValue(name, rawValues, field2column, Values.Share);
+        var value = getValue(name, rawValues, field2column, Values.Share);
         if (value == null)
             return null;
         return Math.abs(value);
@@ -196,7 +195,7 @@ public abstract class CSVExtractor implements Extractor
     protected final <E extends Enum<E>> E getEnum(String name, Class<E> type, String[] rawValues,
                     Map<String, Column> field2column) throws ParseException
     {
-        String value = getText(name, rawValues, field2column);
+        var value = getText(name, rawValues, field2column);
         if (value == null)
             return null;
         FieldFormat ff = field2column.get(name).getFormat();
@@ -224,15 +223,15 @@ public abstract class CSVExtractor implements Extractor
     protected final Account getAccount(Client client, String[] rawValues, Map<String, Column> field2column,
                     boolean use2nd)
     {
-        String type = use2nd ? Messages.CSVColumn_AccountName2nd : Messages.CSVColumn_AccountName;
-        String accountName = getText(type, rawValues, field2column);
-        Account account = null;
+        var type = use2nd ? Messages.CSVColumn_AccountName2nd : Messages.CSVColumn_AccountName;
+        var accountName = getText(type, rawValues, field2column);
+
         if (accountName != null && !accountName.isEmpty())
         {
-            account = client.getAccounts().stream().filter(x -> x.getName().equals(accountName)).findFirst()
+            return client.getAccounts().stream().filter(x -> x.getName().equals(accountName)).findFirst()
                             .orElse(null);
         }
-        return account;
+        return null;
     }
 
     protected final Portfolio getPortfolio(Client client, String[] rawValues, Map<String, Column> field2column)
@@ -243,14 +242,14 @@ public abstract class CSVExtractor implements Extractor
     protected final Portfolio getPortfolio(Client client, String[] rawValues, Map<String, Column> field2column,
                     boolean use2nd)
     {
-        String type = use2nd ? Messages.CSVColumn_PortfolioName2nd : Messages.CSVColumn_PortfolioName;
-        String portfolioName = getText(type, rawValues, field2column);
-        Portfolio portfolio = null;
+        var type = use2nd ? Messages.CSVColumn_PortfolioName2nd : Messages.CSVColumn_PortfolioName;
+        var portfolioName = getText(type, rawValues, field2column);
+
         if (portfolioName != null && !portfolioName.isEmpty())
         {
-            portfolio = client.getPortfolios().stream().filter(x -> x.getName().equals(portfolioName)).findFirst()
+            return client.getPortfolios().stream().filter(x -> x.getName().equals(portfolioName)).findFirst()
                             .orElse(null);
         }
-        return portfolio;
+        return null;
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVPortfolioExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVPortfolioExtractor.java
@@ -3,26 +3,20 @@ package name.abuchen.portfolio.datatransfer.csv;
 import java.text.MessageFormat;
 import java.text.ParseException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
 import name.abuchen.portfolio.Messages;
-import name.abuchen.portfolio.datatransfer.Extractor;
 import name.abuchen.portfolio.datatransfer.csv.CSVImporter.AmountField;
 import name.abuchen.portfolio.datatransfer.csv.CSVImporter.Column;
 import name.abuchen.portfolio.datatransfer.csv.CSVImporter.DateField;
 import name.abuchen.portfolio.datatransfer.csv.CSVImporter.Field;
 import name.abuchen.portfolio.datatransfer.csv.CSVImporter.ISINField;
-import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
-import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
-import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.money.CurrencyUnit;
-import name.abuchen.portfolio.money.Money;
 
 /* package */class CSVPortfolioExtractor extends BaseCSVExtractor
 {
@@ -30,7 +24,7 @@ import name.abuchen.portfolio.money.Money;
     {
         super(client, Messages.CSVDefPortfolio);
 
-        List<Field> fields = getFields();
+        var fields = getFields();
         fields.add(new DateField("date", Messages.CSVColumn_DateValue).setOptional(true)); //$NON-NLS-1$
         fields.add(new Field("time", Messages.CSVColumn_Time).setOptional(true)); //$NON-NLS-1$
 
@@ -62,11 +56,11 @@ import name.abuchen.portfolio.money.Money;
     void extract(List<Item> items, String[] rawValues, Map<String, Column> field2column) throws ParseException
     {
         // check if we have a security
-        Security security = getSecurity(rawValues, field2column, s -> {
-            String currency = getText(Messages.CSVColumn_Currency, rawValues, field2column);
+        var security = getSecurity(rawValues, field2column, s -> {
+            var currency = getText(Messages.CSVColumn_Currency, rawValues, field2column);
             if (currency != null)
             {
-                CurrencyUnit unit = CurrencyUnit.getInstance(currency.trim());
+                var unit = CurrencyUnit.getInstance(currency.trim());
                 s.setCurrencyCode(unit == null ? getClient().getBaseCurrency() : unit.getCurrencyCode());
             }
         });
@@ -78,25 +72,25 @@ import name.abuchen.portfolio.money.Money;
                             0);
 
         // check for valuation (either current or historic)
-        Money valuation = getMoney(Messages.CSVColumn_Value, Messages.CSVColumn_Currency, rawValues, field2column);
+        var valuation = getMoney(Messages.CSVColumn_Value, Messages.CSVColumn_Currency, rawValues, field2column);
 
         // check for the number of shares
-        Long shares = getShares(Messages.CSVColumn_Shares, rawValues, field2column);
+        var shares = getShares(Messages.CSVColumn_Shares, rawValues, field2column);
         if (shares == null)
             throw new ParseException(MessageFormat.format(Messages.CSVImportMissingField, Messages.CSVColumn_Shares),
                             0);
 
         // determine remaining fields
-        LocalDateTime date = getDate(Messages.CSVColumn_DateValue, Messages.CSVColumn_Time, rawValues, field2column);
+        var date = getDate(Messages.CSVColumn_DateValue, Messages.CSVColumn_Time, rawValues, field2column);
         if (date == null)
             date = LocalDate.now().atStartOfDay();
 
-        String note = getText(Messages.CSVColumn_Note, rawValues, field2column);
+        var note = getText(Messages.CSVColumn_Note, rawValues, field2column);
 
-        Account account = getAccount(getClient(), rawValues, field2column);
-        Portfolio portfolio = getPortfolio(getClient(), rawValues, field2column);
+        var account = getAccount(getClient(), rawValues, field2column);
+        var portfolio = getPortfolio(getClient(), rawValues, field2column);
 
-        BuySellEntry entry = new BuySellEntry();
+        var entry = new BuySellEntry();
         entry.setType(PortfolioTransaction.Type.BUY);
         entry.setSecurity(security);
         entry.setDate(date);
@@ -105,7 +99,7 @@ import name.abuchen.portfolio.money.Money;
         entry.setShares(shares);
         entry.setNote(note);
 
-        Extractor.Item item = new BuySellEntryItem(entry);
+        var item = new BuySellEntryItem(entry);
 
         item.setAccountPrimary(account);
         item.setPortfolioPrimary(portfolio);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVSecurityExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVSecurityExtractor.java
@@ -13,7 +13,6 @@ import name.abuchen.portfolio.datatransfer.csv.CSVImporter.Column;
 import name.abuchen.portfolio.datatransfer.csv.CSVImporter.DateField;
 import name.abuchen.portfolio.datatransfer.csv.CSVImporter.Field;
 import name.abuchen.portfolio.model.Client;
-import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.online.impl.YahooFinanceQuoteFeed;
 
 /* package */class CSVSecurityExtractor extends BaseCSVExtractor
@@ -22,7 +21,7 @@ import name.abuchen.portfolio.online.impl.YahooFinanceQuoteFeed;
     {
         super(client, Messages.CSVDefSecurities);
 
-        List<Field> fields = getFields();
+        var fields = getFields();
         fields.add(new Field("isin", Messages.CSVColumn_ISIN).setOptional(true)); //$NON-NLS-1$
         fields.add(new Field("wkn", Messages.CSVColumn_WKN).setOptional(true)); //$NON-NLS-1$
         fields.add(new Field("ticker", Messages.CSVColumn_TickerSymbol).setOptional(true)); //$NON-NLS-1$
@@ -45,13 +44,13 @@ import name.abuchen.portfolio.online.impl.YahooFinanceQuoteFeed;
     void extract(List<Item> items, String[] rawValues, Map<String, Column> field2column) throws ParseException
     {
         // check if we can identify a security
-        Security security = getSecurity(rawValues, field2column, s -> {
+        var security = getSecurity(rawValues, field2column, s -> {
             s.setCurrencyCode(getCurrencyCode(Messages.CSVColumn_Currency, rawValues, field2column));
 
-            String note = getText(Messages.CSVColumn_Note, rawValues, field2column);
+            var note = getText(Messages.CSVColumn_Note, rawValues, field2column);
             s.setNote(note);
 
-            String tickerSymbol = getText(Messages.CSVColumn_TickerSymbol, rawValues, field2column);
+            var tickerSymbol = getText(Messages.CSVColumn_TickerSymbol, rawValues, field2column);
             if (tickerSymbol != null && !tickerSymbol.isBlank())
             {
                 s.setTickerSymbol(tickerSymbol);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVSecurityPriceExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/CSVSecurityPriceExtractor.java
@@ -2,7 +2,6 @@ package name.abuchen.portfolio.datatransfer.csv;
 
 import java.text.MessageFormat;
 import java.text.ParseException;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -48,15 +47,15 @@ import name.abuchen.portfolio.model.SecurityPrice;
     public List<Item> extract(int skipLines, List<String[]> rawValues, Map<String, Column> field2column,
                     List<Exception> errors)
     {
-        Security dummy = new Security(null, null);
+        var dummy = new Security(null, null);
 
         for (String[] line : rawValues)
         {
             try
             {
-                SecurityPrice p = extract(line, field2column);
-                if (p.getValue() >= 0)
-                    dummy.addPrice(p);
+                var price = extract(line, field2column);
+                if (price.getValue() >= 0)
+                    dummy.addPrice(price);
             }
             catch (ParseException e)
             {
@@ -72,11 +71,11 @@ import name.abuchen.portfolio.model.SecurityPrice;
 
     private SecurityPrice extract(String[] rawValues, Map<String, Column> field2column) throws ParseException
     {
-        LocalDateTime date = getDate(Messages.CSVColumn_Date, null, rawValues, field2column);
+        var date = getDate(Messages.CSVColumn_Date, null, rawValues, field2column);
         if (date == null)
             throw new ParseException(MessageFormat.format(Messages.CSVImportMissingField, Messages.CSVColumn_Date), 0);
 
-        Long amount = getQuote(Messages.CSVColumn_Quote, rawValues, field2column);
+        var amount = getQuote(Messages.CSVColumn_Quote, rawValues, field2column);
         if (amount == null)
             throw new ParseException(MessageFormat.format(Messages.CSVImportMissingField, Messages.CSVColumn_Quote), 0);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/VINISExporter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/VINISExporter.java
@@ -7,17 +7,13 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.commons.csv.CSVPrinter;
 
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.model.Client;
-import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyConverterImpl;
 import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
-import name.abuchen.portfolio.money.MonetaryOperator;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MoneyCollectors;
 import name.abuchen.portfolio.money.MutableMoney;
@@ -42,56 +38,55 @@ public class VINISExporter
      */
     public void exportAllValues(File file, Client client, ExchangeRateProviderFactory factory) throws IOException
     {
-        final String baseCurrency = client.getBaseCurrency();
-        CurrencyConverter converter = new CurrencyConverterImpl(factory, baseCurrency);
+        final var baseCurrency = client.getBaseCurrency();
+        var converter = new CurrencyConverterImpl(factory, baseCurrency);
 
-        LocalDate lastYear = LocalDate.now().minusYears(1);
-        LocalDate firstYear = LocalDate.now().minusYears(100);
+        var lastYear = LocalDate.now().minusYears(1);
+        var firstYear = LocalDate.now().minusYears(100);
 
-        ReportingPeriod periodCurrentYear = new ReportingPeriod.YearToDate();
-        ReportingPeriod periodLastYear = new ReportingPeriod.YearX(lastYear.getYear());
-        ReportingPeriod periodAllYears = new ReportingPeriod.FromXtoY(
+        var periodCurrentYear = new ReportingPeriod.YearToDate();
+        var periodLastYear = new ReportingPeriod.YearX(lastYear.getYear());
+        var periodAllYears = new ReportingPeriod.FromXtoY(
                         firstYear.with(TemporalAdjusters.firstDayOfYear()), LocalDate.now());
 
-        ClientPerformanceSnapshot performanceAllYears = new ClientPerformanceSnapshot(client, converter,
+        var performanceAllYears = new ClientPerformanceSnapshot(client, converter,
                         periodAllYears.toInterval(LocalDate.now()));
-        ClientPerformanceSnapshot performanceCurrentYear = new ClientPerformanceSnapshot(client, converter,
+        var performanceCurrentYear = new ClientPerformanceSnapshot(client, converter,
                         periodCurrentYear.toInterval(LocalDate.now()));
-        ClientPerformanceSnapshot performanceLastYear = new ClientPerformanceSnapshot(client, converter,
+        var performanceLastYear = new ClientPerformanceSnapshot(client, converter,
                         periodLastYear.toInterval(LocalDate.now()));
 
-        Money earningsCurrentYear = performanceCurrentYear.getValue(CategoryType.EARNINGS);
-        Money earningsLastYear = performanceLastYear.getValue(CategoryType.EARNINGS);
-        Money earningsAll = performanceAllYears.getValue(CategoryType.EARNINGS);
+        var earningsCurrentYear = performanceCurrentYear.getValue(CategoryType.EARNINGS);
+        var earningsLastYear = performanceLastYear.getValue(CategoryType.EARNINGS);
+        var earningsAll = performanceAllYears.getValue(CategoryType.EARNINGS);
 
-        Money capitalGainsCurrentYear = performanceCurrentYear.getValue(CategoryType.CAPITAL_GAINS);
-        Money capitalGainsLastYear = performanceLastYear.getValue(CategoryType.CAPITAL_GAINS);
-        Money capitalGainsAll = performanceAllYears.getValue(CategoryType.CAPITAL_GAINS);
+        var capitalGainsCurrentYear = performanceCurrentYear.getValue(CategoryType.CAPITAL_GAINS);
+        var capitalGainsLastYear = performanceLastYear.getValue(CategoryType.CAPITAL_GAINS);
+        var capitalGainsAll = performanceAllYears.getValue(CategoryType.CAPITAL_GAINS);
 
-        Money realizedCapitalGainsCurrentYear = performanceCurrentYear.getValue(CategoryType.REALIZED_CAPITAL_GAINS);
-        Money realizedCapitalGainsLastYear = performanceLastYear.getValue(CategoryType.REALIZED_CAPITAL_GAINS);
-        Money realizedCapitalGainsAll = performanceAllYears.getValue(CategoryType.REALIZED_CAPITAL_GAINS);
+        var realizedCapitalGainsCurrentYear = performanceCurrentYear.getValue(CategoryType.REALIZED_CAPITAL_GAINS);
+        var realizedCapitalGainsLastYear = performanceLastYear.getValue(CategoryType.REALIZED_CAPITAL_GAINS);
+        var realizedCapitalGainsAll = performanceAllYears.getValue(CategoryType.REALIZED_CAPITAL_GAINS);
 
-        MutableMoney buySecurityValue = MutableMoney.of(baseCurrency);
-        MutableMoney currentSecurityValue = MutableMoney.of(baseCurrency);
-        MutableMoney buyTotalValue = MutableMoney.of(baseCurrency);
-        MutableMoney currentTotalValue = MutableMoney.of(baseCurrency);
+        var buySecurityValue = MutableMoney.of(baseCurrency);
+        var currentSecurityValue = MutableMoney.of(baseCurrency);
+        var buyTotalValue = MutableMoney.of(baseCurrency);
+        var currentTotalValue = MutableMoney.of(baseCurrency);
 
-        SecurityPerformanceSnapshot securityPerformance = SecurityPerformanceSnapshot.create(client, converter,
+        var securityPerformance = SecurityPerformanceSnapshot.create(client, converter,
                         Interval.of(LocalDate.MIN, LocalDate.now()), SecurityPerformanceIndicator.Costs.class);
 
-        List<AssetPosition> assets = performanceCurrentYear.getEndClientSnapshot().getAssetPositions()
-                        .collect(Collectors.toList());
+        var assets = performanceCurrentYear.getEndClientSnapshot().getAssetPositions().toList();
 
-        MonetaryOperator toBaseCurrency = converter.at(LocalDate.now());
+        var toBaseCurrency = converter.at(LocalDate.now());
 
         for (AssetPosition asset : assets)
         {
-            Money valuation = asset.getValuation().with(toBaseCurrency);
+            var valuation = asset.getValuation().with(toBaseCurrency);
 
             if (asset.getSecurity() != null)
             {
-                Money fifo = securityPerformance.getRecord(asset.getSecurity())
+                var fifo = securityPerformance.getRecord(asset.getSecurity())
                                 .map(SecurityPerformanceRecord::getFifoCost).orElse(Money.of(baseCurrency, 0))
                                 .with(toBaseCurrency);
                 buySecurityValue.add(fifo);
@@ -106,11 +101,11 @@ public class VINISExporter
             currentTotalValue.add(valuation);
         }
 
-        Money cash = performanceCurrentYear.getEndClientSnapshot().getAccounts().stream().map(AccountSnapshot::getFunds)
+        var cash = performanceCurrentYear.getEndClientSnapshot().getAccounts().stream().map(AccountSnapshot::getFunds)
                         .collect(MoneyCollectors.sum(baseCurrency));
 
         // write to file
-        try (CSVPrinter printer = new CSVPrinter(
+        try (var printer = new CSVPrinter(
                         new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8),
                         CSVExporter.STRATEGY))
         {


### PR DESCRIPTION
I read through the CSV-classes (exporter and importer) and while doing this noted that this seems to be older code, so thought I give it some smaller touch-ups
- In most cases changed to `var` according to code-guidelines
- Modernized switch-statements. Either rewrote them to have a return or bundled connected types with comma

There are no functional changes and everything works as before, I haven't touched any test-classes to display this.

Thought while going through the code, I think it'll be better to offload csv-parsing to existing libs (e.g. `de.siegmar:fastcsv`) to reduce complexity and size of the code-base while focussing on the main business logic. However as the code already exists might be an unnecessary bigger refactoring.