### PR TITLE
Fixed a seemingly conflicting documentation of the gross value.

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AccountTransaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/AccountTransaction.java
@@ -75,8 +75,8 @@ public class AccountTransaction extends Transaction
     }
 
     /**
-     * Returns the gross value, i.e. the value including taxes. See
-     * {@link #getGrossValue()}.
+     * Returns the gross value, i.e. the value before taxes and fees are
+     * applied. See {@link #getGrossValue()}.
      */
     public long getGrossValueAmount()
     {
@@ -85,8 +85,8 @@ public class AccountTransaction extends Transaction
     }
 
     /**
-     * Returns the gross value, i.e. the value before taxes are applied. At the
-     * moment, only dividend transactions are supported.
+     * Returns the gross value, i.e. the value before taxes and fees are
+     * applied. At the moment, only dividend transactions are supported.
      */
     @Override
     public Money getGrossValue()


### PR DESCRIPTION
The first overload said "including taxes", the second "before taxes are applied". This appears contradictory. At least due to the fact that the extra costs can be added or subtracted depending on the type of transaction. Therfore, we just sync the documentation.