### PR TITLE
Update copyright year to include 2026.

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -2,7 +2,7 @@
 #Eclipse modern messages class
 #Sat Jun 13 22:27:33 CEST 2020
 
-AboutText = Portfolio Performance\n\nVersion: {0} ({1})\nPlatform: {2}, {3}\nJava: {4}, {5}\n\n\u00A9 2012 - 2025, Andreas Buchen. All rights reserved. \n\nIn memory of my mother.
+AboutText = Portfolio Performance\n\nVersion: {0} ({1})\nPlatform: {2}, {3}\nJava: {4}, {5}\n\n\u00A9 2012 - 2026, Andreas Buchen. All rights reserved. \n\nIn memory of my mother.
 
 AboutTextDeveloped = Developed with code contributions by\n\n{0}
 


### PR DESCRIPTION

Btw: there would be a slight legal advantage of stating the years separately (rather than a range). In order to stress that there was at least one release each year.  But "2020, 2021, 2022, 2023, 2024, 2025 and 2026" is a bit long and will get longer. :)