### PR TITLE
separate filter dropdowns in All Transactions view

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AllTransactionsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/AllTransactionsView.java
@@ -11,8 +11,6 @@ import java.util.List;
 
 import jakarta.inject.Inject;
 
-import org.eclipse.jface.action.IMenuListener;
-import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.action.ToolBarManager;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -28,18 +26,15 @@ import org.eclipse.swt.widgets.FileDialog;
 
 import name.abuchen.portfolio.json.JClient;
 import name.abuchen.portfolio.model.TransactionPair;
-import name.abuchen.portfolio.snapshot.filter.ClientFilter;
 import name.abuchen.portfolio.snapshot.filter.PortfolioClientFilter;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.PortfolioPlugin;
 import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
-import name.abuchen.portfolio.ui.util.ClientFilterMenu;
+import name.abuchen.portfolio.ui.util.ClientFilterDropDown;
 import name.abuchen.portfolio.ui.util.DropDown;
-import name.abuchen.portfolio.ui.util.LabelOnly;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.TableViewerCSVExporter;
-import name.abuchen.portfolio.ui.util.searchfilter.TransactionFilterCriteria;
 import name.abuchen.portfolio.ui.util.searchfilter.TransactionFilterDropDown;
 import name.abuchen.portfolio.ui.util.searchfilter.TransactionSearchField;
 import name.abuchen.portfolio.ui.views.panes.HistoricalPricesPane;
@@ -51,73 +46,11 @@ import name.abuchen.portfolio.util.TextUtil;
 
 public class AllTransactionsView extends AbstractFinanceView
 {
-
-    private class FilterDropDown extends DropDown implements IMenuListener
-    {
-        private TransactionFilterDropDown transactionFilterMenu;
-        private ClientFilterMenu clientFilterMenu;
-
-        public FilterDropDown(IPreferenceStore preferenceStore)
-        {
-            super(Messages.SecurityFilter, Images.FILTER_OFF, SWT.NONE);
-
-            setMenuListener(this);
-
-            transactionFilterMenu = new TransactionFilterDropDown(preferenceStore,
-                            AllTransactionsView.class.getSimpleName() + "-transaction-type-filter", //$NON-NLS-1$
-                            criteria -> {
-                                typeFilter = criteria;
-                                updateIcon();
-                                notifyModelUpdated();
-                            });
-
-            clientFilterMenu = new ClientFilterMenu(getClient(), getPreferenceStore());
-
-            clientFilterMenu.addListener(f -> {
-                setInformationPaneInput(null);
-                setupFilterInView(f);
-                notifyModelUpdated();
-                updateIcon();
-            });
-
-            clientFilterMenu.trackSelectedFilterConfigurationKey(AllTransactionsView.class.getSimpleName());
-
-            // set initial filter
-            setupFilterInView(clientFilterMenu.getSelectedFilter());
-
-            updateIcon();
-        }
-
-        private void setupFilterInView(ClientFilter filter)
-        {
-            if (filter instanceof PortfolioClientFilter pcf)
-                AllTransactionsView.this.clientFilter = pcf;
-            else
-                AllTransactionsView.this.clientFilter = null;
-        }
-
-        private void updateIcon()
-        {
-            boolean hasActiveFilter = clientFilterMenu.hasActiveFilter() || transactionFilterMenu.hasActiveCriteria();
-            setImage(hasActiveFilter ? Images.FILTER_ON : Images.FILTER_OFF);
-        }
-
-        @Override
-        public void menuAboutToShow(IMenuManager manager)
-        {
-            transactionFilterMenu.menuAboutToShow(manager);
-
-            manager.add(new Separator());
-            manager.add(new LabelOnly(Messages.MenuChooseClientFilter));
-            clientFilterMenu.menuAboutToShow(manager);
-        }
-    }
-
     private TransactionsViewer table;
 
     private TransactionSearchField textFilter;
-    private PortfolioClientFilter clientFilter;
-    private TransactionFilterCriteria typeFilter = TransactionFilterCriteria.NONE;
+    private ClientFilterDropDown clientFilterDropDown;
+    private TransactionFilterDropDown transactionFilterDropDown;
 
     @Inject
     public AllTransactionsView(IPreferenceStore preferenceStore)
@@ -149,7 +82,17 @@ public class AllTransactionsView extends AbstractFinanceView
 
         toolBar.add(new Separator());
 
-        toolBar.add(new FilterDropDown(getPreferenceStore()));
+        transactionFilterDropDown = new TransactionFilterDropDown(getPreferenceStore(),
+                        AllTransactionsView.class.getSimpleName() + "-transaction-type-filter", //$NON-NLS-1$
+                        criteria -> notifyModelUpdated());
+        toolBar.add(transactionFilterDropDown);
+
+        clientFilterDropDown = new ClientFilterDropDown(getClient(), getPreferenceStore(),
+                        AllTransactionsView.class.getSimpleName(), filter -> {
+                            setInformationPaneInput(null);
+                            notifyModelUpdated();
+                        });
+        toolBar.add(clientFilterDropDown);
 
         toolBar.add(new DropDown(Messages.MenuExportData, Images.EXPORT, SWT.NONE, manager -> {
             manager.add(new SimpleAction(Messages.LabelAllTransactions + " (CSV)", //$NON-NLS-1$
@@ -187,12 +130,11 @@ public class AllTransactionsView extends AbstractFinanceView
 
         table.addFilter(new ViewerFilter()
         {
-
             @Override
             public boolean select(Viewer viewer, Object parentElement, Object element)
             {
                 TransactionPair<?> tx = (TransactionPair<?>) element;
-                return typeFilter.matches(tx.getTransaction());
+                return transactionFilterDropDown.getFilterCriteria().matches(tx.getTransaction());
             }
         });
 
@@ -203,10 +145,11 @@ public class AllTransactionsView extends AbstractFinanceView
         // portfolio without the account passes the filter)
         table.addFilter(new ViewerFilter()
         {
-
             @Override
             public boolean select(Viewer viewer, Object parentElement, Object element)
             {
+                var clientFilter = clientFilterDropDown.getSelectedFilter() instanceof PortfolioClientFilter pcf ? pcf
+                                : null;
                 if (clientFilter == null)
                     return true;
                 TransactionPair<?> tx = (TransactionPair<?>) element;


### PR DESCRIPTION
and fix saved config for transaction filter criteria

Hello,

In the All Transactions view, there is one filter dropdown which consist in a transaction filter and a client filter, while in other views client filters have their own dedicated dropdown.
So this PR proposes to separate those two filters for consistency + it is easier to use smaller dropdowns. 

And : currently the transaction filter is not remembered when switching views or closing the file, this separation also fixes this. 
Unless this was intentional for this particular filter to not be remembered ?

**Before :**
<img width="391" height="603" alt="Capture d’écran 2026-03-30 à 19 40 39" src="https://github.com/user-attachments/assets/a2be96fd-3fe2-4680-8965-75e46817c711" />

**After :**
<img width="352" height="417" alt="Capture d’écran 2026-03-30 à 19 38 59" src="https://github.com/user-attachments/assets/7012042d-ecd6-4157-aefb-5b56f3f26d32" />

I was wondering if the number of transactions in the title of the view should be updated along with the filters ? It always shown the full total number of transactions, independently from the transaction or client filters.