### PR TITLE
add bold to treemap label

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyNodeRenderer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyNodeRenderer.java
@@ -7,8 +7,11 @@ import java.util.Map;
 import java.util.function.DoubleFunction;
 import java.util.function.Function;
 
+import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.jface.resource.LocalResourceManager;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
@@ -105,6 +108,8 @@ import name.abuchen.portfolio.util.ColorConversion;
     protected Map<String, Color> hex2color = new HashMap<>();
     protected Function<String, Color> colorFactory = color -> new Color(ColorConversion.hex2RGB(color));
 
+    private Font boldFont;
+
     public TaxonomyNodeRenderer(TaxonomyModel model, LocalResourceManager resources)
     {
         this.model = model;
@@ -121,9 +126,17 @@ import name.abuchen.portfolio.util.ColorConversion;
         return new String[] { label, info };
     }
 
+    public Font getBoldFont(GC gc)
+    {
+        if (boldFont == null)
+            boldFont = resources.create(FontDescriptor.createFrom(gc.getFont().getFontData()).setStyle(SWT.BOLD));
+        return boldFont;
+    }
+
     public final void drawRectangle(TaxonomyNode rootNode, TaxonomyNode node, GC gc, Rectangle r)
     {
         var color = getColorFor(rootNode, node);
+        var defaultFont = gc.getFont();
 
         gc.setBackground(color);
         gc.fillRectangle(r.x, r.y, r.width, r.height);
@@ -148,6 +161,7 @@ import name.abuchen.portfolio.util.ColorConversion;
             var widestLabel = 0;
             for (int ii = 0; ii < label.length; ii++)
             {
+                gc.setFont(ii == 0 ? boldFont : defaultFont);
                 Point extent = gc.textExtent(label[ii]);
                 textExtents[ii] = extent;
                 if (extent.x > widestLabel)
@@ -161,6 +175,7 @@ import name.abuchen.portfolio.util.ColorConversion;
                 // horizontal
                 for (int ii = 0; ii < label.length; ii++)
                 {
+                    gc.setFont(ii == 0 ? boldFont : defaultFont);
                     gc.drawString(label[ii], r.x + 2, r.y + 2 + ii * lineHeight, true);
                 }
             }
@@ -180,6 +195,7 @@ import name.abuchen.portfolio.util.ColorConversion;
 
                     for (int ii = 0; ii < label.length; ii++)
                     {
+                        gc.setFont(ii == 0 ? boldFont : defaultFont);
                         gc.drawString(label[ii], //
                                         Math.max(-textExtents[ii].x - 2, -r.height + 2), //
                                         2 + ii * lineHeight, true);
@@ -194,6 +210,7 @@ import name.abuchen.portfolio.util.ColorConversion;
         }
         finally
         {
+            gc.setFont(defaultFont);
             gc.setClipping((Rectangle) null);
         }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TreeMapLegend.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TreeMapLegend.java
@@ -116,8 +116,13 @@ import de.engehausen.treemap.swt.TreeMap;
             GC gc = new GC(this);
             var width = 0;
             var height = 0;
+
+            var defaultFont = gc.getFont();
+            var boldFont = renderer.getBoldFont(gc);
+
             for (int ii = 0; ii < label.length; ii++)
             {
+                gc.setFont(ii == 0 ? boldFont : defaultFont);
                 Point extent = gc.textExtent(label[ii]);
                 if (extent.x > width)
                     width = extent.x;


### PR DESCRIPTION
Hello,

This is a proposition to add bold to the security name in TreeMap.
In the tooltips of Donut and Pie Chart they are already in bold, so I thought it looks more consistent.

**Before :**
<img width="1505" height="913" alt="Capture d’écran 2026-03-14 112758" src="https://github.com/user-attachments/assets/8852f148-b0d9-479b-844d-435720335371" />

**After :**
<img width="1427" height="908" alt="Capture d’écran 2026-03-14 112930" src="https://github.com/user-attachments/assets/1dca6e32-9c7b-45b7-8ffc-b4b0fc494412" />

I assumed there would always be two lines of label at least, so `setFont(defaultFont)` is always called in the different loops, so no need to set it again after the loops. but maybe it would have been safer ?
