### PR TITLE
fix currency initialisation for locale with region instead of country

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/money/CurrencyUnit.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/money/CurrencyUnit.java
@@ -11,6 +11,7 @@ import java.util.MissingResourceException;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.ResourceBundle;
+import java.util.Set;
 import java.util.TreeMap;
 
 import name.abuchen.portfolio.Messages;
@@ -77,15 +78,22 @@ public final class CurrencyUnit implements Comparable<CurrencyUnit>
 
     public static CurrencyUnit getDefaultInstance()
     {
-        if (Locale.getDefault().getCountry().isEmpty())
-            return CurrencyUnit.getInstance(EUR);
+        try
+        {
+            if (!Set.of(Locale.getISOCountries()).contains(Locale.getDefault().getCountry()))
+                return CurrencyUnit.getInstance(EUR);
 
-        var defaultCurrencyISO4217 = java.util.Currency.getInstance(Locale.getDefault());
-        if (defaultCurrencyISO4217 == null || defaultCurrencyISO4217.getCurrencyCode() == null)
-            return CurrencyUnit.getInstance(EUR);
+            var defaultCurrencyISO4217 = java.util.Currency.getInstance(Locale.getDefault());
+            if (defaultCurrencyISO4217 == null || defaultCurrencyISO4217.getCurrencyCode() == null)
+                return CurrencyUnit.getInstance(EUR);
 
-        var defaultCurrencyUnit = CurrencyUnit.getInstance(defaultCurrencyISO4217.getCurrencyCode());
-        return defaultCurrencyUnit != null ? defaultCurrencyUnit : CurrencyUnit.getInstance(EUR);
+            var defaultCurrencyUnit = CurrencyUnit.getInstance(defaultCurrencyISO4217.getCurrencyCode());
+            return defaultCurrencyUnit != null ? defaultCurrencyUnit : CurrencyUnit.getInstance(EUR);
+        }
+        catch (NullPointerException | IllegalArgumentException e)
+        {
+            return CurrencyUnit.getInstance(EUR);
+        }
     }
 
     public static CurrencyUnit getInstanceBySymbol(String currencySymbol)


### PR DESCRIPTION
Closes https://github.com/portfolio-performance/portfolio/issues/4471
Issue https://forum.portfolio-performance.info/t/command-name-abuchen-portfolio-ui-command-newclient-failed/38488

Hello,

The previous fix about this issue (cannot create new file) dealt with empty country, however it seems there are still some particular cases leading to the same issue :

Locale can contain both ISO 3166 country code (2 letters) or UN M.49 area (three digit); while `java.util.Currency.getInstance `only accepts ISO 3166 local, so en_001 (English-World) or en_150 (English-Europe) locale were throwing IllegalArgumentException and no new file could be created.

`Locale.getISOCountries `returns the list of the ISO 3166 countries, so what should be accepted by `java.util.Currency.getInstance`, so we can check if the locale country is in there or not.
For good measure, I have added a try catch too, but I assume it is now redundant with the getISOCountries fix.


