### PR TITLE
Scalable: Support new Sparplan PDF-format

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/ScalableCapitalPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/ScalableCapitalPDFExtractorTest.java
@@ -29,6 +29,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAc
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countItemsWithFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSkippedItems;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -706,6 +707,40 @@ public class ScalableCapitalPDFExtractorTest
                         hasSource("Sparplanausfuehrung06.txt"), //
                         hasNote("Ord.-Nr.: SCALNUFeqbHQBbc"), //
                         hasAmount("EUR", 2.61), hasGrossValue("EUR", 2.61), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testSparplanausfuehrung07()
+    {
+        var extractor = new ScalableCapitalPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Sparplanausfuehrung07.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00BTN1Y115"), hasWkn(null), hasTicker(null), //
+                        hasName("Medtronic"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-16T11:07:00"), hasShares(0.585137), //
+                        hasSource("Sparplanausfuehrung07.txt"), //
+                        hasNote("Ord.-Nr.: SCALQCpPumUCcUV"), //
+                        hasAmount("EUR", 50.00), hasGrossValue("EUR", 50.00), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/Sparplanausfuehrung07.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/Sparplanausfuehrung07.txt
@@ -1,0 +1,26 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.1
+System: macosx | aarch64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Scalable Capital Bank GmbH • Seitzstraße 8e • 80538 München • Deutschland 
+iMeIXG QJTxr
+aSuAAF 
+iIDV DAeOPgnChYK 5 Datum 16.01.2026
+70812 KuT Seite 1 / 1
+Deutschland 
+Wertpapierabrechnung 
+Sparplan / Automatische Wiederanlage 
+Typ LIMIT Order SCALQCpPumUCcUV
+Ausführung 16.01.2026 11:07:00 Geschäft 2489324001
+Ausführungsplatz EIX Lagerland Deutschland
+Depot 5132275283 Verwahrart Girosammelverwahrung
+Typ Wertpapier Anzahl Kurs Betrag
+Kauf Medtronic 0,585137 Stk. 85,45 EUR 50,00 EUR
+IE00BTN1Y115
+Belastung 50,00 EUR
+Der Betrag wird mit dem Verrechnungskonto RU99110397066270066155 (Valuta: 20.01.2026) verrechnet. 
+Bitte überprüfen Sie die Informationen auf Richtigkeit und melden Sie etwaige Einwände unverzüglich bei uns.
+Verwenden Sie dafür den Menüpunkt Support im Kundenbereich. 
+Scalable Capital Bank GmbH HRB 217778 Geschäftsführer: Aufsichtsrat: Seite 
+Seitzstraße 8e Amtsgericht München Florian Prucker, Martin Krebs, Patrick Olson (Vorsitzender) 
+80538 München USt.-Id. Nr.: DE300434774 Dirk Franzmeyer 1 / 1

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
@@ -44,14 +44,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
 
         var pdfTransaction = new Transaction<BuySellEntry>();
 
-        var firstRelevantLine = new Block("^(f.r|voor|per) " //
-                        + "(Kundenauftrag" //
-                        + "|Sparplanausf.hrung" //
-                        + "|savings plan order" //
-                        + "|client order" //
-                        + "|Auftrag" //
-                        + "|beleggingsplanorder" //
-                        + "|l.ordine del piano di accumulo).*$");
+        var firstRelevantLine = new Block();
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 


### PR DESCRIPTION
Closes #5320
Closes #5354

The phrase which is used for "first relevant line" was changed from `für Sparplanausführung` into `Sparplan / Automatische Wiederanlage`. 
The regex was done for multiple languages, split into "für" & "Sparplan.." and already quite long and not having any value. Think the new "block without regex" to get the whole document which @buchen recently introduced is working quite well in this case.


Additional report of the issue (with English text): https://forum.portfolio-performance.info/t/import-error-scalable-capital-contract-note/38651