### PR TITLE
Factor out a getStatusImage(Status.Code) convenience function.

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/datatransfer/ReviewExtractedItemsPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/datatransfer/ReviewExtractedItemsPage.java
@@ -192,6 +192,17 @@ public class ReviewExtractedItemsPage extends AbstractWizardPage implements Impo
         return allEntries;
     }
 
+    private Images getStatusImage(Code code)
+    {
+        return switch (code)
+        {
+            case WARNING -> Images.WARNING;
+            case ERROR -> Images.ERROR;
+            case OK -> Images.OK;
+            default -> throw new IllegalArgumentException();
+        };
+    }
+
     @Override
     public Portfolio getPortfolio()
     {
@@ -437,21 +448,7 @@ public class ReviewExtractedItemsPage extends AbstractWizardPage implements Impo
             @Override
             public Image getImage(ExtractedEntry entry)
             {
-                Images image = null;
-                switch (entry.getMaxCode())
-                {
-                    case WARNING:
-                        image = Images.WARNING;
-                        break;
-                    case ERROR:
-                        image = Images.ERROR;
-                        break;
-                    case OK:
-                        image = Images.OK;
-                        break;
-                    default:
-                }
-                return image != null ? image.image() : null;
+                return getStatusImage(entry.getMaxCode()).image();
             }
 
             @Override
@@ -672,8 +669,7 @@ public class ReviewExtractedItemsPage extends AbstractWizardPage implements Impo
             entry.getStatus() //
                             .filter(s -> s.getCode() != ImportAction.Status.Code.OK) //
                             .forEach(s -> {
-                                Images image = s.getCode() == ImportAction.Status.Code.WARNING ? //
-                                                Images.WARNING : Images.ERROR;
+                                Images image = getStatusImage(s.getCode());
                                 manager.add(new LabelOnly(s.getMessage(), image.descriptor()));
                             });
         }


### PR DESCRIPTION
We had the same logic implemented in two separate places that risk getting out of sync in case of new codes being introduced.

Note: the new implementation is simpler but also stricter than before. On unknown status codes it will throw an
exception. But all current statuses should be covered right now. So future coding errors will be caught earlier.

(This is a preparation for a bigger change being worked on)