### PR TITLE
Improvement: IBFlex handle currency unit mismatches

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
@@ -3486,4 +3486,72 @@ public class IBFlexStatementExtractorTest
                                         hasAmount("EUR", 62.05), //
                                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
+
+    @Test
+    public void testIBFlexStatementFile27() throws IOException
+    {
+        // Test minor unit currency handling: IBKR provides GBP, security is GBX
+        var client = new Client();
+
+        // Create security with GBX currency (minor unit)
+        var eqqq = new Security("INVESCO NASDAQ-100 DIST", "GBX");
+        eqqq.setTickerSymbol("EQQQ.L");
+        eqqq.setIsin("IE0032077012");
+        eqqq.setWkn("35628280");
+        client.addSecurity(eqqq);
+
+        var referenceAccount = new Account("A");
+        referenceAccount.setCurrencyCode("GBP");
+        client.addAccount(referenceAccount);
+
+        var portfolio = new Portfolio("U1234567");
+        portfolio.setReferenceAccount(referenceAccount);
+        client.addPortfolio(portfolio);
+
+        var extractor = new IBFlexStatementExtractor(client);
+
+        var activityStatement = getClass().getResourceAsStream("testIBFlexStatementFile27.xml");
+        var tempFile = createTempFile(activityStatement);
+
+        var errors = new ArrayList<Exception>();
+
+        var results = extractor.extract(Collections.singletonList(tempFile), errors);
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L)); // Security already exists
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+
+        // Find the buy transaction
+        BuySellEntry entry = (BuySellEntry) results.stream() //
+                        .filter(BuySellEntryItem.class::isInstance) //
+                        .findFirst() //
+                        .orElseThrow(() -> new AssertionError("Buy transaction not found")) //
+                        .getSubject();
+
+        // Verify transaction currency is GBP (from IBKR)
+        assertThat(entry.getPortfolioTransaction().getCurrencyCode(), is("GBP"));
+        // netCash is -1369.52, but transaction amount should be absolute value
+        assertThat(entry.getPortfolioTransaction().getAmount(), is(136952L)); // 1369.52 GBP
+
+        // Verify security currency is GBX
+        assertThat(entry.getPortfolioTransaction().getSecurity().getCurrencyCode(), is("GBX"));
+
+        // Verify GROSS_VALUE unit exists and has correct conversion
+        var grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE);
+        assertThat("GROSS_VALUE unit should be present for GBP->GBX conversion", grossValueUnit.isPresent(), is(true));
+
+        var unit = grossValueUnit.get();
+        // GROSS_VALUE unit amount is the gross value before fees
+        // Transaction amount is 1369.52 GBP (netCash), fees are 3.00 GBP
+        // Gross value = 1369.52 - 3.00 = 1366.52 GBP = 136652 (in smallest unit)
+        assertThat(unit.getAmount().getCurrencyCode(), is("GBP"));
+        assertThat(unit.getAmount().getAmount(), is(136652L));
+
+        // Forex amount in GBX: 1369.52 GBP * 100 = 136952 GBX (in smallest unit)
+        assertThat(unit.getForex().getCurrencyCode(), is("GBX"));
+        assertThat(unit.getForex().getAmount(), is(13695200L)); // 136952.00 GBX
+
+        // Exchange rate should be 0.01 (GBP to GBX: 1 GBP = 100 GBX, so rate is 0.01)
+        assertThat(unit.getExchangeRate().compareTo(new java.math.BigDecimal("0.01")), is(0));
+    }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/testIBFlexStatementFile27.xml
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/testIBFlexStatementFile27.xml
@@ -1,0 +1,11 @@
+<FlexQueryResponse queryName="PP" type="AF">
+<FlexStatements count="1">
+<FlexStatement accountId="U1234567" fromDate="20251201" toDate="20251231" period="LastMonth" whenGenerated="20251220;120000">
+<AccountInformation accountId="U1234567" acctAlias="A" model="" currency="GBP" name="John Doe" accountType="Individual" customerType="Individual" />
+<Trades>
+<Trade accountId="U1234567" acctAlias="" model="" currency="GBP" fxRateToBase="1.1426" assetCategory="STK" subCategory="ETF" symbol="EQQQ.L" description="INVESCO NASDAQ-100 DIST" conid="35628280" securityID="IE0032077012" securityIDType="ISIN" cusip="" isin="IE0032077012" figi="BBG000QYQVV5" listingExchange="LSEETF" underlyingConid="" underlyingSymbol="EQQQ.L" underlyingSecurityID="" underlyingListingExchange="" issuer="" issuerCountryCode="IE" tradeID="1252050191" multiplier="1" relatedTradeID="" strike="" reportDate="20251216" expiry="" dateTime="20251216;103059" putCall="" tradeDate="20251216" principalAdjustFactor="" settleDateTarget="20251218" transactionType="ExchTrade" exchange="TRWBUKETF" quantity="3" tradePrice="455.5054" tradeMoney="1366.52" proceeds="-1366.52" taxes="0" ibCommission="-3" ibCommissionCurrency="GBP" netCash="-1369.52" closePrice="455.49" openCloseIndicator="O" notes="" cost="1369.52" fifoPnlRealized="0" mtmPnl="-0.05" origTradePrice="0" origTradeDate="" origTradeID="" origOrderID="0" origTransactionID="0" buySell="BUY" clearingFirmID="" ibOrderID="1022115019" transactionID="5103375270" ibExecID="00015269.69411ea0.01.01" relatedTransactionID="" rtn="" brokerageOrderID="000e3ea6.0001cbfa.6940ef59.0001" orderReference="" volatilityOrderLink="" exchOrderId="N/A" extExecID="PC16JANEETF201531" orderTime="20251216;103058" openDateTime="" holdingPeriodDateTime="" whenRealized="" whenReopened="" levelOfDetail="EXECUTION" changeInPrice="0" changeInQuantity="0" orderType="LMT" traderID="" isAPIOrder="N" accruedInt="0" initialInvestment="" positionActionID="" serialNumber="" deliveryType="" commodityType="" fineness="0.0" weight="0.0" />
+</Trades>
+</FlexStatement>
+</FlexStatements>
+</FlexQueryResponse>
+


### PR DESCRIPTION
When using the IBFlex importer, some of my transactions will not import.

Problem:
- Some currencies have major and minor units, such as UK Sterling, with GBX (pence) and GBP (pound, equal to 100 GBX)
- It seems that Interactive Brokers flex queries do not always report the unit that the security is quoted in
- For example, EQQQ on LSE is quoted in GBX, but transactions in the IBKR export are in GBP

Until now, the importer flagged these cases as a currency mismatch and they were not imported. But there is no real mismatch – they just require a fixed-rate conversion between major and minor unit.

This PR attempts to do that, and complete the import. It works correctly with my personal data.

Some minor logic changes were needed, to detect mismatches, and ensure correct handling when GROSS_AMOUNT is set.