### PR TITLE
Modify DeutscheBankPDFExtractor for new format

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
@@ -751,13 +751,10 @@ public class DeutscheBankPDFExtractorTest
         new AssertImportActions().check(results, "EUR");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("LU0392494562"));
-        assertThat(security.getWkn(), is("ETF110"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("COMSTAGE-MSCI WORLD TRN U.ETF INH.ANT.I O.N. 1/1"));
-        assertThat(security.getCurrencyCode(), is("EUR"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("LU0392494562"), hasWkn("ETF110"), hasTicker(null), //
+                        hasName("COMSTAGE-MSCI WORLD TRN U.ETF INH.ANT.I O.N."), //
+                        hasCurrencyCode("EUR"))));
 
         // check buy sell transaction
         var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
@@ -801,13 +798,10 @@ public class DeutscheBankPDFExtractorTest
         new AssertImportActions().check(results, "EUR");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("IE00BK1PV551"));
-        assertThat(security.getWkn(), is("A1XEY2"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("X(IE)-MSCI WORLD 1D FUNDS 1/1"));
-        assertThat(security.getCurrencyCode(), is("EUR"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00BK1PV551"), hasWkn("A1XEY2"), hasTicker(null), //
+                        hasName("X(IE)-MSCI WORLD 1D FUNDS"), //
+                        hasCurrencyCode("EUR"))));
 
         // check buy sell transaction
         var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
@@ -851,13 +845,10 @@ public class DeutscheBankPDFExtractorTest
         new AssertImportActions().check(results, "EUR");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("IE00BL25JL35"));
-        assertThat(security.getWkn(), is("A1103D"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("X(IE)-MSCI WRLD QUAL.1CDL FUNDS 1/1"));
-        assertThat(security.getCurrencyCode(), is("EUR"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00BL25JL35"), hasWkn("A1103D"), hasTicker(null), //
+                        hasName("X(IE)-MSCI WRLD QUAL.1CDL FUNDS"), //
+                        hasCurrencyCode("EUR"))));
 
         // check buy sell transaction
         var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
@@ -901,13 +892,10 @@ public class DeutscheBankPDFExtractorTest
         new AssertImportActions().check(results, "EUR");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("IE00BTJRMP35"));
-        assertThat(security.getWkn(), is("A12GVR"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("X(IE)-MSCI EM.MKTS 1CDL FUNDS 1/1"));
-        assertThat(security.getCurrencyCode(), is("EUR"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00BTJRMP35"), hasWkn("A12GVR"), hasTicker(null), //
+                        hasName("X(IE)-MSCI EM.MKTS 1CDL FUNDS"), //
+                        hasCurrencyCode("EUR"))));
 
         // check buy sell transaction
         var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
@@ -953,7 +941,7 @@ public class DeutscheBankPDFExtractorTest
         // check security
         assertThat(results, hasItem(security( //
                         hasIsin("LU0321464652"), hasWkn("DBX0A1"), hasTicker(null), //
-                        hasName("XTRACKERS II GBP OVER.RATE SW.INH.ANT.1D ON 1/1"), //
+                        hasName("XTRACKERS II GBP OVER.RATE SW.INH.ANT.1D ON"), //
                         hasCurrencyCode("EUR"))));
 
         // check buy sell transaction
@@ -987,7 +975,7 @@ public class DeutscheBankPDFExtractorTest
         // check security
         assertThat(results, hasItem(security( //
                         hasIsin("DE0008476524"), hasWkn("847652"), hasTicker(null), //
-                        hasName("DWS VERMÖGENSBG.FONDS I INHABER-ANTEILE LD 1/1"), //
+                        hasName("DWS VERMÖGENSBG.FONDS I INHABER-ANTEILE LD"), //
                         hasCurrencyCode("EUR"))));
 
         // check buy sell transaction
@@ -1021,7 +1009,7 @@ public class DeutscheBankPDFExtractorTest
         // check security
         assertThat(results, hasItem(security( //
                         hasIsin("DE0008476524"), hasWkn("847652"), hasTicker(null), //
-                        hasName("DWS VERMÖGENSBG.FONDS I INHABER-ANTEILE LD 1/1"), //
+                        hasName("DWS VERMÖGENSBG.FONDS I INHABER-ANTEILE LD"), //
                         hasCurrencyCode("EUR"))));
 
         // check buy sell transaction
@@ -1283,6 +1271,40 @@ public class DeutscheBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(58.90 + 2.00 + 1.33))));
+    }
+
+    @Test
+    public void testWertpapierVerkauf05()
+    {
+        var extractor = new DeutscheBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf05.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("HK0992009065"), hasWkn("894983"), hasTicker(null), //
+                        hasName("LENOVO GROUP LTD.REGISTERED SHARES O.N."), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-02-24T08:02:00"), hasShares(8000), //
+                        hasSource("Verkauf05.txt"), //
+                        hasNote("Belegnummer 6978580640 / 890153444"), //
+                        hasAmount("EUR", 7185.60), hasGrossValue("EUR", 8200.00), //
+                        hasTaxes("EUR", 933.16 + 51.32), hasFees("EUR", 20.50 + 4.50 + 4.92))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/Verkauf05.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/Verkauf05.txt
@@ -1,0 +1,57 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.5
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Deutsche Bank AG
+Zentrale Frankfurt 
+60262 Frankfurt
+zeQEjk gasnMqIgMDi 
+WtLOTCUCGoCcS Geschäftskundenberatung Süd 
+ 49 U 
+81101 Telefon 06131 203-771
+ rQATlV
+24/7-Kundenservice (069) 910-10000
+24. Februar 2026
+Abrechnung: Verkauf von Wertpapieren 
+Depotinhaber: tlfFMA rnwbglApaVC
+Filialnummer Depotnummer Wertpapierbezeichnung Seite
+057 5567849 57 LENOVO GROUP LTD.REGISTERED SHARES O.N. 1/2
+WKN 894983 Nominal ST 8.000
+ISIN HK0992009065 Kurs EUR 1,025
+Verwahrart Wertpapierrechnung Hongkong
+Geschäft Kommissionsgeschäft
+Börse Frankfurt - Deutsche Börse - Frankfurter Wertpapierbörse
+Belegnummer 6978580640 / 890153444 Schlusstag/-zeit MEZ 24.02.2026 / 08:02
+Auftragsart Limitauftrag
+Abrechnung Währung Betrag
+Kurswert EUR 8.200,00
+Provision EUR -20,50
+Weitere Provision der Bank bei der börslichen Orderausführung EUR -4,50
+Fremde Spesen und Auslagen EUR -4,92
+Kapitalertragsteuer EUR -933,16
+Solidaritätszuschlag auf Kapitalertragsteuer EUR -51,32
+Gutschrift
+Buchung auf Kontonummer EUR 7.185,60
+ 3854999 51 mit Wertstellung 26.02.2026
+Summe der in der Abrechnung enthaltenen Provisionen und Auslagen EUR 29,92
+Informationen zum Steuerabzug 
+- keine Steuerbescheinigung Währung Betrag
+  -
+Veräußerungsgewinn EUR 4.013,62
+Auf Ihren Freistellungsbetrag angerechnet EUR 281,00
+KESt-pflichtiger Kapitalertrag EUR 3.732,62
+Vorsitzender des Aufsichtsrats: Alexander R. Wynaendts
+Vorstand: Christian Sewing (Vorsitzender), James von Moltke, Raja Akram, Fabrizio Campelli, Marcus Chromik, Bernd Leukert, Alexander von zur Mühlen, Laura Padovani, 
+Claudio de Sanctis, Rebecca Short
+Deutsche Bank Aktiengesellschaft mit Sitz in Frankfurt am Main; Amtsgericht Frankfurt am Main, HRB Nr. 30 000; Umsatzsteuer-Id.-Nr. DE114103379; www.db.com/de
+TR00000001 20260224 619_000_
+  
+Zu dem abgerechneten Geschäft haben wir keine Empfehlung gegeben. Daher liegt keine entsprechende 
+Beratungsdokumentation vor.
+Die Wertpapiere haben wir entsprechend der Abrechnung gebucht. Unser Geschäftsverkehr mit Ihnen wird durch unsere Allgemeinen Geschäftsbedingungen 
+und die Sonderbedingungen für Wertpapiergeschäfte geregelt. Bitte überprüfen Sie diese Abrechnung schnellstmöglich und richten Sie etwaige Einwendungen 
+in den Geschäftsräumen der Bank oder schriftlich an Deutsche Bank AG, QM - Support, 04082 Leipzig. Andernfalls gilt diese Abrechnung als genehmigt. 
+Die unter § 4 Nr. 8 UStG im Inland fallenden Bank- und Finanzdienstleistungen sind von der Umsatzsteuer befreit, sofern Umsatzsteuer nicht gesondert 
+ausgewiesen ist. Soweit der Leistungsempfänger umsatzsteuerlicher Unternehmer ist und seinen Sitz in einem anderen EU-Mitgliedstaat hat und die Bank 
+und Finanzdienstleistungen nach dortigem Recht umsatzsteuerpflichtig sind, gilt die Steuerschuldnerschaft des Leistungsempfängers. Umsatzsteuer ID Nr.: 
+Deutsche Bank AG, 60262 Frankfurt DE114103379

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
@@ -72,6 +72,18 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .oneOf( //
+                        // @formatter:off
+                                        // 057 5567849 57 LENOVO GROUP LTD.REGISTERED SHARES O.N. 1/2
+                                        // WKN 894983 Nominal ST 8.000
+                                        // ISIN HK0992009065 Kurs EUR 1,025
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("name", "wkn", "isin", "currency") //
+                                                        .match("^[\\d]{3} [\\d]+ [\\d]{2} (?<name>.*) [\\d]\\/[\\d]{1,2}$") //
+                                                        .match("^WKN (?<wkn>[A-Z0-9]{6}) Nominal ST [\\.,\\d]+$") //
+                                                        .match("^ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) Kurs (?<currency>[A-Z]{3}).*$") //
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
+
                                         // @formatter:off
                                         // 123 1234567 00 BASF SE
                                         // WKN BASF11 Nominal ST 19
@@ -83,6 +95,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
                                                         .match("^WKN (?<wkn>[A-Z0-9]{6}) Nominal ST [\\.,\\d]+$") //
                                                         .match("^ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) Kurs (?<currency>[A-Z]{3}).*$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
+
                                         // @formatter:off
                                         // 444 1234567 02 IVU TRAFFIC TECHNOLOGIES AG INH.AKT. O.N. 1/2
                                         // WKN 744850 Nominal 120
@@ -94,6 +107,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
                                                         .match("^WKN (?<wkn>[A-Z0-9]{6}) Nominal [\\.,\\d]+$") //
                                                         .match("^ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) .* \\((?<currency>[A-Z]{3})\\).*$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
+
                                         // @formatter:off
                                         // 123 1234567 01 6,875% TÜRKEI, REPUBLIK NT.06 17.M/S 03.36 1/2
                                         // WKN A0GLU5 Nominal USD 5.000,00
@@ -183,7 +197,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
                                         // EUR 9.613,77
                                         // @formatter:on
                                         section -> section //
-                                                        .attributes("amount", "currency") //
+                                                        .attributes("currency", "amount") //
                                                         .find("Gesamtbetrag") //
                                                         .match("^(?<currency>[A-Z]{3}) (?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
@@ -192,10 +206,11 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
                                                         }),
                                         // @formatter:off
                                         // Buchung auf Kontonummer 1234567 40 mit Wertstellung 08.04.2015 EUR 675,50
+                                        // Buchung auf Kontonummer EUR 7.185,60
                                         // @formatter:on
                                         section -> section //
-                                                        .attributes("amount", "currency") //
-                                                        .match("^Buchung auf Kontonummer [\\s\\d]+ mit Wertstellung [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<currency>[A-Z]{3}) (?<amount>[\\.,\\d]+)$") //
+                                                        .attributes("currency", "amount") //
+                                                        .match("^Buchung auf Kontonummer .*(?<currency>[A-Z]{3}) (?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
                                                             t.setAmount(asAmount(v.get("amount")));
                                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));


### PR DESCRIPTION
Closes #5535

- Updated old tests as well, because the security name contained the page-number there