### PR TITLE
Handle negative timestamps in date parsing

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeedTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeedTest.java
@@ -710,6 +710,19 @@ public class GenericJSONQuoteFeedTest
     }
 
     @Test
+    public void testDateExtractionNegativeTimestamp()
+    {
+        // Date is in seconds from epoch, negative for pre-1970 dates (e.g. onvista API)
+        String json = "{\"data\":[{\"date\":-86400,\"close\":\"123.00\"}],\"info\":\"Json Feed for APPLE ORD\"}";
+        GenericJSONQuoteFeed feed = new GenericJSONQuoteFeed();
+
+        Object object = this.readJson(json, security, GenericJSONQuoteFeed.DATE_PROPERTY_NAME_HISTORIC);
+        LocalDate date = feed.extractDate(object, Optional.empty(), Optional.empty());
+
+        assertEquals(LocalDate.of(1969, 12, 31), date);
+    }
+
+    @Test
     public void testDateExtractionInvalid()
     {
         // Date is an array -> invalid

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
@@ -478,6 +478,9 @@ public class GenericJSONQuoteFeed implements QuoteFeed
 
     private LocalDate parseDateTimestamp(Long object, ZoneOffset offset)
     {
+        if (object < 0)
+            return LocalDateTime.ofEpochSecond(object, 0, offset).toLocalDate();
+
         Long futureEpoch = LocalDateTime.of(2200, 1, 1, 0, 0, 0, 0).toEpochSecond(offset);
 
         if (object > futureEpoch)


### PR DESCRIPTION
Fixes #5618

Turns out some APIs like onvista use negative timestamps for pre-1970 dates, which the code wasn't handling. Added a check for negative values and a test case to keep this from breaking again.