### PR TITLE
sort Reference Accounts alphabetically in Portfolio List view

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioListView.java
@@ -4,6 +4,8 @@ import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import jakarta.annotation.PostConstruct;
@@ -228,7 +230,9 @@ public class PortfolioListView extends AbstractFinanceView implements Modificati
             }
         });
         ColumnViewerSorter.create(Portfolio.class, "referenceAccount").attachTo(column); //$NON-NLS-1$
-        new ListEditingSupport(Portfolio.class, "referenceAccount", getClient().getAccounts()) //$NON-NLS-1$
+        List<Account> modifiableAccountList = new ArrayList<>(getClient().getAccounts());
+        Collections.sort(modifiableAccountList, new Account.ByName());
+        new ListEditingSupport(Portfolio.class, "referenceAccount", modifiableAccountList) //$NON-NLS-1$
                         .addListener(this).attachTo(column);
         portfolioColumns.addColumn(column);
 


### PR DESCRIPTION
Issue : https://forum.portfolio-performance.info/t/konten-oder-depotliste-in-auswahlmenus-nicht-alphabetisch-sortiert/38499

Hello, in Portfolio List View, the column reference account allows to select a reference cash account. This selection was not sorted, this is a proposition to have it sorted. There might be another location where a sort is needed, as per the forum thread first post, but I did understood where exactly.

**Before :** 
<img width="371" height="184" alt="2025-12-30 16_48_14-Portfolio Performance" src="https://github.com/user-attachments/assets/104a5e13-b80a-46fc-8508-50aed1b7e8f6" />

**After :**
<img width="386" height="180" alt="2025-12-30 16_47_36-Portfolio Performance" src="https://github.com/user-attachments/assets/21ae1761-40e0-4d4b-baaf-6f9dff014685" />
