### PR TITLE
Adjust randomizer to replace IBAN numbers

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/CreateTextFromPDFHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/CreateTextFromPDFHandler.java
@@ -31,27 +31,27 @@ public class CreateTextFromPDFHandler
     public void execute(@Named(IServiceConstants.ACTIVE_PART) MPart part,
                     @Named(IServiceConstants.ACTIVE_SHELL) Shell shell) throws IOException
     {
-        FileDialog fileDialog = new FileDialog(shell, SWT.OPEN | SWT.SINGLE);
+        var fileDialog = new FileDialog(shell, SWT.OPEN | SWT.SINGLE);
         fileDialog.setText(Messages.PDFImportDebugTextExtraction);
-        fileDialog.setFilterNames(new String[] { Messages.PDFImportFilterName });
-        fileDialog.setFilterExtensions(new String[] { "*.pdf;*.PDF" }); //$NON-NLS-1$
+        fileDialog.setFilterNames(Messages.PDFImportFilterName);
+        fileDialog.setFilterExtensions("*.pdf;*.PDF"); //$NON-NLS-1$
         fileDialog.open();
 
-        String fileName = fileDialog.getFileName();
+        var fileName = fileDialog.getFileName();
         if (fileName == null || fileName.isEmpty())
             return;
 
         try
         {
-            File file = new File(fileDialog.getFilterPath(), fileName);
-            PDFInputFile inputFile = new PDFInputFile(file);
+            var file = new File(fileDialog.getFilterPath(), fileName);
+            var inputFile = new PDFInputFile(file);
 
             // create text from PDF
             inputFile.convertPDFtoText();
             var extractedText = inputFile.getText();
             var pdfBoxVersion = inputFile.getPDFBoxVersion();
 
-            StringBuilder textBuilder = new StringBuilder();
+            var textBuilder = new StringBuilder();
             textBuilder.append("```").append("\n");
             textBuilder.append("PDFBox Version: ").append(pdfBoxVersion).append("\n");
             textBuilder.append("Portfolio Performance Version: ")
@@ -68,9 +68,7 @@ public class CreateTextFromPDFHandler
             textBuilder.append(extractedText).append("\n");
             textBuilder.append("```");
 
-            String text = textBuilder.toString();
-
-            DisplayTextDialog dialog = new DisplayPDFTextDialog(shell, file, text);
+            var dialog = new DisplayPDFTextDialog(shell, file, textBuilder.toString());
             dialog.setDialogTitle(Messages.PDFImportDebugTextExtraction);
             dialog.setAdditionalText(Messages.PDFImportDebugInformation);
             dialog.open();
@@ -93,7 +91,7 @@ public class CreateTextFromPDFHandler
         @Override
         protected Text createTextArea(Composite container)
         {
-            Text textArea = super.createTextArea(container);
+            var textArea = super.createTextArea(container);
 
             textArea.addMouseListener(new PDFDebugMouseListener(textArea));
 
@@ -114,7 +112,7 @@ public class CreateTextFromPDFHandler
         @Override
         public void mouseDoubleClick(MouseEvent e)
         {
-            String selectedText = widget.getSelectionText();
+            var selectedText = widget.getSelectionText();
 
             // Check if selectedText is not empty and does not contain forbidden
             // characters or currency codes
@@ -123,24 +121,19 @@ public class CreateTextFromPDFHandler
             {
                 // Generate a new string of random characters to replace the
                 // selected text
-                StringBuilder replacementTextBuilder = new StringBuilder();
+                var replacementTextBuilder = new StringBuilder();
                 for (int i = 0; i < selectedText.length(); i++)
                 {
                     char c = selectedText.charAt(i);
-                    if (Character.isLetter(c))
+                    replacementTextBuilder.append(switch (Character.valueOf(c))
                     {
-                        replacementTextBuilder.append(generateRandomLetter());
-                    }
-                    else if (Character.isDigit(c))
-                    {
-                        replacementTextBuilder.append(generateRandomNumber());
-                    }
-                    else
-                    {
-                        replacementTextBuilder.append(c);
-                    }
+                        case Character ch when Character.isLetter(ch) -> generateRandomLetter();
+                        case Character ch when Character.isDigit(ch) -> generateRandomNumber();
+                        default -> c;
+                    });
+
                 }
-                String replacementText = replacementTextBuilder.toString();
+                var replacementText = replacementTextBuilder.toString();
 
                 // Replace selectedText with replacementText
                 int startIndex = widget.getSelection().x;
@@ -149,13 +142,13 @@ public class CreateTextFromPDFHandler
             }
         }
 
-        /** Check if the selected string contains any forbidden characters */
-        private boolean containsForbiddenCharacters(String string)
+        private boolean containsForbiddenCharacters(String text)
         {
-            return string.matches(".*[\\-\\.,':\\/].*") || string.matches(".*[A-Z]{2}[A-Z0-9]{9}\\d.*"); //$NON-NLS-1$ //$NON-NLS-2$
+            // we don't want to replace special characters and an ISIN
+            return text.matches(".*[\\-\\.,':\\/].*") // $NON-NLS-1$
+                            || text.matches("[A-Z]{2}[A-Z0-9]{9}[0-9]"); // $NON-NLS-1$
         }
 
-        /** Generates a random letter */
         private char generateRandomLetter()
         {
             boolean isUpperCase = random.nextBoolean();


### PR DESCRIPTION
Closes #5306

The 2nd regex was too soft and also found IBAN-formats. As a double-click is just selecting the text which is clicked on, the regex could be adjusted to match ISIN-numbers which has been the goal to keep in the first place.

Tested locally with a Scalable pdf that ISIN isn't replaced while IBAN is replaced when performing a double-click on it.