### PR TITLE
Fix AssertionFailedException in TreeColumnLayout during view initialization

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/AbstractFinanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/AbstractFinanceView.java
@@ -175,11 +175,24 @@ public abstract class AbstractFinanceView
         sl.setTag(UIConstants.Tag.INFORMATIONPANE);
         sash.setLayout(sl);
 
-        createBody(sash);
-        sashLayout = sl;
+        // Defer layout until both children (body + information pane) have been
+        // added. Without this, createBody may trigger a layout cascade (e.g.
+        // via setRedraw or updateTitle) while the sash has only one child,
+        // causing TreeColumnLayout to assert on partially initialized columns.
+        sash.setLayoutDeferred(true);
+        try
+        {
+            createBody(sash);
+            sashLayout = sl;
 
-        pane = make(InformationPane.class);
-        pane.createViewControl(sash);
+            pane = make(InformationPane.class);
+            pane.createViewControl(sash);
+        }
+        finally
+        {
+            sash.setLayoutDeferred(false);
+        }
+
         pane.setView(this);
         pane.setLayoutData(new SashLayoutData(-200));
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ShowHideColumnHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ShowHideColumnHelper.java
@@ -270,6 +270,11 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
             tableColumn.setWidth(width);
             tableColumn.setData(Column.class.getName(), column);
 
+            // register column data immediately after creation so that
+            // TableColumnLayout never encounters a column without layout data
+            // (even if a later step in this method triggers a layout cascade)
+            layout.setColumnData(tableColumn, new ColumnPixelData(width));
+
             if (column.getImage() != null)
                 tableColumn.setImage(column.getImage().image());
 
@@ -288,8 +293,6 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
 
                 tableColumn.setData(OPTIONS_KEY, option);
             }
-
-            layout.setColumnData(tableColumn, new ColumnPixelData(width));
 
             CellLabelProvider labelProvider = column.getLabelProvider().get();
             col.setLabelProvider(labelProvider);
@@ -438,6 +441,11 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
             treeColumn.setWidth(width);
             treeColumn.setData(Column.class.getName(), column);
 
+            // register column data immediately after creation so that
+            // TreeColumnLayout never encounters a column without layout data
+            // (even if a later step in this method triggers a layout cascade)
+            layout.setColumnData(treeColumn, new ColumnPixelData(width));
+
             if (column.getImage() != null)
                 treeColumn.setImage(column.getImage().image());
 
@@ -455,8 +463,6 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
                 treeColumn.setToolTipText(createToolTip(text, description, column.getMenuLabel()));
                 treeColumn.setData(OPTIONS_KEY, option);
             }
-
-            layout.setColumnData(treeColumn, new ColumnPixelData(width));
 
             CellLabelProvider labelProvider = column.getLabelProvider().get();
             col.setLabelProvider(labelProvider);


### PR DESCRIPTION
Defer sash layout until both children are added and register column layout data immediately after column creation to prevent layout cascades from encountering partially initialized columns.

Issue: https://forum.portfolio-performance.info/t/nach-update-auf-0-40-1-fehler-unknown-column-layout-data/5470/6