### PR TITLE
Scalable: Support additional format and capital repayment for dividends

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/Dividende08.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/Dividende08.txt
@@ -1,0 +1,47 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.1
+System: macosx | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Scalable Capital Bank GmbH • Seitzstraße 8e • 80538 München • Deutschland
+LrvPTL JdUVXYd
+mpMNjz
+lb iEh osLoPWWmTKu 37 fNebV 09.01.2026
+54707 XGDVnudyI bf PKRbE Seite 1 / 2
+Deutschland
+Dividende
+Für 01.01.2025 - 31.12.2025
+BerechtigtesWertpapier PepsiCo Inc.
+ISIN US7134481081
+Berechtigte Anzahl 1,588739
+Ex Tag 05.12.2025
+Verrechnungskonto sm90337005369548163163 (XXXXDEFFXXX)
+Kontobewegung
+Buchung Wertstellung Typ Betrag / Stk. BerechtigteAnzahl Gesamt
+Wechselkurs
+09.01.2026 09.01.2026 Gutschrift 1,42 USD 1,588739 1,93 EUR
+USD / EUR 1,1683
+Ausländische Quellensteuer -0,29 EUR
+Steuern -0,22 EUR
+Gesamtbetrag 1,42 EUR
+Bitte beachten Sie Ihre eventuelle Meldepflicht nach § 67 AWV. Einkünfte aus Kapitalvermögen im Sinne von § 20 EStG sind
+einkommensteuerpflichtig.
+Scalable Capital Bank GmbH HRB 217778 Geschäftsführer: Aufsichtsrat: Seite
+Seitzstraße 8e Amtsgericht München Florian Prucker, Martin Krebs, Patrick Olson (Vorsitzender)
+80538 München USt.-Id. Nr.: DE300434774 Dirk Franzmeyer 1 / 2
+Dividende
+Ermittlung steuerrelevante Erträge
+Typ Betrag
+Gewinn oder Verlust 1,93 EUR
+Verrechnung anrechenbarer Quellensteuer -1,16 EUR
+Zu versteuern 0,77 EUR
+Anfallende Steuern
+Typ Betrag
+Kapitalertragsteuer 0,19 EUR
+Solidaritätszuschlag 0,01 EUR
+Kirchensteuer 0,02 EUR
+Anfallende
+0,22 EUR
+Steuern
+Scalable Capital Bank GmbH HRB 217778 Geschäftsführer: Aufsichtsrat: Seite
+Seitzstraße 8e Amtsgericht München Florian Prucker, Martin Krebs, Patrick Olson (Vorsitzender)
+80538 München USt.-Id. Nr.: DE300434774 Dirk Franzmeyer 2 / 2

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/Dividende09.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/Dividende09.txt
@@ -1,0 +1,43 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.1
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Scalable Capital Bank GmbH • Seitzstraße 8e • 80538 München • Deutschland 
+rgxkqr SKdFrC
+HzkAtcwGtIYtp Str. 4 
+70996 DCCPikX Datum 08.01.2026
+Deutschland Seite 1 / 2
+Kapitalrückzahlung 
+Berechtigtes Wertpapier Garmin Ltd. 
+ISIN CH0114405324 
+Berechtigte Anzahl 6 
+Ex Tag 12.12.2025 
+Verrechnungskonto AO71190858474283218305 (DEUTDEFFXXX)
+Kontobewegung 
+Buchung Wertstellung Typ Betrag / Stk. Berechtigte Anzahl Gesamt 
+Wechselkurs 
+08.01.2026 31.12.2025 Gutschrift 0,90 USD 6 4,58 EUR 
+USD / EUR 1,178 
+Steuern -1,28 EUR
+Gesamtbetrag 3,30 EUR
+Bitte beachten Sie Ihre eventuelle Meldepflicht nach § 67 AWV. Einkünfte aus Kapitalvermögen im Sinne von § 20 EStG sind
+einkommensteuerpflichtig. 
+Ermittlung steuerrelevante Erträge
+Typ Betrag
+Gewinn oder Verlust 4,58 EUR
+Zu versteuern 4,58 EUR
+Scalable Capital Bank GmbH HRB 217778 Geschäftsführer: Aufsichtsrat: Seite 
+Seitzstraße 8e Amtsgericht München Florian Prucker, Martin Krebs, Patrick Olson (Vorsitzender) 
+80538 München USt.-Id. Nr.: DE300434774 Dirk Franzmeyer 1 / 2
+Kapitalrückzahlung
+Anfallende Steuern 
+Typ Betrag
+Kapitalertragsteuer 1,13 EUR
+Solidaritätszuschlag 0,06 EUR
+Kirchensteuer 0,09 EUR
+Anfallende
+1,28 EUR
+Steuern 
+Scalable Capital Bank GmbH HRB 217778 Geschäftsführer: Aufsichtsrat: Seite 
+Seitzstraße 8e Amtsgericht München Florian Prucker, Martin Krebs, Patrick Olson (Vorsitzender) 
+80538 München USt.-Id. Nr.: DE300434774 Dirk Franzmeyer 2 / 2

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/ScalableCapitalPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/ScalableCapitalPDFExtractorTest.java
@@ -29,6 +29,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAc
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countItemsWithFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSkippedItems;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -1174,6 +1175,74 @@ public class ScalableCapitalPDFExtractorTest
                         hasNote(null), //
                         hasAmount("EUR", 0.12), hasGrossValue("EUR", 0.17), //
                         hasTaxes("EUR", 0.05), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende08()
+    {
+        var extractor = new ScalableCapitalPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende08.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US7134481081"), hasWkn(null), hasTicker(null), //
+                        hasName("PepsiCo Inc."), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-01-09"), hasShares(1.588739), //
+                        hasSource("Dividende08.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 1.42), hasGrossValue("EUR", 1.93), //
+                        hasTaxes("EUR", (0.29 + 0.22)), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende09()
+    {
+        var extractor = new ScalableCapitalPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende09.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("CH0114405324"), hasWkn(null), hasTicker(null), //
+                        hasName("Garmin Ltd."), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-12-31"), hasShares(6.0), //
+                        hasSource("Dividende09.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 3.30), hasGrossValue("EUR", 4.58), //
+                        hasTaxes("EUR", 1.28), hasFees("EUR", 0.00))));
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
@@ -212,7 +212,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        final var type = new DocumentType("(Dividende|Zinszahlung|Dividend)", //
+        final var type = new DocumentType("(Dividende|Zinszahlung|Dividend|Kapitalr.ckzahlung)", //
                         "(Kauf|Buy|Kopen|Acquisto|Verkauf|Sell)");
         this.addDocumentTyp(type);
 
@@ -244,12 +244,13 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
                                         // Berechtigtes Wertpapier AGNC Investment Corp.
+                                        // BerechtigtesWertpapier PepsiCo Inc.
                                         // ISIN US00123Q1040
-                                        // 15.01.2025 15.01.2025 Gutschrift 0,12 USD 0,663129 0,08 EUR
+                                        // 15.01.2025 15.01.2025 Gutschrift 0,12 USD 0,663129 0,08 EUR     
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "isin", "currency") //
-                                                        .match("^Berechtigtes Wertpapier (?<name>.*)$") //
+                                                        .match("^Berechtigtes(\\s)?Wertpapier (?<name>.*)$") //
                                                         .match("^ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]).*$") //
                                                         .match("^[\\d]{2}\\.[\\w]{2}\\.[\\d]{4} [\\d]{2}\\.[\\w]{2}\\.[\\d]{4} Gutschrift [\\.,\\d]+ (?<currency>[A-Z]{3}).*$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))


### PR DESCRIPTION
Closes #5336

- not sure if Dividend08 is valid as there's a missing whitespace in the text, but think no real harm supporting this as there was a bug report
- Adding Kapitalrückzahlung as supported dividend document