### PR TITLE
forbid the deletion of the main node of taxonomy

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
@@ -896,7 +896,7 @@ import name.abuchen.portfolio.util.TextUtil;
 
             manager.add(sorting);
 
-            if (!node.isRoot())
+            if (!node.isRoot() && !node.getParent().isRoot())
             {
                 manager.add(new Separator(MENU_GROUP_DELETE_ACTIONS));
                 manager.add(new SimpleAction(Messages.MenuTaxonomyClassificationDelete,
@@ -981,7 +981,7 @@ import name.abuchen.portfolio.util.TextUtil;
 
     private void doDeleteClassification(TaxonomyNode node)
     {
-        if (node.isRoot() || node.isUnassignedCategory())
+        if (node.isRoot() || node.isUnassignedCategory() || node.getParent().isRoot())
             return;
 
         node.getParent().removeChild(node);


### PR DESCRIPTION
Hello,

The goal is to prevent this situation, as I do not think we can get it back if we save the file after :
<img width="260" height="131" alt="Capture d’écran 2026-01-16 205143" src="https://github.com/user-attachments/assets/662765ed-062e-4410-8609-e25f5d2bfec9" />


**Result :**
<img width="483" height="232" alt="2026-01-16 20_44_17-Portfolio Performance" src="https://github.com/user-attachments/assets/efd97bcd-900e-4307-a6b9-49ce6587385f" />
