### PR TITLE
Reset transaction date to today when stale

### DIFF
--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/dialogs/transactions/PresetValuesTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/dialogs/transactions/PresetValuesTest.java
@@ -30,7 +30,7 @@ public class PresetValuesTest
         PresetValues.setLastTransactionDate(testDate);
 
         LocalDate result = PresetValues.getLastTransactionDate();
-        assertThat(result, is(testDate));
+        assertThat(result, is(LocalDate.now()));
     }
 
     @Test
@@ -50,14 +50,34 @@ public class PresetValuesTest
     {
         LocalDate date1 = LocalDate.now().minusMonths(6);
         PresetValues.setLastTransactionDate(date1);
-        assertThat(PresetValues.getLastTransactionDate(), is(date1));
+        assertThat(PresetValues.getLastTransactionDate(), is(LocalDate.now()));
 
         LocalDate date2 = LocalDate.now().minusMonths(3);
         PresetValues.setLastTransactionDate(date2);
-        assertThat(PresetValues.getLastTransactionDate(), is(date2));
+        assertThat(PresetValues.getLastTransactionDate(), is(LocalDate.now()));
 
         LocalDate date3 = LocalDate.now().minusMonths(1);
         PresetValues.setLastTransactionDate(date3);
-        assertThat(PresetValues.getLastTransactionDate(), is(date3));
+        assertThat(PresetValues.getLastTransactionDate(), is(LocalDate.now()));
+    }
+
+    @Test
+    public void testStoredDateFromPreviousDayReturnsToday()
+    {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        PresetValues.setLastTransactionDate(yesterday);
+
+        LocalDate result = PresetValues.getLastTransactionDate();
+        assertThat(result, is(LocalDate.now()));
+    }
+
+    @Test
+    public void testStoredTodayDateReturnsTodaysDate()
+    {
+        LocalDate today = LocalDate.now();
+        PresetValues.setLastTransactionDate(today);
+
+        LocalDate result = PresetValues.getLastTransactionDate();
+        assertThat(result, is(today));
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/PresetValues.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/PresetValues.java
@@ -36,8 +36,9 @@ public class PresetValues
      */
     public static LocalDate getLastTransactionDate()
     {
+        LocalDate today = LocalDate.now();
         LocalDate date = lastTransactionDate.get();
-        return date != null ? date : LocalDate.now();
+        return date != null && date.equals(today) ? date : today;
     }
 
     public static void setLastTransactionDate(LocalDate date)


### PR DESCRIPTION
Fixes #5515

When retrieving the pre-selected transaction date, return today's date if the stored date is from a previous day. This prevents stale dates from being used as defaults for new transactions.

The implementation compares the stored date to today: older dates are replaced with today, while today's date is preserved.