### PR TITLE
Dropped doubled caret from regular expressions.

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
@@ -303,7 +303,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
         var type = new DocumentType("(Dividendengutschrift|Ertragsgutschrift|Kupongutschrift)");
         this.addDocumentTyp(type);
 
-        var firstRelevantLine = new Block("^^(Dividendengutschrift|Ertragsgutschrift|Kupongutschrift)$");
+        var firstRelevantLine = new Block("^(Dividendengutschrift|Ertragsgutschrift|Kupongutschrift)$");
         type.addBlock(firstRelevantLine);
 
         var pdfTransaction = new Transaction<AccountTransaction>();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EbasePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EbasePDFExtractor.java
@@ -70,7 +70,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
                         .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)") //
                         .match("^St.ck [\\.,\\d]+ (?<name>.*) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\((?<wkn>[A-Z0-9]{6})\\)$") //
                         .match("^(?<nameContinued>.*)$") //
-                        .match("^^Zahlbarkeitstag [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Dividende pro St.ck [\\.,\\d]+ (?<currency>[A-Z]{3})$") //
+                        .match("^Zahlbarkeitstag [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Dividende pro St.ck [\\.,\\d]+ (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                         // @formatter:off


### PR DESCRIPTION
Just typos I guess. The only documentation for a double caret I was able to find was here: https://www.mindprod.com/jgloss/regex.html That page says it stands for "start of file". That may be true for some engine. But the Java reference documentation does not mention this feature. And what sense would "start of file" make in these two extractors? The parsing happens line-by-line. The expected pattern should be at the beginning of a line but definitely not at the beginning of the whole file.

The tests still pass.