### PR TITLE
Adapt AT-Format for Renault-Bank-Direkt PDF Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/renaultbankdirekt/Kontoauszug11.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/renaultbankdirekt/Kontoauszug11.txt
@@ -1,0 +1,40 @@
+```
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.1.qualifier
+System: linux | x86_64 | 21.0.8+9-LTS | Eclipse Adoptium
+-----------------------------------------
+Ihre Kontodaten
+BIC RCNOATW1
+IBAN AT123456111111111111
+Herrn
+Max Muster MITTEILUNG
+Teststraße 1 Kontonummer 1111111-001-1
+1234 Musterstadt
+Kontoeigner Mustermann Max
+Verfügernummer 1234456
+Wien, am 29.11.2025
+Kunden Service Center
+Tel.: 01 / 7200270
+Kontoauszug Tagesgeld
+Saldo zu Ihren Gunsten in EUR 9,66
+Datum Informationen Referenz Betrag in EUR Valuta Kontostand in EUR
+01.11.2025 Anfangssaldo 9,65
+28.11.2025  Habenzinsen A2511IDQC 0,01 30.11.2025 9,66
+Schlusssaldo in EUR 9,66
+Bitte überprüfen Sie alle Angaben auf Vollständigkeit und Richtigkeit. Wenn vorstehende Aufstellung mit dem Hinweis 
+Schlusssaldo gekennzeichnet ist, wurden die im vertraglich vereinbarten Abrechnungszeitraum entstandenen 
+wechselseitigen Ansprüche (einschließlich Zinsen und Entgelte) verrechnet. Umsätze, die nach dem Abrechnungsdatum 
+entstehen, werden erst in der folgenden Abrechnung berücksichtigt. Einwendungen gegen den Inhalt dieses 
+Kontoauszuges sind längstens binnen 6 Wochen nach Zugang dieses Kontoauszuges an die Bank zu richten. Wenn Sie 
+innerhalb dieser Frist keine Einwendungen gegen den Inhalt dieses Kontoauszuges erheben, anerkennen Sie diesen 
+damit. 
+Wichtiger Hinweis zur Einlagensicherung
+Einlagensicherung ist die Bezeichnung für die gesetzlichen und freiwilligen Maßnahmen zum Schutz der Einlagen 
+(Guthaben) von Kunden bei Kreditinstituten im Falle der Insolvenz. Die Renault Bank direkt ist dem französischen 
+Einlagensicherungsfonds FGDR angeschlossen. Der französische Einlagensicherungsfonds FGDR sichert Einlagen bis 
+100.000 Euro pro Person zu 100 Prozent ab. 
+Nähere Informationen zum FGDR können Sie auf unserer Website unter dem Menüpunkt "Über uns" im Untermenü 
+"Einlagensicherung" entnehmen. 
+Seite 1 von 1
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/renaultbankdirekt/RenaultBankDirektPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/renaultbankdirekt/RenaultBankDirektPDFExtractorTest.java
@@ -10,8 +10,8 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
-import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countItemsWithFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countItemsWithFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -354,4 +354,27 @@ public class RenaultBankDirektPDFExtractorTest
                         hasSource("Kontoauszug10.txt"))));
 
     }
+
+    @Test
+    public void testKontoauszug11()
+    {
+        var extractor = new RenaultBankDirektPDFExtractor(new Client());
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kontoauszug11.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "EUR");
+
+        assertThat(results, hasItem(interest(hasDate("2025-11-28"), hasAmount("EUR", 0.01), //
+                        hasSource("Kontoauszug11.txt"))));
+
+    }
+
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RenaultBankDirektPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RenaultBankDirektPDFExtractor.java
@@ -24,7 +24,7 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
 
     private static final String DEPOSIT_AT = "^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (Zahlungseingang) (\\w+) (?<amount>[\\.,\\d]+) (.*)$";
     private static final String REMOVAL_AT = "^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (.berweisung) (\\w+) (\\-)(?<amount>[\\.,\\d]+) (.*)$";
-    private static final String INTEREST_AT = "^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (\\w+zinsen) (\\w+) (?<amount>[\\.,\\d]+) (.*)";
+    private static final String INTEREST_AT = "^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) +(\\w+zinsen) (\\w+) (?<amount>[\\.,\\d]+) (.*)";
     private static final String TAXES_AT = "^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (Kapitalertragsteuer) (\\w+) (\\-)(?<amount>[\\.,\\d]+) (.*)$";
 
     private static final String CONTEXT_KEY_YEAR = "year";


### PR DESCRIPTION
Correctly handle multiple whitespace characters in interest transactions

I have received multiple statements with more than one whitespace / tab character in the interest lines