### PR TITLE
sort alphabetically accounts and portofolios in the transaction tables

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/TransactionOwnerListEditingSupport.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/TransactionOwnerListEditingSupport.java
@@ -136,11 +136,13 @@ public class TransactionOwnerListEditingSupport extends ColumnEditingSupport
         {
             String ownerCurrencyCode = account.getCurrencyCode();
             comboBoxItems = client.getAccounts().stream().filter(a -> !a.equals(skipTransfer))
-                            .filter(a -> a.getCurrencyCode().equals(ownerCurrencyCode)).collect(Collectors.toList());
+                            .filter(a -> a.getCurrencyCode().equals(ownerCurrencyCode)).sorted(new Account.ByName())
+                            .collect(Collectors.toList());
         }
         else if (ownerToEdit instanceof Portfolio)
         {
             comboBoxItems = client.getPortfolios().stream().filter(p -> !p.equals(skipTransfer))
+                            .sorted(new Portfolio.ByName())
                             .collect(Collectors.toList());
         }
         else


### PR DESCRIPTION
for inline transactions editing

Issue : https://forum.portfolio-performance.info/t/konten-oder-depotliste-in-auswahlmenus-nicht-alphabetisch-sortiert/38499/3

Hello, this time it is for the inline transaction edition where a combolist of accounts is available and was unsorted.

I was wondering if we need the inactive accounts there ? If not, then I think another way would be to call `client.getActiveAccounts` and `client.getActivePortfolios` which are already sorted. I do not really use those combo list a lot myself, so no strong opinion. Maybe the answer is different for this inline edition combolist of accounts and for the list of available reference accounts from yesterday ?
