### PR TITLE
Deutsche Bank: accept optional seconds specification.

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/DeutscheBankPDFExtractorTest.java
@@ -1092,6 +1092,40 @@ public class DeutscheBankPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierKauf12()
+    {
+        var extractor = new DeutscheBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf12.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00BP3QZ825"), hasWkn("A12ATF"), hasTicker(null), //
+                        hasName("ISIV-E.MSCI WMF U.ETF DLA FUNDS"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-03-20T08:00:46"), hasShares(0.3945), //
+                        hasSource("Kauf12.txt"), //
+                        hasNote("Belegnummer 1595497338 / 718623085"), //
+                        hasAmount("EUR", 32.60), hasGrossValue("EUR", 32.60), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.0))));
+    }
+
+    @Test
     public void testWertpapierVerkauf01()
     {
         var extractor = new DeutscheBankPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/Kauf12.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/deutschebank/Kauf12.txt
@@ -1,0 +1,43 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.82.1
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Deutsche Bank AG
+Zentrale Frankfurt
+60262 Frankfurt
+eNDOYG lLuxum
+ZkwZZXDcp Mayuren Balachandran
+ Str. 47
+22820 WiakHBnmCu Telefon 0211 8838330
+24/7-Kundenservice (069) 910-10000
+20. März 2026
+Abrechnung: Kauf von Wertpapieren
+Depotinhaber: WTbxIh IBuXgY
+Filialnummer Depotnummer Wertpapierbezeichnung Seite
+201 3264459 28 ISIV-E.MSCI WMF U.ETF DLA FUNDS 1/1
+WKN A12ATF Nominal ST 0,3945
+ISIN IE00BP3QZ825 Kurs EUR 82,64
+Verwahrart Wertpapierrechnung Irland
+Geschäft Kommissionsgeschäft
+Börse Frankfurt a.M. - Deutsche Börse - Frankfurter Wertpapierbörse (FWB) - Xetra
+Belegnummer 1595497338 / 718623085 Schlusstag/-zeit MEZ 20.03.2026 / 08:00:46
+Ihre Referenz gLZ05
+Auftragsart sonstiger Auftrag
+Abrechnung Währung Betrag
+Kurswert EUR 32,60
+Provision EUR 0,41
+Provisions-Rabatt EUR -0,41
+Belastung
+Buchung auf Kontonummer 1864976 80 mit Wertstellung 24.03.2026 EUR 32,60
+Die Wertpapiere haben wir entsprechend der Abrechnung gebucht. Unser Geschäftsverkehr mit Ihnen wird durch unsere Allgemeinen Geschäftsbedingungen
+und die Sonderbedingungen für Wertpapiergeschäfte geregelt. Bitte überprüfen Sie diese Abrechnung schnellstmöglich und richten Sie etwaige Einwendungen
+in den Geschäftsräumen der Bank oder schriftlich an Deutsche Bank AG, QM - Support, 04082 Leipzig. Andernfalls gilt diese Abrechnung als genehmigt.
+Die unter § 4 Nr. 8 UStG im Inland fallenden Bank- und Finanzdienstleistungen sind von der Umsatzsteuer befreit, sofern Umsatzsteuer nicht gesondert
+ausgewiesen ist. Soweit der Leistungsempfänger umsatzsteuerlicher Unternehmer ist und seinen Sitz in einem anderen EU-Mitgliedstaat hat und die Bank
+und Finanzdienstleistungen nach dortigem Recht umsatzsteuerpflichtig sind, gilt die Steuerschuldnerschaft des Leistungsempfängers. Umsatzsteuer ID
+Nr.: Deutsche Bank AG, 60262 Frankfurt DE114103379
+Vorsitzender des Aufsichtsrats: Alexander R. Wynaendts
+Vorstand: Christian Sewing (Vorsitzender), James von Moltke, Raja Akram, Fabrizio Campelli, Marcus Chromik, Bernd Leukert, Alexander von zur Mühlen, Laura Padovani,
+Claudio de Sanctis, Rebecca Short
+Deutsche Bank Aktiengesellschaft mit Sitz in Frankfurt am Main; Amtsgericht Frankfurt am Main, HRB Nr. 30 000; Umsatzsteuer-Id.-Nr. DE114103379; www.db.com/de
+TR00000001 20260320 338_000_

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
@@ -172,10 +172,11 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time")))),
                                         // @formatter:off
                                         // Belegnummer 1234567890 / 123456 Schlusstag/-zeit MEZ 02.04.2015 / 09:04
+                                        // Belegnummer 1595497338 / 718623085 Schlusstag/-zeit MEZ 20.03.2026 / 08:00:46
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date", "time") //
-                                                        .match("^Belegnummer .* Schlusstag\\/\\-zeit .* (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) \\/ (?<time>[\\d]{2}:[\\d]{2})$") //
+                                                        .match("^Belegnummer .* Schlusstag\\/\\-zeit .* (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) \\/ (?<time>[\\d]{2}:[\\d]{2}(:[\\d]{2})?)$") //
                                                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time")))),
                                         // @formatter:off
                                         // Belegnummer 1039975477 / 91752537 Schlusstag/-zeit MEZ 23.07.2024 18:20


### PR DESCRIPTION
A PDF has surfaced that suddenly includes seconds:

  Schlusstag/-zeit MEZ 20.03.2026 / 08:00:46

Note: there are other places in the code that parse the time. Until we find proof of them also carrying seconds, we leave their patterns untouched.

Closes #5583