### PR TITLE
fix taxonomy name with '@' in MenuManager action

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -1123,7 +1123,7 @@ public class StatementOfAssetsViewer
 
         for (final Taxonomy t : client.getTaxonomies())
         {
-            Action action = new SimpleAction(TextUtil.tooltip(t.getName()), a -> {
+            Action action = new SimpleAction(TextUtil.tooltipAddTab(t.getName()), a -> {
                 taxonomy = t;
                 setInput(model.clientFilter, model.getDate(), model.getCurrencyConverter());
             });

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
@@ -420,7 +420,7 @@ public final class TradeDetailsView extends AbstractFinanceView
 
             for (final Taxonomy t : getClient().getTaxonomies())
             {
-                Action action = new SimpleAction(TextUtil.tooltip(t.getName()), a -> {
+                Action action = new SimpleAction(TextUtil.tooltipAddTab(t.getName()), a -> {
                     taxonomy = t;
                     getPreferenceStore().setValue(PREF_TAXONOMY, t.getId());
                     update();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TextUtil.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TextUtil.java
@@ -107,6 +107,19 @@ public final class TextUtil
     }
 
     /**
+     * As the TextUtil.tooltip method, creates a tooltip text by escaping '&'
+     * characters to ensure correct display in graphical user interfaces, but in
+     * addition, adds a TAB ("\t") character to allow MenuManager to display "@"
+     * character instead of space for Action texts.
+     * https://stackoverflow.com/questions/77472261/how-to-keep-character-in-swt-menu-item-text
+     * https://github.com/portfolio-performance/portfolio/issues/5288
+     */
+    public static final String tooltipAddTab(String text)
+    {
+        return text == null ? null : tooltip(text) + "\t"; //$NON-NLS-1$
+    }
+
+    /**
      * Sanitizes a given filename by filtering out characters that may cause
      * issues in file systems. Replaces characters such as ?, \, /, :, |, <, >,
      * //, and * with spaces, and removes multiple spaces by replacing them with


### PR DESCRIPTION
Issue : https://github.com/portfolio-performance/portfolio/issues/5288

Hello, I can reproduce the issue of #5288. The proposition of fix is to use the idea of the stackoverflow thread : 
https://stackoverflow.com/questions/77472261/how-to-keep-character-in-swt-menu-item-text
Feels a bit strange, but on Windows it works and I do not notice visual impact from the added tab.
This adds the tab by default, maybe best to add only if there is the @ character ?

With : 
<img width="178" height="58" alt="Capture d’écran 2026-01-03 144834" src="https://github.com/user-attachments/assets/e4829c55-433d-4aed-9236-155f16a82d2b" />

**Before :**
<img width="354" height="183" alt="2026-01-03 14_49_52-" src="https://github.com/user-attachments/assets/8ea4a01b-3033-4109-a344-5c878768a534" />

**After :**
<img width="241" height="165" alt="2026-01-03 14_56_05-" src="https://github.com/user-attachments/assets/d8246dea-66cb-4919-9554-3e84197373a0" />