### PR TITLE
Deutsche Bank: recognize documents of type "Vorabpauschale"

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
@@ -21,6 +21,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxRefund;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
@@ -3037,4 +3038,37 @@ public class DeutscheBankPDFExtractorTest
         assertThat(results, hasItem(taxRefund(hasDate("2025-08-25"), hasAmount("EUR", 34.30), //
                         hasSource("GiroKontoauszug11.txt"), hasNote("Steuererstattung"))));
     }
+
+    @Test
+    public void testVorabpauschale01()
+    {
+        var extractor = new DeutscheBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Vorabpauschale01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00B4X9L533"), hasWkn("A1C9KK"), hasTicker(null), //
+                        hasName("HSBC MSCI WORLD UCITS ETF FUNDS"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check taxes transaction
+        assertThat(results, hasItem(taxes(hasDate("2026-01-02T00:00"), hasShares(300),
+                        hasSource("Vorabpauschale01.txt"),
+                        hasNote(null), hasAmount("EUR", 8.87), hasGrossValue("EUR", 8.87), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/Vorabpauschale01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/Vorabpauschale01.txt
@@ -1,0 +1,46 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.6.qualifier
+System: linux | x86_64 | 21.0.9+10-Ubuntu-125.04 | Ubuntu
+-----------------------------------------
+Deutsche Bank AG
+24/7-Kundenservice (069) 910-10000
+Max Mustermann
+Musterallee 1
+11111 Musterhof
+22. Januar 2026
+Ihr Depot Nr. 100 7777777 01
+Vorabpauschale
+CorpID: 2027882211400
+Stück WKN ISIN
+300,000000 A1C9KK IE00B4X9L533
+HSBC MSCI WORLD UCITS ETF FUNDS
+Vorabpauschale Jahreswert (p.St.) 0,1508190400 EUR Kalenderjahr 2025
+Fondsart Aktienfonds (30% Teilfreistellung) Steuerjahr 2026
+KESt-pflichtige Vorabpauschale 31,67 EUR
+Kapitalertragsteuer (KESt) - 7,74 EUR
+Solidaritätszuschlag auf KESt - 0,43 EUR
+ 
+Kirchensteuer auf KESt - 0,70 EUR
+Belastung mit Wert 02.01.2026 8,87 EUR
+Steuerliche Bemessungsgrundlagen zur Vorabpauschale - keine Steuerbescheinigung
+Vorabpauschale vor Teilfreistellung* 45,25 EUR
+Abzüglich Teilfreistellung der Vorabpauschale 13,57 EUR
+Vorabpauschale nach Teilfreistellung 31,67 EUR
+KESt-pflichtige Vorabpauschale 31,67 EUR
+Vorsitzender des Aufsichtsrats: Alexander R. Wynaendts
+Vorstand: Christian Sewing (Vorsitzender), James von Moltke, Raja Akram, Fabrizio Campelli, Marcus Chromik, Bernd Leukert, Alexander von zur Mühlen, Laura Padovani, 
+Claudio de Sanctis, Rebecca Short
+Deutsche Bank Aktiengesellschaft mit Sitz in Frankfurt am Main; Amtsgericht Frankfurt am Main, HRB Nr. 30 000; Umsatzsteuer-Id.-Nr. DE114103379; www.db.com/de 1/2
+TRINCM0001 VOPA 20260122 23977220
+  
+ 
+Wir belasten den Betrag von 8,87 EUR Ihrem Konto 7777777 00.
+Hinweise
+Im Steuerabzugsverfahren sind generell die für Privatanleger geltenden Teilfreistellungssätze anzuwenden. Für einkommensteuerpflichtige Anleger, die ihre 
+Anteile im Betriebsvermögen halten, und körperschaftsteuerpflichtige Anleger werden die erhöhten Teilfreistellungssätze erst im Veranlagungsverfahren der 
+Besteuerung zu Grunde gelegt.
+* Unterjährige Anschaffungen des bezogenen Kalenderjahres wurden mit einer anteiligen Vorabpauschale gemäß §18 Abs. 2 InvStG 2018
+(1/12 des Jahreswertes pro Haltemonat) berücksichtigt.
+Kapitalerträge sind einkommensteuerpflichtig!
+Diese Mitteilung wurde maschinell erstellt und wird nicht unterschrieben.
+2/2

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
@@ -35,6 +35,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
         addBuySellTransaction();
         addBuyTransactionFundsSavingsPlan();
         addDividendeTransaction();
+        addAdvanceTaxTransaction();
         addAccountStatementTransaction();
     }
 
@@ -463,6 +464,63 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
 
         addTaxesSectionsTransaction(pdfTransaction, type);
         addFeesSectionsTransaction(pdfTransaction, type);
+    }
+
+    private void addAdvanceTaxTransaction()
+    {
+        final var type = new DocumentType("Vorabpauschale");
+        this.addDocumentTyp(type);
+
+        var pdfTransaction = new Transaction<AccountTransaction>();
+
+        var firstRelevantLine = new Block("^Vorabpauschale$");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
+
+        pdfTransaction //
+
+                        .subject(() -> {
+                            var accountTransaction = new AccountTransaction();
+                            accountTransaction.setType(AccountTransaction.Type.TAXES);
+                            return accountTransaction;
+                        })
+
+                        // @formatter:off
+                        // Stück WKN ISIN
+                        // 300,000000 A1C9KK IE00B4X9L533
+                        // HSBC MSCI WORLD UCITS ETF FUNDS
+                        // Vorabpauschale Jahreswert (p.St.) 0,1508190400 EUR Kalenderjahr 2025
+                        // @formatter:on
+                        .section("wkn", "isin", "name", "currency") //
+                        .find("St.ck WKN ISIN")
+                        .match("^[\\.,\\d]+ (?<wkn>[A-Z0-9]{6}) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                        .match("(?<name>.*)") //
+                        .match("^Vorabpauschale Jahreswert .* [\\.,\\d]+ (?<currency>[A-Z]{3}).*$") //
+                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+
+                        // @formatter:off
+                        // Stück WKN ISIN
+                        // 3.000,000000 A1C9KK IE00B4X9L533
+                        // @formatter:on
+                        .section("shares") //
+                        .find("St.ck WKN ISIN").match("^(?<shares>[\\.,\\d]+) [A-Z0-9]{6} [A-Z]{2}[A-Z0-9]{9}[0-9]$") //
+                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+
+                        // @formatter:off
+                        // Belastung mit Wert 02.01.2026 8,87 EUR
+                        // @formatter:on
+                        .section("date", "currency", "amount") //
+                        .match("^Belastung mit Wert (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                        .assign((t, v) -> {
+                            t.setDateTime(asDate(v.get("date")));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setAmount(asAmount(v.get("amount")));
+                        })
+
+                        .wrap(t -> t.getAmount() == 0
+                                        ? new SkippedItem(new TransactionItem(t),
+                                                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired)
+                                        : new TransactionItem(t));
     }
 
     private void addAccountStatementTransaction()


### PR DESCRIPTION
In the end, the matching patterns from Postbank were reusable to a very large degree.