### PR TITLE
Improvement: IBFlex support cross-currency dividend import

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
@@ -37,6 +37,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.file.Files;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -3674,5 +3676,198 @@ public class IBFlexStatementExtractorTest
 
         // Invalid format should return null
         assertThat(IBFlexStatementExtractor.parseDateTime("invalid"), is(nullValue()));
+    }
+
+    @Test
+    public void testIBFlexStatementFile29() throws IOException
+    {
+        // Test cross-rate calculation using fxRateToBase when direct rate is missing
+        // Case 1: Transaction currency: USD, Security currency: GBP, Base currency: EUR
+        // Case 2: Transaction currency: USD, Security currency: GBX (minor unit), Base currency: EUR
+        // Case 3: Transaction currency: USD, Security currency: GBX (minor unit), Base currency: GBP
+        // USD/EUR available via fxRateToBase, GBP/EUR available via ConversionRate
+        var client = new Client();
+
+        // Create security with GBP currency (security currency differs from transaction currency)
+        var hidr = new Security("HSBC MSCI INDONESIA UCITS ET", "GBP");
+        hidr.setTickerSymbol("HIDR");
+        hidr.setIsin("IE00B46G8275");
+        hidr.setWkn("86281326");
+        client.addSecurity(hidr);
+
+        // Create security with GBX currency (minor unit)
+        var eqqq = new Security("INVESCO NASDAQ-100 DIST", "GBX");
+        eqqq.setTickerSymbol("EQQQ");
+        eqqq.setIsin("IE0032077012");
+        eqqq.setWkn("18706552");
+        client.addSecurity(eqqq);
+
+        // Create security with USD currency for reverse minor-unit conversion
+        var gbdv = new Security("Global USD Dividend Fund", "USD");
+        gbdv.setTickerSymbol("GBDV");
+        gbdv.setIsin("US1234567890");
+        gbdv.setWkn("12345678");
+        client.addSecurity(gbdv);
+
+        var referenceAccount = new Account("A");
+        referenceAccount.setCurrencyCode("EUR");
+        client.addAccount(referenceAccount);
+
+        var extractor = new IBFlexStatementExtractor(client);
+
+        var activityStatement = getClass().getResourceAsStream("testIBFlexStatementFile29.xml");
+        var tempFile = createTempFile(activityStatement);
+
+        var errors = new ArrayList<Exception>();
+
+        var results = extractor.extract(Collections.singletonList(tempFile), errors);
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L)); // Securities already exist
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(4L));
+
+        // Find the first dividend transaction (HIDR - USD->GBP)
+        List<AccountTransaction> transactions = results.stream() //
+                        .filter(TransactionItem.class::isInstance) //
+                        .map(item -> (AccountTransaction) ((TransactionItem) item).getSubject()) //
+                        .filter(t -> t.getType() == AccountTransaction.Type.DIVIDENDS) //
+                        .toList();
+
+        assertThat(transactions.size(), is(4));
+
+        // Test first transaction: HIDR (USD->GBP)
+        AccountTransaction hidrTransaction = transactions.stream() //
+                        .filter(t -> "HIDR".equals(t.getSecurity().getTickerSymbol())) //
+                        .findFirst() //
+                        .orElseThrow(() -> new AssertionError("HIDR dividend transaction not found"));
+
+        assertThat(hidrTransaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(hidrTransaction.getDateTime(), is(LocalDateTime.parse("2025-03-04T00:00")));
+
+        assertThat(hidrTransaction.getCurrencyCode(), is("USD"));
+        assertThat(hidrTransaction.getAmount(), is(18_15L)); // 18.15 USD
+        assertThat(hidrTransaction.getSecurity().getCurrencyCode(), is("GBP"));
+
+        // Verify GROSS_VALUE unit exists and has correct conversion
+        // USD/EUR = 0.94106 (from fxRateToBase)
+        // GBP/EUR = 1.2041 (from ConversionRate on 20250304)
+        // USD/GBP = (USD/EUR) / (GBP/EUR) = 0.94106 / 1.2041 ≈ 0.781546
+        // After inversion in setAmount: GBP/USD ≈ 1.2795
+        var hidrGrossValueUnit = hidrTransaction.getUnit(Unit.Type.GROSS_VALUE);
+        assertThat("GROSS_VALUE unit should be present for USD->GBP conversion", hidrGrossValueUnit.isPresent(), is(true));
+
+        var hidrUnit = hidrGrossValueUnit.get();
+        assertThat(hidrUnit.getAmount().getCurrencyCode(), is("USD"));
+        assertThat(hidrUnit.getAmount().getAmount(), is(18_15L)); // 18.15 USD
+        assertThat(hidrUnit.getForex().getCurrencyCode(), is("GBP"));
+        assertThat(hidrUnit.getForex().getAmount(), is(14_19L)); // 14.19 GBP (rounded)
+
+        BigDecimal hidrExpectedRate = new BigDecimal("1.2795145899");
+        BigDecimal tolerance = new BigDecimal("0.0000001");
+        assertThat(hidrUnit.getExchangeRate().subtract(hidrExpectedRate).abs().compareTo(tolerance) < 0, is(true));
+
+        // Test second transaction: EQQQ (USD->GBX via GBP)
+        AccountTransaction eqqqTransaction = transactions.stream() //
+                        .filter(t -> "EQQQ".equals(t.getSecurity().getTickerSymbol())) //
+                        .filter(t -> LocalDateTime.parse("2025-03-21T00:00").equals(t.getDateTime())) //
+                        .findFirst() //
+                        .orElseThrow(() -> new AssertionError("EQQQ dividend transaction not found"));
+
+        assertThat(eqqqTransaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(eqqqTransaction.getDateTime(), is(LocalDateTime.parse("2025-03-21T00:00")));
+
+        assertThat(eqqqTransaction.getCurrencyCode(), is("USD"));
+        assertThat(eqqqTransaction.getAmount(), is(1_36L)); // 1.36 USD
+        assertThat(eqqqTransaction.getSecurity().getCurrencyCode(), is("GBX"));
+
+        // Verify GROSS_VALUE unit exists and has correct conversion
+        // USD/EUR = 0.92464 (from fxRateToBase)
+        // GBP/EUR = 1.1726 (from ConversionRate on 20250321)
+        // USD/GBP = (USD/EUR) / (GBP/EUR) = 0.92464 / 1.1726 ≈ 0.7887
+        // GBX/GBP = 0.01 (from FixedExchangeRateProvider)
+        // USD/GBX = USD/GBP / GBX/GBP = 0.7887 / 0.01 = 78.87
+        // After inversion in setAmount: GBX/USD ≈ 0.01268
+        var eqqqGrossValueUnit = eqqqTransaction.getUnit(Unit.Type.GROSS_VALUE);
+        assertThat("GROSS_VALUE unit should be present for USD->GBX conversion", eqqqGrossValueUnit.isPresent(), is(true));
+
+        var eqqqUnit = eqqqGrossValueUnit.get();
+        assertThat(eqqqUnit.getAmount().getCurrencyCode(), is("USD"));
+        assertThat(eqqqUnit.getAmount().getAmount(), is(1_36L)); // 1.36 USD
+        assertThat(eqqqUnit.getForex().getCurrencyCode(), is("GBX"));
+        assertThat(eqqqUnit.getForex().getAmount(), is(107_24L)); // 107.24 GBX (rounded)
+
+        // Exchange rate calculation (with 10 decimal precision, HALF_DOWN in divisions):
+        // USD/EUR = 0.92464, GBP/EUR = 1.1726
+        // USD/GBP = 0.92464 / 1.1726 = 0.7887030844... (exact)
+        //   With 10 decimals HALF_DOWN: 0.7887030844
+        // USD/GBX = 0.7887030844 / 0.01 = 78.87030844
+        // After inversion in setAmount (10 decimals, HALF_DOWN): GBX/USD = 1 / 78.87030844
+        // Calculate expected rate with same precision as implementation
+        BigDecimal usdToGbp = new BigDecimal("0.92464").divide(new BigDecimal("1.1726"), 10, RoundingMode.HALF_DOWN);
+        BigDecimal usdToGbx = usdToGbp.divide(new BigDecimal("0.01"), 10, RoundingMode.HALF_DOWN);
+        BigDecimal eqqqExpectedRate = BigDecimal.ONE.divide(usdToGbx, 10, RoundingMode.HALF_DOWN);
+        BigDecimal eqqqTolerance = new BigDecimal("0.0000001"); // Same tolerance as HIDR test
+        assertThat(eqqqUnit.getExchangeRate().subtract(eqqqExpectedRate).abs().compareTo(eqqqTolerance) < 0, is(true));
+
+        // Test third transaction: EQQQ (USD->GBX with GBP base currency)
+        AccountTransaction eqqqGbpBaseTransaction = transactions.stream() //
+                        .filter(t -> "EQQQ".equals(t.getSecurity().getTickerSymbol())) //
+                        .filter(t -> LocalDateTime.parse("2025-03-25T00:00").equals(t.getDateTime())) //
+                        .findFirst() //
+                        .orElseThrow(() -> new AssertionError("EQQQ GBP-base dividend transaction not found"));
+
+        assertThat(eqqqGbpBaseTransaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(eqqqGbpBaseTransaction.getDateTime(), is(LocalDateTime.parse("2025-03-25T00:00")));
+
+        assertThat(eqqqGbpBaseTransaction.getCurrencyCode(), is("USD"));
+        assertThat(eqqqGbpBaseTransaction.getAmount(), is(1_27L)); // 1.27 USD
+        assertThat(eqqqGbpBaseTransaction.getSecurity().getCurrencyCode(), is("GBX"));
+
+        // Base currency already matches the major unit (GBP), so fxRateToBase should still
+        // allow deriving USD->GBX via USD->GBP and GBP->GBX.
+        var eqqqGbpBaseGrossValueUnit = eqqqGbpBaseTransaction.getUnit(Unit.Type.GROSS_VALUE);
+        assertThat("GROSS_VALUE unit should be present for USD->GBX conversion with GBP base currency",
+                        eqqqGbpBaseGrossValueUnit.isPresent(), is(true));
+
+        var eqqqGbpBaseUnit = eqqqGbpBaseGrossValueUnit.get();
+        assertThat(eqqqGbpBaseUnit.getAmount().getCurrencyCode(), is("USD"));
+        assertThat(eqqqGbpBaseUnit.getAmount().getAmount(), is(1_27L)); // 1.27 USD
+        assertThat(eqqqGbpBaseUnit.getForex().getCurrencyCode(), is("GBX"));
+        assertThat(eqqqGbpBaseUnit.getForex().getAmount(), is(98_62L)); // 98.62 GBX (rounded)
+
+        BigDecimal usdToGbxWithGbpBase = new BigDecimal("0.77654").divide(new BigDecimal("0.01"), 10, RoundingMode.HALF_DOWN);
+        BigDecimal eqqqGbpBaseExpectedRate = BigDecimal.ONE.divide(usdToGbxWithGbpBase, 10, RoundingMode.HALF_DOWN);
+        assertThat(eqqqGbpBaseUnit.getExchangeRate().subtract(eqqqGbpBaseExpectedRate).abs().compareTo(eqqqTolerance) < 0,
+                        is(true));
+
+        // Test fourth transaction: GBDV (GBX->USD with GBP base currency)
+        AccountTransaction gbdvTransaction = transactions.stream() //
+                        .filter(t -> "GBDV".equals(t.getSecurity().getTickerSymbol())) //
+                        .filter(t -> LocalDateTime.parse("2025-03-26T00:00").equals(t.getDateTime())) //
+                        .findFirst() //
+                        .orElseThrow(() -> new AssertionError("GBDV GBP-base dividend transaction not found"));
+
+        assertThat(gbdvTransaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(gbdvTransaction.getDateTime(), is(LocalDateTime.parse("2025-03-26T00:00")));
+
+        assertThat(gbdvTransaction.getCurrencyCode(), is("GBX"));
+        assertThat(gbdvTransaction.getAmount(), is(138_00L)); // 138.00 GBX
+        assertThat(gbdvTransaction.getSecurity().getCurrencyCode(), is("USD"));
+
+        // Base currency already matches the major unit (GBP), so fxRateToBase should still
+        // allow deriving GBX->USD via GBX->GBP and GBP->USD.
+        var gbdvGrossValueUnit = gbdvTransaction.getUnit(Unit.Type.GROSS_VALUE);
+        assertThat("GROSS_VALUE unit should be present for GBX->USD conversion with GBP base currency",
+                        gbdvGrossValueUnit.isPresent(), is(true));
+
+        var gbdvUnit = gbdvGrossValueUnit.get();
+        assertThat(gbdvUnit.getAmount().getCurrencyCode(), is("GBX"));
+        assertThat(gbdvUnit.getAmount().getAmount(), is(138_00L)); // 138.00 GBX
+        assertThat(gbdvUnit.getForex().getCurrencyCode(), is("USD"));
+        assertThat(gbdvUnit.getForex().getAmount(), is(1_79L)); // 1.79 USD (rounded)
+
+        BigDecimal gbxToUsd = new BigDecimal("0.01").multiply(BigDecimal.ONE.divide(new BigDecimal("0.7722"), 10, RoundingMode.HALF_DOWN));
+        BigDecimal gbdvExpectedRate = BigDecimal.ONE.divide(gbxToUsd, 10, RoundingMode.HALF_DOWN);
+        assertThat(gbdvUnit.getExchangeRate().subtract(gbdvExpectedRate).abs().compareTo(eqqqTolerance) < 0, is(true));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/testIBFlexStatementFile29.xml
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/testIBFlexStatementFile29.xml
@@ -1,0 +1,26 @@
+<FlexQueryResponse queryName="PP" type="AF">
+<FlexStatements count="2">
+<FlexStatement accountId="U1234567" fromDate="20250201" toDate="20250331" period="LastQuarter" whenGenerated="20250310;120000">
+<AccountInformation accountId="U1234567" acctAlias="A" model="" currency="EUR" name="John Doe" accountType="Individual" customerType="Individual" />
+<CashTransactions>
+<CashTransaction accountId="U1234567" acctAlias="" model="" currency="USD" fxRateToBase="0.94106" assetCategory="STK" symbol="HIDR" description="HIDR(IE00B46G8275) CASH DIVIDEND USD 0.9076 PER SHARE (Mixed Income)" conid="86281326" securityID="IE00B46G8275" securityIDType="ISIN" isin="IE00B46G8275" amount="18.15" type="Dividends" reportDate="20250304" />
+<CashTransaction accountId="U1234567" acctAlias="" model="" currency="USD" fxRateToBase="0.92464" assetCategory="STK" subCategory="ETF" symbol="EQQQ" description="EQQQ(IE0032077012) CASH DIVIDEND USD 0.4531 PER SHARE (Mixed Income)" conid="18706552" securityID="IE0032077012" securityIDType="ISIN" isin="IE0032077012" amount="1.36" type="Dividends" reportDate="20250321" />
+</CashTransactions>
+<ConversionRates>
+<ConversionRate reportDate="20250304" fromCurrency="GBP" toCurrency="EUR" rate="1.2041" />
+<ConversionRate reportDate="20250321" fromCurrency="GBP" toCurrency="EUR" rate="1.1726" />
+</ConversionRates>
+
+</FlexStatement>
+<FlexStatement accountId="U1234567" fromDate="20250201" toDate="20250331" period="LastQuarter" whenGenerated="20250326;120000">
+<AccountInformation accountId="U1234567" acctAlias="B" model="" currency="GBP" name="John Doe" accountType="Individual" customerType="Individual" />
+<CashTransactions>
+<CashTransaction accountId="U1234567" acctAlias="" model="" currency="USD" fxRateToBase="0.77654" assetCategory="STK" subCategory="ETF" symbol="EQQQ" description="EQQQ(IE0032077012) CASH DIVIDEND USD 0.4233 PER SHARE (Mixed Income)" conid="18706552" securityID="IE0032077012" securityIDType="ISIN" isin="IE0032077012" amount="1.27" type="Dividends" reportDate="20250325" />
+<CashTransaction accountId="U1234567" acctAlias="" model="" currency="GBX" fxRateToBase="0.01" assetCategory="STK" symbol="GBDV" description="GBDV(US1234567890) CASH DIVIDEND GBX 0.5520 PER SHARE (Mixed Income)" conid="12345678" securityID="US1234567890" securityIDType="ISIN" isin="US1234567890" amount="138.00" type="Dividends" reportDate="20250326" />
+</CashTransactions>
+<ConversionRates>
+<ConversionRate reportDate="20250326" fromCurrency="USD" toCurrency="GBP" rate="0.7722" />
+</ConversionRates>
+</FlexStatement>
+</FlexStatements>
+</FlexQueryResponse>

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractor.java
@@ -60,7 +60,6 @@ import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.ExchangeRate;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
-import name.abuchen.portfolio.money.impl.FixedExchangeRateProvider;
 import name.abuchen.portfolio.online.QuoteFeed;
 import name.abuchen.portfolio.online.impl.YahooFinanceQuoteFeed;
 import name.abuchen.portfolio.util.Pair;
@@ -355,7 +354,12 @@ public class IBFlexStatementExtractor implements Extractor
         private static final String ASSETKEY_FUTURE_OPTION = "FOP";
         private static final String ASSETKEY_WARRANTS = "WAR";
 
-        private static final FixedExchangeRateProvider FIXED_RATE_PROVIDER = new FixedExchangeRateProvider();
+        private static final Map<String, String> MINOR_TO_MAJOR_CURRENCY = Map.of(
+            "GBX", "GBP",
+            "ILA", "ILS",
+            "ZAC", "ZAR"
+        );
+        private static final BigDecimal MINOR_UNIT_RATE = new BigDecimal("0.01");
 
         private Element statement;
         private List<Exception> errors = new ArrayList<>();
@@ -988,6 +992,74 @@ public class IBFlexStatementExtractor implements Extractor
                     return asExchangeRate(element.getAttribute("fxRateToBase"));
                 }
 
+                // Before trying accountCurrency conversion, check if toCurrency is a minor unit
+                // (e.g., GBX is minor unit of GBP). If so, convert to the major unit first.
+                String toMajorUnit = findMajorUnitCurrency(toCurrency);
+                if (toMajorUnit != null)
+                {
+                    // Convert fromCurrency -> toMajorUnit via accountCurrency
+                    // Then apply minor unit conversion
+                    Pair<String, String> fromKey = new Pair<>(dateStr, fromCurrency + "-" + accountCurrency);
+                    Pair<String, String> toKey = new Pair<>(dateStr, toMajorUnit + "-" + accountCurrency);
+
+                    BigDecimal fromRate = conversionRates.get(fromKey);
+                    // If fromRate is not in conversionRates, try using fxRateToBase from the element
+                    // (fxRateToBase is the rate from transaction currency to base currency)
+                    // Only use fxRateToBase when fromCurrency != accountCurrency, otherwise
+                    // fxRateToBase is meaningless (rate from base to base should be 1.0)
+                    if (fromRate == null && element.hasAttribute("fxRateToBase")
+                                    && !fromCurrency.equals(accountCurrency))
+                    {
+                        fromRate = asExchangeRate(element.getAttribute("fxRateToBase"));
+                    }
+                    // If toMajorUnit equals accountCurrency, no conversion is needed (rate is 1.0)
+                    BigDecimal majorUnitRate = toMajorUnit.equals(accountCurrency)
+                                    ? BigDecimal.ONE
+                                    : conversionRates.get(toKey);
+
+                    if (fromRate != null && majorUnitRate != null)
+                    {
+                        // Calculate fromCurrency -> toMajorUnit
+                        BigDecimal toMajorUnitRate = fromRate.divide(majorUnitRate, 10, RoundingMode.HALF_DOWN);
+                        // Apply minor unit conversion: toMajorUnitRate / minorUnitRate
+                        // (e.g., USD->GBP / GBX->GBP = USD->GBX)
+                        BigDecimal minorUnitRate = getWellKnownFixedExchangeRate(toCurrency, toMajorUnit);
+                        if (minorUnitRate != null)
+                        {
+                            return toMajorUnitRate.divide(minorUnitRate, 10, RoundingMode.HALF_DOWN);
+                        }
+                    }
+                }
+
+                // Check if fromCurrency is a minor unit (e.g., GBX -> USD)
+                String fromMajorUnit = findMajorUnitCurrency(fromCurrency);
+                if (fromMajorUnit != null)
+                {
+                    // First convert fromCurrency (minor) -> fromMajorUnit (major)
+                    // Then convert fromMajorUnit -> toCurrency via accountCurrency
+                    BigDecimal minorToMajorRate = getWellKnownFixedExchangeRate(fromCurrency, fromMajorUnit);
+                    if (minorToMajorRate != null)
+                    {
+                        Pair<String, String> fromKey = new Pair<>(dateStr, fromMajorUnit + "-" + accountCurrency);
+                        Pair<String, String> toKey = new Pair<>(dateStr, toCurrency + "-" + accountCurrency);
+
+                        // If fromMajorUnit equals accountCurrency, no conversion is needed (rate is 1.0)
+                        BigDecimal fromMajorRate = fromMajorUnit.equals(accountCurrency)
+                                        ? BigDecimal.ONE
+                                        : conversionRates.get(fromKey);
+                        BigDecimal toRate = conversionRates.get(toKey);
+
+                        if (fromMajorRate != null && toRate != null)
+                        {
+                            // Calculate fromMajorUnit -> toCurrency
+                            BigDecimal majorToTargetRate = fromMajorRate.divide(toRate, 10, RoundingMode.HALF_DOWN);
+                            // Combine: fromCurrency -> fromMajorUnit -> toCurrency
+                            // (e.g., GBX->GBP * GBP->USD = GBX->USD)
+                            return minorToMajorRate.multiply(majorToTargetRate);
+                        }
+                    }
+                }
+
                 // Attempt to calculate cross rate via accountCurrency. No use
                 // in trying a different intermediate currency, it seems like
                 // toCurrency is only ever the account's base.
@@ -995,6 +1067,12 @@ public class IBFlexStatementExtractor implements Extractor
                 Pair<String, String> toKey = new Pair<>(dateStr, toCurrency + "-" + accountCurrency);
 
                 BigDecimal fromRate = conversionRates.get(fromKey);
+                // If fromRate is not in conversionRates, try using fxRateToBase from the element
+                // (fxRateToBase is the rate from transaction currency to base currency)
+                if (fromRate == null && element.hasAttribute("fxRateToBase"))
+                {
+                    fromRate = asExchangeRate(element.getAttribute("fxRateToBase"));
+                }
                 BigDecimal toRate = conversionRates.get(toKey);
 
                 if (fromRate != null && toRate != null)
@@ -1009,31 +1087,20 @@ public class IBFlexStatementExtractor implements Extractor
             return null;
         }
 
-        /**
-         * Returns the exchange rate for currency pairs with a fixed
-         * relationship (e.g. GBX/GBP) using FixedExchangeRateProvider. Handles
-         * both directions.
-         *
-         * @param fromCurrency
-         *            The source currency
-         * @param toCurrency
-         *            The target currency
-         * @return The exchange rate, or null if not a known fixed-rate pair
-         */
+        private String findMajorUnitCurrency(String minorUnitCurrency)
+        {
+            return MINOR_TO_MAJOR_CURRENCY.get(minorUnitCurrency);
+        }
+
         private BigDecimal getWellKnownFixedExchangeRate(String fromCurrency, String toCurrency)
         {
-            for (var series : FIXED_RATE_PROVIDER.getAvailableTimeSeries(null))
-            {
-                if (series.getRates() == null || series.getRates().isEmpty())
-                    continue;
+            var majorUnit = MINOR_TO_MAJOR_CURRENCY.get(fromCurrency);
+            if (majorUnit != null && majorUnit.equals(toCurrency))
+                return MINOR_UNIT_RATE;
 
-                var rate = series.getRates().get(0).getValue();
-
-                if (series.getBaseCurrency().equals(fromCurrency) && series.getTermCurrency().equals(toCurrency))
-                    return rate;
-                else if (series.getBaseCurrency().equals(toCurrency) && series.getTermCurrency().equals(fromCurrency))
-                    return BigDecimal.ONE.divide(rate, 10, RoundingMode.HALF_UP);
-            }
+            majorUnit = MINOR_TO_MAJOR_CURRENCY.get(toCurrency);
+            if (majorUnit != null && majorUnit.equals(fromCurrency))
+                return BigDecimal.ONE.divide(MINOR_UNIT_RATE, 10, RoundingMode.HALF_UP);
 
             return null;
         }


### PR DESCRIPTION
**Note: depends on #5291**

I have identified a problematic scenario when using the IBFlex importer. Example:

- Portfolio base currency is EUR
- Security is quoted in GBP
- Dividend is paid in USD

Result: import of the dividend transaction fails, since the IB export only contains ConversionRate elements for the base currency – PP finds no rate to convert the USD dividend to GBP.

However, in my export files, the CashTransaction element representing the dividend payment **does** contain the EUR/USD rate in fxRateToBase. Thus it is, in fact, possible to calculate the GBP value of the USD dividend, using the EUR/USD and EUR/GBP rates.

A further complexity is that the security could also be quoted in a minor unit such as GBX, requiring an additional fixed-rate conversion (USD→EUR→GBP→GBX!).

This PR extends the importer to handle both cases. It depends on #5291 to handle the minor currency unit case.

Both of these occur in my personal data, and that is the basis for the new tests in the PR. With the code changes, my real-world transactions import correctly.