### PR TITLE
Improve UI responsiveness when UpdatePricesJob is running on slower computers

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientInput.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientInput.java
@@ -83,6 +83,10 @@ public class ClientInput
     private List<Runnable> disposeJobs = new ArrayList<>();
     private List<ClientInputListener> listeners = new ArrayList<>();
 
+    private final Object scheduleLock = new Object();
+    private boolean scheduleSetDirty;
+    private boolean scheduleRecalculate;
+
     @Inject
     private IEventBroker broker;
 
@@ -148,13 +152,49 @@ public class ClientInput
         setDirty(true, false);
     }
 
-    private void setDirty(boolean isDirty, boolean recalculate)
+    private void setDirty(Boolean isDirty, boolean recalculate)
     {
+        synchronized (scheduleLock)
+        {
+            if (scheduleSetDirty)
+            {
+                isDirty = true;
+                recalculate |= scheduleRecalculate;
+                scheduleSetDirty = false;
+                scheduleRecalculate = false;
+            }
+            if (isDirty == null)
+            {
+                return;
+            }
+        }
+
         this.isDirty = isDirty;
         this.listeners.forEach(l -> l.onDirty(this.isDirty));
 
         if (isDirty && recalculate)
             this.listeners.forEach(ClientInputListener::onRecalculationNeeded);
+    }
+
+    private void scheduleSetDirty(boolean recalculate)
+    {
+        if (Display.getDefault().getThread() == Thread.currentThread())
+        {
+            setDirty(true, recalculate);
+        }
+        else
+        {
+            synchronized (scheduleLock)
+            {
+                scheduleRecalculate |= recalculate;
+                if (scheduleSetDirty)
+                {
+                    return;
+                }
+                scheduleSetDirty = true;
+            }
+            Display.getDefault().asyncExec(() -> setDirty(null, false));
+        }
     }
 
     public String getLabel()
@@ -658,15 +698,7 @@ public class ClientInput
             // convenience: Client#markDirty can be called on any thread, but
             // ClientInputListener#onDirty will always be called on the UI
             // thread
-
-            if (Display.getDefault().getThread() == Thread.currentThread())
-            {
-                setDirty(true, recalculate);
-            }
-            else
-            {
-                Display.getDefault().asyncExec(() -> setDirty(true, recalculate));
-            }
+            scheduleSetDirty(recalculate);
         };
         client.addPropertyChangeListener(listener);
         disposeJobs.add(() -> client.removePropertyChangeListener(listener));


### PR DESCRIPTION
The change ensures that running asynchronously `ClientInput.setDirty` in the display thread is not scheduled if the previous request has not yet been executed and thus no backlog of requests arises.

---

Logging of execution of `ClientInput.setDirty` during an update of quotes on my slightly older notebook (same test file, same price updates):

Before (backlog= number of scheduled but not yet executed calls of setDirty):
> [17:05:16.762] ui-setDirty: duration= 0.758s, backlog= 0
[17:05:17.661] ui-setDirty: duration= 0.469s, backlog= 0
[17:05:18.273] ui-setDirty: duration= 0.510s, backlog= 0
[17:05:18.863] ui-setDirty: duration= 0.471s, backlog= 0
[17:05:19.344] ui-setDirty: duration= 0.556s, backlog= 0
[17:05:19.906] ui-setDirty: duration= 0.636s, backlog= 1
[17:05:20.547] ui-setDirty: duration= 0.630s, backlog= 1
[17:05:25.418] ui-setDirty: duration= 0.462s, backlog= 12
[17:05:25.883] ui-setDirty: duration= 0.430s, backlog= 12
[17:05:26.317] ui-setDirty: duration= 0.504s, backlog= 12
[17:05:26.829] ui-setDirty: duration= 0.404s, backlog= 13
[17:05:33.290] ui-setDirty: duration= 0.613s, backlog= 32
[17:05:35.050] ui-setDirty: duration= 0.483s, backlog= 34
[17:05:36.665] ui-setDirty: duration= 0.417s, backlog= 36
[17:05:38.163] ui-setDirty: duration= 0.381s, backlog= 36
[17:05:39.687] ui-setDirty: duration= 0.389s, backlog= 35
[17:05:41.137] ui-setDirty: duration= 0.373s, backlog= 34
[17:05:42.577] ui-setDirty: duration= 0.362s, backlog= 33
[17:05:44.007] ui-setDirty: duration= 0.365s, backlog= 32
[17:05:45.438] ui-setDirty: duration= 0.363s, backlog= 31
[17:05:46.882] ui-setDirty: duration= 0.352s, backlog= 30
[17:05:48.281] ui-setDirty: duration= 0.357s, backlog= 29
[17:05:49.697] ui-setDirty: duration= 0.359s, backlog= 28
[17:05:51.117] ui-setDirty: duration= 0.355s, backlog= 27
[17:05:52.543] ui-setDirty: duration= 0.406s, backlog= 26
[17:05:54.017] ui-setDirty: duration= 0.358s, backlog= 25
[17:05:55.437] ui-setDirty: duration= 0.362s, backlog= 24
[17:05:56.882] ui-setDirty: duration= 0.357s, backlog= 23
[17:05:58.289] ui-setDirty: duration= 0.350s, backlog= 22
[17:05:59.687] ui-setDirty: duration= 0.359s, backlog= 21
[17:06:01.111] ui-setDirty: duration= 0.344s, backlog= 20
[17:06:02.527] ui-setDirty: duration= 0.346s, backlog= 19
[17:06:03.932] ui-setDirty: duration= 0.346s, backlog= 18
[17:06:05.345] ui-setDirty: duration= 0.361s, backlog= 17
[17:06:06.779] ui-setDirty: duration= 0.339s, backlog= 16
[17:06:08.167] ui-setDirty: duration= 0.334s, backlog= 15
[17:06:09.572] ui-setDirty: duration= 0.344s, backlog= 14
[17:06:10.967] ui-setDirty: duration= 0.339s, backlog= 13
[17:06:12.379] ui-setDirty: duration= 0.344s, backlog= 12
[17:06:13.777] ui-setDirty: duration= 0.342s, backlog= 11
[17:06:15.187] ui-setDirty: duration= 0.336s, backlog= 10
[17:06:16.583] ui-setDirty: duration= 0.346s, backlog= 9
[17:06:17.987] ui-setDirty: duration= 0.365s, backlog= 8
[17:06:19.417] ui-setDirty: duration= 0.339s, backlog= 7
[17:06:20.818] ui-setDirty: duration= 0.334s, backlog= 6
[17:06:22.211] ui-setDirty: duration= 0.337s, backlog= 5
[17:06:23.597] ui-setDirty: duration= 0.336s, backlog= 4
[17:06:25.012] ui-setDirty: duration= 0.330s, backlog= 3
[17:06:26.397] ui-setDirty: duration= 0.338s, backlog= 2
[17:06:27.793] ui-setDirty: duration= 0.338s, backlog= 1
[17:06:29.197] ui-setDirty: duration= 0.336s, backlog= 0

After (avoided= number of avoided scheduling of calls of setDirty):
> [16:35:16.762] ui-setDirty: duration= 0.543s, avoided= 0
[16:35:17.326] ui-setDirty: duration= 0.602s, avoided= 0
[16:35:17.961] ui-setDirty: duration= 0.522s, avoided= 0
[16:35:18.561] ui-setDirty: duration= 0.472s, avoided= 0
[16:35:19.163] ui-setDirty: duration= 0.455s, avoided= 0
[16:35:19.625] ui-setDirty: duration= 0.475s, avoided= 0
[16:35:20.105] ui-setDirty: duration= 0.434s, avoided= 0
[16:35:24.355] ui-setDirty: duration= 0.355s, avoided= 10
[16:35:32.587] ui-setDirty: duration= 0.702s, avoided= 25
[16:35:34.492] ui-setDirty: duration= 0.608s, avoided= 6
[16:35:36.275] ui-setDirty: duration= 0.468s, avoided= 4
[16:35:37.852] ui-setDirty: duration= 0.385s, avoided= 0

The actual update takes ~20 seconds. Of course, during the update, the UI is slow on slow computers.

But before the change, the UI is slowed down for another minute because PP executes further unnecessary calls to setDirty.

Code for the logging as shown above: https://github.com/wahlbrink/f.pp/commits/improve-ui-update-debug/