### PR TITLE
dedicated submenu for TWR reporting period choice for TreeMap color

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TreeMapViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TreeMapViewer.java
@@ -271,10 +271,11 @@ import name.abuchen.portfolio.ui.views.taxonomy.TaxonomyNodeRenderer.Performance
         action.setChecked(selectedRenderer == null);
         manager.add(action);
 
-        manager.add(new LabelOnly(Messages.LabelTTWROR));
+        var twrSubMenuManager = new MenuManager(Messages.LabelTTWROR);
+        manager.add(twrSubMenuManager);
 
         // display the first 10 elements in the menu directly
-        var limit = 10;
+        var limit = 25;
         var reportingPeriods = view.getPart().getClientInput().getReportingPeriods();
         reportingPeriods.stream().limit(limit).forEach(period -> {
             Action byPeriod = new SimpleAction(period.toString(), a -> {
@@ -284,13 +285,13 @@ import name.abuchen.portfolio.ui.views.taxonomy.TaxonomyNodeRenderer.Performance
                 treeMap.recolor();
             });
             byPeriod.setChecked(selectedRenderer != null && selectedRenderer.getReportingPeriod().equals(period));
-            manager.add(byPeriod);
+            twrSubMenuManager.add(byPeriod);
         });
 
         if (reportingPeriods.size() > limit)
         {
             var subMenu = new MenuManager(Messages.LabelMore);
-            manager.add(subMenu);
+            twrSubMenuManager.add(subMenu);
             reportingPeriods.stream().skip(limit).forEach(period -> {
                 Action byPeriod = new SimpleAction(period.toString(), a -> {
                     getModel().setColoringStrategy(COLORING_STRATEGY_TTWROR + period.getCode());


### PR DESCRIPTION
Issue https://forum.portfolio-performance.info/t/treemap-farbe-nach-twr/38652

Hello,

It seems the selection of TWR for color use in TreeMap is not clear , I think adding a sub menu makes it clearer :

**Before**
<img width="434" height="465" alt="2026-01-17 14_59_54-" src="https://github.com/user-attachments/assets/166bbb31-f84d-42dd-b1dd-4b4d5acf5e41" />

**After**
<img width="669" height="485" alt="2026-01-17 15_12_36-Portfolio Performance" src="https://github.com/user-attachments/assets/5be195c5-f0dd-48e6-bc13-859bff3e7e90" />

