### PR TITLE
fix pie chart when title is shared between subtaxonomy

### DIFF
--- a/name.abuchen.portfolio.ui/META-INF/html/pie.html
+++ b/name.abuchen.portfolio.ui/META-INF/html/pie.html
@@ -86,7 +86,7 @@ var thePieChart = {
         }
 
         this.path = pathGroup.selectAll("path.pie")
-            .data(this.piedata, function(d) { return d.data.uuid; });
+            .data(this.piedata);
 
         // Enter: create new paths
         this.path.enter()
@@ -132,7 +132,7 @@ var thePieChart = {
             .sort(function(p1, p2) { return p1.startAngle - p2.startAngle; });
 
         var labels = labelGroup.selectAll("text")
-            .data(labelData, function(d) { return d.data.uuid; });
+            .data(labelData);
 
         // Enter: create new labels
         labels.enter()
@@ -213,7 +213,7 @@ var thePieChart = {
             .sort(function(p1, p2) { return p1.startAngle - p2.startAngle; });
 
         this.valueLabels = labelGroup.selectAll("text")
-            .data(valueData, function(d) { return d.data.uuid; });
+            .data(valueData);
 
         // Enter: create new value labels
         this.valueLabels.enter()


### PR DESCRIPTION
Hello, sorry I did not catch this issue :
https://forum.portfolio-performance.info/t/strobo-wenn-pp-in-kuchendiagramm-startet-und-kurse-aktualisiert/38671/7

I can reproduce when the security is shared between several sub-taxonomy, I did not have this case when checking..
I am now checking against kommer/Industries taxonomy which clearly show the issue

**Before**
<img width="1598" height="807" alt="Capture d’écran 2026-01-25 150855" src="https://github.com/user-attachments/assets/65fc585e-ddf0-4108-8652-8689aa22ba14" />

**After**
<img width="1496" height="868" alt="Capture d’écran 2026-01-25 151155" src="https://github.com/user-attachments/assets/4d9a9842-280f-488c-8eca-db244ae4c22c" />
I think this was the previous behavior ?


What do you think ? It is bit trial and error, I am not sure why it works, I guess uuid is unique per security, but not per slice in the case the security weight is shared among several folder. I hope this is not introducing other issues.

Similar issue for flare, I did not find yet the fix.