### PR TITLE
Ex-Date Support: Performance Calculation

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientIndexTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientIndexTest.java
@@ -22,6 +22,7 @@ import name.abuchen.portfolio.junit.PortfolioBuilder;
 import name.abuchen.portfolio.junit.SecurityBuilder;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Account;
+import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.money.CurrencyConverter;
@@ -409,6 +410,35 @@ public class ClientIndexTest
 
         long taxes[] = index.getTaxes();
         assertThat(taxes[taxes.length - 8], is(7_50L));
+    }
+
+    @Test
+    public void testDividendUsesExDateForDailyAttribution()
+    {
+        Client client = new Client();
+        Security security = new SecurityBuilder().addTo(client);
+
+        Account account = new AccountBuilder() //
+                        .deposit_("2012-01-01", 1000_00) //
+                        .addTo(client);
+
+        AccountTransaction dividend = new AccountTransaction();
+        dividend.setType(AccountTransaction.Type.DIVIDENDS);
+        dividend.setSecurity(security);
+        dividend.setDateTime(LocalDateTime.parse("2012-01-10T00:00"));
+        dividend.setExDate(LocalDateTime.parse("2012-01-05T00:00"));
+        dividend.setAmount(42_50);
+        dividend.setCurrencyCode(account.getCurrencyCode());
+        account.addTransaction(dividend);
+
+        Interval reportInterval = Interval.of(LocalDate.of(2012, Month.JANUARY, 1), //
+                        LocalDate.of(2012, Month.JANUARY, 8));
+        CurrencyConverter converter = new TestCurrencyConverter();
+        PerformanceIndex index = PerformanceIndex.forClient(client, converter, reportInterval, new ArrayList<>());
+
+        long[] dividends = index.getDividends();
+        assertThat(dividends[4], is(42_50L));
+        assertThat(dividends[7], is(0L));
     }
 
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshotTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshotTest.java
@@ -423,6 +423,38 @@ public class ClientPerformanceSnapshotTest
     }
 
     @Test
+    public void testDividendUsesExDateForPeriodAttribution()
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder().addTo(client);
+        Account account = new AccountBuilder().addTo(client);
+
+        AccountTransaction withExDate = new AccountTransaction();
+        withExDate.setDateTime(LocalDateTime.parse("2012-01-10T00:00"));
+        withExDate.setExDate(LocalDateTime.parse("2011-12-15T00:00"));
+        withExDate.setType(AccountTransaction.Type.DIVIDENDS);
+        withExDate.setSecurity(security);
+        withExDate.setMonetaryAmount(Money.of(CurrencyUnit.EUR, 100_00));
+
+        AccountTransaction withoutExDate = new AccountTransaction();
+        withoutExDate.setDateTime(LocalDateTime.parse("2012-01-10T00:00"));
+        withoutExDate.setType(AccountTransaction.Type.DIVIDENDS);
+        withoutExDate.setSecurity(security);
+        withoutExDate.setMonetaryAmount(Money.of(CurrencyUnit.EUR, 50_00));
+
+        account.addTransaction(withExDate);
+        account.addTransaction(withoutExDate);
+
+        CurrencyConverter converter = new TestCurrencyConverter();
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate);
+
+        assertThat(snapshot.getValue(CategoryType.EARNINGS), is(Money.of(CurrencyUnit.EUR, 100_00)));
+        assertThat(snapshot.getEarnings().size(), is(1));
+        assertThat(snapshot.getEarnings().get(0).getTransaction(), is(withExDate));
+    }
+
+    @Test
     public void testInboundDeliveryWithFees()
     {
         Client client = new Client();

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendTransactionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendTransactionTest.java
@@ -216,4 +216,31 @@ public class DividendTransactionTest
 
         assertEquals(0.06666, result, 0.001d);
     }
+
+    @Test
+    public void testGetDateTimeUsesExDateForDividends()
+    {
+        AccountTransaction t = new AccountTransaction();
+        t.setType(AccountTransaction.Type.DIVIDENDS);
+        t.setSecurity(security);
+        t.setDateTime(LocalDateTime.parse("2020-05-20T00:00"));
+        t.setExDate(LocalDateTime.parse("2020-05-15T00:00"));
+        t.setAmount(100L);
+        t.setShares(10);
+        t.setCurrencyCode(security.getCurrencyCode());
+
+        CalculationLineItem.DividendPayment payment = (CalculationLineItem.DividendPayment) CalculationLineItem
+                        .of(account, t);
+
+        assertEquals(LocalDateTime.parse("2020-05-15T00:00"), payment.getDateTime());
+    }
+
+    @Test
+    public void testGetDateTimeFallsBackToBookingDateWithoutExDate()
+    {
+        CalculationLineItem.DividendPayment payment = this.createDividendTransaction(100L, 10L, 0L,
+                        LocalDateTime.parse("2020-05-20T00:00"));
+
+        assertEquals(LocalDateTime.parse("2020-05-20T00:00"), payment.getDateTime());
+    }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshotTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshotTest.java
@@ -5,12 +5,16 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import org.junit.Test;
 
+import name.abuchen.portfolio.junit.AccountBuilder;
 import name.abuchen.portfolio.junit.PortfolioBuilder;
 import name.abuchen.portfolio.junit.SecurityBuilder;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
+import name.abuchen.portfolio.model.Account;
+import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.money.CurrencyUnit;
@@ -99,5 +103,40 @@ public class SecurityPerformanceSnapshotTest
 
         assertThat(position.getShares(), is(record.getSharesHeld()));
         assertThat(position.calculateValue(), is(record.getMarketValue()));
+    }
+
+    @Test
+    public void testDividendIsAttributedToExDateWithinInterval()
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder().addTo(client);
+        Account account = new AccountBuilder().addTo(client);
+
+        AccountTransaction withExDate = new AccountTransaction();
+        withExDate.setType(AccountTransaction.Type.DIVIDENDS);
+        withExDate.setSecurity(security);
+        withExDate.setDateTime(LocalDateTime.parse("2020-01-15T00:00"));
+        withExDate.setExDate(LocalDateTime.parse("2019-12-20T00:00"));
+        withExDate.setMonetaryAmount(Money.of(CurrencyUnit.EUR, 10_00));
+
+        AccountTransaction withoutExDate = new AccountTransaction();
+        withoutExDate.setType(AccountTransaction.Type.DIVIDENDS);
+        withoutExDate.setSecurity(security);
+        withoutExDate.setDateTime(LocalDateTime.parse("2020-01-15T00:00"));
+        withoutExDate.setMonetaryAmount(Money.of(CurrencyUnit.EUR, 5_00));
+
+        account.addTransaction(withExDate);
+        account.addTransaction(withoutExDate);
+
+        Interval interval = Interval.of(LocalDate.parse("2019-12-01"), LocalDate.parse("2019-12-31"));
+        SecurityPerformanceSnapshot snapshot = SecurityPerformanceSnapshot.create(client, new TestCurrencyConverter(),
+                        interval);
+
+        assertThat(snapshot.getRecords(), hasSize(1));
+        SecurityPerformanceRecord record = snapshot.getRecords().get(0);
+        assertThat(record.getSumOfDividends(), is(Money.of(CurrencyUnit.EUR, 10_00)));
+        assertThat(record.getDividendEventCount(), is(1));
+        assertThat(record.getLastDividendPayment(), is(LocalDate.parse("2019-12-20")));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientIndex.java
@@ -17,6 +17,7 @@ import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.util.Dates;
 import name.abuchen.portfolio.util.Interval;
+import name.abuchen.portfolio.util.SnapshotUtil;
 
 /* package */class ClientIndex extends PerformanceIndex
 {
@@ -124,10 +125,12 @@ import name.abuchen.portfolio.util.Interval;
         {
             account.getTransactions() //
                             .stream() //
-                            .filter(t -> !t.getDateTime().toLocalDate().isBefore(interval.getStart())
-                                            && !t.getDateTime().toLocalDate().isAfter(interval.getEnd()))
+                            .filter(t -> {
+                                LocalDate date = SnapshotUtil.getPerformanceDateTime(t).toLocalDate();
+                                return !date.isBefore(interval.getStart()) && !date.isAfter(interval.getEnd());
+                            })
                             .forEach(t -> { // NOSONAR
-                                LocalDate d = t.getDateTime().toLocalDate();
+                                LocalDate d = SnapshotUtil.getPerformanceDateTime(t).toLocalDate();
                                 switch (t.getType())
                                 {
                                     case DEPOSIT:

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshot.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshot.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.snapshot;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -37,6 +38,7 @@ import name.abuchen.portfolio.snapshot.trail.Trail;
 import name.abuchen.portfolio.snapshot.trail.TrailProvider;
 import name.abuchen.portfolio.snapshot.trail.TrailRecord;
 import name.abuchen.portfolio.util.Interval;
+import name.abuchen.portfolio.util.SnapshotUtil;
 import name.abuchen.portfolio.util.TextUtil;
 
 public class ClientPerformanceSnapshot
@@ -436,10 +438,11 @@ public class ClientPerformanceSnapshot
         {
             for (AccountTransaction t : account.getTransactions())
             {
-                if (!period.contains(t.getDateTime()))
+                LocalDateTime performanceDateTime = SnapshotUtil.getPerformanceDateTime(t);
+                if (!period.contains(performanceDateTime))
                     continue;
 
-                Money value = t.getMonetaryAmount().with(converter.at(t.getDateTime()));
+                Money value = t.getMonetaryAmount().with(converter.at(performanceDateTime));
 
                 switch (t.getType())
                 {
@@ -571,13 +574,15 @@ public class ClientPerformanceSnapshot
                     Map<Security, MutableMoney> earningsBySecurity, MutableMoney mFees, MutableMoney mTaxes,
                     Map<Security, MutableMoney> feesBySecurity, Map<Security, MutableMoney> taxesBySecurity)
     {
+        LocalDateTime performanceDateTime = SnapshotUtil.getPerformanceDateTime(transaction);
+
         Money earned = transaction.getGrossValue().with(converter.at(transaction.getDateTime()));
         mEarnings.add(earned);
         this.earnings.add(new TransactionPair<AccountTransaction>(account, transaction));
         earningsBySecurity.computeIfAbsent(transaction.getSecurity(), k -> MutableMoney.of(converter.getTermCurrency()))
                         .add(earned);
 
-        Money fee = transaction.getUnitSum(Unit.Type.FEE, converter).with(converter.at(transaction.getDateTime()));
+        Money fee = transaction.getUnitSum(Unit.Type.FEE, converter).with(converter.at(performanceDateTime));
         if (!fee.isZero())
         {
             mFees.add(fee);
@@ -586,7 +591,7 @@ public class ClientPerformanceSnapshot
                             .add(fee);
         }
 
-        Money tax = transaction.getUnitSum(Unit.Type.TAX, converter).with(converter.at(transaction.getDateTime()));
+        Money tax = transaction.getUnitSum(Unit.Type.TAX, converter).with(converter.at(performanceDateTime));
         if (!tax.isZero())
         {
             mTaxes.add(tax);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CalculationLineItem.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CalculationLineItem.java
@@ -19,6 +19,7 @@ import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MoneyCollectors;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.SecurityPosition;
+import name.abuchen.portfolio.util.SnapshotUtil;
 
 public interface CalculationLineItem
 {
@@ -51,7 +52,9 @@ public interface CalculationLineItem
         @Override
         public LocalDateTime getDateTime()
         {
-            return txPair.getTransaction().getDateTime();
+            Transaction transaction = txPair.getTransaction();
+
+            return SnapshotUtil.getPerformanceDateTime(transaction);
         }
 
         @Override

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshotBuilder.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshotBuilder.java
@@ -17,6 +17,7 @@ import name.abuchen.portfolio.snapshot.ClientSnapshot;
 import name.abuchen.portfolio.snapshot.PortfolioSnapshot;
 import name.abuchen.portfolio.snapshot.SecurityPosition;
 import name.abuchen.portfolio.util.Interval;
+import name.abuchen.portfolio.util.SnapshotUtil;
 
 /* package */ class SecurityPerformanceSnapshotBuilder<T extends BaseSecurityPerformanceRecord>
 {
@@ -115,7 +116,7 @@ import name.abuchen.portfolio.util.Interval;
             if (t.getSecurity() == null)
                 continue;
 
-            if (!interval.contains(t.getDateTime()))
+            if (!interval.contains(SnapshotUtil.getPerformanceDateTime(t)))
                 continue;
 
             switch (t.getType())

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/SnapshotUtil.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/SnapshotUtil.java
@@ -1,0 +1,25 @@
+package name.abuchen.portfolio.util;
+
+import java.time.LocalDateTime;
+
+import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.Transaction;
+
+public class SnapshotUtil
+{
+    private SnapshotUtil()
+    {
+        /* This utility class should not be instantiated */
+    }
+
+    public static LocalDateTime getPerformanceDateTime(Transaction transaction)
+    {
+        if (transaction instanceof AccountTransaction accountTransaction
+                        && accountTransaction.getType() == AccountTransaction.Type.DIVIDENDS
+                        && accountTransaction.getExDate() != null)
+            return accountTransaction.getExDate();
+
+        return transaction.getDateTime();
+    }
+
+}


### PR DESCRIPTION
From https://github.com/portfolio-performance/portfolio/issues/5513

> Performance calculation: Accrue dividends at the time of the ex-date rather than the payment date, to correctly attribute returns to the holding period

This is a first draft/attempt to apply the ex-date, if available, to dividend payments in the calculation logic... 
Feedback is welcome :)