### PR TITLE
Collapsible Statement of Assets page

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TreeViewerCSVExporter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TreeViewerCSVExporter.java
@@ -16,7 +16,9 @@ import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.widgets.Shell;
 
 import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.util.viewers.OptionLabelProvider;
 import name.abuchen.portfolio.ui.util.viewers.SharesLabelProvider;
+import name.abuchen.portfolio.ui.util.viewers.ShowHideColumnHelper;
 import name.abuchen.portfolio.util.TextUtil;
 
 public class TreeViewerCSVExporter extends AbstractCSVExporter
@@ -86,6 +88,19 @@ public class TreeViewerCSVExporter extends AbstractCSVExporter
                     {
                         Long value = labelProvider.getValue(element);
                         return value != null ? Values.Share.format(value) : null;
+                    }
+                };
+            }
+            else if (blp instanceof OptionLabelProvider<?> labelProvider)
+            {
+                var option = viewer.getTree().getColumn(ii).getData(ShowHideColumnHelper.OPTIONS_KEY);
+                labels[ii] = new LabelProvider()
+                {
+                    @SuppressWarnings("unchecked")
+                    @Override
+                    public String getText(Object element)
+                    {
+                        return ((OptionLabelProvider<Object>) labelProvider).getText(element, option);
                     }
                 };
             }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/OptionLabelProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/OptionLabelProvider.java
@@ -5,7 +5,9 @@ import org.eclipse.jface.viewers.ViewerCell;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.Tree;
 
 public class OptionLabelProvider<O> extends CellLabelProvider
 {
@@ -23,7 +25,7 @@ public class OptionLabelProvider<O> extends CellLabelProvider
     {
         return null;
     }
-    
+
     public Font getFont(Object element, O option) // NOSONAR
     {
         return null;
@@ -32,10 +34,19 @@ public class OptionLabelProvider<O> extends CellLabelProvider
     @Override
     public void update(ViewerCell cell)
     {
-        Table table = (Table) cell.getControl();
         int columnIndex = cell.getColumnIndex();
+        Control control = cell.getControl();
+
+        Object data;
+        switch (control)
+        {
+            case Table table -> data = table.getColumn(columnIndex).getData(ShowHideColumnHelper.OPTIONS_KEY);
+            case Tree tree -> data = tree.getColumn(columnIndex).getData(ShowHideColumnHelper.OPTIONS_KEY);
+            default -> throw new IllegalArgumentException("Unsupported control type: " + control.getClass().getName()); //$NON-NLS-1$
+        }
+
         @SuppressWarnings("unchecked")
-        O option = (O) table.getColumn(columnIndex).getData(ShowHideColumnHelper.OPTIONS_KEY);
+        O option = (O) data;
 
         Object element = cell.getElement();
         cell.setText(getText(element, option));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ParameterizedColumnLabelProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ParameterizedColumnLabelProvider.java
@@ -2,6 +2,8 @@ package name.abuchen.portfolio.ui.util.viewers;
 
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.TreeColumn;
+import org.eclipse.swt.widgets.Widget;
 
 /**
  * ColumnLabelProvider subclass which allows to access "option value" associated
@@ -10,25 +12,42 @@ import org.eclipse.swt.widgets.TableColumn;
  */
 public class ParameterizedColumnLabelProvider<O> extends ColumnLabelProvider
 {
-    private TableColumn tableColumn;
+    private Widget column;
 
     public TableColumn getTableColumn()
     {
-        return this.tableColumn;
+        return this.column instanceof TableColumn tableColumn ? tableColumn : null;
+    }
+
+    public TreeColumn getTreeColumn()
+    {
+        return this.column instanceof TreeColumn treeColumn ? treeColumn : null;
     }
 
     public void setTableColumn(TableColumn tableColumn)
     {
-        if (this.tableColumn != null)
-            throw new IllegalStateException(
-                            "ParameterizedColumnLabelProvider cannot be reused across multiple columns. Use Column#setLabelProvider(Supplier<CellLabelProvider> labelProvider) method."); //$NON-NLS-1$
-        this.tableColumn = tableColumn;
+        setColumn(tableColumn);
     }
 
+    public void setTreeColumn(TreeColumn treeColumn)
+    {
+        setColumn(treeColumn);
+    }
+
+    private void setColumn(Widget column)
+    {
+        if (this.column != null)
+            throw new IllegalStateException(
+                            "ParameterizedColumnLabelProvider cannot be reused across multiple columns. Use Column#setLabelProvider(Supplier<CellLabelProvider> labelProvider) method."); //$NON-NLS-1$
+        this.column = column;
+    }
 
     @SuppressWarnings("unchecked")
     public O getOption()
     {
-        return (O) this.tableColumn.getData(ShowHideColumnHelper.OPTIONS_KEY);
+        if (this.column == null)
+            throw new IllegalStateException("ParameterizedColumnLabelProvider is not attached to a column"); //$NON-NLS-1$
+
+        return (O) this.column.getData(ShowHideColumnHelper.OPTIONS_KEY);
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ParameterizedOwnerDrawLabelProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ParameterizedOwnerDrawLabelProvider.java
@@ -6,9 +6,8 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
-import org.eclipse.swt.widgets.Table;
-import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
+import org.eclipse.swt.widgets.TreeItem;
 
 import name.abuchen.portfolio.PortfolioLog;
 
@@ -47,11 +46,24 @@ public class ParameterizedOwnerDrawLabelProvider<O> extends ParameterizedColumnL
     @Override
     public void handleEvent(Event event)
     {
-        TableItem item = (TableItem) event.item;
-        Table table = item.getParent();
-        TableColumn tColumn = table.getColumn(event.index);
-        if (tColumn != getTableColumn())
+        if (event.item instanceof TableItem tableItem)
+        {
+            var table = tableItem.getParent();
+            var tableColumn = table.getColumn(event.index);
+            if (tableColumn != getTableColumn())
+                return;
+        }
+        else if (event.item instanceof TreeItem treeItem)
+        {
+            var tree = treeItem.getParent();
+            var treeColumn = tree.getColumn(event.index);
+            if (treeColumn != getTreeColumn())
+                return;
+        }
+        else
+        {
             return;
+        }
 
         switch (event.type)
         {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ShowHideColumnHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ShowHideColumnHelper.java
@@ -466,6 +466,9 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
             if (labelProvider instanceof CellItemImageClickedListener listener)
                 setupImageClickedListener(col, listener);
 
+            if (labelProvider instanceof ParameterizedColumnLabelProvider<?> parametrized)
+                parametrized.setTreeColumn(treeColumn);
+
             return treeColumn;
         }
 
@@ -493,7 +496,7 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
 
     }
 
-    /* package */static final String OPTIONS_KEY = Column.class.getName() + "_OPTION"; //$NON-NLS-1$
+    public static final String OPTIONS_KEY = Column.class.getName() + "_OPTION"; //$NON-NLS-1$
     private static final String ORIGINAL_LABEL_KEY = "$original_label$"; //$NON-NLS-1$
     private static final int NO_COLUMN_SELECTED = -1;
 
@@ -514,6 +517,12 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
                     TreeColumnLayout layout)
     {
         this(identifier, null, preferences, new TreeViewerPolicy(viewer, layout));
+    }
+
+    public ShowHideColumnHelper(String identifier, Client client, IPreferenceStore preferences, TreeViewer viewer,
+                    TreeColumnLayout layout)
+    {
+        this(identifier, client, preferences, new TreeViewerPolicy(viewer, layout));
     }
 
     public ShowHideColumnHelper(String identifier, IPreferenceStore preferences, TableViewer viewer,

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
@@ -217,11 +217,11 @@ public class PerformanceView extends AbstractHistoricView
         createCalculationItem(folder, Messages.PerformanceTabCalculation);
 
         snapshotStart = createStatementOfAssetsItem(folder, Messages.PerformanceTabAssetsAtStart);
-        snapshotStart.getTableViewer().addSelectionChangedListener(
+        snapshotStart.getTreeViewer().addSelectionChangedListener(
                         e -> setInformationPaneInput(e.getStructuredSelection().getFirstElement()));
 
         snapshotEnd = createStatementOfAssetsItem(folder, Messages.PerformanceTabAssetsAtEnd);
-        snapshotEnd.getTableViewer().addSelectionChangedListener(
+        snapshotEnd.getTreeViewer().addSelectionChangedListener(
                         e -> setInformationPaneInput(e.getStructuredSelection().getFirstElement()));
 
         earnings = createTransactionViewer(folder, Messages.PerformanceTabEarnings);
@@ -1003,11 +1003,11 @@ public class PerformanceView extends AbstractHistoricView
 
             manager.add(new SimpleAction(
                             MessageFormat.format(Messages.LabelExport, Messages.PerformanceTabAssetsAtStart),
-                            a -> new TableViewerCSVExporter(snapshotStart.getTableViewer())
+                            a -> new TreeViewerCSVExporter(snapshotStart.getTreeViewer())
                                             .export(Messages.PerformanceTabAssetsAtStart + fileSuffix)));
 
             manager.add(new SimpleAction(MessageFormat.format(Messages.LabelExport, Messages.PerformanceTabAssetsAtEnd),
-                            a -> new TableViewerCSVExporter(snapshotEnd.getTableViewer())
+                            a -> new TreeViewerCSVExporter(snapshotEnd.getTreeViewer())
                                             .export(Messages.PerformanceTabAssetsAtEnd + fileSuffix)));
 
             manager.add(new SimpleAction(MessageFormat.format(Messages.LabelExport, Messages.PerformanceTabEarnings),

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsView.java
@@ -29,8 +29,8 @@ import name.abuchen.portfolio.ui.selection.SecuritySelection;
 import name.abuchen.portfolio.ui.util.ClientFilterDropDown;
 import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.SimpleAction;
-import name.abuchen.portfolio.ui.util.TableViewerCSVExporter;
 import name.abuchen.portfolio.ui.util.TimeMachineDropDown;
+import name.abuchen.portfolio.ui.util.TreeViewerCSVExporter;
 import name.abuchen.portfolio.ui.views.panes.ChartPane;
 import name.abuchen.portfolio.ui.views.panes.HistoricalPricesDataQualityPane;
 import name.abuchen.portfolio.ui.views.panes.HistoricalPricesPane;
@@ -60,7 +60,7 @@ public class StatementOfAssetsView extends AbstractFinanceView
     @Override
     public void notifyModelUpdated()
     {
-        StatementOfAssetsViewer.Element selection = (StatementOfAssetsViewer.Element) assetViewer.getTableViewer()
+        StatementOfAssetsViewer.Element selection = (StatementOfAssetsViewer.Element) assetViewer.getTreeViewer()
                         .getStructuredSelection().getFirstElement();
 
         Client filteredClient = clientFilter.getSelectedFilter().filter(getClient());
@@ -122,7 +122,7 @@ public class StatementOfAssetsView extends AbstractFinanceView
                         StatementOfAssetsView.class.getSimpleName(), filter -> notifyModelUpdated());
         toolBar.add(clientFilter);
 
-        Action export = new SimpleAction(null, action -> new TableViewerCSVExporter(assetViewer.getTableViewer())
+        Action export = new SimpleAction(null, action -> new TreeViewerCSVExporter(assetViewer.getTreeViewer())
                         .export(Messages.LabelStatementOfAssets + ".csv")); //$NON-NLS-1$
         export.setImageDescriptor(Images.EXPORT.descriptor());
         export.setToolTipText(Messages.MenuExportData);
@@ -148,11 +148,11 @@ public class StatementOfAssetsView extends AbstractFinanceView
                 notifyModelUpdated();
         });
 
-        hookContextMenu(assetViewer.getTableViewer().getControl(),
+        hookContextMenu(assetViewer.getTreeViewer().getControl(),
                         manager -> assetViewer.hookMenuListener(manager, StatementOfAssetsView.this));
         assetViewer.hookKeyListener();
 
-        assetViewer.getTableViewer().addSelectionChangedListener(e -> {
+        assetViewer.getTreeViewer().addSelectionChangedListener(e -> {
             var selection = e.getStructuredSelection();
 
             // test for a single selection because it might be a cash account or

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -4,6 +4,7 @@ import static name.abuchen.portfolio.util.CollectorsUtil.toMutableList;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -25,17 +26,18 @@ import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.action.ToolBarManager;
-import org.eclipse.jface.layout.TableColumnLayout;
+import org.eclipse.jface.layout.TreeColumnLayout;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.LocalResourceManager;
-import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.window.ToolTip;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.DND;
@@ -137,7 +139,8 @@ public class StatementOfAssetsViewer
         private CurrencyConverter converter;
 
         private ClientSnapshot clientSnapshot;
-        private List<Element> elements = new ArrayList<>();
+        private List<Element> allElements = new ArrayList<>();
+        private List<Element> rootElements = new ArrayList<>();
         private GroupByTaxonomy groupByTaxonomy;
 
         private final Interval globalInterval;
@@ -166,12 +169,17 @@ public class StatementOfAssetsViewer
             this.hideTotalsAtTheTop = preferences.getBoolean(TOP);
             this.hideTotalsAtTheBottom = preferences.getBoolean(BOTTOM);
 
-            this.elements.addAll(flatten(groupByTaxonomy));
+            createModelElements(groupByTaxonomy);
         }
 
         public List<Element> getElements()
         {
-            return elements.stream().filter(e -> e.getSortOrder() != 0 || !hideTotalsAtTheTop)
+            return flattenVisible(getRootElements());
+        }
+
+        public List<Element> getRootElements()
+        {
+            return rootElements.stream().filter(e -> e.getSortOrder() != 0 || !hideTotalsAtTheTop)
                             .filter(e -> e.getSortOrder() != Integer.MAX_VALUE || !hideTotalsAtTheBottom)
                             .collect(Collectors.toList());
         }
@@ -213,18 +221,20 @@ public class StatementOfAssetsViewer
             preferences.setValue(BOTTOM, hideTotalsAtTheBottom);
         }
 
-        private final List<Element> flatten(GroupByTaxonomy groupByTaxonomy)
+        private void createModelElements(GroupByTaxonomy groupByTaxonomy)
         {
             // when flattening, assign sortOrder to keep the tree structure for
             // sorting (only positions within a category are sorted)
             int sortOrder = 1;
-            List<Element> answer = new ArrayList<>();
+            this.allElements.clear();
+            this.rootElements.clear();
 
             // totals elements
             Element totalTop = new Element(groupByTaxonomy, 0);
             Element totalBottom = new Element(groupByTaxonomy, Integer.MAX_VALUE);
 
-            answer.add(totalTop);
+            allElements.add(totalTop);
+            rootElements.add(totalTop);
 
             for (AssetCategory cat : groupByTaxonomy.asList())
             {
@@ -233,8 +243,9 @@ public class StatementOfAssetsViewer
                 var hideCategory = taxonomy == null && isUnassignedCategory;
 
                 Element category = new Element(groupByTaxonomy, cat, sortOrder);
+                allElements.add(category);
                 if (!hideCategory)
-                    answer.add(category);
+                    rootElements.add(category);
                 totalTop.addChild(category);
                 totalBottom.addChild(category);
                 sortOrder++;
@@ -242,13 +253,31 @@ public class StatementOfAssetsViewer
                 for (AssetPosition p : cat.getPositions())
                 {
                     Element child = new Element(groupByTaxonomy, p, sortOrder);
-                    answer.add(child);
+                    allElements.add(child);
                     category.addChild(child);
+
+                    // If the (unassigned) category is hidden, show positions
+                    // at root level.
+                    if (hideCategory)
+                        rootElements.add(child);
                 }
                 sortOrder++;
             }
 
-            answer.add(totalBottom);
+            allElements.add(totalBottom);
+            rootElements.add(totalBottom);
+        }
+
+        private List<Element> flattenVisible(List<Element> roots)
+        {
+            List<Element> answer = new ArrayList<>();
+
+            for (Element root : roots)
+            {
+                answer.add(root);
+                if (root.isCategory())
+                    root.getChildren().forEach(answer::add);
+            }
 
             return answer;
         }
@@ -268,12 +297,12 @@ public class StatementOfAssetsViewer
             Map<Security, LazySecurityPerformanceRecord> map = snapshot.getRecords().stream()
                             .collect(Collectors.toMap(LazySecurityPerformanceRecord::getSecurity, r -> r));
 
-            elements.stream().filter(Element::isSecurity)
+            allElements.stream().filter(Element::isSecurity)
                             .forEach(e -> e.setPerformance(currencyCode, interval, map.get(e.getSecurity())));
 
             // create (lazily!) the performance index for categories
 
-            elements.stream() //
+            allElements.stream() //
                             .filter(Element::isCategory) //
                             .filter(e -> !Objects.equals(Classification.UNASSIGNED_ID,
                                             e.getCategory().getClassification().getId()))
@@ -287,7 +316,7 @@ public class StatementOfAssetsViewer
             // create (lazily!) the performance index for the total lines
             var index = new LazyValue<PerformanceIndex>(() -> PerformanceIndex.forClient(filteredClient,
                             converter.with(currencyCode), interval, new ArrayList<>()));
-            elements.stream().filter(Element::isGroupByTaxonomy)
+            allElements.stream().filter(Element::isGroupByTaxonomy)
                             .forEach(e -> e.setPerformanceForCategoryTotals(currencyCode, interval, index));
 
             calculated.add(key);
@@ -305,7 +334,7 @@ public class StatementOfAssetsViewer
 
     private boolean useIndirectQuotation = false;
 
-    private TableViewer assets;
+    private TreeViewer assets;
 
     private Font boldFont;
     private Menu contextMenu;
@@ -338,7 +367,7 @@ public class StatementOfAssetsViewer
     {
         Control control = createColumns(parent, isConfigurable);
 
-        this.assets.getTable().addDisposeListener(e -> StatementOfAssetsViewer.this.widgetDisposed());
+        this.assets.getTree().addDisposeListener(e -> StatementOfAssetsViewer.this.widgetDisposed());
 
         return control;
     }
@@ -370,10 +399,10 @@ public class StatementOfAssetsViewer
     private Control createColumns(Composite parent, boolean isConfigurable) // NOSONAR
     {
         Composite container = new Composite(parent, SWT.NONE);
-        TableColumnLayout layout = new TableColumnLayout();
+        TreeColumnLayout layout = new TreeColumnLayout();
         container.setLayout(layout);
 
-        assets = new TableViewer(container, SWT.FULL_SELECTION | SWT.MULTI);
+        assets = new TreeViewer(container, SWT.FULL_SELECTION | SWT.MULTI);
         ColumnViewerToolTipSupport.enableFor(assets, ToolTip.NO_RECREATE);
         ColumnEditingSupport.prepare(owner.getEditorActivationState(), assets);
         CopyPasteSupport.enableFor(assets);
@@ -614,10 +643,10 @@ public class StatementOfAssetsViewer
 
         support.createColumns(isConfigurable);
 
-        assets.getTable().setHeaderVisible(true);
-        assets.getTable().setLinesVisible(true);
+        assets.getTree().setHeaderVisible(true);
+        assets.getTree().setLinesVisible(true);
 
-        assets.setContentProvider(ArrayContentProvider.getInstance());
+        assets.setContentProvider(new ElementContentProvider());
 
         assets.addDragSupport(DND.DROP_MOVE, //
                         new Transfer[] { SecurityTransfer.getTransfer() }, //
@@ -626,10 +655,10 @@ public class StatementOfAssetsViewer
         // make sure to apply the styles (including font information to the
         // table) before creating the bold font. Otherwise the font does not
         // match the styles in CSS
-        stylingEngine.style(assets.getTable());
+        stylingEngine.style(assets.getTree());
 
-        LocalResourceManager resources = new LocalResourceManager(JFaceResources.getResources(), assets.getTable());
-        boldFont = resources.create(FontDescriptor.createFrom(assets.getTable().getFont()).setStyle(SWT.BOLD));
+        LocalResourceManager resources = new LocalResourceManager(JFaceResources.getResources(), assets.getTree());
+        boldFont = resources.create(FontDescriptor.createFrom(assets.getTree().getFont()).setStyle(SWT.BOLD));
 
         return container;
     }
@@ -1074,6 +1103,13 @@ public class StatementOfAssetsViewer
 
             new SecurityContextMenu(view).menuAboutToShow(manager, element.getSecurity(), reference);
         }
+
+        if (element.isCategory())
+        {
+            if (!manager.isEmpty())
+                manager.add(new Separator());
+            addTreeActionsContextMenu(manager, element);
+        }
     }
 
     public void hookKeyListener()
@@ -1085,7 +1121,7 @@ public class StatementOfAssetsViewer
         }));
     }
 
-    public TableViewer getTableViewer()
+    public TreeViewer getTreeViewer()
     {
         return assets;
     }
@@ -1139,7 +1175,9 @@ public class StatementOfAssetsViewer
 
         Action action = new SimpleAction(Messages.LabelTotalsAtTheTop, a -> {
             model.setHideTotalsAtTheTop(!model.isHideTotalsAtTheTop());
-            assets.setInput(model.getElements());
+            var expandedCategoryIds = getExpandedCategoryIds();
+            assets.setInput(model.getRootElements());
+            restoreExpandedCategories(expandedCategoryIds);
             assets.refresh();
         });
         action.setChecked(!model.isHideTotalsAtTheTop());
@@ -1147,7 +1185,9 @@ public class StatementOfAssetsViewer
 
         action = new SimpleAction(Messages.LabelTotalsAtTheBottom, a -> {
             model.setHideTotalsAtTheBottom(!model.isHideTotalsAtTheBottom());
-            assets.setInput(model.getElements());
+            var expandedCategoryIds = getExpandedCategoryIds();
+            assets.setInput(model.getRootElements());
+            restoreExpandedCategories(expandedCategoryIds);
             assets.refresh();
         });
         action.setChecked(!model.isHideTotalsAtTheBottom());
@@ -1157,25 +1197,73 @@ public class StatementOfAssetsViewer
 
     public void setInput(ClientFilter filter, LocalDate date, CurrencyConverter converter)
     {
-        assets.getTable().setRedraw(false);
+        assets.getTree().setRedraw(false);
         try
         {
+            Set<String> expandedCategoryIds = model != null ? getExpandedCategoryIds() : null;
+            boolean taxonomyChanged = model != null && !Objects.equals(model.taxonomy, taxonomy);
+
             this.model = new Model(preference, client, filter, converter, date, taxonomy);
 
             support.invalidateCache();
-            assets.setInput(model.getElements());
+            assets.setInput(model.getRootElements());
+            if (expandedCategoryIds == null || taxonomyChanged)
+                assets.expandAll();
+            else
+                restoreExpandedCategories(expandedCategoryIds);
             assets.refresh();
         }
         finally
         {
-            assets.getTable().setRedraw(true);
+            assets.getTree().setRedraw(true);
         }
+    }
+
+    private Set<String> getExpandedCategoryIds()
+    {
+        return Arrays.stream(assets.getExpandedElements()).filter(Element.class::isInstance).map(Element.class::cast)
+                        .filter(Element::isCategory).map(e -> e.getCategory().getClassification().getId())
+                        .collect(Collectors.toSet());
+    }
+
+    private void restoreExpandedCategories(Set<String> expandedCategoryIds)
+    {
+        Object[] expandedElements = model.getRootElements().stream().filter(Element::isCategory)
+                        .filter(e -> expandedCategoryIds.contains(e.getCategory().getClassification().getId()))
+                        .toArray();
+
+        assets.setExpandedElements(expandedElements);
+    }
+
+    private void addTreeActionsContextMenu(IMenuManager manager, Element element)
+    {
+        manager.add(new SimpleAction(Messages.LabelExpand, a -> assets.setExpandedState(element, true))
+        {
+            @Override
+            public boolean isEnabled()
+            {
+                return assets.isExpandable(element) && !assets.getExpandedState(element);
+            }
+        });
+
+        manager.add(new SimpleAction(Messages.LabelCollapse, a -> assets.setExpandedState(element, false))
+        {
+            @Override
+            public boolean isEnabled()
+            {
+                return assets.getExpandedState(element);
+            }
+        });
+
+        manager.add(new Separator());
+        manager.add(new SimpleAction(Messages.LabelExpandAll, a -> assets.expandAll()));
+        manager.add(new SimpleAction(Messages.LabelCollapseAll, a -> assets.collapseAll()));
     }
 
     public void selectSubject(Object subject)
     {
         model.getElements().stream().filter(e -> Objects.equals(e.getSubject(), subject)).findAny()
-                        .ifPresent(e -> assets.setSelection(new StructuredSelection(e)));
+                        .ifPresent(e -> assets.setSelection(new StructuredSelection(e), true));
     }
 
     public Function<Stream<Object>, Object> withSum()
@@ -1200,6 +1288,60 @@ public class StatementOfAssetsViewer
 
         if (contextMenu != null)
             contextMenu.dispose();
+    }
+
+    private static class ElementContentProvider implements ITreeContentProvider
+    {
+        private List<Element> rootElements = List.of();
+
+        @Override
+        public void inputChanged(Viewer viewer, Object oldInput, Object newInput)
+        {
+            if (newInput == null)
+            {
+                rootElements = List.of();
+            }
+            else if (newInput instanceof List<?> list)
+            {
+                rootElements = list.stream().filter(Element.class::isInstance).map(Element.class::cast).toList();
+            }
+            else
+            {
+                throw new IllegalArgumentException("Unsupported type: " + newInput.getClass().getName()); //$NON-NLS-1$
+            }
+        }
+
+        @Override
+        public Object[] getElements(Object inputElement)
+        {
+            return rootElements.toArray();
+        }
+
+        @Override
+        public Object[] getChildren(Object parentElement)
+        {
+            if (parentElement instanceof Element element && element.isCategory())
+                return element.getChildren().toArray();
+            return new Object[0];
+        }
+
+        @Override
+        public Object getParent(Object element)
+        {
+            return null;
+        }
+
+        @Override
+        public boolean hasChildren(Object element)
+        {
+            return element instanceof Element e && e.isCategory() && e.getChildren().findAny().isPresent();
+        }
+
+        @Override
+        public void dispose()
+        {
+            rootElements = List.of();
+        }
     }
 
     public static class Element implements Adaptable

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/QuoteRangeColumn.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/columns/QuoteRangeColumn.java
@@ -70,7 +70,7 @@ public class QuoteRangeColumn extends Column implements Column.CacheInvalidation
             double pos = value;
 
             // Leave some space in case 2 such columns go side by side
-            int width = getTableColumn().getWidth() - 2;
+            int width = (getTableColumn() != null ? getTableColumn().getWidth() : getTreeColumn().getWidth()) - 2;
             int yOff = (event.height - BAR_HEIGHT) / 2;
 
             event.gc.setForeground(Colors.theme().defaultForeground());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/StatementOfAssetsPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/StatementOfAssetsPane.java
@@ -28,7 +28,7 @@ import name.abuchen.portfolio.ui.util.ClientFilterMenu;
 import name.abuchen.portfolio.ui.util.ContextMenu;
 import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.SimpleAction;
-import name.abuchen.portfolio.ui.util.TableViewerCSVExporter;
+import name.abuchen.portfolio.ui.util.TreeViewerCSVExporter;
 import name.abuchen.portfolio.ui.views.StatementOfAssetsViewer;
 
 public class StatementOfAssetsPane implements InformationPanePage
@@ -61,7 +61,7 @@ public class StatementOfAssetsPane implements InformationPanePage
 
         Control control = viewer.createControl(parent, true);
 
-        new ContextMenu(viewer.getTableViewer().getControl(), manager -> viewer.hookMenuListener(manager, view)).hook();
+        new ContextMenu(viewer.getTreeViewer().getControl(), manager -> viewer.hookMenuListener(manager, view)).hook();
 
         return control;
     }
@@ -70,7 +70,7 @@ public class StatementOfAssetsPane implements InformationPanePage
     public void addButtons(ToolBarManager toolBar)
     {
         toolBar.add(new SimpleAction(Messages.MenuExportData, Images.EXPORT,
-                        a -> new TableViewerCSVExporter(viewer.getTableViewer()).export(getLabel(),
+                        a -> new TreeViewerCSVExporter(viewer.getTreeViewer()).export(getLabel(),
                                         genericAccount)));
 
         configurationMenu = new DropDown(Messages.MenuShowHideColumns, Images.CONFIG, SWT.NONE,


### PR DESCRIPTION
Allow taxonomies to be collapsed on the Statement of Assets page.

Reimplements [PR #4664](https://github.com/portfolio-performance/portfolio/pull/4664) using TreeViewer.

Closes https://github.com/portfolio-performance/portfolio/issues/4420

![Peek 2026-02-26 19-26](https://github.com/user-attachments/assets/95b14d8a-1633-4497-9662-99bf663ff165)
