### PR TITLE
Add percentage change dashboard widgets

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -688,6 +688,7 @@ public class Messages extends NLS
     public static String LabelEarningsPerMonth;
     public static String LabelEarningsPerQuarter;
     public static String LabelEarningsPerYear;
+    public static String LabelEarningsPercentageChangeYoY;
     public static String LabelEarningsTransactionList;
     public static String LabelEmptyDashboard;
     public static String LabelEmptyTaxonomy;
@@ -818,6 +819,7 @@ public class Messages extends NLS
     public static String LabelPaymentsSelectStartYear;
     public static String LabelPaymentsTradeProfitLoss;
     public static String LabelPaymentsUseConsolidateRetired;
+    public static String LabelPercentageChange;
     public static String LabelPerformanceCalculation;
     public static String LabelPerformanceChart;
     public static String LabelPerformanceIRR;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1368,6 +1368,8 @@ LabelEarningsPerQuarter = Earnings per quarter
 
 LabelEarningsPerYear = Earnings per year
 
+LabelEarningsPercentageChangeYoY = Percentage Earnings Change (YoY)
+
 LabelEarningsTransactionList = Transactions overview
 
 LabelEmptyDashboard = Blank dashboard
@@ -1629,6 +1631,8 @@ LabelPaymentsSelectStartYear = Payments starting with year:
 LabelPaymentsTradeProfitLoss = Closed trades
 
 LabelPaymentsUseConsolidateRetired = Consolidation of inactive securities
+
+LabelPercentageChange = Percentage Change
 
 LabelPerformanceCalculation = Performance Calculation
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1361,6 +1361,8 @@ LabelEarningsPerQuarter = Ertr\u00E4ge pro Quartal
 
 LabelEarningsPerYear = Ertr\u00E4ge pro Jahr
 
+LabelEarningsPercentageChangeYoY = Prozentuale Ertragsver\u00E4nderung (Vorjahr)
+
 LabelEarningsTransactionList = \u00DCbersicht der Transaktionen
 
 LabelEmptyDashboard = Leeres Dashboard
@@ -1622,6 +1624,8 @@ LabelPaymentsSelectStartYear = Zahlungen ab Jahr:
 LabelPaymentsTradeProfitLoss = Geschlossene Trades
 
 LabelPaymentsUseConsolidateRetired = Konsolidierung inaktive Wertpapiere
+
+LabelPercentageChange = Prozentuale Ver\u00E4nderung
 
 LabelPerformanceCalculation = Performance-Berechnung
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
@@ -31,6 +31,8 @@ import name.abuchen.portfolio.ui.views.dashboard.charts.RebalancingChartWidget;
 import name.abuchen.portfolio.ui.views.dashboard.charts.RebalancingTargetChartWidget;
 import name.abuchen.portfolio.ui.views.dashboard.charts.TaxonomyChartWidget;
 import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsByTaxonomyChartWidget;
+import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningType;
+import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningTypeConfig;
 import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsChartWidget;
 import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsHeatmapWidget;
 import name.abuchen.portfolio.ui.views.dashboard.earnings.EarningsListWidget;
@@ -45,6 +47,7 @@ import name.abuchen.portfolio.ui.views.dashboard.lists.FollowUpWidget;
 import name.abuchen.portfolio.ui.views.dashboard.lists.LimitExceededWidget;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeries;
 import name.abuchen.portfolio.ui.views.payments.PaymentsViewModel;
+import name.abuchen.portfolio.util.Interval;
 
 public enum WidgetFactory
 {
@@ -93,6 +96,19 @@ public enum WidgetFactory
                                         int length = index.getTotals().length;
                                         return Money.of(index.getCurrency(),
                                                         index.getTotals()[length - 1] - index.getTotals()[0]);
+                                    }) //
+                                    .withBenchmarkDataSeries(false) //
+                                    .build()),
+
+    PERCENTAGE_CHANGE(Messages.LabelPercentageChange, Messages.LabelStatementOfAssets, //
+                    (widget, data) -> IndicatorWidget.<Double>create(widget, data) //
+                                    .with(Values.Percent2) //
+                                    .with((ds, period) -> {
+                                        PerformanceIndex index = data.calculate(ds, period);
+                                        long[] totals = index.getTotals();
+                                        if (totals.length < 2 || totals[0] == 0)
+                                            return 0.0;
+                                        return (double) (totals[totals.length - 1] - totals[0]) / totals[0];
                                     }) //
                                     .withBenchmarkDataSeries(false) //
                                     .build()),
@@ -364,6 +380,27 @@ public enum WidgetFactory
     EARNINGS_BY_TAXONOMY(Messages.LabelEarningsByTaxonomy, Messages.LabelEarnings, Images.VIEW_PIECHART,
                     EarningsByTaxonomyChartWidget::new),
 
+    EARNINGS_PERCENTAGE_CHANGE_YOY(Messages.LabelEarningsPercentageChangeYoY, Messages.LabelEarnings, //
+                    (widget, data) -> IndicatorWidget.<Double>create(widget, data) //
+                                    .with(Values.Percent2) //
+                                    .withConfig(delegate -> new EarningTypeConfig(delegate)) //
+                                    .with((ds, period) -> {
+                                        var earningType = readEarningType(widget);
+
+                                        long currentEarnings = sumEarnings(data.calculate(ds, period), earningType);
+
+                                        var priorPeriod = Interval.of(
+                                                        period.getStart().minusYears(1),
+                                                        period.getEnd().minusYears(1));
+                                        long priorEarnings = sumEarnings(data.calculate(ds, priorPeriod), earningType);
+
+                                        if (priorEarnings == 0)
+                                            return 0.0;
+                                        return (double) (currentEarnings - priorEarnings) / priorEarnings;
+                                    }) //
+                                    .withBenchmarkDataSeries(false) //
+                                    .build()),
+
     TRADES_BASIC_STATISTICS(Messages.LabelTradesBasicStatistics, Messages.LabelTrades, TradesWidget::new),
 
     TRADES_PROFIT_LOSS(Messages.LabelTradesProfitLoss, Messages.LabelTrades, TradesProfitLossWidget::new),
@@ -613,5 +650,44 @@ public enum WidgetFactory
             defaultConfigFunction.accept(widget.getConfiguration());
 
         return widget;
+    }
+
+    private static EarningType readEarningType(Dashboard.Widget widget)
+    {
+        var value = widget.getConfiguration().get(Dashboard.Config.EARNING_TYPE.name());
+        if (value != null)
+        {
+            try
+            {
+                return EarningType.valueOf(value);
+            }
+            catch (IllegalArgumentException e)
+            {
+                // fall through to default
+            }
+        }
+        return EarningType.EARNINGS;
+    }
+
+    private static long sumEarnings(PerformanceIndex index, EarningType earningType)
+    {
+        long sum = 0;
+        switch (earningType)
+        {
+            case DIVIDENDS:
+                sum = LongStream.of(index.getDividends()).sum();
+                break;
+            case INTEREST:
+                sum = LongStream.of(index.getInterest()).sum()
+                                - LongStream.of(index.getInterestCharge()).sum();
+                break;
+            case EARNINGS:
+            default:
+                sum = LongStream.of(index.getDividends()).sum()
+                                + LongStream.of(index.getInterest()).sum()
+                                - LongStream.of(index.getInterestCharge()).sum();
+                break;
+        }
+        return sum;
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/earnings/EarningType.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/earnings/EarningType.java
@@ -6,7 +6,7 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.views.payments.PaymentsViewModel;
 
-enum EarningType
+public enum EarningType
 {
     EARNINGS(Messages.LabelDividends + " + " + Messages.LabelInterest, //$NON-NLS-1$
                     t -> t.getType() == AccountTransaction.Type.DIVIDENDS

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/earnings/EarningTypeConfig.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/earnings/EarningTypeConfig.java
@@ -5,7 +5,7 @@ import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.views.dashboard.EnumBasedConfig;
 import name.abuchen.portfolio.ui.views.dashboard.WidgetDelegate;
 
-class EarningTypeConfig extends EnumBasedConfig<EarningType>
+public class EarningTypeConfig extends EnumBasedConfig<EarningType>
 {
     public EarningTypeConfig(WidgetDelegate<?> delegate)
     {


### PR DESCRIPTION
## Summary

- **Percentage Change widget** (Statement of Assets category): Shows the percentage change of total assets for the selected reporting period, comparing end value to start value. Calculation: `(end - start) / start × 100`.

- **Earnings Percentage Change YoY widget** (Earnings category): Shows the year-over-year percentage change of earnings. Users can filter by earning type (dividends, interest, or both) via the context menu.

Both widgets support the standard reporting period and data series configuration via context menu.

## Changes

- `WidgetFactory.java`: Added `PERCENTAGE_CHANGE` and `EARNINGS_PERCENTAGE_CHANGE_YOY` widget definitions with helper methods `readEarningType()` and `sumEarnings()`
- `EarningType.java` / `EarningTypeConfig.java`: Changed visibility from package-private to public for reuse from `WidgetFactory`
- `Messages.java`, `messages.properties`, `messages_de.properties`: Added labels for both widgets

## Test plan

- [ ] Add "Percentage Change" widget from Statement of Assets category to dashboard
- [ ] Verify it shows correct percentage for different reporting periods (1 month, 1 year, etc.)
- [ ] Add "Earnings Percentage Change YoY" widget from Earnings category to dashboard
- [ ] Verify it compares earnings to the same period one year ago
- [ ] Test earning type filter: dividends only, interest only, both
- [ ] Test edge cases: portfolio younger than 1 year, no dividends in comparison period

🤖 Generated with [Claude Code](https://claude.com/claude-code)