### PR TITLE
Improvement: switch theme automatically

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/addons/OSXStartupAddon.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/addons/OSXStartupAddon.java
@@ -1,10 +1,16 @@
 package name.abuchen.portfolio.ui.addons;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 
 import org.eclipse.core.commands.Command;
@@ -25,15 +31,31 @@ import org.eclipse.swt.widgets.MenuItem;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.PortfolioPlugin;
 import name.abuchen.portfolio.ui.UIConstants;
+import name.abuchen.portfolio.ui.theme.CustomThemeEngineManager;
+import name.abuchen.portfolio.ui.theme.ThemePreferences;
 import name.abuchen.portfolio.ui.update.UpdateHelper;
 
 public class OSXStartupAddon
 {
+    private static final int THEME_POLL_INTERVAL_MS = 2000;
+    private static final String APPLE_INTERFACE_STYLE_ABSENT = "AppleInterfaceStyle) does not exist"; //$NON-NLS-1$
+
     @Inject
     private ECommandService commandService;
 
     @Inject
     private EHandlerService handlerService;
+
+    private Display display;
+    private boolean lastSystemDarkTheme;
+    private Runnable themePoller;
+    private final CustomThemeEngineManager themeEngineManager = new CustomThemeEngineManager();
+    private final ExecutorService themeProbeExecutor = Executors.newSingleThreadExecutor(r -> {
+        Thread thread = new Thread(r, "MacOS Theme Poller"); //$NON-NLS-1$
+        thread.setDaemon(true);
+        return thread;
+    });
+    private final AtomicBoolean isThemeProbeRunning = new AtomicBoolean();
 
     @PostConstruct
     public void setupOSXApplicationMenu()
@@ -98,6 +120,42 @@ public class OSXStartupAddon
         }
     }
 
+    @PostConstruct
+    public void monitorSystemTheme(Display display)
+    {
+        if (!"Mac OS X".equals(System.getProperty("os.name"))) //$NON-NLS-1$ //$NON-NLS-2$
+            return;
+
+        this.display = display;
+        Boolean initialSystemDarkTheme = detectMacOSDarkMode();
+        this.lastSystemDarkTheme = initialSystemDarkTheme != null ? initialSystemDarkTheme.booleanValue()
+                        : UIConstants.Theme.DARK.equals(themeEngineManager.getEngineForDisplay(display).getActiveTheme().getId());
+
+        this.themePoller = new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                if (OSXStartupAddon.this.display == null || OSXStartupAddon.this.display.isDisposed())
+                    return;
+
+                OSXStartupAddon.this.display.timerExec(THEME_POLL_INTERVAL_MS, this);
+                pollSystemThemeAsync();
+            }
+        };
+
+        this.display.timerExec(THEME_POLL_INTERVAL_MS, themePoller);
+    }
+
+    @PreDestroy
+    public void stopMonitoringSystemTheme()
+    {
+        if (display != null && !display.isDisposed() && themePoller != null)
+            display.timerExec(-1, themePoller);
+
+        themeProbeExecutor.shutdownNow();
+    }
+
     private boolean isAtLeastMacOS13()
     {
         var osVersion = System.getProperty("os.version"); //$NON-NLS-1$
@@ -153,5 +211,95 @@ public class OSXStartupAddon
             PortfolioPlugin.log(e);
             MessageDialog.openError(Display.getDefault().getActiveShell(), Messages.LabelError, e.getMessage());
         }
+    }
+
+    private void pollSystemThemeAsync()
+    {
+        if (!isThemeProbeRunning.compareAndSet(false, true))
+            return;
+
+        try
+        {
+            themeProbeExecutor.execute(() -> {
+                try
+                {
+                    Boolean isDark = detectMacOSDarkMode();
+                    if (isDark == null)
+                        return;
+
+                    Display currentDisplay = OSXStartupAddon.this.display;
+                    if (currentDisplay == null || currentDisplay.isDisposed())
+                        return;
+
+                    currentDisplay.asyncExec(() -> applyDetectedTheme(isDark.booleanValue()));
+                }
+                finally
+                {
+                    isThemeProbeRunning.set(false);
+                }
+            });
+        }
+        catch (RejectedExecutionException e)
+        {
+            isThemeProbeRunning.set(false);
+        }
+    }
+
+    private void applyDetectedTheme(boolean isDark)
+    {
+        if (display == null || display.isDisposed() || isDark == lastSystemDarkTheme)
+            return;
+
+        var configuredTheme = ThemePreferences.getConfiguredThemeId();
+        lastSystemDarkTheme = isDark;
+
+        if (configuredTheme.isEmpty())
+        {
+            // SWT.Settings is not reliable for macOS appearance changes in this application,
+            // so poll the system setting and update the automatic theme explicitly.
+            String themeId = isDark ? UIConstants.Theme.DARK : UIConstants.Theme.LIGHT;
+            themeEngineManager.getEngineForDisplay(display).setTheme(themeId, false);
+        }
+    }
+
+    private Boolean detectMacOSDarkMode()
+    {
+        Process process = null;
+
+        try
+        {
+            process = new ProcessBuilder("defaults", "read", "-g", "AppleInterfaceStyle").start(); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            String output = new String(process.getInputStream().readAllBytes()).trim();
+            String error = new String(process.getErrorStream().readAllBytes()).trim();
+            int exitCode = process.waitFor();
+
+            if (exitCode == 0)
+                return Boolean.valueOf("Dark".equalsIgnoreCase(output)); //$NON-NLS-1$
+
+            if (isMissingAppleInterfaceStyle(error))
+                return Boolean.FALSE;
+
+            return null;
+        }
+        catch (IOException e)
+        {
+            PortfolioPlugin.log(e);
+            return null;
+        }
+        catch (InterruptedException e)
+        {
+            Thread.currentThread().interrupt();
+            return null;
+        }
+        finally
+        {
+            if (process != null)
+                process.destroy();
+        }
+    }
+
+    private boolean isMissingAppleInterfaceStyle(String error)
+    {
+        return error != null && error.contains(APPLE_INTERFACE_STYLE_ABSENT);
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ThemeAddon.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ThemeAddon.java
@@ -1,18 +1,55 @@
 package name.abuchen.portfolio.ui.theme;
 
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.ui.css.swt.theme.IThemeEngine;
 import org.eclipse.e4.ui.di.UIEventTopic;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Listener;
 import org.osgi.service.event.Event;
 
+import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.ValueColorScheme;
 
 @SuppressWarnings("restriction")
 public class ThemeAddon
 {
+    private Display display;
+    private Listener settingsListener;
+    private boolean lastSystemDarkTheme;
+    private final CustomThemeEngineManager themeEngineManager = new CustomThemeEngineManager();
+
+    @PostConstruct
+    public void trackSystemTheme(Display display)
+    {
+        if ("Mac OS X".equals(System.getProperty("os.name"))) //$NON-NLS-1$ //$NON-NLS-2$
+            return;
+
+        this.display = display;
+        this.lastSystemDarkTheme = Display.isSystemDarkTheme();
+        this.settingsListener = event -> {
+            var configuredTheme = ThemePreferences.getConfiguredThemeId();
+            boolean isDark = Display.isSystemDarkTheme();
+
+            if (configuredTheme.isPresent())
+                return;
+
+            if (isDark == lastSystemDarkTheme)
+                return;
+
+            lastSystemDarkTheme = isDark;
+            IThemeEngine engine = themeEngineManager.getEngineForDisplay(display);
+            engine.setTheme(isDark ? UIConstants.Theme.DARK : UIConstants.Theme.LIGHT, false);
+        };
+
+        display.addListener(SWT.Settings, settingsListener);
+    }
+
     @Inject
     @Optional
     public void onThemeChanged(@UIEventTopic(IThemeEngine.Events.THEME_CHANGED) Event event)
@@ -24,4 +61,10 @@ public class ThemeAddon
             engine.applyStyles(scheme, false);
     }
 
+    @PreDestroy
+    public void stopTrackingSystemTheme()
+    {
+        if (display != null && !display.isDisposed() && settingsListener != null)
+            display.removeListener(SWT.Settings, settingsListener);
+    }
 }


### PR DESCRIPTION
- Add automatic theme switching while the app is running when the theme preference is set to System
- Use polling on macOS and SWT.Settings handling for non-macOS platforms