### PR TITLE
Remove obsolet trim  and chance "sign" to "type"

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
@@ -1215,9 +1215,9 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                         //  ab g e f ü h rt e S t e u er n                                                                                                                    _E _U R_ _ _ _ _ _ _ _  _ _ _ _ __  __0_,_0 _0
                                         // @formatter:on
                                         section -> section //
-                                                        .attributes("currencyBeforeTaxes", "grossBeforeTaxes", "currencyTaxesBaseBeforeLossOffset", "sign", "grossTaxesBaseBeforeLossOffset", "currencyDeductedTaxes", "deductedTaxes") //
+                                                        .attributes("currencyBeforeTaxes", "grossBeforeTaxes", "currencyTaxesBaseBeforeLossOffset", "type", "grossTaxesBaseBeforeLossOffset", "currencyDeductedTaxes", "deductedTaxes") //
                                                         .match("^[\\s]*Z[\\s]*u[\\s]*I[\\s]*h[\\s]*r[\\s]*e[\\s]*n[\\s]*(G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n|L[\\s]*a[\\s]*s[\\s]*t[\\s]*e[\\s]*n)[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*: [\\s]{1,}(?<currencyBeforeTaxes>(?:[A-Z][\\s]*){3})[\\-\\s]{1,}(?<grossBeforeTaxes>[\\.,\\d\\s]+).*$") //
-                                                        .match("^[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*b[\\s]*e[\\s]*m[\\s]*e[\\s]*s[\\s]*s[\\s]*u[\\s]*n[\\s]*g[\\s]*s[\\s]*g[\\s]*r[\\s]*u[\\s]*n[\\s]*d[\\s]*l[\\s]*a[\\s]*g[\\s]*e[\\s]*v[\\s]*o[\\s]*r[\\s]*V[\\s]*e[\\s]*r[\\s]*l[\\s]*u[\\s]*s[\\s]*t[\\s]*v[\\s]*e[\\s]*r[\\s]*r[\\s]*e[\\s]*c[\\s]*h[\\s]*n[\\s]*u[\\s]*n[\\s]*g[\\s]{1,}([\\(\\s\\d\\)]+)?(?<currencyTaxesBaseBeforeLossOffset>(?:[A-Z][\\s]*){3})(?<sign>[\\-\\s]{1,})(?<grossTaxesBaseBeforeLossOffset>[\\.,\\d\\s]+).*$") //
+                                                        .match("^[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*b[\\s]*e[\\s]*m[\\s]*e[\\s]*s[\\s]*s[\\s]*u[\\s]*n[\\s]*g[\\s]*s[\\s]*g[\\s]*r[\\s]*u[\\s]*n[\\s]*d[\\s]*l[\\s]*a[\\s]*g[\\s]*e[\\s]*v[\\s]*o[\\s]*r[\\s]*V[\\s]*e[\\s]*r[\\s]*l[\\s]*u[\\s]*s[\\s]*t[\\s]*v[\\s]*e[\\s]*r[\\s]*r[\\s]*e[\\s]*c[\\s]*h[\\s]*n[\\s]*u[\\s]*n[\\s]*g[\\s]{1,}([\\(\\s\\d\\)]+)?(?<currencyTaxesBaseBeforeLossOffset>(?:[A-Z][\\s]*){3})(?<type>[\\-\\s]{1,})(?<grossTaxesBaseBeforeLossOffset>[\\.,\\d\\s]+).*$") //
                                                         .match("^[\\s]*a[\\s]*b[\\s]*g[\\s]*e[\\s]*f[\\s]*.[\\s]*h[\\s]*r[\\s]*t[\\s]*e[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]{1,}(?<currencyDeductedTaxes>[A-Z_\\s]+)[\\-_\\s]{1,}(?<deductedTaxes>[\\.,\\d_\\s]+).*$") //
                                                         .assign((t, v) -> {
                                                             var grossBeforeTaxes = Money.of(asCurrencyCode(stripBlanks(v.get("currencyBeforeTaxes"))), asAmount(stripBlanks(v.get("grossBeforeTaxes"))));
@@ -1225,7 +1225,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                                             var deductedTaxes = Money.of(asCurrencyCode(stripBlanksAndUnderscores(v.get("currencyDeductedTaxes"))), asAmount(stripBlanksAndUnderscores(v.get("deductedTaxes"))));
 
                                                             // Calculate the taxes
-                                                            if (!grossBeforeTaxes.isZero() && grossTaxesBaseBeforeLossOffset.isGreaterThan(grossBeforeTaxes) && !"-".equals(trim(v.get("sign"))))
+                                                            if (!grossBeforeTaxes.isZero() && grossTaxesBaseBeforeLossOffset.isGreaterThan(grossBeforeTaxes) && !"-".equals(trim(v.get("type"))))
                                                             {
                                                                 t.setMonetaryAmount(grossTaxesBaseBeforeLossOffset.subtract(grossBeforeTaxes).add(deductedTaxes));
 
@@ -1292,11 +1292,11 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                         // a b g e f ü h rt e S t e u er n                                                                                                                    E_ U_ R_ _ _ _ _ _ _ _  _ _ _ _ _ _ _0_,_0_ 0_
                                         // @formatter:on
                                         section -> section //
-                                                        .attributes("currencyBeforeTaxes", "grossBeforeTaxes", "currencyAssessmentBasis", "sign", "grossAssessmentBasis", "currencyDeductedTaxes", "deductedTaxes") //
+                                                        .attributes("currencyBeforeTaxes", "grossBeforeTaxes", "currencyAssessmentBasis", "type", "grossAssessmentBasis", "currencyDeductedTaxes", "deductedTaxes") //
                                                         .match("^[\\s]*Z[\\s]*u[\\s]*I[\\s]*h[\\s]*r[\\s]*e[\\s]*n[\\s]*" //
                                                                         + "(G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n|L[\\s]*a[\\s]*s[\\s]*t[\\s]*e[\\s]*n)" //
                                                                         + "[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?<currencyBeforeTaxes>(?:[A-Z][\\s]*){3})[\\-\\s]{1,}(?<grossBeforeTaxes>[\\.,\\d\\s]+).*$") //
-                                                        .match("^[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*b[\\s]*e[\\s]*m[\\s]*e[\\s]*s[\\s]*s[\\s]*u[\\s]*n[\\s]*g[\\s]*s[\\s]*g[\\s]*r[\\s]*u[\\s]*n[\\s]*d[\\s]*l[\\s]*a[\\s]*g[\\s]*e[\\s]{1,}([\\(\\s\\d\\)]+)?(?<currencyAssessmentBasis>(?:[A-Z][\\s]*){3})(?<sign>[\\-\\s]{1,})(?<grossAssessmentBasis>[\\.,\\d\\s]+).*$") //
+                                                        .match("^[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*b[\\s]*e[\\s]*m[\\s]*e[\\s]*s[\\s]*s[\\s]*u[\\s]*n[\\s]*g[\\s]*s[\\s]*g[\\s]*r[\\s]*u[\\s]*n[\\s]*d[\\s]*l[\\s]*a[\\s]*g[\\s]*e[\\s]{1,}([\\(\\s\\d\\)]+)?(?<currencyAssessmentBasis>(?:[A-Z][\\s]*){3})(?<type>[\\-\\s]{1,})(?<grossAssessmentBasis>[\\.,\\d\\s]+).*$") //
                                                         .match("^[\\s]*a[\\s]*b[\\s]*g[\\s]*e[\\s]*f[\\s]*.[\\s]*h[\\s]*r[\\s]*t[\\s]*e[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]{1,}(?<currencyDeductedTaxes>[A-Z_\\s]+)[\\-_\\s]{1,}(?<deductedTaxes>[\\.,\\d_\\s]+).*$") //
                                                         .assign((t, v) -> {
                                                             var grossBeforeTaxes = Money.of(asCurrencyCode(stripBlanks(v.get("currencyBeforeTaxes"))), asAmount(stripBlanks(v.get("grossBeforeTaxes"))));
@@ -1304,7 +1304,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                                             var deductedTaxes = Money.of(asCurrencyCode(stripBlanksAndUnderscores(v.get("currencyDeductedTaxes"))), asAmount(stripBlanksAndUnderscores(v.get("deductedTaxes"))));
 
                                                             // Calculate the taxes and store gross amount
-                                                            if (!grossBeforeTaxes.isZero() && grossAssessmentBasis.isGreaterThan(grossBeforeTaxes) && !"-".equals(trim(v.get("sign"))))
+                                                            if (!grossBeforeTaxes.isZero() && grossAssessmentBasis.isGreaterThan(grossBeforeTaxes) && !"-".equals(trim(v.get("type"))))
                                                             {
                                                                 t.setMonetaryAmount(grossAssessmentBasis.subtract(grossBeforeTaxes).add(deductedTaxes));
 
@@ -1843,7 +1843,9 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> {
                             Map<String, String> context = type.getCurrentContext();
 
-                            // Is sign --> "-" change from INTEREST to INTEREST_CHARGE
+                            // @formatter:off
+                            // Is type --> "-" change from INTEREST to INTEREST_CHARGE
+                            // @formatter:on
                             if ("-".equals(v.get("type")))
                                 t.setType(AccountTransaction.Type.INTEREST_CHARGE);
 
@@ -1902,7 +1904,9 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> {
                             Map<String, String> context = type.getCurrentContext();
 
-                            // Is sign --> "-" change from TAX_REFUND to TAXES
+                            // @formatter:off
+                            // Is type --> "-" change from TAX_REFUND to TAXES
+                            // @formatter:on
                             if ("-".equals(v.get("type")))
                                 t.setType(AccountTransaction.Type.TAXES);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
@@ -463,9 +463,9 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                                         // abgeführte Steuern EUR 0 , 0 0
                                         // @formatter:on
                                         section -> section //
-                                                        .attributes("currencyBeforeTaxes", "grossBeforeTaxes", "currencyTaxesBaseBeforeLossOffset", "sign", "grossTaxesBaseBeforeLossOffset", "currencyDeductedTaxes", "deductedTaxes") //
+                                                        .attributes("currencyBeforeTaxes", "grossBeforeTaxes", "currencyTaxesBaseBeforeLossOffset", "type", "grossTaxesBaseBeforeLossOffset", "currencyDeductedTaxes", "deductedTaxes") //
                                                         .match("^Zu Ihren (Gunsten|Lasten) vor Steuern:[\\s]{1,}(?<currencyBeforeTaxes>[A-Z]{3})[\\-\\s]{1,}(?<grossBeforeTaxes>[\\.,\\d\\s]+).*$") //
-                                                        .match("^Steuerbemessungsgrundlage vor Verlustverrechnung[\\s]{1,}([\\(\\s\\d\\)]+)?(?<currencyTaxesBaseBeforeLossOffset>[A-Z]{3})(?<sign>[\\-\\s]{1,})(?<grossTaxesBaseBeforeLossOffset>[\\.,\\d\\s]+).*$") //
+                                                        .match("^Steuerbemessungsgrundlage vor Verlustverrechnung[\\s]{1,}([\\(\\s\\d\\)]+)?(?<currencyTaxesBaseBeforeLossOffset>[A-Z]{3})(?<type>[\\-\\s]{1,})(?<grossTaxesBaseBeforeLossOffset>[\\.,\\d\\s]+).*$") //
                                                         .match("^abgef.hrte Steuern[\\s]{1,}(?<currencyDeductedTaxes>[A-Z]{3})[\\-\\s]{1,}(?<deductedTaxes>[\\.,\\d\\s]+).*$") //
                                                         .assign((t, v) -> {
                                                             var grossBeforeTaxes = Money.of(asCurrencyCode(v.get("currencyBeforeTaxes")), asAmount(stripBlanks(v.get("grossBeforeTaxes"))));
@@ -473,7 +473,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                                                             var deductedTaxes = Money.of(asCurrencyCode(v.get("currencyDeductedTaxes")), asAmount(stripBlanks(v.get("deductedTaxes"))));
 
                                                             // Calculate the taxes
-                                                            if (!grossBeforeTaxes.isZero() && grossTaxesBaseBeforeLossOffset.isGreaterThan(grossBeforeTaxes) && !"-".equals(trim(v.get("sign"))))
+                                                            if (!grossBeforeTaxes.isZero() && grossTaxesBaseBeforeLossOffset.isGreaterThan(grossBeforeTaxes) && !"-".equals(trim(v.get("type"))))
                                                             {
                                                                 t.setMonetaryAmount(grossTaxesBaseBeforeLossOffset.subtract(grossBeforeTaxes).add(deductedTaxes));
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -866,14 +866,17 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         //                                                                 90,61
                         // @formatter:on
 
-                        .section("amount", "sign") //
+                        .section("amount", "type") //
                         .find("^[\\s]*Erstattung\\/Belastung \\(\\-\\) von Steuern.*") //
-                        .match("[\\s]*(?<amount>[\\.,\\d]+)(?<sign>(\\-)?).*") //
+                        .match("[\\s]*(?<amount>[\\.,\\d]+)(?<type>(\\-)?).*") //
                         .assign((t, v) -> {
-                            t.setAmount(asAmount(v.get("amount")));
-
-                            if ("-".equals(v.get("sign")))
+                            // @formatter:off
+                            // Is type --> "-" change from TAX_REFUND to TAXES
+                            // @formatter:on
+                            if ("-".equals(v.get("type")))
                                 t.setType(AccountTransaction.Type.TAXES);
+
+                            t.setAmount(asAmount(v.get("amount")));
                         })
 
                         .wrap(t -> {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FordMoneyPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FordMoneyPDFExtractor.java
@@ -52,14 +52,14 @@ public class FordMoneyPDFExtractor extends AbstractPDFExtractor
                             return accountTransaction;
                         })
 
-                        .section("date","note", "sign", "amount") //
+                        .section("date","note", "type", "amount") //
                         .documentContext("currency") //
-                        .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note>(Gutschrift|.berweisung))(?<sign>[\\s|\\-]{1,})(?<amount>[\\.,\\d]+)$") //
+                        .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<note>(Gutschrift|.berweisung))(?<type>[\\s|\\-]{1,})(?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             // @formatter:off
-                            // Is sign --> "-" change from DEPOSIT to REMOVAL
+                            // Is type --> "-" change from DEPOSIT to REMOVAL
                             // @formatter:on
-                            if ("-".equals(trim(v.get("sign"))))
+                            if ("-".equals(trim(v.get("type"))))
                                 t.setType(AccountTransaction.Type.REMOVAL);
 
                             t.setDateTime(asDate(v.get("date")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MLPBankingAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MLPBankingAGPDFExtractor.java
@@ -318,7 +318,7 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                                                         .match("^.* (?<note1>(DEPOTPREIS|DEPOTENTGELT|VERWALTUNGSENTGELT|VERMOEGENSDEPOT)) [\\d]+ (?<note2>[\\w]{2}\\/[\\d]{4}) .*$") //
                                                         .assign((t, v) -> {
                                                             // @formatter:off
-                                                            // Is sign --> "S" change from FEES_REFUND to FEES
+                                                            // Is type --> "S" change from FEES_REFUND to FEES
                                                             // @formatter:on
                                                             if ("S".equals(v.get("type")))
                                                                 t.setType(AccountTransaction.Type.FEES);
@@ -351,7 +351,7 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
                                                         .match("^.* (?<note1>(DEPOTPREIS|DEPOTENTGELT|VERWALTUNGSENTGELT|VERMOEGENSDEPOT)) VERW\\.G\\. (?<note2>[\\d]{4}) (?<note3>QUARTAL .*)$") //
                                                         .assign((t, v) -> {
                                                             // @formatter:off
-                                                            // Is sign --> "S" change from FEES_REFUND to FEES
+                                                            // Is type --> "S" change from FEES_REFUND to FEES
                                                             // @formatter:on
                                                             if ("S".equals(v.get("type")))
                                                                 t.setType(AccountTransaction.Type.FEES);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/N26BankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/N26BankAGPDFExtractor.java
@@ -1,7 +1,5 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
-import static name.abuchen.portfolio.util.TextUtil.trim;
-
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
@@ -58,7 +56,7 @@ public class N26BankAGPDFExtractor extends AbstractPDFExtractor
                             // @formatter:off
                             // Is type is "-" change from DEPOSIT to REMOVAL
                             // @formatter:on
-                            if ("-".equals(trim(v.get("type"))))
+                            if ("-".equals(v.get("type")))
                                 t.setType(AccountTransaction.Type.REMOVAL);
 
                             t.setDateTime(asDate(v.get("date")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OldenburgischeLandesbankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OldenburgischeLandesbankAGPDFExtractor.java
@@ -2,7 +2,6 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
 import static name.abuchen.portfolio.util.TextUtil.concatenate;
-import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
@@ -382,7 +381,7 @@ public class OldenburgischeLandesbankAGPDFExtractor extends AbstractPDFExtractor
                                                             // @formatter:off
                                                             // Is type is "-" change from DEPOSIT to REMOVAL
                                                             // @formatter:on
-                                                            if ("-".equals(trim(v.get("type"))))
+                                                            if ("-".equals(v.get("type")))
                                                                 t.setType(AccountTransaction.Type.REMOVAL);
 
                                                             t.setDateTime(asDate(v.get("date") + v.get("year")));
@@ -404,7 +403,7 @@ public class OldenburgischeLandesbankAGPDFExtractor extends AbstractPDFExtractor
                                                             // @formatter:off
                                                             // Is type is "-" change from DEPOSIT to REMOVAL
                                                             // @formatter:on
-                                                            if ("-".equals(trim(v.get("type"))))
+                                                            if ("-".equals(v.get("type")))
                                                                 t.setType(AccountTransaction.Type.REMOVAL);
 
                                                             t.setDateTime(asDate(v.get("date") + v.get("year")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
@@ -806,7 +806,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                         // 27.08. 27.08. Auszahlung girocard PN:931                                           20,00 S
                         // 08.06. 08.06. Überweisung SEPA                                                      4,00 S
                         // @formatter:on
-                        .section("day", "month", "note", "amount", "sign").optional() //
+                        .section("day", "month", "note", "amount", "type").optional() //
                         .documentContext("currency", "nr", "year") //
                         .match("^(?i)[\\d]{2}\\.[\\d]{2}\\. (?<day>[\\d]{2})\\.(?<month>[\\d]{2})\\. " //
                                         + "(?<note>Einnahmen" //
@@ -823,14 +823,14 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                                         + "|UEBERTRAG) " //
                                         + ".* " //
                                         + "(?<amount>[\\.,\\d]+) " //
-                                        + "(?<sign>[S|H])$") //
+                                        + "(?<type>[S|H])$") //
                         .match("^(?![\\s]+ [Dividende]).*$") //
                         .match("^(?![\\s]+ [Dividende]).*$") //
                         .assign((t, v) -> {
                             // @formatter:off
-                            // Is sign --> "H" change from DEPOSIT to REMOVAL
+                            // Is type --> "H" change from DEPOSIT to REMOVAL
                             // @formatter:on
-                            if ("H".equals(v.get("sign")))
+                            if ("H".equals(v.get("type")))
                                 t.setType(AccountTransaction.Type.DEPOSIT);
 
                             dateTranactionHelper(t, v);
@@ -877,16 +877,16 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                         //  DEU 495522500131 EUR 5,52
                         //  Umsatz vom 23.04.2024 MC Hauptkarte
                         // @formatter:on
-                        .section("day", "month", "note", "note2", "amount", "sign").optional() //
+                        .section("day", "month", "note", "note2", "amount", "type").optional() //
                         .documentContext("currency", "nr", "year") //
-                        .match("^(?i)[\\d]{2}\\.[\\d]{2}\\. (?<day>[\\d]{2})\\.(?<month>[\\d]{2})\\. (?<note>.*) PN:4444 (?<amount>[\\.,\\d]+) (?<sign>[S|H])$") //
+                        .match("^(?i)[\\d]{2}\\.[\\d]{2}\\. (?<day>[\\d]{2})\\.(?<month>[\\d]{2})\\. (?<note>.*) PN:4444 (?<amount>[\\.,\\d]+) (?<type>[S|H])$") //
                         .match("^.*$") //
                         .match("^ (?<note2>.*)$") //
                         .assign((t, v) -> {
                             // @formatter:off
-                            // Is sign --> "H" change from DEPOSIT to REMOVAL
+                            // Is type --> "H" change from DEPOSIT to REMOVAL
                             // @formatter:on
-                            if ("H".equals(v.get("sign")))
+                            if ("H".equals(v.get("type")))
                                 t.setType(AccountTransaction.Type.DEPOSIT);
 
                             dateTranactionHelper(t, v);
@@ -943,11 +943,11 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                                         // 30.04. 30.04. Abschluss lt. Anlage 1 PN:905 0,11 S
                                         // @formatter:on
                                         section -> section //
-                                                        .attributes("day", "month", "amount", "sign") //
+                                                        .attributes("day", "month", "amount", "type") //
                                                         .documentContext("currency", "nr", "year") //
-                                                        .match("^[\\d]{2}\\.[\\d]{2}\\. (?<day>[\\d]{2}).(?<month>[\\d]{2}). Abschluss lt\\. Anlage [\\d] .* (?<amount>[\\.,\\d]+) (?<sign>[S|H])$") //
+                                                        .match("^[\\d]{2}\\.[\\d]{2}\\. (?<day>[\\d]{2}).(?<month>[\\d]{2}). Abschluss lt\\. Anlage [\\d] .* (?<amount>[\\.,\\d]+) (?<type>[S|H])$") //
                                                         .assign((t, v) -> {
-                                                            if ("S".equals(v.get("sign")))
+                                                            if ("S".equals(v.get("type")))
                                                                 t.setType(Type.INTEREST_CHARGE);
 
                                                             dateTranactionHelper(t, v);
@@ -1030,9 +1030,9 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                         //          Kontoführungsentgelt        3112       1,95S
                         // Abschluss vom 01.10.2020 bis 31.12.2020
                         // @formatter:on
-                        .section("day", "month", "sign", "amount1", "amount2", "amount3", "note").optional() //
+                        .section("day", "month", "type", "amount1", "amount2", "amount3", "note").optional() //
                         .documentContext("currency", "nr", "year") //
-                        .match("^[\\d]{2}\\.[\\d]{2}\\. (?<day>[\\d]{2}).(?<month>[\\d]{2}). (Abschluss) .* [\\.,\\d]+ (?<sign>[S|H])$") //
+                        .match("^[\\d]{2}\\.[\\d]{2}\\. (?<day>[\\d]{2}).(?<month>[\\d]{2}). (Abschluss) .* [\\.,\\d]+ (?<type>[S|H])$") //
                         .match("^[\\s]+ Buchungen Online .* (?<amount1>[\\.,\\d]+)[S|H]$") //
                         .match("^[\\s]+ Buchungen automatisch .* (?<amount2>[\\.,\\d]+)[S|H]$") //
                         .match("^[\\s]+ Kontof.hrungsentgelt .* (?<amount3>[\\.,\\d]+)[S|H]$") //
@@ -1041,7 +1041,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                             // @formatter:off
                             // Is type --> "H" change from FEES to FEES_REFUND
                             // @formatter:on
-                            if ("H".equals(v.get("sign")))
+                            if ("H".equals(v.get("type")))
                                 t.setType(AccountTransaction.Type.FEES_REFUND);
 
                             dateTranactionHelper(t, v);
@@ -1057,9 +1057,9 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                         //          Kontoführungsentgelt        2345       1,95S
                         // Abschluss vom 30.07.2021 bis 31.08.2021
                         // @formatter:on
-                        .section("day", "month", "sign", "amount1", "amount2", "note").optional() //
+                        .section("day", "month", "type", "amount1", "amount2", "note").optional() //
                         .documentContext("currency", "nr", "year") //
-                        .match("^[\\d]{2}\\.[\\d]{2}\\. (?<day>[\\d]{2}).(?<month>[\\d]{2}). (Abschluss) .* [\\.,\\d]+ (?<sign>[S|H])$") //
+                        .match("^[\\d]{2}\\.[\\d]{2}\\. (?<day>[\\d]{2}).(?<month>[\\d]{2}). (Abschluss) .* [\\.,\\d]+ (?<type>[S|H])$") //
                         .match("^[\\s]+ Buchungen automatisch .* (?<amount1>[\\.,\\d]+)[S|H]$") //
                         .match("^[\\s]+ Kontof.hrungsentgelt .* (?<amount2>[\\.,\\d]+)[S|H]$") //
                         .match("^[\\s]+ (?<note>Abschluss vom [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} .* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$") //
@@ -1067,7 +1067,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                             // @formatter:off
                             // Is type --> "H" change from FEES to FEES_REFUND
                             // @formatter:on
-                            if ("H".equals(v.get("sign")))
+                            if ("H".equals(v.get("type")))
                                 t.setType(AccountTransaction.Type.FEES_REFUND);
 
                             dateTranactionHelper(t, v);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SberbankEuropeAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SberbankEuropeAGPDFExtractor.java
@@ -60,16 +60,18 @@ public class SberbankEuropeAGPDFExtractor extends AbstractPDFExtractor
                             return transaction;
                         })
 
-                        .section("date", "note", "amount", "sign") //
+                        .section("date", "note", "amount", "type") //
                         .documentContext("currency", "year") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\. " //
                                         + "(?<date>[\\d]{2}\\.[\\d]{2}\\.) " //
                                         + "(?<note>.berweisungsgutschr\\.) " //
                                         + "(?<amount>[\\.,\\d]+) " //
-                                        + "(?<sign>[S|H])$")
+                                        + "(?<type>[S|H])$")
                         .assign((t, v) -> {
-                            // Is sign --> "S" change from DEPOSIT to REMOVAL
-                            if ("S".equals(v.get("sign")))
+                            // @formatter:off
+                            // Is type --> "-" change from DEPOSIT to REMOVAL
+                            // @formatter:on
+                            if ("S".equals(v.get("type")))
                                 t.setType(AccountTransaction.Type.REMOVAL);
 
                             // create a long date from the year in the context

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
@@ -538,7 +538,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
                                         + "(?<type>[\\-|\\+])(?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3}).*$") //
                         .assign((t, v) -> {
                          // Is type --> "-" change from TAXES to TAX_REFUND
-                            if ("-".equals(trim(v.get("type"))))
+                            if ("-".equals(v.get("type")))
                                 t.setType(AccountTransaction.Type.TAX_REFUND);
 
                             t.setDateTime(asDate(v.get("date")));
@@ -569,7 +569,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
                          v.getTransactionContext().put(FAILURE, Messages.MsgErrorTransactionAlternativeDocumentRequired);
 
                          // Is type --> "-" change from INTEREST to INTEREST_CHARGE
-                            if ("-".equals(trim(v.get("type"))))
+                            if ("-".equals(v.get("type")))
                                 t.setType(AccountTransaction.Type.INTEREST_CHARGE);
 
                             t.setDateTime(asDate(v.get("date")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SuresseDirektBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SuresseDirektBankPDFExtractor.java
@@ -55,15 +55,15 @@ public class SuresseDirektBankPDFExtractor extends AbstractPDFExtractor
                             return accountTransaction;
                         })
 
-                        .section("date", "sign", "amount", "currency", "note") //
+                        .section("date", "type", "amount", "currency", "note") //
                         .documentContext("year") //
-                        .match("^[\\d]+ (?<date>[\\d]{2}\\-[\\d]{2}) [\\d]{2}\\-[\\d]{2} .*.berweisung.*(?<sign>[\\s|\\-]{1,})(?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                        .match("^[\\d]+ (?<date>[\\d]{2}\\-[\\d]{2}) [\\d]{2}\\-[\\d]{2} .*.berweisung.*(?<type>[\\s|\\-]{1,})(?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
                         .match("^(?<note>Referenz : .*)$") //
                         .assign((t, v) -> {
                             // @formatter:off
-                            // Is sign --> "-" change from DEPOSIT to REMOVAL
+                            // Is type --> "-" change from DEPOSIT to REMOVAL
                             // @formatter:on
-                            if ("-".equals(trim(v.get("sign"))))
+                            if ("-".equals(trim(v.get("type"))))
                                 t.setType(AccountTransaction.Type.REMOVAL);
 
                             t.setDateTime(asDate(v.get("date") + "-" + v.get("year")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SutorBankGmbHPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SutorBankGmbHPDFExtractor.java
@@ -917,7 +917,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                                         + "(\\-)?(?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
                                                             // Is type is "-" change from DEPOSIT to REMOVAL
-                                                            if ("Auszahlung".equals(trim(v.get("type"))) || "Überweisung".equals(trim(v.get("type"))))
+                                                            if ("Auszahlung".equals(v.get("type")) || "Überweisung".equals(v.get("type")))
                                                                 t.setType(AccountTransaction.Type.REMOVAL);
 
                                                             t.setDateTime(asDate(v.get("date")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -3711,7 +3711,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                                         .match("^(?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) . .*(?<type>[\\s|\\-]{1,})(?<amount>[\\.,\\d]+) (?<currency>\\p{Sc})$") //
                                                         .assign((t, v) -> {
                                                             // @formatter:off
-                                                            // Is sign --> "-" change from TAX_REFUND to TAXES
+                                                            // Is type --> "-" change from TAX_REFUND to TAXES
                                                             // @formatter:on
                                                             if ("-".equals(trim(v.get("type"))))
                                                                 t.setType(AccountTransaction.Type.TAXES);


### PR DESCRIPTION
Remove obsolete trim logic and rename sign to type for clearer and more consistent naming of attributes