### PR TITLE
fix tooltip label of Payment Interest charts

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerMonthChartBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerMonthChartBuilder.java
@@ -70,7 +70,12 @@ public class PaymentsPerMonthChartBuilder implements PaymentsChartBuilder
 
             int noOfYears = (totalNoOfMonths / 12) + (totalNoOfMonths % 12 > month ? 1 : 0);
 
-            builder.addColumns(new Column(Messages.ColumnSecurity, SWT.LEFT, 220).withLogo());
+            var firstColumnLabel = switch (model.getMode())
+            {
+                case INTEREST -> Messages.ColumnAccount;
+                default -> Messages.ColumnSecurity;
+            };
+            builder.addColumns(new Column(firstColumnLabel, SWT.LEFT, 220).withLogo());
             for (int year = 0; year < noOfYears; year++)
             {
                 builder.addColumns(new Column(String.valueOf(model.getStartYear() + year))

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerQuarterChartBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerQuarterChartBuilder.java
@@ -71,7 +71,12 @@ public class PaymentsPerQuarterChartBuilder implements PaymentsChartBuilder
 
             int noOfYears = (totalNoOfMonths / 12) + (totalNoOfMonths % 12 > quarter * 3 ? 1 : 0);
 
-            builder.addColumns(new Column(Messages.ColumnSecurity, SWT.LEFT, 220).withLogo());
+            var firstColumnLabel = switch (model.getMode())
+            {
+                case INTEREST -> Messages.ColumnAccount;
+                default -> Messages.ColumnSecurity;
+            };
+            builder.addColumns(new Column(firstColumnLabel, SWT.LEFT, 220).withLogo());
             for (int year = 0; year < noOfYears; year++)
             {
                 builder.addColumns(new Column(String.valueOf(model.getStartYear() + year))

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerYearChartBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPerYearChartBuilder.java
@@ -67,8 +67,13 @@ public class PaymentsPerYearChartBuilder implements PaymentsChartBuilder
                             .sorted((l1, l2) -> TextUtil.compare(l1.getVehicle().getName(), l2.getVehicle().getName()))
                             .toList();
 
+            var firstColumnLabel = switch (model.getMode())
+            {
+                case INTEREST -> Messages.ColumnAccount;
+                default -> Messages.ColumnSecurity;
+            };
             builder.addColumns( //
-                            new Column(Messages.ColumnSecurity, SWT.LEFT, 220).withLogo(),
+                            new Column(firstColumnLabel, SWT.LEFT, 220).withLogo(),
                             new Column(String.valueOf(model.getStartYear() + year))
                                             .withBackgroundColor(PaymentsColors.getColor(model.getStartYear() + year))
                                             .withFormatter(cell -> Values.Amount.format((long) cell)));


### PR DESCRIPTION
In the Payments charts, and in the associated widgets, for Interest, the tooltip main label should not be related to "Security" but accounts, as Interest are for account, not for security.

Dividend and Closed Trade view are related to security only. 
Other views Earnings, Tax, Fee, Saving and Sum can contain both securities and cash accounts, but I did not find a relevant name related to both of them so this PR is only proposing a label for the Interest case.