### PR TITLE
fix background color of colored label

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/swt/ColoredLabel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/swt/ColoredLabel.java
@@ -86,7 +86,7 @@ public class ColoredLabel extends Canvas // NOSONAR
     {
         Rectangle bounds = getClientArea();
 
-        Color background = backdropColor != null ? backdropColor : getBackground();
+        Color background = backdropColor != null ? backdropColor : getParent().getBackground();
 
         e.gc.setBackground(background);
         e.gc.fillRectangle(bounds.x, bounds.y, bounds.width, bounds.height);


### PR DESCRIPTION
Hello,

On dark mode (and windows at least if this matters), the tooltip of Payments Per Month/Quarter/Years charts shows different background color for the first column of the tooltip :

<img width="483" height="311" alt="2026-03-08 10_42_41-Portfolio Performance" src="https://github.com/user-attachments/assets/d7c108d5-ae61-498c-9569-a0335639341e" />

PaymentsPer[Month/Quarter/Year]ChartBuilder uses TabularDataSource which uses ColoredLabel for the first and last row.
It does not happen for the tooltips of other charts (other tooltips do not use TabularDataSource).
It does not happen for Light theme :
<img width="453" height="234" alt="2026-03-08 10_46_38-Portfolio Performance" src="https://github.com/user-attachments/assets/97ef4cbb-aa9c-4931-962d-4523c8581cfa" />

I think either TabularDataSource is modified, either a specific color is used when building TabularDataSource in PaymentsPer[Month/Quarter/Year]ChartBuilder, either the ColoredLabel should by default use the background color of its parent (this proposition). I did not notice a case where this last case behaviour is not wanted but maybe I missed some cases ?

When I was working on the topflop widget, I initially used a ColoredLabel, and without specifying a dedicated color the issue was apparent too in light but not in dark mode (but in the end ColoredLabel was not needed at all) 
<img width="293" height="187" alt="Capture d’écran 2026-03-08 112156" src="https://github.com/user-attachments/assets/b877c3d0-99d1-40b1-91a5-a992392a173d" />

So this makes me think that changing ColoredLabel default behavior itself is the good way ? Unless again if there are cases where we do not want that its default background color adapts to the color of its parent.

**After :** 
<img width="583" height="213" alt="2026-03-08 11_33_10-Portfolio Performance" src="https://github.com/user-attachments/assets/702bbd57-7b84-4d60-bb8f-cd58143d7eab" />
