### PR TITLE
Modify Bank Norwegian PDF-Importer, add corrections

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/nordaxbankab/AccountStatement03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/nordaxbankab/AccountStatement03.txt
@@ -1,0 +1,69 @@
+```
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.1.qualifier
+System: linux | x86_64 | 25.0.1+8-LTS-27 | Oracle Corporation
+-----------------------------------------
+Oslo, 01.01.2026
+Bank Norwegian, en filial av 
+NOBA Bank Group AB (publ)
+Postboks 110
+1325 Lysaker, NORWAY
+Org.Nr: 916 573 154
+Max Mustermann
+Musterstr. 2
+54321 Musterhausen
+Germany
+Kontoauszug - NO2093577251509
+Währung: Euro (EUR)
+Buchungsda Valutadatu Beschreibung Zahlungseinga Zahlungsausga
+tum m ng ng
+31.12.2025 01.01.2026 Interest 129,70
+30.12.2025 30.12.2025 Bezahlung von 1.020,00
+DE22513900000075401501 
+xyz PKW Abschlag
+22.12.2025 22.12.2025 Zahlung an 20,00
+DE92500617410200574015 
+19026490 Auszahlung BN 001
+01.12.2025 01.12.2025 Bezahlung von 1.020,00
+DE22513900000075401501 
+xyz PKW Abschlag
+31.10.2025 31.10.2025 Bezahlung von 1.020,00
+DE92500617410200574015 
+xyz PKW Abschlag
+30.09.2025 30.09.2025 Bezahlung von 1.020,00
+DE92500617410200574015 
+xyz PKW Abschlag
+01.09.2025 01.09.2025 Bezahlung von 1.020,00
+DE92500617410200574015 
+xyz PKW Abschlag
+31.07.2025 31.07.2025 Bezahlung von 1.020,00
+DE92500617410200574015 
+xyz PKW Abschlag
+30.06.2025 30.06.2025 Bezahlung von 1.020,00
+DE92500617410200574015 
+xyz PKW Abschlag
+Bank Norwegian, en filial av NOBA Bank Group AB (publ)
+Postboks 110, 1325 Lysaker, Norge
+Telefon 0800 7 238470
+E-Mail post@banknorwegian.de
+Webseite banknorwegian.de
+02.06.2025 02.06.2025 Bezahlung von 1.020,00
+DE92500617410200574015 
+xyz PKW Abschlag
+30.04.2025 30.04.2025 Bezahlung von 1.020,00
+DE92500617410200574015 
+xyz PKW Abschlag
+28.03.2025 28.03.2025 Bezahlung von 1.020,00
+DE92500617410200574015 
+xyz PKW Abschlag
+14.02.2025 14.02.2025 Bezahlung von 1.020,00
+DE92500617410200574015
+14.01.2025 14.01.2025 Bezahlung von 1.020,00
+DE92500617410200574015
+Bank Norwegian, en filial av NOBA Bank Group AB (publ)
+Postboks 110, 1325 Lysaker, Norge
+Telefon 0800 7 238470
+E-Mail post@banknorwegian.de
+Webseite banknorwegian.de
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/nordaxbankab/AccountStatement04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/nordaxbankab/AccountStatement04.txt
@@ -1,0 +1,31 @@
+```
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.1.qualifier
+System: linux | x86_64 | 25.0.1+8-LTS-27 | Oracle Corporation
+-----------------------------------------
+Oslo, 01.01.2026
+Bank Norwegian, en filial av 
+NOBA Bank Group AB (publ)
+Postboks 110
+1325 Lysaker, NORWAY
+Org.Nr: 916 573 154
+Max Mustermann
+Musterstr. 2
+54321 Musterhausen
+Germany
+Kontoauszug - NO1293573415517
+Währung: Euro (EUR)
+Buchungsda Valutadatu Beschreibung Zahlungseinga Zahlungsausga
+tum m ng ng
+31.12.2025 01.01.2026 Interest 34,77
+11.12.2025 11.12.2025 Bezahlung von 24.500,00
+DE22513900000075401501 
+Einzahlung 01 BankNorwegian 
+Spar31
+Bank Norwegian, en filial av NOBA Bank Group AB (publ)
+Postboks 110, 1325 Lysaker, Norge
+Telefon 0800 7 238470
+E-Mail post@banknorwegian.de
+Webseite banknorwegian.de
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/nordaxbankab/NordaxBankABPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/nordaxbankab/NordaxBankABPDFExtractorTest.java
@@ -93,27 +93,119 @@ public class NordaxBankABPDFExtractorTest
         new AssertImportActions().check(results, "EUR");
 
         // assert transaction
-        assertThat(results, hasItem(deposit(hasDate("2025-11-03"), hasAmount("EUR", 2000.00),
-                        hasSource("AccountStatement02.txt"), hasNote(null))));
+        assertThat(results, hasItem(removal(hasDate("2025-11-03"), hasAmount("EUR", 2000.00),
+                        hasSource("AccountStatement02.txt"), hasNote("DEXXX 18633010 Übertrag Girokonto"))));
 
         // assert transaction
-        assertThat(results, hasItem(deposit(hasDate("2025-06-17"), hasAmount("EUR", 2000.00),
-                        hasSource("AccountStatement02.txt"), hasNote(null))));
+        assertThat(results, hasItem(removal(hasDate("2025-06-17"), hasAmount("EUR", 2000.00),
+                        hasSource("AccountStatement02.txt"), hasNote("DEXXX 17557781 Übertrag Tagesgeld"))));
 
         // assert transaction
-        assertThat(results, hasItem(deposit(hasDate("2025-05-12"), hasAmount("EUR", 1000.00),
-                        hasSource("AccountStatement02.txt"), hasNote(null))));
+        assertThat(results, hasItem(removal(hasDate("2025-05-12"), hasAmount("EUR", 1000.00),
+                        hasSource("AccountStatement02.txt"), hasNote("DEXXX 17290216 Übertrag Tagesgeld"))));
 
         // assert transaction
-        assertThat(results, hasItem(removal(hasDate("2024-12-10"), hasAmount("EUR", 12000.00),
-                        hasSource("AccountStatement02.txt"), hasNote(null))));
+        assertThat(results, hasItem(deposit(hasDate("2024-12-10"), hasAmount("EUR", 12000.00),
+                        hasSource("AccountStatement02.txt"), hasNote("DEXXX"))));
 
         // assert transaction
         assertThat(results, hasItem(interest( //
-                        hasDate("2024-12-31"), //
+                        hasDate("2025-01-01"), //
                         hasSource("AccountStatement02.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 24.40), hasGrossValue("EUR", 24.40), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testAccountStatement03()
+    {
+        var extractor = new NordaxBankABPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "AccountStatement03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(14L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(results.size(), is(14));
+        new AssertImportActions().check(results, "EUR");
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2025-01-14"), hasAmount("EUR", 1020.00), //
+                        hasSource("AccountStatement03.txt"), hasNote("DE92500617410200574015"))));
+
+        assertThat(results, hasItem(deposit(hasDate("2025-02-14"), hasAmount("EUR", 1020.00), //
+                        hasSource("AccountStatement03.txt"), hasNote("DE92500617410200574015"))));
+
+        assertThat(results, hasItem(deposit(hasDate("2025-03-28"), hasAmount("EUR", 1020.00), //
+                        hasSource("AccountStatement03.txt"), hasNote("DE92500617410200574015 xyz PKW Abschlag"))));
+
+        assertThat(results, hasItem(deposit(hasDate("2025-04-30"), hasAmount("EUR", 1020.00), //
+                        hasSource("AccountStatement03.txt"), hasNote("DE92500617410200574015 xyz PKW Abschlag"))));
+
+        assertThat(results, hasItem(deposit(hasDate("2025-06-02"), hasAmount("EUR", 1020.00), //
+                        hasSource("AccountStatement03.txt"), hasNote("DE92500617410200574015 xyz PKW Abschlag"))));
+
+        assertThat(results, hasItem(deposit(hasDate("2025-06-30"), hasAmount("EUR", 1020.00), //
+                        hasSource("AccountStatement03.txt"), hasNote("DE92500617410200574015 xyz PKW Abschlag"))));
+
+        assertThat(results, hasItem(deposit(hasDate("2025-07-31"), hasAmount("EUR", 1020.00), //
+                        hasSource("AccountStatement03.txt"), hasNote("DE92500617410200574015 xyz PKW Abschlag"))));
+
+        assertThat(results, hasItem(deposit(hasDate("2025-09-01"), hasAmount("EUR", 1020.00), //
+                        hasSource("AccountStatement03.txt"), hasNote("DE92500617410200574015 xyz PKW Abschlag"))));
+
+        assertThat(results, hasItem(deposit(hasDate("2025-09-30"), hasAmount("EUR", 1020.00), //
+                        hasSource("AccountStatement03.txt"), hasNote("DE92500617410200574015 xyz PKW Abschlag"))));
+
+        assertThat(results, hasItem(deposit(hasDate("2025-10-31"), hasAmount("EUR", 1020.00), //
+                        hasSource("AccountStatement03.txt"), hasNote("DE92500617410200574015 xyz PKW Abschlag"))));
+
+        assertThat(results, hasItem(deposit(hasDate("2025-12-01"), hasAmount("EUR", 1020.00), //
+                        hasSource("AccountStatement03.txt"), hasNote("DE22513900000075401501 xyz PKW Abschlag"))));
+
+        assertThat(results, hasItem(removal(hasDate("2025-12-22"), hasAmount("EUR", 20.00), //
+                        hasSource("AccountStatement03.txt"),
+                        hasNote("DE92500617410200574015 19026490 Auszahlung BN 001"))));
+
+        assertThat(results, hasItem(deposit(hasDate("2025-12-30"), hasAmount("EUR", 1020.00), //
+                        hasSource("AccountStatement03.txt"), hasNote("DE22513900000075401501 xyz PKW Abschlag"))));
+
+        assertThat(results, hasItem(interest(hasDate("2026-01-01"), hasAmount("EUR", 129.70), //
+                        hasSource("AccountStatement03.txt"), hasNote(null))));
+    }
+
+    @Test
+    public void testAccountStatement04()
+    {
+        var extractor = new NordaxBankABPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "AccountStatement04.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(2L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2025-12-11"), hasAmount("EUR", 24500), //
+                        hasSource("AccountStatement04.txt"),
+                        hasNote("DE22513900000075401501 Einzahlung 01 BankNorwegian"))));
+
+        // assert transaction
+        assertThat(results, hasItem(interest(hasDate("2026-01-01"), hasAmount("EUR", 34.77), //
+                        hasSource("AccountStatement04.txt"), hasNote(null))));
+
     }
 }


### PR DESCRIPTION
Some extensions / corrections:

- use value date
- switches deposit/removal: "Bezahlung von "  in account statement is deposit (foreign account to Bank Norwegian account), "Zahlung an " is removal (Bank Norwegian to foreign account)
- added notes
