### PR TITLE
ScorePriority: fixed error message about invalid CUSIP length.

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scorepriorityinc/ScorePriorityIncPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scorepriorityinc/ScorePriorityIncPDFExtractorTest.java
@@ -783,7 +783,7 @@ public class ScorePriorityIncPDFExtractorTest
                         .findFirst().orElseThrow(IllegalArgumentException::new);
 
         assertThat(((AccountTransaction) cancellation.getSubject()).getType(), is(AccountTransaction.Type.FEES));
-        assertThat(cancellation.getFailureMessage(), is(MessageFormat.format(Messages.MsgErrorInvalidWKN, "Tsvt")));
+        assertThat(cancellation.getFailureMessage(), is(MessageFormat.format(Messages.MsgErrorInvalidWKN, "09609")));
 
         assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
                         is(LocalDateTime.parse("2021-11-05T00:00")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScorePriorityIncPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScorePriorityIncPDFExtractor.java
@@ -225,9 +225,9 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
                             v.put("currency", CurrencyUnit.USD);
 
-                            // if CUSIP lenght != 9
-                            if (trim(v.get("wkn")).length() < 9)
-                                v.markAsFailure(MessageFormat.format(Messages.MsgErrorInvalidWKN, trim(v.get("name"))));
+                            // if CUSIP length != 9
+                            if (trim(v.get("wkn")).length() != 9)
+                                v.markAsFailure(MessageFormat.format(Messages.MsgErrorInvalidWKN, trim(v.get("wkn"))));
                             else
                                 t.setSecurity(getOrCreateSecurity(v));
 


### PR DESCRIPTION
1.) Corrected placeholder value for error message
2.) Do what the comment says and reject all lengths other than 9
3.) Fixed typo in comment.

It is questionable to match CUSIPS with "(?<wkn>.*)" btw. Particularly as the dot also matches whitespace that later has to be dropped with trim() again. \w would be better but without more test cases we have to guess whether it needs to be surrounded with \s.

PS: 1-2 more pull requests for similar checks will follow.