### PR TITLE
Use Valuta for Scalable dividends

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/Dividende07.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/Dividende07.txt
@@ -1,0 +1,45 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.1.qualifier
+System: macosx | aarch64 | 21.0.2+13-LTS | Amazon.com Inc.
+-----------------------------------------
+Scalable Capital Bank GmbH • Seitzstraße 8e • 80538 München • Deutschland 
+UkTekUkf WqghY keWZTmbFyuaM
+KxexgwTWUJhXmiNCm 37 
+23726 IKbshC Datum 01.01.2026
+Deutschland Seite 1 / 2
+Dividende 
+Für 01.01.2026 - 31.12.2026 
+Berechtigtes Wertpapier NVIDIA Corp. 
+ISIN US67066G1040 
+Berechtigte Anzahl 20,43685 
+Ex Tag 04.12.2025 
+Verrechnungskonto DE11111 (UdFQQBPAPqC)
+Kontobewegung 
+Buchung Wertstellung Typ Betrag / Stk. Berechtigte Anzahl Gesamt 
+Wechselkurs 
+01.01.2026 31.12.2025 Gutschrift 0,01 USD 20,43685 0,17 EUR 
+USD / EUR 1,178 
+Ausländische Quellensteuer -0,03 EUR
+Steuern -0,02 EUR
+Gesamtbetrag 0,12 EUR
+Bitte beachten Sie Ihre eventuelle Meldepflicht nach § 67 AWV. Einkünfte aus Kapitalvermögen im Sinne von § 20 EStG sind
+einkommensteuerpflichtig. 
+Scalable Capital Bank GmbH HRB 217778 Geschäftsführer: Aufsichtsrat: Seite 
+Seitzstraße 8e Amtsgericht München Florian Prucker, Martin Krebs, Patrick Olson (Vorsitzender) 
+80538 München USt.-Id. Nr.: DE300434774 Dirk Franzmeyer 1 / 2
+Dividende
+Ermittlung steuerrelevante Erträge
+Typ Betrag
+Gewinn oder Verlust 0,17 EUR
+Verrechnung anrechenbarer Quellensteuer -0,12 EUR
+Zu versteuern 0,05 EUR
+Anfallende Steuern 
+Typ Betrag
+Kapitalertragsteuer 0,02 EUR
+Solidaritätszuschlag 0,00 EUR
+Anfallende
+0,02 EUR
+Steuern 
+Scalable Capital Bank GmbH HRB 217778 Geschäftsführer: Aufsichtsrat: Seite 
+Seitzstraße 8e Amtsgericht München Florian Prucker, Martin Krebs, Patrick Olson (Vorsitzender) 
+80538 München USt.-Id. Nr.: DE300434774 Dirk Franzmeyer 2 / 2

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/ScalableCapitalPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/ScalableCapitalPDFExtractorTest.java
@@ -868,7 +868,7 @@ public class ScalableCapitalPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-06-16T00:00"), hasShares(0.284285), //
+                        hasDate("2025-06-17"), hasShares(0.284285), //
                         hasSource("Dividende02.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 0.15), hasGrossValue("EUR", 0.20), //
@@ -902,7 +902,7 @@ public class ScalableCapitalPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-06-16T00:00"), hasShares(0.284285), //
+                        hasDate("2025-06-17"), hasShares(0.284285), //
                         hasSource("Dividende02.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 0.15), hasGrossValue("EUR", 0.20), //
@@ -935,7 +935,7 @@ public class ScalableCapitalPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-06-18T00:00"), hasShares(3.00), //
+                        hasDate("2025-06-23"), hasShares(3.00), //
                         hasSource("Dividende03.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 7.31), hasGrossValue("EUR", 9.93), //
@@ -968,7 +968,7 @@ public class ScalableCapitalPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-09-16T00:00"), hasShares(1.907523), //
+                        hasDate("2025-09-17"), hasShares(1.907523), //
                         hasSource("Dividende04.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 0.69), hasGrossValue("EUR", 0.91), //
@@ -1002,7 +1002,7 @@ public class ScalableCapitalPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-09-16T00:00"), hasShares(1.907523), //
+                        hasDate("2025-09-17"), hasShares(1.907523), //
                         hasSource("Dividende04.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 0.69), hasGrossValue("EUR", 0.91), //
@@ -1035,7 +1035,7 @@ public class ScalableCapitalPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-09-17T00:00"), hasShares(0.489446), //
+                        hasDate("2025-09-18"), hasShares(0.489446), //
                         hasSource("Dividende05.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 0.41), hasGrossValue("EUR", 0.56), //
@@ -1069,7 +1069,7 @@ public class ScalableCapitalPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-09-17T00:00"), hasShares(0.489446), //
+                        hasDate("2025-09-18"), hasShares(0.489446), //
                         hasSource("Dividende05.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 0.41), hasGrossValue("EUR", 0.56), //
@@ -1102,7 +1102,7 @@ public class ScalableCapitalPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-09-14T00:00"), hasShares(5.940872), //
+                        hasDate("2025-09-12"), hasShares(5.940872), //
                         hasSource("Dividende06.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 0.82), hasGrossValue("EUR", 0.82), //
@@ -1136,11 +1136,44 @@ public class ScalableCapitalPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-09-14T00:00"), hasShares(5.940872), //
+                        hasDate("2025-09-12"), hasShares(5.940872), //
                         hasSource("Dividende06.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 0.82), hasGrossValue("EUR", 0.82), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende07()
+    {
+        var extractor = new ScalableCapitalPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende07.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US67066G1040"), hasWkn(null), hasTicker(null), //
+                        hasName("NVIDIA Corp."), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-12-31"), hasShares(20.43685), //
+                        hasSource("Dividende07.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 0.12), hasGrossValue("EUR", 0.17), //
+                        hasTaxes("EUR", 0.05), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -1169,7 +1202,7 @@ public class ScalableCapitalPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-06-03T00:00"), hasShares(2.769834), //
+                        hasDate("2025-06-11"), hasShares(2.769834), //
                         hasSource("Dividend01.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 2.12), hasGrossValue("EUR", 2.49), //
@@ -1379,4 +1412,6 @@ public class ScalableCapitalPDFExtractorTest
         assertThat(results, hasItem(deposit(hasDate("2025-07-04"), hasAmount("EUR", 1300.00), //
                         hasSource("AccountStatement01.txt"), hasNote("Direct debit"))));
     }
+
+
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
@@ -276,14 +276,14 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("^(?<date>[\\d]{2}\\.[\\w]{2}\\.[\\d]{4}) [\\d]{2}\\.[\\w]{2}\\.[\\d]{4} Krediet [\\.,\\d]+ [A-Z]{3} [\\.,\\d]+ [\\.,\\d]+ [A-Z]{3}.*$") //"
+                                                        .match("^[\\d]{2}\\.[\\w]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\w]{2}\\.[\\d]{4}) Krediet [\\.,\\d]+ [A-Z]{3} [\\.,\\d]+ [\\.,\\d]+ [A-Z]{3}.*$") // "
                                                         .assign((t, v) -> t.setDateTime(asDate(v.get("date")))),
                                         // @formatter:off
                                         // 15.01.2025 15.01.2025 Gutschrift 0,12 USD 0,663129 0,08 EUR
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("^(?<date>[\\d]{2}\\.[\\w]{2}\\.[\\d]{4}) [\\d]{2}\\.[\\w]{2}\\.[\\d]{4} Gutschrift [\\.,\\d]+ [A-Z]{3} [\\.,\\d]+ [\\.,\\d]+ [A-Z]{3}.*$") //"
+                                                        .match("^[\\d]{2}\\.[\\w]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\w]{2}\\.[\\d]{4}) Gutschrift [\\.,\\d]+ [A-Z]{3} [\\.,\\d]+ [\\.,\\d]+ [A-Z]{3}.*$") // "
                                                         .assign((t, v) -> t.setDateTime(asDate(v.get("date")))))
 
                         .oneOf( //


### PR DESCRIPTION
Closes #5305

Wertstellungsdatum (Valuta) anstatt Buchungsdatum bei Dividenden nutzen, da dies (mM) nach korrekter ist.

Bei der Anpassung der bestehenden Tests sind mir auch ein paar Fälle aufgefallen, bei denen dieses besser ist:
- Dividende07: Mein case bei dem die Dividende am 01.01. gebucht wurde aber für 31.12 zählen soll. Beides keine Bankarbeitstage
- Dividende03: Der Ex-Tag wird mit 19.06 angegeben, daher kann die Dividende grundsätzlich nicht am 18.06 erfolgen.
- Dividend01 (nicht zu verwechseln mit Dividend**e**01): Ähnlich wie oben der Ex-Tag ist vor dem Buchungsdatum