### PR TITLE
Don't import unsettled trades in Questrade importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/questradegroup/Buy07.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/questradegroup/Buy07.txt
@@ -1,0 +1,399 @@
+Current month balance: 
+Get the most out of your statement ACCOUNT STATEMENT $1,429.85
+Your statement is broken down into five straight-forward (January 31, 2025)
+categories, each designed to help you understand how your Order execution only account Last month balance: $1,355.51
+investments are performing: 
+• (December 31, 2024)
+Measure overall account performance, past and 
+present 
+• Track incoming/outgoing fees and rebates 
+• Monitor your portfolio’s position allocation 
+Talk to us, follow us, watch us MAX MUSTERMANN 
+For help with your account, Monday to Friday, 8 a.m. to 8 p.m. 
+ET: 
+• Account #:  62639842 Current month:  January 31, 2025
+Visit chat and we can help you immediately 
+• 1234 RUE UNKNOWN UNKNOWN ON  G1X 
+Call us at 1.888.783.7866
+• 2J3 Type:  Individual Tax-Free Savings Account (TFSA) Account opened:  February 03, 2021
+Email support@questrade.com 
+For all other help, join the conversation: Currency:  CAD/USD Dealer:  Questrade, Inc.
+• Follow us on Facebook or Twitter 
+• Tune into our YouTube channel 
+• Visit our LinkedIn page 
+CONTENT
+01 SUMMARY
+An overview of current and historical balances. 04 ACTIVITY DETAILS
+A breakdown of cash and position changes during 
+the month.
+02 PERFORMANCE
+Your current and historical rate of return. 05 TRADES TO SETTLE AFTER MONTH END
+A summary of all trades not settled by the end of 
+the month.
+03 INVESTMENT DETAILS
+A detailed summary of cash and settled positions.
+Current month FX rate: $1.00 USD = $1.4539 CAD Previous month FX rate: $1.00 USD = $1.4383 CAD Account #: 62639842 Current month: January 31, 2025
+©Questrade, Inc. All rights reserved. Member of CIRO and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 1 of 15
+ACCOUNT STATEMENT
+Balances 01. SUMMARY
+Combined in (CAD)¹
+CURRENT MONTH PREVIOUS MONTH ¹Combined in CAD
+Owned Borrowed cash/ Total⁴ Owned Borrowed cash/ Total⁴
+Cash/Securities² securities cash/securities² securities shorted³ U.S. dollar amounts are totalled in
+shorted³ Canadian dollars where applicable.
+■ Cash 66.27 - 66.27 45.58 - 45.58
+²Owned cash/securities
+■ Exchange traded funds 1,363.58 - 1,363.58 1,309.93 - 1,309.93
+All assets including cash and securities
+1,429.85 - 1,429.85 1,355.51 - 1,355.51 owned (long positions).
+³Borrowed cash/ securities shorted
+All liabilities including cash, securities
+borrowed, and any written options.
+⁴Total
+The combined total of CAD and USD (if
+applicable) holdings in your account.
+CURRENT MONTH
+PREVIOUS MONTH
+Current month FX rate: $1.00 USD = $1.4539 CAD Previous month FX rate: $1.00 USD = $1.4383 CAD Account #: 62639842 Current month: January 31, 2025
+©Questrade, Inc. All rights reserved. Member of CIRO and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 2 of 15
+ACCOUNT STATEMENT
+01. SUMMARY
+TFSA summary
+Combined in (CAD)¹
+YEAR TO DATE SINCE OPENED ¹Combined in CAD
+U.S. dollar amounts are totalled in
+Contributions² - 1,000.00 Canadian dollars where applicable.
+Withdrawals - - ²Contributions
+The additional contribution room available in 
+each year. 
+Note: contributions to a TFSA are reported to 
+the CRA by all financial institutions. Net 
+contributions exceeding the yearly limit may 
+be taxed. 
+For TFSA contribution limits, go to https://www.questrade.com/resources-support/what-is-a-tfsa
+Current month FX rate: $1.00 USD = $1.4539 CAD Previous month FX rate: $1.00 USD = $1.4383 CAD Account #: 62639842 Current month: January 31, 2025
+©Questrade, Inc. All rights reserved. Member of CIRO and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 3 of 15
+ACCOUNT STATEMENT
+01. SUMMARY
+Total Book Cost
+Combined in (CAD)¹
+CURRENT MONTH PREVIOUS MONTH CURRENT MONTH PREVIOUS MONTH ¹Combined in CAD
+Total Market Value 1,363.58 1,309.93 Total Position 
+Cost 974.50 974.50 U.S. dollar amounts are totalled in
+Canadian dollars where applicable.
+Total Cash 66.27 45.58 Total Cash 66.27 45.58
+If one or more positions in your account 
+Total 1,429.85 1,355.51 Total 1,040.77 1,020.08 has a position cost that was unable to be 
+determined that position cost was 
+considered as zero for the purposes of 
+this summation.
+Current month FX rate: $1.00 USD = $1.4539 CAD Previous month FX rate: $1.00 USD = $1.4383 CAD Account #: 62639842 Current month: January 31, 2025
+©Questrade, Inc. All rights reserved. Member of CIRO and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 4 of 15
+ACCOUNT STATEMENT
+01. SUMMARY
+Balance Changes
+Combined in (CAD)¹
+¹Combined in CAD
+CURRENT MONTH YEAR TO DATE LAST YEAR SINCE OPENED U.S. dollar amounts are totalled in
+Canadian dollars where applicable using
+Opening balance 1,355.51 1,355.51 1,090.96 - the current month FX rate.
+Deposits - - - 1,000.00 ²Change in balance
+Determined using the following formula:
+Withdrawals - - - - A – B – C + D
+A = the market value of all cash and
+Change in balance² 74.34 74.34 264.55 429.85 securities at the end of the period (e.g.
+current month, YTD, 2012, or since
+Closing balance 1,429.85 1,429.85 1,355.51 1,429.85 opened).
+B = the market value of all cash and
+securities at the beginning of the period
+(e.g. current month, YTD, 2012, or since
+opened).
+C = the market value of all deposits and
+transfers-in of cash and securities.
+D = the market value of all withdrawals
+and transfers-out of cash and securities.
+Current month FX rate: $1.00 USD = $1.4539 CAD Previous month FX rate: $1.00 USD = $1.4383 CAD Account #: 62639842 Current month: January 31, 2025
+©Questrade, Inc. All rights reserved. Member of CIRO and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 5 of 15
+ACCOUNT STATEMENT
+02. PERFORMANCE 
+Investment return
+Combined in (CAD)¹
+CURRENT 3 MONTHS 6 MONTHS YEAR TO ONE YEAR 3 YEARS SINCE 
+MONTH DATE OPENED
+Money-weighted total return² 5.5 7.7 11.7 5.5 27.1 12.7 9.5
+¹Combined in CAD: U.S. dollar amounts are totalled in Canadian dollars where applicable.
+²Money-weighted total return:   Tracks all elements affecting your account performance over a specified period of time, expressed as a percentage.Includes cash movements 
+                                                    (i.e. deposits/withdrawals and transfers in/out), as well as the total percentage return on your investments,net of charges. 
+                                                    How cash movements are calculated in your return: 
+                                                        • Cash inflows and outflows for all periods are based on the net change in cash as of the middle of each month. 
+                                                    How total percentage return on your investments is calculated:
+                                                        • The cumulative realized and unrealized capital gains and losses of an investment, plus income from the investment over a period of time, expressed as a percentage. 
+A dash (-) indicates that the money-weighted total return could not be calculated or was not calculated because the initial deposit was in the middle of the period.
+Note: investment return uses a money-weighted total return calculation. In some instances, underlying values may not be correct. Please cross reference these calculations with your records to ensure 
+accuracy.
+When securities are included and the market value was undetermined, these securities are assigned a $0 value for calculation purposes only.
+Current month FX rate: $1.00 USD = $1.4539 CAD Previous month FX rate: $1.00 USD = $1.4383 CAD Account #: 62639842 Current month: January 31, 2025
+©Questrade, Inc. All rights reserved. Member of CIRO and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 6 of 15
+ACCOUNT STATEMENT
+03. INVESTMENT DETAILS
+Allocation of owned cash/securities¹
+Combined in (CAD)² ¹Allocation of owned cash/securities
+ALLOCATION(%)³ MARKET VALUE ($)⁴ All assets including cash and securities
+owned (long positions).
+■ Cash 4.6 66.3
+■ Exchange-traded funds 
+(ETFs) 95.4 1,363.6 ²Combined in CAD
+100.0 1,429.9
+U.S. dollar amounts are totalled in
+Canadian dollars where applicable.
+³Allocation (%)
+The portfolio mix of your investments
+expressed as a percentage.
+⁴Market value ($)
+Securities are generally valued using
+the most recent quoted price from an
+exchange as of the date of the statement.
+For an explanation of market value,
+including illiquid or non-exchange traded
+securities, please refer to the disclosures
+at the end of this statement.
+⁵Allocation of borrowed cash/securities shorted
+All liabilities including cash, securities
+borrowed, and any written options.
+Current month FX rate: $1.00 USD = $1.4539 CAD Previous month FX rate: $1.00 USD = $1.4383 CAD Account #: 62639842 Current month: January 31, 2025
+©Questrade, Inc. All rights reserved. Member of CIRO and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 7 of 15
+ACCOUNT STATEMENT
+Securities Owned 03. INVESTMENT DETAILS
+Combined in (CAD)¹
+¹Combined in CAD
+U.S. dollar amounts are totalled in
+ALLOCATION (%)² MARKET VALUE ($)³ Canadian dollars where applicable.
+■ VANGUARD ALL-EQUITY ETF PORTFOLIO ETF 100.0 1,363.6 ²Allocation (%)
+UNIT (VEQT)
+100.0 1,363.6 The portfolio mix of your investments
+expressed as a percentage.
+³Market value ($)
+Securities are generally valued using
+the most recent quoted price from an
+exchange as of the date of the statement.
+For an explanation of market value,
+including illiquid or non-exchange traded
+securities, please refer to the disclosures
+at the end of this statement.
+In RESP accounts, the market value of any
+securities you own in U.S. dollars are
+converted and displayed in Canadian
+dollars.
+⁴Securities shorted
+All securities that you borrowed and any
+written options.
+Current month FX rate: $1.00 USD = $1.4539 CAD Previous month FX rate: $1.00 USD = $1.4383 CAD Account #: 62639842 Current month: January 31, 2025
+©Questrade, Inc. All rights reserved. Member of CIRO and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 8 of 15
+ACCOUNT STATEMENT
+Cash 03. INVESTMENT DETAILS 
+CURRENT MONTH PREVIOUS MONTH ¹Combined in CAD
+CAD USD Combined in CAD¹ CAD USD Combined in CAD¹ U.S. dollar amounts are totalled in
+Canadian dollars where applicable.
+Owned 66.27 66.27 45.58 45.58
+66.27 66.27 45.58 45.58
+Current month FX rate: $1.00 USD = $1.4539 CAD Previous month FX rate: $1.00 USD = $1.4383 CAD Account #: 62639842 Current month: January 31, 2025
+©Questrade, Inc. All rights reserved. Member of CIRO and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 9 of 15
+ACCOUNT STATEMENT
+03. INVESTMENT DETAILS
+Exchange-traded funds (ETFs) owned
+¹Investment details
+CURRENT MONTH PREVIOUS MONTH
+Securities held Securities held Combined in Securities held Securities held Combined in Cost basis:
+in CAD in USD CAD in CAD in USD CAD • Book cost (BK): The cost of a security
+   adjusted by any corporate actions, reinvested 
+Market Value ($) 1,363.58 1,363.58 1,309.93 1,309.93    dividends, and return of capital.
+• Historical Market value (HMV): The 
+   historical market value of the security
+   is used to estimate some or all of its
+Cost
+Symbol Description basis¹ Qty¹ Segr.¹ Cost/share Pos. cost¹ Mkt. price¹ Mkt. value¹ P&L¹ % return¹ % port.¹    book cost.
+• Historical Market value date (HMVD): The 
+   market value of the security on October 30, 
+Securities held in CAD    2015 was used to estimate some or all of its 
+   book cost.
+VEQT    VANGUARD ALL-EQUITY ETF PORTFOLIO BK 29.00 29.00 33.60 974.50 47.02 1,363.58 389.08 39.93 100.00 • Non-determinable (ND): The security is not
+ETF UNIT    included in your % portfolio calculation
+   because the cost basis cannot be determined.
+Quantity (Qty.): The quantity for each security 
+may include fractional shares which are shown 
+in decimals.
+Segregated (Segr.): fully paid securities
+that require no reimbursement to Questrade.
+Position cost (Pos. cost): the cost of the
+position.
+Market price (Mkt. price)/Market value 
+(Mkt. value): the price at which a security 
+is trading and could presumably be 
+purchased or sold. 
+Market value may include accrued interest. 
+A letter to the right of the market value means:
+E: we have estimated the market value of the
+     security
+N: the market value of the security cannot be
+     determined
+For an explanation of market price, including
+illiquid or non-exchange traded securities,
+please refer to the disclosures at the end of 
+this statement.
+In RESP accounts, the market value of any 
+securities you own in U.S. dollars are 
+converted and displayed in Canadian dollars. 
+P&L: the market value minus the position cost.
+% portfolio (% port.): the value of the security
+divided by the value of all owned positions in 
+your account. Shorted positions are not
+included in this calculation.
+Note: Continue reading on glossary page
+Current month FX rate: $1.00 USD = $1.4539 CAD Previous month FX rate: $1.00 USD = $1.4383 CAD Account #: 62639842 Current month: January 31, 2025
+©Questrade, Inc. All rights reserved. Member of CIRO and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 10 of 15
+ACCOUNT STATEMENT
+04. ACTIVITY DETAILS
+Cash changes
+CURRENT MONTH YEAR TO DATE
+Combined in Combined in ¹Combined in CAD
+CAD USD (CAD)¹ CAD USD (CAD)¹ U.S. dollar amounts are totalled in
+Canadian dollars where applicable.
+Opening balance 45.58 45.58 45.58 45.58
+²Activity details
+Sales - - - -
+Interest: the balance of interest earned
+Purchases - - - - and paid.
+Interest² - - - - Dividends: the balance of dividends
+earned and paid.
+Dividends² 20.69 20.69 20.69 20.69 Deposits: the net amount of money put
+into the account during the month.
+Deposits² - - - -
+Commissions: the balance of
+commissions paid and rebated.
+Withdrawals - - - -
+Dividend reinvestment: the amount
+of cash invested through a dividend
+Dividend reinvestment² - - - - reinvestment plan (DRIP).
+FX conversion² - - - - FX conversion: the net amount of cash
+converted between CAD and USD.
+Transfers² - - - - Transfers: the value of assets transferred
+in and out of your account.
+Corporate actions² - - - -
+Corporate actions: the balance of
+cash earned and paid through non
+Commission² - - - - exchange events. E.g. option exercises
+and assignments, stock splits, mergers,
+acquisitions, rights issues, spin-offs, etc.
+Fees And Rebates - - - -
+Other transactions: the balance of fees
+Other transactions² - - - - paid and rebated that are not categorized
+elsewhere.
+Change in starting cash from exchange 
+rate² - - - - Change in starting cash from exchange
+rate: the change in value of USD cash you
+hold after converting it to CAD.
+Closing balance 66.27 66.27 66.27 66.27
+Current month FX rate: $1.00 USD = $1.4539 CAD Previous month FX rate: $1.00 USD = $1.4383 CAD Account #: 62639842 Current month: January 31, 2025
+©Questrade, Inc. All rights reserved. Member of CIRO and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 11 of 15
+ACCOUNT STATEMENT
+Investment income 04. ACTIVITY DETAILS
+CURRENT MONTH YEAR TO DATE ¹Combined in CAD
+Combined in Combined in
+Earned CAD USD CAD¹ CAD USD U.S. dollar amounts are totalled in
+CAD¹ Canadian dollars where applicable.
+Dividend 20.69 20.69 20.69 20.69
+Interest - - - -
+20.69 20.69 20.69 20.69
+Current month FX rate: $1.00 USD = $1.4539 CAD Previous month FX rate: $1.00 USD = $1.4383 CAD Account #: 62639842 Current month: January 31, 2025
+©Questrade, Inc. All rights reserved. Member of CIRO and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 12 of 15
+ACCOUNT STATEMENT
+                                                         04. ACTIVITY DETAILS
+Transactions
+¹Activity details
+Transaction date (Trans. date): the date a transaction occurred. 
+Settle date: the date cash moved in or out of your account. Stock trades generally settle in one business day and options in one business day. The settle date impacts interest paid and received. 
+Restricted share terms:
+SUB-VTG: subordinate voting shares
+REST-VTG: restricted voting shares
+NON-VTG: non-voting shares 
+Quantity (Qty.): The quantity for each security may include fractional shares which are shown in decimals. 
+Gross: the total before any commission. 
+Commission (Com.): the total commission incurred on the trade.
+Net: the total after commission is paid.
+CAD USD
+Qty¹ Price Gross.¹ Com.¹ Net¹ Price Gross.¹ Com.¹ Net¹
+Trans Date.¹ Settle Date.¹ Activity type Symbol Description
+Opening balance - - - - 248.95 - - - -
+Closing balance - - - - 248.95 - - - -
+Current month FX rate: $1.00 USD = $1.3578 CAD Previous month FX rate: $1.00 USD = $1.3509 CAD Account #: 62639842 Current month: September 29, 2023
+©Questrade, Inc. All rights reserved. Member of IIROC and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 13 of 16
+ACCOUNT STATEMENT
+05. TRADES TO SETTLE AFTER 
+Unsettled trades MONTH END
+¹Trade details
+Transaction date (Trans. date): the date a transaction occurred.
+Settle date: the date cash moved in or out of your account. Stock trades generally settle in two business days and options in one day. The settle date impacts interest paid and received.
+Gross: the total before any commission.
+Commission (Com.): the total commission incurred on the trade.
+Net: the total after commission is paid.
+CAD USD
+Qty
+Trans Date.¹ Settle Date.¹ ActivityType Symbol Description Price Gross.¹ Com.¹ Net¹ Price Gross.¹ Com.¹ Net¹
+09-29-2023 10-04-2023 Buy .XEQT ISHARES CORE EQUITY ETF  PORTFOLIO UNITS  
+WE ACTED AS AGENT 9 25.690 (231.21) (0.03) (231.24)
+Current month FX rate: $1.00 USD = $1.3578 CAD Previous month FX rate: $1.00 USD = $1.3509 CAD Account #: 62639842 Current month: September 29, 2023
+©Questrade, Inc. All rights reserved. Member of IIROC and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 14 of 16
+ACCOUNT STATEMENT
+Glossary
+Deferred sales charge (DSC): A fee charged by the mutual fund company
+when the investment is redeemed early. Learn more by reading the 
+documents provided by the mutual fund company.
+Accrued interest (Accr. int.):Interest income accumulated on a bond or loan 
+but not yet paid.(shown when available).
+% return: the profit and loss value divided by the position cost.
+Note: please cross reference this calculation with your records to ensure 
+accuracy.
+Current month FX rate: $1.00 USD = $1.4539 CAD Previous month FX rate: $1.00 USD = $1.4383 CAD Account #: 62639842 Current month: January 31, 2025
+©Questrade, Inc. All rights reserved. Member of CIRO and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 14 of 15
+ACCOUNT STATEMENT
+For your information
+Transactions this month Questrade, Inc. Related Party Disclosure
+Transactions are displayed in chronological order. Opening and month–end balances are also shown. Transactions Questrade Wealth Management Inc. (QWM) and Questrade, Inc. are wholly owned subsidiaries of Questrade Financial 
+that settle after the date of this statement are excluded from your positions. Group Inc. Questrade, Inc. is a registered investment dealer, a member of the Canadian Investment Regulatory 
+Organization (CIRO) and a member of the Canadian Investor Protection Fund (CIPF), the benefits of which are limited 
+Transactions that have been settled at a price that is less than one tenth of one cent will be shown as having a price of to the activities undertaken by Questrade, Inc. QWM is not a member of CIRO or the CIPF. Questrade Wealth 
+- on your statement. The gross and net amounts will still show the full value of the transaction. Management Inc. is a registered Portfolio Manager, Investment Fund Manager, and Exempt Market Dealer. 
+Security positions Community Trust Company is an affiliate of Questrade, Inc., a subsidiary of Questrade Financial Group Inc. Security 
+transactions of Community Trust Company are considered a related issuer of Questrade Financial Group Inc.
+Quantities listed as "shorted" indicate securities which are currently due from you. The "market value" of an exchange 
+listed security is obtained from sources we believe to be reliable, but we do not guarantee the accuracy. For securities 
+not listed on an exchange, or those that are traded infrequently, the value given is an estimate which may not reflect KYC Updates
+the actual price at which the security can be purchased or sold. When there is no data to indicate an estimated value, Know Your Client information ("KYC") is all of the information you have told us about yourself. This includes 
+the security is priced as zero. "Segregated securities" are securities held in your account either registered in your everything from your address to your investment time horizon. You agree to update your Know Your Client 
+name (SFK) or in bearer form (SEG). information when material changes happen in your life such as a change in your job or income or a change of address 
+or a change in your financial circumstance.
+Any free credit balances represent funds payable on demand which, although properly recorded in our books, are not Retain this statement for income tax purposes. Check for any errors, irregularities, or omissions. If any, 
+segregated and may be used in the conduct of our business. report them within six (6) days by phone or email (details below). If we do not hear from you within the 
+allotted time, this statement is considered correct as delivered. 
+All plan accounts are registered with the Canada Revenue Agency for Questrade, Inc., agent for CIBC Trust 
+Corporation or for Community Trust Company. We reserve the right to adjust this statement for errors or omissions.
+Shareholders communications (CSA National instrument 54–101) – Your instructions may be modified at any time 
+by providing us with written notice. If you have any questions, please contact us:
+Email: support@questrade.com
+The client agrees that notices made available online in our client website or sent to his/her designated email address Phone (toll free within Canada): 1.888.783.7866
+shall be deemed received.
+Questrade, Inc.
+5700 Yonge Street, Unit G1 – Ground floor 
+Price disclosure Toronto, ON 
+Regarding activities that involved more than one transaction on the same security on the same side or transactions M2M 4K2
+that took place on more than one marketplace, the information may be displayed on your statement in the aggregate. 
+Details concerning the transaction will be provided upon request and without additional charge. For tax-related questions about the contents of this statement, please consult a tax advisor.
+Member CIPF
+Customers' accounts are protected by the Canadian Investor Protection Fund within specified limits. A brochure 
+describing the nature and limits of coverage is available upon request. Our Summary Statement of Financial Position 
+as of our most recent financial year and a list of our partners, Directors and Executives is available upon request. Our 
+clients in British Columbia are entitled to certain additional information about us, including information about 
+commissions and fees that we charge, and about any administrative proceedings that may relate to the firm or our 
+staff.
+Current month FX rate: $1.00 USD = $1.4539 CAD Previous month FX rate: $1.00 USD = $1.4383 CAD Account #: 62639842 Current month: January 31, 2025
+©Questrade, Inc. All rights reserved. Member of CIRO and the Canadian Investor Protection Fund. QUESTRADE is a registered trademark of Questrade, Inc. Page 15 of 15

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/questradegroup/QuestradeGroupPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/questradegroup/QuestradeGroupPDFExtractorTest.java
@@ -17,6 +17,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
@@ -33,6 +34,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
 import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
 import name.abuchen.portfolio.datatransfer.pdf.QuestradeGroupPDFExtractor;
@@ -239,6 +241,41 @@ public class QuestradeGroupPDFExtractorTest
                         hasNote(null), //
                         hasAmount("CAD", 756.40), hasGrossValue("CAD", 756.40), //
                         hasTaxes("CAD", 0.00), hasFees("CAD", 0.00))));
+    }
+
+    @Test
+    public void testSecurityBuy07()
+    {
+        var extractor = new QuestradeGroupPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Buy07.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(1L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CAD");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin(null), hasWkn(null), hasTicker("XEQT"), //
+                        hasName("ISHARES CORE EQUITY ETF"), //
+                        hasCurrencyCode("CAD"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupported, //
+                        purchase( //
+                                        hasDate("2023-09-29T00:00"), hasShares(9.00), //
+                                        hasSource("Buy07.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("CAD", 231.24), hasGrossValue("CAD", 231.21), //
+                                        hasTaxes("CAD", 0.00), hasFees("CAD", 0.03)))));
     }
 
     @Test


### PR DESCRIPTION
Builds on top of #5378 (waiting on that one to be merged first).

There can be another page titled "TRADES TO SETTLE AFTER MONTH END" which lists unsettled trades.

I ended up detecting the page title to determine which transactions are part of "ACTIVITY DETAILS" and "ignore" those that are not.