### PR TITLE
IBFlex: support additional date and time formats

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
@@ -3558,4 +3558,82 @@ public class IBFlexStatementExtractorTest
         // 0.01)
         assertThat(unit.getExchangeRate().compareTo(new java.math.BigDecimal("0.01")), is(0));
     }
+
+    @Test
+    public void testParseDateTimeFormats()
+    {
+        // Compact format yyyyMMdd - date only
+        assertThat(IBFlexStatementExtractor.parseDateTime("20240115"),
+                        is(LocalDateTime.of(2024, 1, 15, 0, 0, 0)));
+
+        // Compact format yyyyMMdd with time HHmmss
+        assertThat(IBFlexStatementExtractor.parseDateTime("20240115;143052"),
+                        is(LocalDateTime.of(2024, 1, 15, 14, 30, 52)));
+
+        // Compact format yyyyMMdd with time HH:mm:ss
+        assertThat(IBFlexStatementExtractor.parseDateTime("20240115;14:30:52"),
+                        is(LocalDateTime.of(2024, 1, 15, 14, 30, 52)));
+
+        // Compact format with timezone (timezone is dropped)
+        assertThat(IBFlexStatementExtractor.parseDateTime("20240115;143052 EST"),
+                        is(LocalDateTime.of(2024, 1, 15, 14, 30, 52)));
+
+        // ISO format yyyy-MM-dd - date only
+        assertThat(IBFlexStatementExtractor.parseDateTime("2024-01-15"),
+                        is(LocalDateTime.of(2024, 1, 15, 0, 0, 0)));
+
+        // ISO format with comma+space separator (backward compat with CorporateAction)
+        assertThat(IBFlexStatementExtractor.parseDateTime("2024-01-15, 14:30:52"),
+                        is(LocalDateTime.of(2024, 1, 15, 14, 30, 52)));
+
+        // ISO format with semicolon separator
+        assertThat(IBFlexStatementExtractor.parseDateTime("2024-01-15;143052"),
+                        is(LocalDateTime.of(2024, 1, 15, 14, 30, 52)));
+
+        // US format MM/dd/yyyy
+        assertThat(IBFlexStatementExtractor.parseDateTime("01/15/2024"),
+                        is(LocalDateTime.of(2024, 1, 15, 0, 0, 0)));
+
+        assertThat(IBFlexStatementExtractor.parseDateTime("01/15/2024;143052"),
+                        is(LocalDateTime.of(2024, 1, 15, 14, 30, 52)));
+
+        assertThat(IBFlexStatementExtractor.parseDateTime("01/15/2024;14:30:52"),
+                        is(LocalDateTime.of(2024, 1, 15, 14, 30, 52)));
+
+        // US format MM/dd/yy (2-digit year)
+        assertThat(IBFlexStatementExtractor.parseDateTime("01/15/24;143052"),
+                        is(LocalDateTime.of(2024, 1, 15, 14, 30, 52)));
+
+        // European format dd/MM/yyyy - use day > 12 to avoid ambiguity
+        assertThat(IBFlexStatementExtractor.parseDateTime("15/01/2024"),
+                        is(LocalDateTime.of(2024, 1, 15, 0, 0, 0)));
+
+        assertThat(IBFlexStatementExtractor.parseDateTime("15/01/2024;143052"),
+                        is(LocalDateTime.of(2024, 1, 15, 14, 30, 52)));
+
+        // European format dd/MM/yy (2-digit year)
+        assertThat(IBFlexStatementExtractor.parseDateTime("15/01/24;143052"),
+                        is(LocalDateTime.of(2024, 1, 15, 14, 30, 52)));
+
+        // Month abbreviation format dd-MMM-yy
+        assertThat(IBFlexStatementExtractor.parseDateTime("15-Jan-24"),
+                        is(LocalDateTime.of(2024, 1, 15, 0, 0, 0)));
+
+        assertThat(IBFlexStatementExtractor.parseDateTime("15-Jan-24;143052"),
+                        is(LocalDateTime.of(2024, 1, 15, 14, 30, 52)));
+
+        assertThat(IBFlexStatementExtractor.parseDateTime("15-Jan-24;14:30:52"),
+                        is(LocalDateTime.of(2024, 1, 15, 14, 30, 52)));
+
+        // With timezone (should be dropped)
+        assertThat(IBFlexStatementExtractor.parseDateTime("15-Jan-24;143052 UTC"),
+                        is(LocalDateTime.of(2024, 1, 15, 14, 30, 52)));
+
+        // Null and empty handling
+        assertThat(IBFlexStatementExtractor.parseDateTime(null), is(nullValue()));
+        assertThat(IBFlexStatementExtractor.parseDateTime(""), is(nullValue()));
+
+        // Invalid format should return null
+        assertThat(IBFlexStatementExtractor.parseDateTime("invalid"), is(nullValue()));
+    }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractor.java
@@ -10,10 +10,12 @@ import java.math.RoundingMode;
 import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -92,18 +94,40 @@ public class IBFlexStatementExtractor implements Extractor
     // Map to store exchange mappings from Interactive Broker to Yahoo
     private Map<String, String> exchanges = new HashMap<>();
 
-    // dateTime attribute formats by tag:
-    // @formatter:off
-    // | Tag             | Format Pattern(s)                       |
-    // |-----------------|-----------------------------------------|
-    // | Trade           | YYYYMMDD;HHMMSS                         |
-    // | FxTransaction   | YYYYMMDD;HHMMSS                         |
-    // | CorporateAction | YYYY-MM-DD, HH:MM:SS OR YYYYMMDD;HHMMSS |
-    // | CashTransaction | YYYY-MM-DD OR YYYYMMDD[;HHMMSS]         |
-    // @formatter:on
+    // Supported date formats (from IB Flex Query configuration):
+    // - yyyyMMdd, yyyy-MM-dd, MM/dd/yyyy, MM/dd/yy, dd/MM/yyyy, dd/MM/yy, dd-MMM-yy
+    // Supported time formats:
+    // - HHmmss, HH:mm:ss, HHmmss zzz (with timezone), HH:mm:ss zzz (with timezone)
+    // Date and time are separated by semicolon. Time and timezone are optional.
     private static final DateTimeFormatter[] DATE_TIME_FORMATTER = { //
-                    createFormatter("yyyyMMdd[;HHmmss]"), //
-                    createFormatter("yyyy-MM-dd[, HH:mm:ss]"), //
+                    // Compact format: yyyyMMdd with optional time and timezone
+                    createFormatter("yyyyMMdd[;HHmmss][ z]"), //
+                    createFormatter("yyyyMMdd[;HH:mm:ss][ z]"), //
+
+                    // ISO format (comma+space separator for backward compat with CorporateAction)
+                    createFormatter("yyyy-MM-dd[, HH:mm:ss][ z]"), //
+                    createFormatter("yyyy-MM-dd[;HHmmss][ z]"), //
+                    createFormatter("yyyy-MM-dd[;HH:mm:ss][ z]"), //
+
+                    // US format MM/dd/yyyy (4-digit year first to avoid ambiguity)
+                    createFormatter("MM/dd/yyyy[;HHmmss][ z]"), //
+                    createFormatter("MM/dd/yyyy[;HH:mm:ss][ z]"), //
+
+                    // US format MM/dd/yy (2-digit year)
+                    createFormatter("MM/dd/yy[;HHmmss][ z]"), //
+                    createFormatter("MM/dd/yy[;HH:mm:ss][ z]"), //
+
+                    // European format dd/MM/yyyy (4-digit year first)
+                    createFormatter("dd/MM/yyyy[;HHmmss][ z]"), //
+                    createFormatter("dd/MM/yyyy[;HH:mm:ss][ z]"), //
+
+                    // European format dd/MM/yy (2-digit year)
+                    createFormatter("dd/MM/yy[;HHmmss][ z]"), //
+                    createFormatter("dd/MM/yy[;HH:mm:ss][ z]"), //
+
+                    // Month abbreviation format dd-MMM-yy (e.g., 15-Jan-24)
+                    createFormatter("dd-MMM-yy[;HHmmss][ z]"), //
+                    createFormatter("dd-MMM-yy[;HH:mm:ss][ z]"), //
     };
 
     private static DateTimeFormatter createFormatter(String pattern)
@@ -114,6 +138,38 @@ public class IBFlexStatementExtractor implements Extractor
                         .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0) //
                         .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0) //
                         .toFormatter(Locale.US);
+    }
+
+    /**
+     * Parses a date/time string using all supported formats.
+     * <p/>
+     * If a timezone is present, it is dropped (not converted).
+     *
+     * @param dateTime the date/time string to parse
+     * @return the parsed LocalDateTime, or null if parsing fails
+     */
+    /* package */ static LocalDateTime parseDateTime(String dateTime)
+    {
+        if (dateTime == null || dateTime.isEmpty())
+            return null;
+
+        for (DateTimeFormatter formatter : DATE_TIME_FORMATTER)
+        {
+            try
+            {
+                TemporalAccessor parsed = formatter.parseBest(dateTime,
+                                ZonedDateTime::from, LocalDateTime::from);
+                if (parsed instanceof ZonedDateTime zdt)
+                    return zdt.toLocalDateTime();
+                return LocalDateTime.from(parsed);
+            }
+            catch (DateTimeParseException ignore)
+            {
+                // try next formatter
+            }
+        }
+
+        return null;
     }
 
 
@@ -848,22 +904,7 @@ public class IBFlexStatementExtractor implements Extractor
                 dateTime = element.getAttribute("dateTime");
             }
 
-            if (!dateTime.isEmpty())
-            {
-                for (DateTimeFormatter formatter : DATE_TIME_FORMATTER)
-                {
-                    try
-                    {
-                        return LocalDateTime.parse(dateTime, formatter);
-                    }
-                    catch (DateTimeParseException ignore)
-                    {
-                        continue;
-                    }
-                }
-            }
-
-            return null;
+            return parseDateTime(dateTime);
         }
 
         /**


### PR DESCRIPTION
Interactive Brokers let's customers configure the date and time format of flex queries. Users have reported NPEs on the forum because their existing flex queries use a format that is not recognised by the importer since my changes to correct exchange rates.

Extend the supported date formats. Note that we drop time zone information when converting to LocalDateTime since the rest of the codebase doesn't seem to be TZ aware.

We currently only support semicolons as delimiters, with one exception for a historical test case.