### PR TITLE
CSS theme color migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@
   - [Translations](#translations)
   - [Trade Calendars](#trade-calendars)
   - [Images and Icons](#images-and-icons)
+  - [Centrally defining CSS colors for UI objects](#centrally-defining-css-colors-for-ui-objects)
 - [Getting Help](#getting-help)
 - [Appendix](#appendix)
   - [Regular Expression Reference](#regular-expression-reference)
@@ -386,6 +387,314 @@ All images and icons must be [Creative Commons CC0](https://creativecommons.org/
 - **Error state**: #D11D1D (dark red)
 
 See [Color Code Reference](#color-code-reference) for exact colors.
+
+## Centrally defining CSS colors for UI objects
+
+### Goal
+
+A color should be defined centrally in `light.css` and `dark.css`.
+
+Java code should not decide the final design color.  
+Java should only receive, store, and use the color from CSS.
+
+This template can be used for charts, views, widgets, dialogs, and other UI classes.
+
+> This template uses one consistent example across all steps:
+>
+> | Item | Example |
+> |------|---------|
+> | CSS target name | `YourCssTarget` |
+> | CSS property | `your-color-property` |
+> | Target class | `YourTargetClass` |
+> | Target field | `yourColorProperty` |
+> | Target setter | `setYourColorProperty(Color color)` |
+> | Adapter | `YourElementAdapter` |
+> | Handler | `YourCSSHandler` |
+
+### Step 1: Define the color in CSS
+
+Files:
+
+`name.abuchen.portfolio.ui/css/shared/light.css`  
+`name.abuchen.portfolio.ui/css/shared/dark.css`
+
+Template:
+
+```css
+YourCssTarget {
+    your-color-property: #123456;
+}
+```
+
+Check:
+
+- `YourCssTarget` = CSS target name
+- `your-color-property` = CSS property
+- The same property should exist in both theme files
+
+Important:
+
+The property name does **not** decide which CSS block is used.  
+The CSS target name decides that.
+
+### Step 2: Register the property in `plugin.xml`
+
+File:
+
+`name.abuchen.portfolio.ui/plugin.xml`
+
+Template:
+
+```xml
+<extension point="org.eclipse.e4.ui.css.core.propertyHandler">
+   <handler
+         adapter="name.abuchen.portfolio.ui.theme.YourElementAdapter"
+         composite="false"
+         handler="name.abuchen.portfolio.ui.theme.YourCSSHandler">
+      <property-name name="your-color-property"/>
+   </handler>
+</extension>
+```
+
+Check:
+
+- `adapter` = the `ElementAdapter` class for the target object
+- `handler` = the Java class that processes the CSS property
+- `property-name` must match the CSS name exactly
+
+Important:
+
+If the property is not registered here, the handler will not process it.
+
+### Step 3: Check the CSS target name in the `ElementAdapter`
+
+File:
+
+`name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/YourElementAdapter.java`
+
+Open the adapter class from `plugin.xml`.
+
+In this project, the CSS target name is typically defined by:
+
+```java
+@Override
+public String getLocalName()
+{
+    return "YourCssTarget";
+}
+```
+
+Check:
+
+- The adapter must return the correct CSS target name
+- The CSS block in `light.css` and `dark.css` must use the same name
+
+Example rule:
+
+- If `getLocalName()` returns `"YourCssTarget"`, the CSS block must be:
+
+```css
+YourCssTarget {
+    your-color-property: #123456;
+}
+```
+
+Important:
+
+The property name does **not** select the CSS block.  
+The value from `getLocalName()` selects the CSS block.
+
+### Step 4: Check that the target class is connected in `ElementProvider`
+
+File:
+
+`name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ElementProvider.java`
+
+Template:
+
+```java
+if (element instanceof YourTargetClass target)
+    return new YourElementAdapter(target, engine);
+```
+
+Check:
+
+- `YourTargetClass` is the real Java class that should receive the CSS color
+- `YourElementAdapter` is the adapter registered in `plugin.xml`
+- The adapter must wrap the same target object
+
+Important:
+
+This is the real connection between the final Java class and the CSS engine.
+
+If this entry is missing, the CSS engine may never create the adapter for your target class.
+
+### Step 5: Process the property in the CSS handler and pass it to the target class
+
+File:
+
+`name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/YourCSSHandler.java`
+
+Typical import:
+
+```java
+import your.package.path.YourTargetClass;
+```
+
+```java
+import org.eclipse.swt.graphics.Color;
+```
+
+Possible additional imports:
+
+```java
+import name.abuchen.portfolio.ui.theme.YourElementAdapter;
+import name.abuchen.portfolio.ui.theme.ColorSourceTracker;
+```
+
+Template:
+
+```java
+if (!(element instanceof YourElementAdapter adapter))
+    return false;
+
+YourTargetClass target = adapter.getYourTargetClass();
+
+switch (property)
+{
+    case "your-color-property":
+        target.setYourColorProperty(getColor(value));
+        return true;
+    default:
+        return false;
+}
+```
+
+Check:
+
+- The handler receives the `ElementAdapter`, not the raw target class
+- The handler must get the real target class from the adapter
+- The handler must read the CSS property
+- The handler must pass the color into the correct target object
+
+Important:
+
+The handler does **not** decide which CSS block is used.  
+It only processes a property that was already matched by the CSS engine.
+
+### Step 6: Store and use the color in the target class
+
+File:
+
+`name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/.../YourTargetClass.java`
+
+In this project, the target class usually does both:
+
+1. store the CSS color
+2. later use the stored color on the real UI or chart object
+
+Example:
+
+```java
+private Color yourColorProperty;
+
+public void setYourColorProperty(Color color)
+{
+    this.yourColorProperty = color;
+}
+```
+
+Later in the same class:
+
+```java
+chartObject.setLineColor(yourColorProperty);
+```
+
+Or:
+
+```java
+uiObject.setForeground(yourColorProperty);
+```
+
+Check:
+
+- The CSS handler must write the color into a field or variable in the target class
+- The same field or variable must later be used by the visible UI or chart logic
+
+Important:
+
+In many cases, storing and using the color happens in the same target class.
+
+### Step 7: Check for hard-coded overrides
+
+Search for:
+
+```text
+Colors.
+SWT.COLOR_
+new RGB(
+Colors.getColor(
+setForeground(
+setBackground(
+setLineColor(
+```
+
+Check:
+
+- A later hard-coded color can override the CSS value
+- CSS may be loaded correctly, but Java may still win visually
+
+Important:
+
+The last applied color often decides the visible result.
+
+### Optional: Track CSS application for debugging
+
+Template:
+
+```java
+ColorSourceTracker.markCssApplied("YourCssTarget", "your-color-property");
+```
+
+Check:
+
+- Only mark CSS if the CSS property was really processed
+- Do not mark CSS if only a fallback color is used
+
+Important:
+
+Debug tracking should reflect the real source of the final visible color.
+
+### Full chain
+
+```text
+Java object
+-> ElementProvider creates ElementAdapter
+-> getLocalName() returns CSS target name
+-> CSS engine finds matching CSS block
+-> plugin.xml routes property to the CSS handler
+-> CSS handler gets the real target class from the adapter
+-> Target class stores color
+-> Target class uses color on the final UI object
+```
+
+### Quick validation
+
+A CSS color setup is complete only if all answers are **Yes**:
+
+1. Is the color defined in both `light.css` and `dark.css`?
+2. Is the property registered in `plugin.xml`?
+3. Does `getLocalName()` return the correct CSS target name?
+4. Does `ElementProvider` create the correct adapter for the target class?
+5. Does the CSS handler get the target class from the adapter?
+6. Does the target class store the color?
+7. Does the target class use the stored color on the final UI object?
+8. Is there no later hard-coded override?
+
+### Core rule
+
+**The property name does not select the CSS block.**  
+**`getLocalName()` in the `ElementAdapter` selects the CSS block.**
 
 ## Appendix
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 * [Interactive Flex Query Importers](CONTRIBUTING.md#interactive-flex-query-importers)
 * [PDF Importers](CONTRIBUTING.md#pdf-importers)
 * [Trade Calendars](CONTRIBUTING.md#trade-calendars)
+* [Centrally defining CSS colors for UI objects](CONTRIBUTING.md#Centrally-defining-CSS-colors-for-UI-objects)
 
 
 ## Public GPG Key

--- a/name.abuchen.portfolio.ui/css/shared/dark.css
+++ b/name.abuchen.portfolio.ui/css/shared/dark.css
@@ -1,6 +1,27 @@
 
 /* Common DARK styles */
 
+* {
+	font-family: "#systemfont";
+}
+
+.heading1 {
+	font-family: "#org.eclipse.jface.headerfont";
+	font-weight: bold;
+	color: #D7D8D8;
+}
+
+.heading2 {
+	font-family: "#systemfont";
+	font-weight: bold;
+	color: #D7D8D8;
+}
+
+.kpi {
+	font-family: "#systemfont";
+	font-weight: normal;
+}
+
 .MPartStack {
     padding: 0px;
 }
@@ -79,6 +100,13 @@ ValueColorScheme.blueorange {
 	down-arrow: "scheme/blueorange/dark/down_arrow.svg";
 }
 
+ValueColorScheme.vivid {
+	positive-foreground: #02f500;
+	negative-foreground: #fe2b05;
+	up-arrow: "scheme/vivid/dark/up_arrow.svg";
+	down-arrow: "scheme/vivid/dark/down_arrow.svg";
+}
+
 ValueColorScheme.asia {
 	positive-foreground: #fe2b05;
 	negative-foreground: #02f500;
@@ -86,11 +114,98 @@ ValueColorScheme.asia {
 	down-arrow: "scheme/asia/dark/down_arrow.svg";
 }
 
-ValueColorScheme.vivid {
-	positive-foreground: #02f500;
-	negative-foreground: #fe2b05;
-	up-arrow: "scheme/vivid/dark/up_arrow.svg";
-	down-arrow: "scheme/vivid/dark/down_arrow.svg";
+DataSeries {
+	totals-color: #EEEEEE;
+
+	invested-capital-color: #ffaf4d;
+	absolute-invested-capital-color: #ffaf4d;
+
+	transferals-color: #A0A0A0;
+	transferals-accumulated-color: #ffd562;
+
+	taxes-color: #ff2b30;
+	taxes-accumulated-color: #ff2b30;
+
+	absolute-delta-color: #4ddaff;
+	absolute-delta-all-record-color: #4ddaff;
+
+	dividends-color: #8063A8;
+	dividends-accumulated-color: #8063A8;
+
+	interest-color: #02f500;
+	interest-accumulated-color: #02f500;
+
+	interest-charge-color: #02f500;
+	interest-charge-accumulated-color: #02f500;
+
+	earnings-color: #02f500;
+	earnings-accumulated-color: #02f500;
+
+	fees-color: #808080;
+	fees-accumulated-color: #808080;
+
+	performance-entire-portfolio-color: #EEEEEE;
+	performance-positive-color: #4DA6FF;
+	performance-negative-color: #FFB366;
+}
+
+ColorPalette.payments {
+	color-0: #8C564B;
+	color-1: #E377C2;
+	color-2: #7F7F7F;
+	color-3: #BCBD22;
+	color-4: #17BECF;
+	color-5: #727CC9;
+	color-6: #FA735C;
+	color-7: #FDB667;
+	color-8: #8FCF70;
+	color-9: #57CFFD;
+	color-10: #1F77B4;
+	color-11: #FF7F0E;
+	color-12: #2CA02C;
+	color-13: #D62728;
+	color-14: #9467BD;
+}
+
+ColorGradient.red-to-green {
+	color-0: #A8272A;
+	color-1: #E25B5A;
+	color-2: #F08A89;
+	color-3: #F2B6B5;
+	color-4: #606060;
+	color-5: #8DCB72;
+	color-6: #5EC45B;
+	color-7: #23B0D7;
+	color-8: #1AAD21;
+}
+
+ColorGradient.orange-to-blue {
+	color-0: #FF7A00;
+	color-1: #FFB366;
+	color-2: #FFD3A1;
+	color-3: #606060;
+	color-4: #8ACBFF;
+	color-5: #4DA6FF;
+	color-6: #2D9CFF;
+}
+
+ColorGradient.green-yellow-red {
+	color-0: #FF2B30;
+	color-1: #FFD562;
+	color-2: #02F500;
+}
+
+ColorGradient.green-white-red {
+	color-0: #FF2B30;
+	color-1: #EEEEEE;
+	color-2: #02F500;
+}
+
+ColorGradient.yellow-white-black {
+	color-0: #EEEEEE;
+	color-1: #FFD562;
+	color-2: #808000;
+	color-3: #000000;
 }
 
 SecuritiesChart {
@@ -105,9 +220,29 @@ SecuritiesChart {
 	extreme-marker-high-color: #1aad21;
 	extreme-marker-low-color: #A8272A;
 
-	non-trading-color: #8c4b31;
-	
-	shares-held-color: #ffaf4d;
+	non-trading-color: #FF8959;
+	shares-held-color: #EBC934;
+
+	fifo-purchase-price-color: #E27A79;
+	moving-average-purchase-price-color: #965251;
+	bollinger-bands-color: #C98D44;
+	macd-color: #E29BC8;
+
+	sma-1-color: #B36B6B;
+	sma-2-color: #B3A76B;
+	sma-3-color: #83B36B;
+	sma-4-color: #6BB38F;
+	sma-5-color: #6B9BB3;
+	sma-6-color: #776BB3;
+	sma-7-color: #B36BB3;
+
+	ema-1-color: #C86B6B;
+	ema-2-color: #C8A76B;
+	ema-3-color: #83C86B;
+	ema-4-color: #6BC88F;
+	ema-5-color: #6B9BC8;
+	ema-6-color: #776BC8;
+	ema-7-color: #C86BC8;
 }
 
 SecuritiesChart.blueorange {
@@ -139,25 +274,4 @@ PortfolioBalanceChart {
 PortfolioBalanceChart.asia {
 	delta-area-positive-color: #e25b5a;
 	delta-area-negative-color: #23b0d7;
-}
-
-* {
-	font-family: "#systemfont";
-}
-
-.heading1 {
-	font-family: "#org.eclipse.jface.headerfont";
-	font-weight: bold;
-	color: #D7D8D8;
-}
-
-.heading2 {
-	font-family: "#systemfont";
-	font-weight: bold;
-	color: #D7D8D8;
-}
-
-.kpi {
-	font-family: "#systemfont";
-	font-weight: normal;
 }

--- a/name.abuchen.portfolio.ui/css/shared/light.css
+++ b/name.abuchen.portfolio.ui/css/shared/light.css
@@ -1,6 +1,27 @@
 
 /* Common LIGHT styles */
 
+* {
+	font-family: "#systemfont";
+}
+
+.heading1 {
+	font-family: "#org.eclipse.jface.headerfont";
+	font-weight: bold;
+	color: #393E42;
+}
+
+.heading2 {
+	font-family: "#systemfont";
+	font-weight: bold;
+	color: #393E42;
+}
+
+.kpi {
+	font-family: "#systemfont";
+	font-weight: normal;
+}
+
 .MPart Composite,
 .MPart Label {
 	background-color: white;
@@ -92,6 +113,8 @@ CustomColors {
 	red-foreground: #7f0000;
 	green-foreground: #377500;
 	gray-foreground: #707070;
+	
+	hyperlink: #6FC5EE;
 }
 
 ValueColorScheme.standard {
@@ -108,12 +131,6 @@ ValueColorScheme.blueorange {
 	down-arrow: "scheme/blueorange/light/down_arrow.svg";
 }
 
-ValueColorScheme.asia {
-	positive-foreground: #7f0000;
-	negative-foreground: #377500;
-	up-arrow: "scheme/asia/light/up_arrow.svg";
-	down-arrow: "scheme/asia/light/down_arrow.svg";
-}
 
 ValueColorScheme.vivid {
 	positive-foreground: #009B00;
@@ -122,6 +139,120 @@ ValueColorScheme.vivid {
 	down-arrow: "scheme/vivid/light/down_arrow.svg";
 }
 
+
+ValueColorScheme.asia {
+	positive-foreground: #7f0000;
+	negative-foreground: #377500;
+	up-arrow: "scheme/asia/light/up_arrow.svg";
+	down-arrow: "scheme/asia/light/down_arrow.svg";
+}
+
+PortfolioBalanceChart {
+	invested-capital-color: #EBC934;
+	absolute-delta-color: #6a58db;
+	delta-area-positive-color: #8396f2;
+	delta-area-negative-color: #ed6766;
+}
+
+PortfolioBalanceChart.asia {
+	delta-area-positive-color: #ed6766;
+	delta-area-negative-color: #8396f2;
+}
+
+DataSeries {
+	totals-color: #000000;
+
+	invested-capital-color: #EBC934;
+	absolute-invested-capital-color: #EBC934;
+
+	transferals-color: #A9A9A9;
+	transferals-accumulated-color: #FFFF00;
+
+	taxes-color: #FF0000;
+	taxes-accumulated-color: #FF0000;
+
+	absolute-delta-color: #0000FF;
+	absolute-delta-all-record-color: #0000FF;
+
+	dividends-color: #800080;
+	dividends-accumulated-color: #800080;
+
+	interest-color: #377500;
+	interest-accumulated-color: #377500;
+
+	interest-charge-color: #377500;
+	interest-charge-accumulated-color: #377500;
+
+	earnings-color: #377500;
+	earnings-accumulated-color: #377500;
+
+	fees-color: #808080;
+	fees-accumulated-color: #808080;
+
+	performance-entire-portfolio-color: #000000;
+	performance-positive-color: #3C97DA;
+	performance-negative-color: #FD9C52;
+}
+
+ColorPalette.payments {
+	color-0: #8C564B;
+	color-1: #E377C2;
+	color-2: #7F7F7F;
+	color-3: #BCBD22;
+	color-4: #17BECF;
+	color-5: #727CC9;
+	color-6: #FA735C;
+	color-7: #FDB667;
+	color-8: #8FCF70;
+	color-9: #57CFFD;
+	color-10: #1F77B4;
+	color-11: #FF7F0E;
+	color-12: #2CA02C;
+	color-13: #D62728;
+	color-14: #9467BD;
+}
+
+ColorGradient.red-to-green {
+	color-0: #C92E25;
+	color-1: #FD7F76;
+	color-2: #FD9A93;
+	color-3: #FCBBB7;
+	color-4: #E8E8E8;
+	color-5: #BBE491;
+	color-6: #A1D771;
+	color-7: #80C25E;
+	color-8: #397B27;
+}
+
+ColorGradient.orange-to-blue {
+	color-0: #B36E3A;
+	color-1: #FD9C52;
+	color-2: #FFCEAA;
+	color-3: #DDDDDD;
+	color-4: #9ECBEC;
+	color-5: #3C97DA;
+	color-6: #2A6999;
+}
+
+ColorGradient.green-yellow-red {
+	color-0: #FF2B30;
+	color-1: #FFD562;
+	color-2: #02F500;
+}
+
+ColorGradient.green-white-red {
+	color-0: #FF2B30;
+	color-1: #EEEEEE;
+	color-2: #02F500;
+}
+
+ColorGradient.yellow-white-black {
+	color-0: #EEEEEE;
+	color-1: #FFD562;
+	color-2: #808000;
+	color-3: #000000;
+}
+	
 SecuritiesChart {
 	quote-color: #6a58db;
 	quote-area-positive-color: #8396f2;
@@ -135,8 +266,28 @@ SecuritiesChart {
 	extreme-marker-low-color: #a30000;
 
 	non-trading-color: #FF8959;
-	
-	shares-held-color: #EBC934
+	shares-held-color: #EBC934;
+
+	fifo-purchase-price-color: #E27A79;
+	moving-average-purchase-price-color: #965251;
+	bollinger-bands-color: #C98D44;
+	macd-color: #E29BC8;
+
+	sma-1-color: #B36B6B;
+	sma-2-color: #B3A76B;
+	sma-3-color: #83B36B;
+	sma-4-color: #6BB38F;
+	sma-5-color: #6B9BB3;
+	sma-6-color: #776BB3;
+	sma-7-color: #B36BB3;
+
+	ema-1-color: #C86B6B;
+	ema-2-color: #C8A76B;
+	ema-3-color: #83C86B;
+	ema-4-color: #6BC88F;
+	ema-5-color: #6B9BC8;
+	ema-6-color: #776BC8;
+	ema-7-color: #C86BC8;
 }
 
 SecuritiesChart.blueorange {
@@ -158,37 +309,4 @@ SecuritiesChart.asia {
 
 	extreme-marker-high-color: #a30000;
 	extreme-marker-low-color: #377500;
-}
-
-PortfolioBalanceChart {
-	invested-capital-color: #EBC934;
-	absolute-delta-color: #6a58db;
-	delta-area-positive-color: #8396f2;
-	delta-area-negative-color: #ed6766;
-}
-
-PortfolioBalanceChart.asia {
-	delta-area-positive-color: #ed6766;
-	delta-area-negative-color: #8396f2;
-}
-
-* {
-	font-family: "#systemfont";
-}
-
-.heading1 {
-	font-family: "#org.eclipse.jface.headerfont";
-	font-weight: bold;
-	color: #393E42;
-}
-
-.heading2 {
-	font-family: "#systemfont";
-	font-weight: bold;
-	color: #393E42;
-}
-
-.kpi {
-	font-family: "#systemfont";
-	font-weight: normal;
 }

--- a/name.abuchen.portfolio.ui/plugin.xml
+++ b/name.abuchen.portfolio.ui/plugin.xml
@@ -152,15 +152,78 @@
          <property-name
                name="shares-held-color">
          </property-name>
+         <property-name
+               name="fifo-purchase-price-color">
+         </property-name>
+         <property-name
+               name="moving-average-purchase-price-color">
+         </property-name>
+         <property-name
+               name="bollinger-bands-color">
+         </property-name>
+         <property-name
+               name="macd-color">
+         </property-name>
+         <property-name
+               name="sma-1-color">
+         </property-name>
+         <property-name
+               name="sma-2-color">
+         </property-name>
+         <property-name
+               name="sma-3-color">
+         </property-name>
+         <property-name
+               name="sma-4-color">
+         </property-name>
+         <property-name
+               name="sma-5-color">
+         </property-name>
+         <property-name
+               name="sma-6-color">
+         </property-name>
+         <property-name
+               name="sma-7-color">
+         </property-name>
+         <property-name
+               name="ema-1-color">
+         </property-name>
+         <property-name
+               name="ema-2-color">
+         </property-name>
+         <property-name
+               name="ema-3-color">
+         </property-name>
+         <property-name
+               name="ema-4-color">
+         </property-name>
+         <property-name
+               name="ema-5-color">
+         </property-name>
+         <property-name
+               name="ema-6-color">
+         </property-name>
+         <property-name
+               name="ema-7-color">
+         </property-name>
       </handler>
       <handler
             adapter="name.abuchen.portfolio.ui.theme.PortfolioBalanceChartElementAdapter"
             handler="name.abuchen.portfolio.ui.theme.PortfolioBalanceChartCSSHandler">
          <property-name
+               name="totals-color">
+         </property-name>
+         <property-name
                name="invested-capital-color">
          </property-name>
          <property-name
                name="absolute-delta-color">
+         </property-name>
+         <property-name
+               name="taxes-accumulated-color">
+         </property-name>
+         <property-name
+               name="fees-accumulated-color">
          </property-name>
          <property-name
                name="delta-area-positive-color">
@@ -170,19 +233,153 @@
          </property-name>
       </handler>
       <handler
-            adapter="name.abuchen.portfolio.ui.theme.ValueColorSchemeElementAdapter"
-            handler="name.abuchen.portfolio.ui.theme.ValueColorSchemeCSSHandler">
+            adapter="name.abuchen.portfolio.ui.theme.PaymentsPaletteElementAdapter"
+            handler="name.abuchen.portfolio.ui.theme.PaymentsPaletteCSSHandler">
          <property-name
-               name="positive-foreground">
+               name="color-0">
          </property-name>
          <property-name
-               name="negative-foreground">
+               name="color-1">
          </property-name>
          <property-name
-               name="up-arrow">
+               name="color-2">
          </property-name>
          <property-name
-               name="down-arrow">
+               name="color-3">
+         </property-name>
+         <property-name
+               name="color-4">
+         </property-name>
+         <property-name
+               name="color-5">
+         </property-name>
+         <property-name
+               name="color-6">
+         </property-name>
+         <property-name
+               name="color-7">
+         </property-name>
+         <property-name
+               name="color-8">
+         </property-name>
+         <property-name
+               name="color-9">
+         </property-name>
+         <property-name
+               name="color-10">
+         </property-name>
+         <property-name
+               name="color-11">
+         </property-name>
+         <property-name
+               name="color-12">
+         </property-name>
+         <property-name
+               name="color-13">
+         </property-name>
+         <property-name
+               name="color-14">
+         </property-name>
+      </handler>
+      <handler
+            adapter="name.abuchen.portfolio.ui.theme.ColorGradientElementAdapter"
+            handler="name.abuchen.portfolio.ui.theme.ColorGradientCSSHandler">
+         <property-name
+               name="color-0">
+         </property-name>
+         <property-name
+               name="color-1">
+         </property-name>
+         <property-name
+               name="color-2">
+         </property-name>
+         <property-name
+               name="color-3">
+         </property-name>
+         <property-name
+               name="color-4">
+         </property-name>
+         <property-name
+               name="color-5">
+         </property-name>
+         <property-name
+               name="color-6">
+         </property-name>
+         <property-name
+               name="color-7">
+         </property-name>
+         <property-name
+               name="color-8">
+         </property-name>
+      </handler>
+      <handler
+            adapter="name.abuchen.portfolio.ui.theme.DataSeriesColorsElementAdapter"
+            handler="name.abuchen.portfolio.ui.theme.DataSeriesColorsCSSHandler">
+         <property-name
+               name="totals-color">
+         </property-name>
+         <property-name
+               name="invested-capital-color">
+         </property-name>
+         <property-name
+               name="absolute-invested-capital-color">
+         </property-name>
+         <property-name
+               name="transferals-color">
+         </property-name>
+         <property-name
+               name="transferals-accumulated-color">
+         </property-name>
+         <property-name
+               name="taxes-color">
+         </property-name>
+         <property-name
+               name="taxes-accumulated-color">
+         </property-name>
+         <property-name
+               name="absolute-delta-color">
+         </property-name>
+         <property-name
+               name="absolute-delta-all-record-color">
+         </property-name>
+         <property-name
+               name="dividends-color">
+         </property-name>
+         <property-name
+               name="dividends-accumulated-color">
+         </property-name>
+         <property-name
+               name="interest-color">
+         </property-name>
+         <property-name
+               name="interest-accumulated-color">
+         </property-name>
+         <property-name
+               name="interest-charge-color">
+         </property-name>
+         <property-name
+               name="interest-charge-accumulated-color">
+         </property-name>
+         <property-name
+               name="earnings-color">
+         </property-name>
+         <property-name
+               name="earnings-accumulated-color">
+         </property-name>
+         <property-name
+               name="fees-color">
+         </property-name>
+         <property-name
+               name="fees-accumulated-color">
+         </property-name>
+         <property-name
+               name="performance-entire-portfolio-color">
+         </property-name>
+         <property-name
+               name="performance-positive-color">
+         </property-name>
+         <property-name
+               name="performance-negative-color">
          </property-name>
       </handler>
    </extension>
@@ -222,6 +419,15 @@
          </widget>
          <widget
                class="name.abuchen.portfolio.ui.util.ValueColorScheme">
+         </widget>
+         <widget
+               class="name.abuchen.portfolio.ui.views.payments.PaymentsPalette">
+         </widget>
+         <widget
+               class="name.abuchen.portfolio.ui.util.DataSeriesColors">
+         </widget>
+         <widget
+               class="name.abuchen.portfolio.ui.util.ColorGradientDefinitions$Definition">
          </widget>
       </provider>
    </extension>

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/Navigation.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/Navigation.java
@@ -43,6 +43,7 @@ import name.abuchen.portfolio.ui.util.swt.ActiveShell;
 import name.abuchen.portfolio.ui.views.AccountListView;
 import name.abuchen.portfolio.ui.views.AllTransactionsView;
 import name.abuchen.portfolio.ui.views.BrowserTestView;
+import name.abuchen.portfolio.ui.views.ColorArchitectureDebugView;
 import name.abuchen.portfolio.ui.views.GroupedAccountsListView;
 import name.abuchen.portfolio.ui.views.InvestmentPlanListView;
 import name.abuchen.portfolio.ui.views.PerformanceChartView;
@@ -662,6 +663,9 @@ public final class Navigation
         section.add(progressView);
 
         if ("yes".equals(System.getProperty("name.abuchen.portfolio.debug"))) //$NON-NLS-1$ //$NON-NLS-2$
+        {
             section.add(new Item("Browser Test", BrowserTestView.class)); //$NON-NLS-1$
+            section.add(new Item("Color Architecture Debug", ColorArchitectureDebugView.class)); //$NON-NLS-1$
+        }
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ColorGradientCSSHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ColorGradientCSSHandler.java
@@ -1,0 +1,24 @@
+package name.abuchen.portfolio.ui.theme;
+
+import org.eclipse.e4.ui.css.core.dom.properties.ICSSPropertyHandler;
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.eclipse.e4.ui.css.swt.helpers.CSSSWTColorHelper;
+import org.w3c.dom.css.CSSValue;
+
+@SuppressWarnings("restriction")
+public class ColorGradientCSSHandler implements ICSSPropertyHandler
+{
+    @Override
+    public boolean applyCSSProperty(Object element, String property, CSSValue value, String pseudo, CSSEngine engine)
+                    throws Exception
+    {
+        if (element instanceof ColorGradientElementAdapter adapter)
+        {
+            int index = Integer.parseInt(property.substring("color-".length())); //$NON-NLS-1$
+            adapter.getDefinition().setColor(index, CSSSWTColorHelper.getRGBA(value));
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ColorGradientCSSHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ColorGradientCSSHandler.java
@@ -5,6 +5,8 @@ import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.helpers.CSSSWTColorHelper;
 import org.w3c.dom.css.CSSValue;
 
+import name.abuchen.portfolio.ui.util.ColorSourceTracker;
+
 @SuppressWarnings("restriction")
 public class ColorGradientCSSHandler implements ICSSPropertyHandler
 {
@@ -16,6 +18,8 @@ public class ColorGradientCSSHandler implements ICSSPropertyHandler
         {
             int index = Integer.parseInt(property.substring("color-".length())); //$NON-NLS-1$
             adapter.getDefinition().setColor(index, CSSSWTColorHelper.getRGBA(value));
+            ColorSourceTracker.markCssApplied("ColorGradientDefinitions." + adapter.getDefinition().getCssClass(), //$NON-NLS-1$
+                            property);
             return true;
         }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ColorGradientElementAdapter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ColorGradientElementAdapter.java
@@ -1,0 +1,70 @@
+package name.abuchen.portfolio.ui.theme;
+
+import org.eclipse.e4.ui.css.core.dom.ElementAdapter;
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import name.abuchen.portfolio.ui.util.ColorGradientDefinitions;
+
+@SuppressWarnings("restriction")
+public class ColorGradientElementAdapter extends ElementAdapter
+{
+    public ColorGradientElementAdapter(ColorGradientDefinitions.Definition definition, CSSEngine engine)
+    {
+        super(definition, engine);
+    }
+
+    public ColorGradientDefinitions.Definition getDefinition()
+    {
+        return (ColorGradientDefinitions.Definition) getNativeWidget();
+    }
+
+    @Override
+    public String getCSSId()
+    {
+        return null;
+    }
+
+    @Override
+    public String getCSSClass()
+    {
+        return getDefinition().getCssClass();
+    }
+
+    @Override
+    public String getCSSStyle()
+    {
+        return null;
+    }
+
+    @Override
+    public Node getParentNode()
+    {
+        return null;
+    }
+
+    @Override
+    public NodeList getChildNodes()
+    {
+        return null;
+    }
+
+    @Override
+    public String getNamespaceURI()
+    {
+        return null;
+    }
+
+    @Override
+    public String getLocalName()
+    {
+        return "ColorGradient"; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getAttribute(String name)
+    {
+        return ""; //$NON-NLS-1$
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ColorsThemeCSSHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ColorsThemeCSSHandler.java
@@ -5,6 +5,7 @@ import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.helpers.CSSSWTColorHelper;
 import org.w3c.dom.css.CSSValue;
 
+import name.abuchen.portfolio.ui.util.ColorSourceTracker;
 import name.abuchen.portfolio.ui.util.Colors;
 
 @SuppressWarnings("restriction")
@@ -14,47 +15,55 @@ public class ColorsThemeCSSHandler implements ICSSPropertyHandler
     public boolean applyCSSProperty(Object element, String property, CSSValue value, String pseudo, CSSEngine engine)
                     throws Exception
     {
-        if (element instanceof ColorsThemeElementAdapter colorsThemeAdapter)
+        if (!(element instanceof ColorsThemeElementAdapter colorsThemeAdapter))
+            return false;
+
+        Colors.Theme theme = colorsThemeAdapter.getColorsTheme();
+
+        switch (property)
         {
-            Colors.Theme theme = colorsThemeAdapter.getColorsTheme();
-
-            switch (property)
-            {
-                case "default-foreground": //$NON-NLS-1$
-                    theme.setDefaultForeground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "default-background": //$NON-NLS-1$
-                    theme.setDefaultBackground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "chip-background": //$NON-NLS-1$
-                    theme.setChipBackground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "warning-background": //$NON-NLS-1$
-                    theme.setWarningBackground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "red-background": //$NON-NLS-1$
-                    theme.setRedBackground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "green-background": //$NON-NLS-1$
-                    theme.setGreenBackground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "red-foreground": //$NON-NLS-1$
-                    theme.setRedForeground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "green-foreground": //$NON-NLS-1$
-                    theme.setGreenForeground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "gray-foreground": //$NON-NLS-1$
-                    theme.setGrayForeground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "hyperlink": //$NON-NLS-1$
-                    theme.setHyperlink(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                default:
-            }
+            case "default-foreground": //$NON-NLS-1$
+                theme.setDefaultForeground(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("CustomColors", "default-foreground"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+            case "default-background": //$NON-NLS-1$
+                theme.setDefaultBackground(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("CustomColors", "default-background"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+            case "chip-background": //$NON-NLS-1$
+                theme.setChipBackground(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("CustomColors", "chip-background"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+            case "warning-background": //$NON-NLS-1$
+                theme.setWarningBackground(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("CustomColors", "warning-background"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+            case "red-background": //$NON-NLS-1$
+                theme.setRedBackground(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("CustomColors", "red-background"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+            case "green-background": //$NON-NLS-1$
+                theme.setGreenBackground(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("CustomColors", "green-background"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+            case "red-foreground": //$NON-NLS-1$
+                theme.setRedForeground(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("CustomColors", "red-foreground"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+            case "green-foreground": //$NON-NLS-1$
+                theme.setGreenForeground(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("CustomColors", "green-foreground"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+            case "gray-foreground": //$NON-NLS-1$
+                theme.setGrayForeground(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("CustomColors", "gray-foreground"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+            case "hyperlink": //$NON-NLS-1$
+                theme.setHyperlink(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("CustomColors", "hyperlink"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+            default:
+                return false;
         }
-
-        return false;
     }
-
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/DataSeriesColorsCSSHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/DataSeriesColorsCSSHandler.java
@@ -1,0 +1,100 @@
+package name.abuchen.portfolio.ui.theme;
+
+import org.eclipse.e4.ui.css.core.dom.properties.ICSSPropertyHandler;
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.eclipse.e4.ui.css.swt.helpers.CSSSWTColorHelper;
+import org.w3c.dom.css.CSSValue;
+
+import name.abuchen.portfolio.ui.util.DataSeriesColors;
+
+@SuppressWarnings("restriction")
+public class DataSeriesColorsCSSHandler implements ICSSPropertyHandler
+{
+    @Override
+    public boolean applyCSSProperty(Object element, String property, CSSValue value, String pseudo, CSSEngine engine)
+                    throws Exception
+    {
+        if (element instanceof DataSeriesColorsElementAdapter adapter)
+        {
+            var colors = adapter.getColors();
+            return applyTo(colors, property, value);
+        }
+
+        return false;
+    }
+
+    private boolean applyTo(DataSeriesColors colors, String property, CSSValue value)
+    {
+        switch (property)
+        {
+            case "totals-color": //$NON-NLS-1$
+                colors.setTotalsColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "invested-capital-color": //$NON-NLS-1$
+                colors.setInvestedCapitalColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "absolute-invested-capital-color": //$NON-NLS-1$
+                colors.setAbsoluteInvestedCapitalColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "transferals-color": //$NON-NLS-1$
+                colors.setTransferalsColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "transferals-accumulated-color": //$NON-NLS-1$
+                colors.setTransferalsAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "taxes-color": //$NON-NLS-1$
+                colors.setTaxesColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "taxes-accumulated-color": //$NON-NLS-1$
+                colors.setTaxesAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "absolute-delta-color": //$NON-NLS-1$
+                colors.setAbsoluteDeltaColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "absolute-delta-all-record-color": //$NON-NLS-1$
+                colors.setAbsoluteDeltaAllRecordColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "dividends-color": //$NON-NLS-1$
+                colors.setDividendsColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "dividends-accumulated-color": //$NON-NLS-1$
+                colors.setDividendsAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "interest-color": //$NON-NLS-1$
+                colors.setInterestColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "interest-accumulated-color": //$NON-NLS-1$
+                colors.setInterestAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "interest-charge-color": //$NON-NLS-1$
+                colors.setInterestChargeColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "interest-charge-accumulated-color": //$NON-NLS-1$
+                colors.setInterestChargeAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "earnings-color": //$NON-NLS-1$
+                colors.setEarningsColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "earnings-accumulated-color": //$NON-NLS-1$
+                colors.setEarningsAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "fees-color": //$NON-NLS-1$
+                colors.setFeesColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "fees-accumulated-color": //$NON-NLS-1$
+                colors.setFeesAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "performance-entire-portfolio-color": //$NON-NLS-1$
+                colors.setPerformanceEntirePortfolioColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "performance-positive-color": //$NON-NLS-1$
+                colors.setPerformancePositiveColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "performance-negative-color": //$NON-NLS-1$
+                colors.setPerformanceNegativeColor(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/DataSeriesColorsCSSHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/DataSeriesColorsCSSHandler.java
@@ -5,6 +5,7 @@ import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.helpers.CSSSWTColorHelper;
 import org.w3c.dom.css.CSSValue;
 
+import name.abuchen.portfolio.ui.util.ColorSourceTracker;
 import name.abuchen.portfolio.ui.util.DataSeriesColors;
 
 @SuppressWarnings("restriction")
@@ -29,69 +30,91 @@ public class DataSeriesColorsCSSHandler implements ICSSPropertyHandler
         {
             case "totals-color": //$NON-NLS-1$
                 colors.setTotalsColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "totals-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "invested-capital-color": //$NON-NLS-1$
                 colors.setInvestedCapitalColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "invested-capital-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "absolute-invested-capital-color": //$NON-NLS-1$
                 colors.setAbsoluteInvestedCapitalColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "absolute-invested-capital-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "transferals-color": //$NON-NLS-1$
                 colors.setTransferalsColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "transferals-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "transferals-accumulated-color": //$NON-NLS-1$
                 colors.setTransferalsAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "transferals-accumulated-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "taxes-color": //$NON-NLS-1$
                 colors.setTaxesColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "taxes-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "taxes-accumulated-color": //$NON-NLS-1$
                 colors.setTaxesAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "taxes-accumulated-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "absolute-delta-color": //$NON-NLS-1$
                 colors.setAbsoluteDeltaColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "absolute-delta-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "absolute-delta-all-record-color": //$NON-NLS-1$
                 colors.setAbsoluteDeltaAllRecordColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "absolute-delta-all-record-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "dividends-color": //$NON-NLS-1$
                 colors.setDividendsColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "dividends-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "dividends-accumulated-color": //$NON-NLS-1$
                 colors.setDividendsAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "dividends-accumulated-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "interest-color": //$NON-NLS-1$
                 colors.setInterestColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "interest-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "interest-accumulated-color": //$NON-NLS-1$
                 colors.setInterestAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "interest-accumulated-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "interest-charge-color": //$NON-NLS-1$
                 colors.setInterestChargeColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "interest-charge-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "interest-charge-accumulated-color": //$NON-NLS-1$
                 colors.setInterestChargeAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "interest-charge-accumulated-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "earnings-color": //$NON-NLS-1$
                 colors.setEarningsColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "earnings-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "earnings-accumulated-color": //$NON-NLS-1$
                 colors.setEarningsAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "earnings-accumulated-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "fees-color": //$NON-NLS-1$
                 colors.setFeesColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "fees-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "fees-accumulated-color": //$NON-NLS-1$
                 colors.setFeesAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "fees-accumulated-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "performance-entire-portfolio-color": //$NON-NLS-1$
                 colors.setPerformanceEntirePortfolioColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "performance-entire-portfolio-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "performance-positive-color": //$NON-NLS-1$
                 colors.setPerformancePositiveColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "performance-positive-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "performance-negative-color": //$NON-NLS-1$
                 colors.setPerformanceNegativeColor(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("DataSeries", "performance-negative-color"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             default:
                 return false;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/DataSeriesColorsElementAdapter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/DataSeriesColorsElementAdapter.java
@@ -1,0 +1,70 @@
+package name.abuchen.portfolio.ui.theme;
+
+import org.eclipse.e4.ui.css.core.dom.ElementAdapter;
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import name.abuchen.portfolio.ui.util.DataSeriesColors;
+
+@SuppressWarnings("restriction")
+public class DataSeriesColorsElementAdapter extends ElementAdapter
+{
+    public DataSeriesColorsElementAdapter(DataSeriesColors colors, CSSEngine engine)
+    {
+        super(colors, engine);
+    }
+
+    public DataSeriesColors getColors()
+    {
+        return (DataSeriesColors) getNativeWidget();
+    }
+
+    @Override
+    public String getCSSId()
+    {
+        return null;
+    }
+
+    @Override
+    public String getCSSClass()
+    {
+        return null;
+    }
+
+    @Override
+    public String getCSSStyle()
+    {
+        return null;
+    }
+
+    @Override
+    public Node getParentNode()
+    {
+        return null;
+    }
+
+    @Override
+    public NodeList getChildNodes()
+    {
+        return null;
+    }
+
+    @Override
+    public String getNamespaceURI()
+    {
+        return null;
+    }
+
+    @Override
+    public String getLocalName()
+    {
+        return "DataSeries"; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getAttribute(String name)
+    {
+        return ""; //$NON-NLS-1$
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ElementProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ElementProvider.java
@@ -14,10 +14,13 @@ import org.eclipse.swtchart.Chart;
 import org.w3c.dom.Element;
 
 import name.abuchen.portfolio.ui.editor.Sidebar;
+import name.abuchen.portfolio.ui.util.ColorGradientDefinitions;
 import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.DataSeriesColors;
 import name.abuchen.portfolio.ui.util.ValueColorScheme;
 import name.abuchen.portfolio.ui.views.PortfolioBalanceChart;
 import name.abuchen.portfolio.ui.views.SecuritiesChart;
+import name.abuchen.portfolio.ui.views.payments.PaymentsPalette;
 
 @SuppressWarnings("restriction")
 public class ElementProvider implements IElementProvider
@@ -37,6 +40,8 @@ public class ElementProvider implements IElementProvider
             return new ChartElementAdapter(chart, engine);
         if (element instanceof Colors.Theme colorsTheme)
             return new ColorsThemeElementAdapter(colorsTheme, engine);
+        if (element instanceof DataSeriesColors dataSeriesColors)
+            return new DataSeriesColorsElementAdapter(dataSeriesColors, engine);
         if (element instanceof Table table)
             return new TableElementAdapter(table, engine);
         if (element instanceof Tree tree)
@@ -47,6 +52,10 @@ public class ElementProvider implements IElementProvider
             return new PortfolioBalanceChartElementAdapter(portfolioBalanceChart, engine);
         if (element instanceof ValueColorScheme scheme)
             return new ValueColorSchemeElementAdapter(scheme, engine);
+        if (element instanceof ColorGradientDefinitions.Definition definition)
+            return new ColorGradientElementAdapter(definition, engine);
+        if (element instanceof PaymentsPalette palette)
+            return new PaymentsPaletteElementAdapter(palette, engine);
 
         return null;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/PaymentsPaletteCSSHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/PaymentsPaletteCSSHandler.java
@@ -1,0 +1,79 @@
+package name.abuchen.portfolio.ui.theme;
+
+import org.eclipse.e4.ui.css.core.dom.properties.ICSSPropertyHandler;
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.eclipse.e4.ui.css.swt.helpers.CSSSWTColorHelper;
+import org.w3c.dom.css.CSSValue;
+
+import name.abuchen.portfolio.ui.views.payments.PaymentsPalette;
+
+@SuppressWarnings("restriction")
+public class PaymentsPaletteCSSHandler implements ICSSPropertyHandler
+{
+    @Override
+    public boolean applyCSSProperty(Object element, String property, CSSValue value, String pseudo, CSSEngine engine)
+                    throws Exception
+    {
+        if (element instanceof PaymentsPaletteElementAdapter adapter)
+        {
+            var palette = adapter.getPalette();
+            return applyTo(palette, property, value);
+        }
+
+        return false;
+    }
+
+    private boolean applyTo(PaymentsPalette palette, String property, CSSValue value)
+    {
+        switch (property)
+        {
+            case "color-0": //$NON-NLS-1$
+                palette.setColor(0, CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "color-1": //$NON-NLS-1$
+                palette.setColor(1, CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "color-2": //$NON-NLS-1$
+                palette.setColor(2, CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "color-3": //$NON-NLS-1$
+                palette.setColor(3, CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "color-4": //$NON-NLS-1$
+                palette.setColor(4, CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "color-5": //$NON-NLS-1$
+                palette.setColor(5, CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "color-6": //$NON-NLS-1$
+                palette.setColor(6, CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "color-7": //$NON-NLS-1$
+                palette.setColor(7, CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "color-8": //$NON-NLS-1$
+                palette.setColor(8, CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "color-9": //$NON-NLS-1$
+                palette.setColor(9, CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "color-10": //$NON-NLS-1$
+                palette.setColor(10, CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "color-11": //$NON-NLS-1$
+                palette.setColor(11, CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "color-12": //$NON-NLS-1$
+                palette.setColor(12, CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "color-13": //$NON-NLS-1$
+                palette.setColor(13, CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "color-14": //$NON-NLS-1$
+                palette.setColor(14, CSSSWTColorHelper.getRGBA(value));
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/PaymentsPaletteCSSHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/PaymentsPaletteCSSHandler.java
@@ -5,6 +5,7 @@ import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.helpers.CSSSWTColorHelper;
 import org.w3c.dom.css.CSSValue;
 
+import name.abuchen.portfolio.ui.util.ColorSourceTracker;
 import name.abuchen.portfolio.ui.views.payments.PaymentsPalette;
 
 @SuppressWarnings("restriction")
@@ -14,64 +15,88 @@ public class PaymentsPaletteCSSHandler implements ICSSPropertyHandler
     public boolean applyCSSProperty(Object element, String property, CSSValue value, String pseudo, CSSEngine engine)
                     throws Exception
     {
-        if (element instanceof PaymentsPaletteElementAdapter adapter)
-        {
-            var palette = adapter.getPalette();
-            return applyTo(palette, property, value);
-        }
+        if (!(element instanceof PaymentsPaletteElementAdapter adapter))
+            return false;
 
-        return false;
-    }
+        PaymentsPalette palette = adapter.getPalette();
 
-    private boolean applyTo(PaymentsPalette palette, String property, CSSValue value)
-    {
         switch (property)
         {
             case "color-0": //$NON-NLS-1$
                 palette.setColor(0, CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("PaymentsPalette", "color-0"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
+
             case "color-1": //$NON-NLS-1$
                 palette.setColor(1, CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("PaymentsPalette", "color-1"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
+
             case "color-2": //$NON-NLS-1$
                 palette.setColor(2, CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("PaymentsPalette", "color-2"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
+
             case "color-3": //$NON-NLS-1$
                 palette.setColor(3, CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("PaymentsPalette", "color-3"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
+
             case "color-4": //$NON-NLS-1$
                 palette.setColor(4, CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("PaymentsPalette", "color-4"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
+
             case "color-5": //$NON-NLS-1$
                 palette.setColor(5, CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("PaymentsPalette", "color-5"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
+
             case "color-6": //$NON-NLS-1$
                 palette.setColor(6, CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("PaymentsPalette", "color-6"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
+
             case "color-7": //$NON-NLS-1$
                 palette.setColor(7, CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("PaymentsPalette", "color-7"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
+
             case "color-8": //$NON-NLS-1$
                 palette.setColor(8, CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("PaymentsPalette", "color-8"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
+
             case "color-9": //$NON-NLS-1$
                 palette.setColor(9, CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("PaymentsPalette", "color-9"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
+
             case "color-10": //$NON-NLS-1$
                 palette.setColor(10, CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("PaymentsPalette", "color-10"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
+
             case "color-11": //$NON-NLS-1$
                 palette.setColor(11, CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("PaymentsPalette", "color-11"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
+
             case "color-12": //$NON-NLS-1$
                 palette.setColor(12, CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("PaymentsPalette", "color-12"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
+
             case "color-13": //$NON-NLS-1$
                 palette.setColor(13, CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("PaymentsPalette", "color-13"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
+
             case "color-14": //$NON-NLS-1$
                 palette.setColor(14, CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("PaymentsPalette", "color-14"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
+
             default:
                 return false;
         }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/PaymentsPaletteElementAdapter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/PaymentsPaletteElementAdapter.java
@@ -1,0 +1,70 @@
+package name.abuchen.portfolio.ui.theme;
+
+import org.eclipse.e4.ui.css.core.dom.ElementAdapter;
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import name.abuchen.portfolio.ui.views.payments.PaymentsPalette;
+
+@SuppressWarnings("restriction")
+public class PaymentsPaletteElementAdapter extends ElementAdapter
+{
+    public PaymentsPaletteElementAdapter(PaymentsPalette palette, CSSEngine engine)
+    {
+        super(palette, engine);
+    }
+
+    public PaymentsPalette getPalette()
+    {
+        return (PaymentsPalette) getNativeWidget();
+    }
+
+    @Override
+    public String getCSSId()
+    {
+        return null;
+    }
+
+    @Override
+    public String getCSSClass()
+    {
+        return "payments"; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getCSSStyle()
+    {
+        return null;
+    }
+
+    @Override
+    public Node getParentNode()
+    {
+        return null;
+    }
+
+    @Override
+    public NodeList getChildNodes()
+    {
+        return null;
+    }
+
+    @Override
+    public String getNamespaceURI()
+    {
+        return null;
+    }
+
+    @Override
+    public String getLocalName()
+    {
+        return "ColorPalette"; //$NON-NLS-1$
+    }
+
+    @Override
+    public String getAttribute(String name)
+    {
+        return ""; //$NON-NLS-1$
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/PortfolioBalanceChartCSSHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/PortfolioBalanceChartCSSHandler.java
@@ -1,75 +1,71 @@
 package name.abuchen.portfolio.ui.theme;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.eclipse.e4.ui.css.core.dom.properties.ICSSPropertyHandler;
 import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.helpers.CSSSWTColorHelper;
 import org.eclipse.swt.graphics.Color;
 import org.w3c.dom.css.CSSValue;
 
+import name.abuchen.portfolio.ui.util.ColorSourceTracker;
 import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.views.PortfolioBalanceChart;
 
 /**
  * The PortfolioChartCSSHandler class is responsible for customizing the visual
- * appearance of PortfolioChart elements using CSS properties. It uses a mapping
- * of CSS properties to color setters to apply the specified colors to
- * corresponding elements within the chart.
+ * appearance of PortfolioChart elements using CSS properties.
  */
 @SuppressWarnings("restriction")
 public class PortfolioBalanceChartCSSHandler implements ICSSPropertyHandler
 {
-    private interface ColorSetter
-    {
-        /**
-         * Sets the color on the PortfolioChart element.
-         */
-        void setColor(PortfolioBalanceChart chart, CSSValue value);
-    }
-
-    private final Map<String, ColorSetter> propertyMap = new HashMap<>();
-
-    public PortfolioBalanceChartCSSHandler()
-    {
-        initializePropertyMap();
-    }
-
-    private void initializePropertyMap()
-    {
-        propertyMap.put("totals-color", //$NON-NLS-1$
-                        (chart, value) -> chart.setTotalsColor(getColor(value)));
-        propertyMap.put("invested-capital-color", //$NON-NLS-1$
-                        (chart, value) -> chart.setAbsoluteInvestedCapitalColor(getColor(value)));
-        propertyMap.put("absolute-delta-color", //$NON-NLS-1$
-                        (chart, value) -> chart.setAbsoluteDeltaColor(getColor(value)));
-        propertyMap.put("taxes-accumulated-color", //$NON-NLS-1$
-                        (chart, value) -> chart.setTaxesAccumulatedColor(getColor(value)));
-        propertyMap.put("fees-accumulated-color", //$NON-NLS-1$
-                        (chart, value) -> chart.setFeesAccumulatedColor(getColor(value)));
-        propertyMap.put("delta-area-positive-color", //$NON-NLS-1$
-                        (chart, value) -> chart.setDeltaAreaPositive(getColor(value)));
-        propertyMap.put("delta-area-negative-color", //$NON-NLS-1$
-                        (chart, value) -> chart.setDeltaAreaNegative(getColor(value)));
-    }
-
     @Override
     public boolean applyCSSProperty(Object element, String property, CSSValue value, String pseudo, CSSEngine engine)
                     throws Exception
     {
-        if (element instanceof PortfolioBalanceChartElementAdapter adapter)
+        if (!(element instanceof PortfolioBalanceChartElementAdapter adapter))
+            return false;
+
+        PortfolioBalanceChart chart = adapter.getPortfolioChart();
+
+        switch (property)
         {
-            PortfolioBalanceChart chart = adapter.getPortfolioChart();
-            ColorSetter colorSetter = propertyMap.get(property);
+            case "totals-color": //$NON-NLS-1$
+                chart.setTotalsColor(getColor(value));
+                ColorSourceTracker.markCssApplied("PortfolioBalanceChart", "totals-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
 
-            if (colorSetter != null)
-            {
-                colorSetter.setColor(chart, value);
-            }
+            case "invested-capital-color": //$NON-NLS-1$
+                chart.setAbsoluteInvestedCapitalColor(getColor(value));
+                ColorSourceTracker.markCssApplied("PortfolioBalanceChart", "invested-capital-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "absolute-delta-color": //$NON-NLS-1$
+                chart.setAbsoluteDeltaColor(getColor(value));
+                ColorSourceTracker.markCssApplied("PortfolioBalanceChart", "absolute-delta-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "taxes-accumulated-color": //$NON-NLS-1$
+                chart.setTaxesAccumulatedColor(getColor(value));
+                ColorSourceTracker.markCssApplied("PortfolioBalanceChart", "taxes-accumulated-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "fees-accumulated-color": //$NON-NLS-1$
+                chart.setFeesAccumulatedColor(getColor(value));
+                ColorSourceTracker.markCssApplied("PortfolioBalanceChart", "fees-accumulated-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "delta-area-positive-color": //$NON-NLS-1$
+                chart.setDeltaAreaPositive(getColor(value));
+                ColorSourceTracker.markCssApplied("PortfolioBalanceChart", "delta-area-positive-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "delta-area-negative-color": //$NON-NLS-1$
+                chart.setDeltaAreaNegative(getColor(value));
+                ColorSourceTracker.markCssApplied("PortfolioBalanceChart", "delta-area-negative-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            default:
+                return false;
         }
-
-        return false;
     }
 
     /**
@@ -79,5 +75,4 @@ public class PortfolioBalanceChartCSSHandler implements ICSSPropertyHandler
     {
         return Colors.getColor(CSSSWTColorHelper.getRGBA(value).rgb);
     }
-
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/PortfolioBalanceChartCSSHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/PortfolioBalanceChartCSSHandler.java
@@ -38,11 +38,20 @@ public class PortfolioBalanceChartCSSHandler implements ICSSPropertyHandler
 
     private void initializePropertyMap()
     {
+        propertyMap.put("totals-color", //$NON-NLS-1$
+                        (chart, value) -> chart.setTotalsColor(getColor(value)));
         propertyMap.put("invested-capital-color", //$NON-NLS-1$
                         (chart, value) -> chart.setAbsoluteInvestedCapitalColor(getColor(value)));
-        propertyMap.put("absolute-delta-color", (chart, value) -> chart.setAbsoluteDeltaColor(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("delta-area-positive-color", (chart, value) -> chart.setDeltaAreaPositive(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("delta-area-negative-color", (chart, value) -> chart.setDeltaAreaNegative(getColor(value))); //$NON-NLS-1$
+        propertyMap.put("absolute-delta-color", //$NON-NLS-1$
+                        (chart, value) -> chart.setAbsoluteDeltaColor(getColor(value)));
+        propertyMap.put("taxes-accumulated-color", //$NON-NLS-1$
+                        (chart, value) -> chart.setTaxesAccumulatedColor(getColor(value)));
+        propertyMap.put("fees-accumulated-color", //$NON-NLS-1$
+                        (chart, value) -> chart.setFeesAccumulatedColor(getColor(value)));
+        propertyMap.put("delta-area-positive-color", //$NON-NLS-1$
+                        (chart, value) -> chart.setDeltaAreaPositive(getColor(value)));
+        propertyMap.put("delta-area-negative-color", //$NON-NLS-1$
+                        (chart, value) -> chart.setDeltaAreaNegative(getColor(value)));
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/SecuritiesChartCSSHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/SecuritiesChartCSSHandler.java
@@ -1,104 +1,180 @@
 package name.abuchen.portfolio.ui.theme;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.eclipse.e4.ui.css.core.dom.properties.ICSSPropertyHandler;
 import org.eclipse.e4.ui.css.core.engine.CSSEngine;
 import org.eclipse.e4.ui.css.swt.helpers.CSSSWTColorHelper;
 import org.eclipse.swt.graphics.Color;
 import org.w3c.dom.css.CSSValue;
 
+import name.abuchen.portfolio.ui.util.ColorSourceTracker;
 import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.views.SecuritiesChart;
 
 /**
  * The SecuritiesChartCSSHandler class is responsible for customizing the visual
- * appearance of SecuritiesChart elements using CSS properties. It uses a
- * mapping of CSS properties to color setters to apply the specified colors to
- * corresponding elements within the chart.
+ * appearance of SecuritiesChart elements using CSS properties.
  */
 @SuppressWarnings("restriction")
 public class SecuritiesChartCSSHandler implements ICSSPropertyHandler
 {
-    private interface ColorSetter
-    {
-        /**
-         * Sets the color on the SecuritiesChart element.
-         */
-        void setColor(SecuritiesChart chart, CSSValue value);
-    }
-
-    private final Map<String, ColorSetter> propertyMap = new HashMap<>();
-
-    public SecuritiesChartCSSHandler()
-    {
-        initializePropertyMap();
-    }
-
-    private void initializePropertyMap()
-    {
-        propertyMap.put("quote-color", (chart, value) -> chart.setQuoteColor(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("quote-area-positive-color", (chart, value) -> chart.setQuoteAreaPositive(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("quote-area-negative-color", (chart, value) -> chart.setQuoteAreaNegative(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("purchase-event-color", (chart, value) -> chart.setPurchaseColor(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("sale-event-color", (chart, value) -> chart.setSaleColor(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("dividend-event-color", (chart, value) -> chart.setDividendColor(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("extreme-marker-high-color", //$NON-NLS-1$
-                        (chart, value) -> chart.setExtremeMarkerHighColor(getColor(value)));
-        propertyMap.put("extreme-marker-low-color", (chart, value) -> chart.setExtremeMarkerLowColor(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("non-trading-color", (chart, value) -> chart.setNonTradingColor(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("shares-held-color", (chart, value) -> chart.setSharesHeldColor(getColor(value))); //$NON-NLS-1$
-
-        propertyMap.put("fifo-purchase-price-color", //$NON-NLS-1$
-                        (chart, value) -> chart.setFifoPurchasePriceColor(getColor(value)));
-        propertyMap.put("moving-average-purchase-price-color", //$NON-NLS-1$
-                        (chart, value) -> chart.setMovingAveragePurchasePriceColor(getColor(value)));
-        propertyMap.put("bollinger-bands-color", //$NON-NLS-1$
-                        (chart, value) -> chart.setBollingerBandsColor(getColor(value)));
-        propertyMap.put("macd-color", (chart, value) -> chart.setMacdColor(getColor(value))); //$NON-NLS-1$
-
-        propertyMap.put("sma-1-color", (chart, value) -> chart.setSma1Color(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("sma-2-color", (chart, value) -> chart.setSma2Color(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("sma-3-color", (chart, value) -> chart.setSma3Color(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("sma-4-color", (chart, value) -> chart.setSma4Color(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("sma-5-color", (chart, value) -> chart.setSma5Color(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("sma-6-color", (chart, value) -> chart.setSma6Color(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("sma-7-color", (chart, value) -> chart.setSma7Color(getColor(value))); //$NON-NLS-1$
-
-        propertyMap.put("ema-1-color", (chart, value) -> chart.setEma1Color(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("ema-2-color", (chart, value) -> chart.setEma2Color(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("ema-3-color", (chart, value) -> chart.setEma3Color(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("ema-4-color", (chart, value) -> chart.setEma4Color(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("ema-5-color", (chart, value) -> chart.setEma5Color(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("ema-6-color", (chart, value) -> chart.setEma6Color(getColor(value))); //$NON-NLS-1$
-        propertyMap.put("ema-7-color", (chart, value) -> chart.setEma7Color(getColor(value))); //$NON-NLS-1$
-    }
-
     @Override
     public boolean applyCSSProperty(Object element, String property, CSSValue value, String pseudo, CSSEngine engine)
                     throws Exception
     {
-        if (element instanceof SecuritiesChartElementAdapter adapter)
+        if (!(element instanceof SecuritiesChartElementAdapter adapter))
+            return false;
+
+        SecuritiesChart chart = adapter.getSecuritiesChart();
+
+        switch (property)
         {
-            SecuritiesChart chart = adapter.getSecuritiesChart();
-            ColorSetter colorSetter = propertyMap.get(property);
+            case "quote-color": //$NON-NLS-1$
+                chart.setQuoteColor(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "quote-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
 
-            if (colorSetter != null)
-            {
-                colorSetter.setColor(chart, value);
-            }
+            case "quote-area-positive-color": //$NON-NLS-1$
+                chart.setQuoteAreaPositive(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "quote-area-positive-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "quote-area-negative-color": //$NON-NLS-1$
+                chart.setQuoteAreaNegative(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "quote-area-negative-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "purchase-event-color": //$NON-NLS-1$
+                chart.setPurchaseColor(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "purchase-event-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "sale-event-color": //$NON-NLS-1$
+                chart.setSaleColor(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "sale-event-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "dividend-event-color": //$NON-NLS-1$
+                chart.setDividendColor(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "dividend-event-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "extreme-marker-high-color": //$NON-NLS-1$
+                chart.setExtremeMarkerHighColor(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "extreme-marker-high-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "extreme-marker-low-color": //$NON-NLS-1$
+                chart.setExtremeMarkerLowColor(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "extreme-marker-low-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "non-trading-color": //$NON-NLS-1$
+                chart.setNonTradingColor(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "non-trading-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "shares-held-color": //$NON-NLS-1$
+                chart.setSharesHeldColor(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "shares-held-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "fifo-purchase-price-color": //$NON-NLS-1$
+                chart.setFifoPurchasePriceColor(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "fifo-purchase-price-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "moving-average-purchase-price-color": //$NON-NLS-1$
+                chart.setMovingAveragePurchasePriceColor(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "moving-average-purchase-price-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "bollinger-bands-color": //$NON-NLS-1$
+                chart.setBollingerBandsColor(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "bollinger-bands-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "macd-color": //$NON-NLS-1$
+                chart.setMacdColor(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "macd-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "sma-1-color": //$NON-NLS-1$
+                chart.setSma1Color(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "sma-1-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "sma-2-color": //$NON-NLS-1$
+                chart.setSma2Color(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "sma-2-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "sma-3-color": //$NON-NLS-1$
+                chart.setSma3Color(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "sma-3-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "sma-4-color": //$NON-NLS-1$
+                chart.setSma4Color(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "sma-4-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "sma-5-color": //$NON-NLS-1$
+                chart.setSma5Color(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "sma-5-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "sma-6-color": //$NON-NLS-1$
+                chart.setSma6Color(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "sma-6-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "sma-7-color": //$NON-NLS-1$
+                chart.setSma7Color(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "sma-7-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "ema-1-color": //$NON-NLS-1$
+                chart.setEma1Color(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "ema-1-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "ema-2-color": //$NON-NLS-1$
+                chart.setEma2Color(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "ema-2-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "ema-3-color": //$NON-NLS-1$
+                chart.setEma3Color(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "ema-3-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "ema-4-color": //$NON-NLS-1$
+                chart.setEma4Color(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "ema-4-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "ema-5-color": //$NON-NLS-1$
+                chart.setEma5Color(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "ema-5-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "ema-6-color": //$NON-NLS-1$
+                chart.setEma6Color(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "ema-6-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            case "ema-7-color": //$NON-NLS-1$
+                chart.setEma7Color(getColor(value));
+                ColorSourceTracker.markCssApplied("SecuritiesChart", "ema-7-color"); //$NON-NLS-1$ //$NON-NLS-2$
+                return true;
+
+            default:
+                return false;
         }
-
-        return false;
     }
 
-    /**
-     * Converts a CSSValue to a Color.
-     */
     private Color getColor(CSSValue value)
     {
         return Colors.getColor(CSSSWTColorHelper.getRGBA(value).rgb);
     }
-
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/SecuritiesChartCSSHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/SecuritiesChartCSSHandler.java
@@ -49,6 +49,30 @@ public class SecuritiesChartCSSHandler implements ICSSPropertyHandler
         propertyMap.put("extreme-marker-low-color", (chart, value) -> chart.setExtremeMarkerLowColor(getColor(value))); //$NON-NLS-1$
         propertyMap.put("non-trading-color", (chart, value) -> chart.setNonTradingColor(getColor(value))); //$NON-NLS-1$
         propertyMap.put("shares-held-color", (chart, value) -> chart.setSharesHeldColor(getColor(value))); //$NON-NLS-1$
+
+        propertyMap.put("fifo-purchase-price-color", //$NON-NLS-1$
+                        (chart, value) -> chart.setFifoPurchasePriceColor(getColor(value)));
+        propertyMap.put("moving-average-purchase-price-color", //$NON-NLS-1$
+                        (chart, value) -> chart.setMovingAveragePurchasePriceColor(getColor(value)));
+        propertyMap.put("bollinger-bands-color", //$NON-NLS-1$
+                        (chart, value) -> chart.setBollingerBandsColor(getColor(value)));
+        propertyMap.put("macd-color", (chart, value) -> chart.setMacdColor(getColor(value))); //$NON-NLS-1$
+
+        propertyMap.put("sma-1-color", (chart, value) -> chart.setSma1Color(getColor(value))); //$NON-NLS-1$
+        propertyMap.put("sma-2-color", (chart, value) -> chart.setSma2Color(getColor(value))); //$NON-NLS-1$
+        propertyMap.put("sma-3-color", (chart, value) -> chart.setSma3Color(getColor(value))); //$NON-NLS-1$
+        propertyMap.put("sma-4-color", (chart, value) -> chart.setSma4Color(getColor(value))); //$NON-NLS-1$
+        propertyMap.put("sma-5-color", (chart, value) -> chart.setSma5Color(getColor(value))); //$NON-NLS-1$
+        propertyMap.put("sma-6-color", (chart, value) -> chart.setSma6Color(getColor(value))); //$NON-NLS-1$
+        propertyMap.put("sma-7-color", (chart, value) -> chart.setSma7Color(getColor(value))); //$NON-NLS-1$
+
+        propertyMap.put("ema-1-color", (chart, value) -> chart.setEma1Color(getColor(value))); //$NON-NLS-1$
+        propertyMap.put("ema-2-color", (chart, value) -> chart.setEma2Color(getColor(value))); //$NON-NLS-1$
+        propertyMap.put("ema-3-color", (chart, value) -> chart.setEma3Color(getColor(value))); //$NON-NLS-1$
+        propertyMap.put("ema-4-color", (chart, value) -> chart.setEma4Color(getColor(value))); //$NON-NLS-1$
+        propertyMap.put("ema-5-color", (chart, value) -> chart.setEma5Color(getColor(value))); //$NON-NLS-1$
+        propertyMap.put("ema-6-color", (chart, value) -> chart.setEma6Color(getColor(value))); //$NON-NLS-1$
+        propertyMap.put("ema-7-color", (chart, value) -> chart.setEma7Color(getColor(value))); //$NON-NLS-1$
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ThemeAddon.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ThemeAddon.java
@@ -9,8 +9,11 @@ import org.eclipse.e4.ui.di.UIEventTopic;
 import org.osgi.service.event.Event;
 
 import name.abuchen.portfolio.ui.UIConstants;
+import name.abuchen.portfolio.ui.util.ColorGradientDefinitions;
 import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.DataSeriesColors;
 import name.abuchen.portfolio.ui.util.ValueColorScheme;
+import name.abuchen.portfolio.ui.views.payments.PaymentsPalette;
 
 @SuppressWarnings("restriction")
 public class ThemeAddon
@@ -24,6 +27,10 @@ public class ThemeAddon
     {
         IThemeEngine engine = (IThemeEngine) event.getProperty(IThemeEngine.Events.THEME_ENGINE);
         engine.applyStyles(Colors.theme(), false);
+        engine.applyStyles(DataSeriesColors.instance(), false);
+        engine.applyStyles(PaymentsPalette.instance(), false);
+        engine.applyStyles(ColorGradientDefinitions.redToGreen(), false);
+        engine.applyStyles(ColorGradientDefinitions.orangeToBlue(), false);
 
         for (var scheme : ValueColorScheme.getAvailableSchemes())
             engine.applyStyles(scheme, false);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ThemeAddon.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ThemeAddon.java
@@ -31,6 +31,9 @@ public class ThemeAddon
         engine.applyStyles(PaymentsPalette.instance(), false);
         engine.applyStyles(ColorGradientDefinitions.redToGreen(), false);
         engine.applyStyles(ColorGradientDefinitions.orangeToBlue(), false);
+        engine.applyStyles(ColorGradientDefinitions.greenYellowRed(), false);
+        engine.applyStyles(ColorGradientDefinitions.greenWhiteRed(), false);
+        engine.applyStyles(ColorGradientDefinitions.yellowWhiteBlack(), false);
 
         for (var scheme : ValueColorScheme.getAvailableSchemes())
             engine.applyStyles(scheme, false);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ValueColorSchemeCSSHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ValueColorSchemeCSSHandler.java
@@ -6,6 +6,7 @@ import org.eclipse.e4.ui.css.swt.helpers.CSSSWTColorHelper;
 import org.w3c.dom.css.CSSPrimitiveValue;
 import org.w3c.dom.css.CSSValue;
 
+import name.abuchen.portfolio.ui.util.ColorSourceTracker;
 import name.abuchen.portfolio.ui.util.ValueColorScheme;
 
 @SuppressWarnings("restriction")
@@ -30,9 +31,11 @@ public class ValueColorSchemeCSSHandler implements ICSSPropertyHandler
         {
             case "positive-foreground": //$NON-NLS-1$
                 scheme.setPositiveForeground(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("ValueColorScheme." + scheme.getIdentifier(), "positive-foreground"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "negative-foreground": //$NON-NLS-1$
                 scheme.setNegativeForeground(CSSSWTColorHelper.getRGBA(value));
+                ColorSourceTracker.markCssApplied("ValueColorScheme." + scheme.getIdentifier(), "negative-foreground"); //$NON-NLS-1$ //$NON-NLS-2$
                 return true;
             case "up-arrow": //$NON-NLS-1$
                 var upArrow = getText(value);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ColorGradient.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ColorGradient.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.ui.util;
 
+import java.util.function.Supplier;
+
 import org.eclipse.swt.graphics.Color;
 
 /**
@@ -20,33 +22,24 @@ public class ColorGradient
         }
     }
 
-    public static final ColorGradient RED_TO_GREEN = new ColorGradient( //
-                    Colors.getColor(201, 46, 37), // C92E25
-                    Colors.getColor(253, 127, 118), // FD7F76
-                    Colors.getColor(253, 154, 147), // FD9A93
-                    Colors.getColor(252, 187, 183), // FCBBB7
-                    Colors.getColor(232, 232, 232), // E8E8E8
-                    Colors.getColor(187, 228, 145), // BBE491
-                    Colors.getColor(161, 215, 113), // A1D771
-                    Colors.getColor(128, 194, 94), // 80C25E
-                    Colors.getColor(57, 123, 39) // 397B27
-    );
-
-    public static final ColorGradient ORANGE_TO_BLUE = new ColorGradient( //
-                    Colors.getColor(179, 110, 58), // B36E3A
-                    Colors.getColor(253, 156, 82), // FD9C52
-                    Colors.getColor(255, 206, 170), // FFCEAA
-                    Colors.getColor(221, 221, 221), // DDDDDD
-                    Colors.getColor(158, 203, 236), // 9ECBEC
-                    Colors.getColor(60, 151, 218), // 3C97DA
-                    Colors.getColor(42, 105, 153) // 2A6999
-    );
+    public static final ColorGradient RED_TO_GREEN = new ColorGradient(
+                    () -> ColorGradientDefinitions.redToGreen().getGradient().getColors());
+    public static final ColorGradient ORANGE_TO_BLUE = new ColorGradient(
+                    () -> ColorGradientDefinitions.orangeToBlue().getGradient().getColors());
+    public static final ColorGradient GREEN_YELLOW_RED = new ColorGradient(
+                    () -> ColorGradientDefinitions.greenYellowRed().getGradient().getColors());
+    public static final ColorGradient GREEN_WHITE_RED = new ColorGradient(
+                    () -> ColorGradientDefinitions.greenWhiteRed().getGradient().getColors());
+    public static final ColorGradient YELLOW_WHITE_BLACK = new ColorGradient(
+                    () -> ColorGradientDefinitions.yellowWhiteBlack().getGradient().getColors());
 
     private final ColorPoint[] colors;
+    private final Supplier<ColorPoint[]> dynamicColorsSupplier;
 
     public ColorGradient(ColorPoint... colors)
     {
         this.colors = colors;
+        this.dynamicColorsSupplier = null;
     }
 
     public ColorGradient(Color... colors)
@@ -54,22 +47,36 @@ public class ColorGradient
         this.colors = new ColorPoint[colors.length];
         for (int ii = 0; ii < colors.length; ii++)
             this.colors[ii] = new ColorPoint(colors[ii], ii / (float) (colors.length - 1));
+        this.dynamicColorsSupplier = null;
+    }
+
+    private ColorGradient(Supplier<ColorPoint[]> dynamicColorsSupplier)
+    {
+        this.colors = null;
+        this.dynamicColorsSupplier = dynamicColorsSupplier;
+    }
+
+    private ColorPoint[] getColors()
+    {
+        return dynamicColorsSupplier != null ? dynamicColorsSupplier.get() : colors;
     }
 
     public Color getColorAt(float value)
     {
+        var effectiveColors = getColors();
+
         if (value <= 0)
-            return colors[0].color;
+            return effectiveColors[0].color;
 
         if (value >= 1)
-            return colors[colors.length - 1].color;
+            return effectiveColors[effectiveColors.length - 1].color;
 
-        for (int ii = 0; ii < colors.length; ii++)
+        for (int ii = 0; ii < effectiveColors.length; ii++)
         {
-            var current = colors[ii];
+            var current = effectiveColors[ii];
             if (value <= current.position)
             {
-                var previous = colors[Math.max(0, ii - 1)];
+                var previous = effectiveColors[Math.max(0, ii - 1)];
                 var diff = current.position - previous.position;
                 if (diff == 0)
                     return current.color;
@@ -79,6 +86,6 @@ public class ColorGradient
             }
         }
 
-        return colors[colors.length - 1].color;
+        return effectiveColors[effectiveColors.length - 1].color;
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ColorGradientDefinitions.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ColorGradientDefinitions.java
@@ -10,10 +10,10 @@ public final class ColorGradientDefinitions
         private final String cssClass;
         private final Color[] colors;
 
-        private Definition(String cssClass, Color... colors)
+        private Definition(String cssClass, int size)
         {
             this.cssClass = cssClass;
-            this.colors = colors;
+            this.colors = new Color[size];
         }
 
         public String getCssClass()
@@ -23,6 +23,12 @@ public final class ColorGradientDefinitions
 
         public ColorGradient getGradient()
         {
+            for (Color color : colors)
+            {
+                if (color == null)
+                    throw new IllegalStateException("ColorGradient '" + cssClass + "' is not initialized from CSS"); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+
             return new ColorGradient(colors);
         }
 
@@ -32,41 +38,15 @@ public final class ColorGradientDefinitions
         }
     }
 
-    private static final Definition RED_TO_GREEN = new Definition("red-to-green", //$NON-NLS-1$
-                    Colors.getColor(201, 46, 37), //
-                    Colors.getColor(253, 127, 118), //
-                    Colors.getColor(253, 154, 147), //
-                    Colors.getColor(252, 187, 183), //
-                    Colors.getColor(232, 232, 232), //
-                    Colors.getColor(187, 228, 145), //
-                    Colors.getColor(161, 215, 113), //
-                    Colors.getColor(128, 194, 94), //
-                    Colors.getColor(57, 123, 39));
+    private static final Definition RED_TO_GREEN = new Definition("red-to-green", 9); //$NON-NLS-1$
 
-    private static final Definition ORANGE_TO_BLUE = new Definition("orange-to-blue", //$NON-NLS-1$
-                    Colors.getColor(179, 110, 58), //
-                    Colors.getColor(253, 156, 82), //
-                    Colors.getColor(255, 206, 170), //
-                    Colors.getColor(221, 221, 221), //
-                    Colors.getColor(158, 203, 236), //
-                    Colors.getColor(60, 151, 218), //
-                    Colors.getColor(42, 105, 153));
+    private static final Definition ORANGE_TO_BLUE = new Definition("orange-to-blue", 7); //$NON-NLS-1$
 
-    private static final Definition GREEN_YELLOW_RED = new Definition("green-yellow-red", //$NON-NLS-1$
-                    Colors.getColor(255, 0, 0), //
-                    Colors.getColor(255, 255, 0), //
-                    Colors.getColor(0, 255, 0));
+    private static final Definition GREEN_YELLOW_RED = new Definition("green-yellow-red", 3); //$NON-NLS-1$
 
-    private static final Definition GREEN_WHITE_RED = new Definition("green-white-red", //$NON-NLS-1$
-                    Colors.getColor(255, 0, 0), //
-                    Colors.getColor(255, 255, 255), //
-                    Colors.getColor(104, 229, 23));
+    private static final Definition GREEN_WHITE_RED = new Definition("green-white-red", 3); //$NON-NLS-1$
 
-    private static final Definition YELLOW_WHITE_BLACK = new Definition("yellow-white-black", //$NON-NLS-1$
-                    Colors.getColor(255, 255, 255), //
-                    Colors.getColor(255, 255, 0), //
-                    Colors.getColor(91, 91, 0), //
-                    Colors.getColor(0, 0, 0));
+    private static final Definition YELLOW_WHITE_BLACK = new Definition("yellow-white-black", 4); //$NON-NLS-1$
 
     private ColorGradientDefinitions()
     {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ColorGradientDefinitions.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ColorGradientDefinitions.java
@@ -1,0 +1,99 @@
+package name.abuchen.portfolio.ui.util;
+
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGBA;
+
+public final class ColorGradientDefinitions
+{
+    public static final class Definition
+    {
+        private final String cssClass;
+        private final Color[] colors;
+
+        private Definition(String cssClass, Color... colors)
+        {
+            this.cssClass = cssClass;
+            this.colors = colors;
+        }
+
+        public String getCssClass()
+        {
+            return cssClass;
+        }
+
+        public ColorGradient getGradient()
+        {
+            return new ColorGradient(colors);
+        }
+
+        public void setColor(int index, RGBA color)
+        {
+            colors[index] = Colors.getColor(color.rgb);
+        }
+    }
+
+    private static final Definition RED_TO_GREEN = new Definition("red-to-green", //$NON-NLS-1$
+                    Colors.getColor(201, 46, 37), //
+                    Colors.getColor(253, 127, 118), //
+                    Colors.getColor(253, 154, 147), //
+                    Colors.getColor(252, 187, 183), //
+                    Colors.getColor(232, 232, 232), //
+                    Colors.getColor(187, 228, 145), //
+                    Colors.getColor(161, 215, 113), //
+                    Colors.getColor(128, 194, 94), //
+                    Colors.getColor(57, 123, 39));
+
+    private static final Definition ORANGE_TO_BLUE = new Definition("orange-to-blue", //$NON-NLS-1$
+                    Colors.getColor(179, 110, 58), //
+                    Colors.getColor(253, 156, 82), //
+                    Colors.getColor(255, 206, 170), //
+                    Colors.getColor(221, 221, 221), //
+                    Colors.getColor(158, 203, 236), //
+                    Colors.getColor(60, 151, 218), //
+                    Colors.getColor(42, 105, 153));
+
+    private static final Definition GREEN_YELLOW_RED = new Definition("green-yellow-red", //$NON-NLS-1$
+                    Colors.getColor(255, 0, 0), //
+                    Colors.getColor(255, 255, 0), //
+                    Colors.getColor(0, 255, 0));
+
+    private static final Definition GREEN_WHITE_RED = new Definition("green-white-red", //$NON-NLS-1$
+                    Colors.getColor(255, 0, 0), //
+                    Colors.getColor(255, 255, 255), //
+                    Colors.getColor(104, 229, 23));
+
+    private static final Definition YELLOW_WHITE_BLACK = new Definition("yellow-white-black", //$NON-NLS-1$
+                    Colors.getColor(255, 255, 255), //
+                    Colors.getColor(255, 255, 0), //
+                    Colors.getColor(91, 91, 0), //
+                    Colors.getColor(0, 0, 0));
+
+    private ColorGradientDefinitions()
+    {
+    }
+
+    public static Definition redToGreen()
+    {
+        return RED_TO_GREEN;
+    }
+
+    public static Definition orangeToBlue()
+    {
+        return ORANGE_TO_BLUE;
+    }
+
+    public static Definition greenYellowRed()
+    {
+        return GREEN_YELLOW_RED;
+    }
+
+    public static Definition greenWhiteRed()
+    {
+        return GREEN_WHITE_RED;
+    }
+
+    public static Definition yellowWhiteBlack()
+    {
+        return YELLOW_WHITE_BLACK;
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ColorSourceTracker.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ColorSourceTracker.java
@@ -1,0 +1,51 @@
+package name.abuchen.portfolio.ui.util;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Debug-only helper to track whether a color property has been applied via CSS.
+ * This does not replace the actual color storage. It only records whether a
+ * given domain/property combination has been written by a CSS handler during
+ * runtime so that debug views can distinguish CSS-backed from fallback values.
+ */
+public final class ColorSourceTracker
+{
+    private static final Map<String, Set<String>> CSS_APPLIED = new ConcurrentHashMap<>();
+
+    private ColorSourceTracker()
+    {
+    }
+
+    public static void markCssApplied(String domain, String property)
+    {
+        CSS_APPLIED.computeIfAbsent(domain, key -> ConcurrentHashMap.newKeySet()).add(property);
+    }
+
+    public static boolean isCssApplied(String domain, String property)
+    {
+        return CSS_APPLIED.getOrDefault(domain, Collections.emptySet()).contains(property);
+    }
+
+    public static boolean hasAnyCssApplied(String domain)
+    {
+        return !CSS_APPLIED.getOrDefault(domain, Collections.emptySet()).isEmpty();
+    }
+
+    public static int countCssApplied(String domain)
+    {
+        return CSS_APPLIED.getOrDefault(domain, Collections.emptySet()).size();
+    }
+
+    public static Set<String> getAppliedProperties(String domain)
+    {
+        return Collections.unmodifiableSet(CSS_APPLIED.getOrDefault(domain, Collections.emptySet()));
+    }
+
+    public static void clear()
+    {
+        CSS_APPLIED.clear();
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/Colors.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/Colors.java
@@ -18,20 +18,28 @@ public final class Colors
      */
     public static class Theme
     {
-        private Color defaultForeground = Colors.BLACK;
-        private Color defaultBackground = Colors.WHITE;
-        private Color chipBackground = Colors.LIGHT_GRAY;
-        private Color warningBackground = Colors.LIGHT_GRAY;
-        private Color redBackground = Colors.LIGHT_GRAY;
-        private Color greenBackground = Colors.LIGHT_GRAY;
-        private Color redForeground = Colors.BLACK;
-        private Color greenForeground = Colors.BLACK;
-        private Color grayForeground = Colors.GRAY;
-        private Color hyperlink = Display.getDefault().getSystemColor(SWT.COLOR_LINK_FOREGROUND);
+        private Color defaultForeground;
+        private Color defaultBackground;
+        private Color chipBackground;
+        private Color warningBackground;
+        private Color redBackground;
+        private Color greenBackground;
+        private Color redForeground;
+        private Color greenForeground;
+        private Color grayForeground;
+        private Color hyperlink;
+
+        private Color requireConfigured(Color color, String property)
+        {
+            if (color == null)
+                throw new IllegalStateException("CSS theme color not configured: " + property); //$NON-NLS-1$
+
+            return color;
+        }
 
         public Color defaultForeground()
         {
-            return defaultForeground;
+            return requireConfigured(defaultForeground, "CustomColors.default-foreground"); //$NON-NLS-1$
         }
 
         public void setDefaultForeground(RGBA color)
@@ -41,7 +49,7 @@ public final class Colors
 
         public Color defaultBackground()
         {
-            return defaultBackground;
+            return requireConfigured(defaultBackground, "CustomColors.default-background"); //$NON-NLS-1$
         }
 
         public void setDefaultBackground(RGBA color)
@@ -51,7 +59,7 @@ public final class Colors
 
         public Color chipBackground()
         {
-            return chipBackground;
+            return requireConfigured(chipBackground, "CustomColors.chip-background"); //$NON-NLS-1$
         }
 
         public void setChipBackground(RGBA color)
@@ -61,7 +69,7 @@ public final class Colors
 
         public Color warningBackground()
         {
-            return warningBackground;
+            return requireConfigured(warningBackground, "CustomColors.warning-background"); //$NON-NLS-1$
         }
 
         public void setWarningBackground(RGBA color)
@@ -71,7 +79,7 @@ public final class Colors
 
         public Color redBackground()
         {
-            return redBackground;
+            return requireConfigured(redBackground, "CustomColors.red-background"); //$NON-NLS-1$
         }
 
         public void setRedBackground(RGBA color)
@@ -81,7 +89,7 @@ public final class Colors
 
         public Color greenBackground()
         {
-            return greenBackground;
+            return requireConfigured(greenBackground, "CustomColors.green-background"); //$NON-NLS-1$
         }
 
         public void setGreenBackground(RGBA color)
@@ -91,7 +99,7 @@ public final class Colors
 
         public Color redForeground()
         {
-            return redForeground;
+            return requireConfigured(redForeground, "CustomColors.red-foreground"); //$NON-NLS-1$
         }
 
         public void setRedForeground(RGBA color)
@@ -101,7 +109,7 @@ public final class Colors
 
         public Color greenForeground()
         {
-            return greenForeground;
+            return requireConfigured(greenForeground, "CustomColors.green-foreground"); //$NON-NLS-1$
         }
 
         public void setGreenForeground(RGBA color)
@@ -111,7 +119,7 @@ public final class Colors
 
         public Color grayForeground()
         {
-            return grayForeground;
+            return requireConfigured(grayForeground, "CustomColors.gray-foreground"); //$NON-NLS-1$
         }
 
         public void setGrayForeground(RGBA color)
@@ -121,7 +129,7 @@ public final class Colors
 
         public Color hyperlink()
         {
-            return hyperlink;
+            return requireConfigured(hyperlink, "CustomColors.hyperlink"); //$NON-NLS-1$
         }
 
         public void setHyperlink(RGBA color)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/Colors.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/Colors.java
@@ -20,13 +20,13 @@ public final class Colors
     {
         private Color defaultForeground = Colors.BLACK;
         private Color defaultBackground = Colors.WHITE;
-        private Color chipBackground = Colors.WHITE;
-        private Color warningBackground = getColor(254, 223, 107); // FEDF6B
-        private Color redBackground = Colors.RED;
-        private Color greenBackground = Colors.GREEN;
-        private Color redForeground = Colors.DARK_RED;
-        private Color greenForeground = Colors.DARK_GREEN;
-        private Color grayForeground = getColor(112, 112, 112); // 707070
+        private Color chipBackground = Colors.LIGHT_GRAY;
+        private Color warningBackground = Colors.LIGHT_GRAY;
+        private Color redBackground = Colors.LIGHT_GRAY;
+        private Color greenBackground = Colors.LIGHT_GRAY;
+        private Color redForeground = Colors.BLACK;
+        private Color greenForeground = Colors.BLACK;
+        private Color grayForeground = Colors.GRAY;
         private Color hyperlink = Display.getDefault().getSystemColor(SWT.COLOR_LINK_FOREGROUND);
 
         public Color defaultForeground()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/DataSeriesColors.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/DataSeriesColors.java
@@ -7,38 +7,38 @@ public final class DataSeriesColors
 {
     private static final DataSeriesColors INSTANCE = new DataSeriesColors();
 
-    private Color totalsColor = Colors.BLACK;
+    private Color totalsColor;
 
-    private Color investedCapitalColor = Colors.GRAY;
-    private Color absoluteInvestedCapitalColor = Colors.GRAY;
+    private Color investedCapitalColor;
+    private Color absoluteInvestedCapitalColor;
 
-    private Color transferalsColor = Colors.GRAY;
-    private Color transferalsAccumulatedColor = Colors.LIGHT_GRAY;
+    private Color transferalsColor;
+    private Color transferalsAccumulatedColor;
 
-    private Color taxesColor = Colors.GRAY;
-    private Color taxesAccumulatedColor = Colors.GRAY;
+    private Color taxesColor;
+    private Color taxesAccumulatedColor;
 
-    private Color absoluteDeltaColor = Colors.GRAY;
-    private Color absoluteDeltaAllRecordColor = Colors.GRAY;
+    private Color absoluteDeltaColor;
+    private Color absoluteDeltaAllRecordColor;
 
-    private Color dividendsColor = Colors.GRAY;
-    private Color dividendsAccumulatedColor = Colors.GRAY;
+    private Color dividendsColor;
+    private Color dividendsAccumulatedColor;
 
-    private Color interestColor = Colors.GRAY;
-    private Color interestAccumulatedColor = Colors.GRAY;
+    private Color interestColor;
+    private Color interestAccumulatedColor;
 
-    private Color interestChargeColor = Colors.GRAY;
-    private Color interestChargeAccumulatedColor = Colors.GRAY;
+    private Color interestChargeColor;
+    private Color interestChargeAccumulatedColor;
 
-    private Color earningsColor = Colors.GRAY;
-    private Color earningsAccumulatedColor = Colors.GRAY;
+    private Color earningsColor;
+    private Color earningsAccumulatedColor;
 
-    private Color feesColor = Colors.GRAY;
-    private Color feesAccumulatedColor = Colors.GRAY;
+    private Color feesColor;
+    private Color feesAccumulatedColor;
 
-    private Color performanceEntirePortfolioColor = Colors.BLACK;
-    private Color performancePositiveColor = Colors.GRAY;
-    private Color performanceNegativeColor = Colors.GRAY;
+    private Color performanceEntirePortfolioColor;
+    private Color performancePositiveColor;
+    private Color performanceNegativeColor;
 
     private DataSeriesColors()
     {
@@ -49,9 +49,17 @@ public final class DataSeriesColors
         return INSTANCE;
     }
 
+    private Color requireConfigured(Color color, String property)
+    {
+        if (color == null)
+            throw new IllegalStateException("CSS data series color not configured: " + property); //$NON-NLS-1$
+
+        return color;
+    }
+
     public Color totalsColor()
     {
-        return totalsColor;
+        return requireConfigured(totalsColor, "DataSeries.totals-color"); //$NON-NLS-1$
     }
 
     public void setTotalsColor(RGBA color)
@@ -61,7 +69,7 @@ public final class DataSeriesColors
 
     public Color investedCapitalColor()
     {
-        return investedCapitalColor;
+        return requireConfigured(investedCapitalColor, "DataSeries.invested-capital-color"); //$NON-NLS-1$
     }
 
     public void setInvestedCapitalColor(RGBA color)
@@ -71,7 +79,7 @@ public final class DataSeriesColors
 
     public Color absoluteInvestedCapitalColor()
     {
-        return absoluteInvestedCapitalColor;
+        return requireConfigured(absoluteInvestedCapitalColor, "DataSeries.absolute-invested-capital-color"); //$NON-NLS-1$
     }
 
     public void setAbsoluteInvestedCapitalColor(RGBA color)
@@ -81,7 +89,7 @@ public final class DataSeriesColors
 
     public Color transferalsColor()
     {
-        return transferalsColor;
+        return requireConfigured(transferalsColor, "DataSeries.transferals-color"); //$NON-NLS-1$
     }
 
     public void setTransferalsColor(RGBA color)
@@ -91,7 +99,7 @@ public final class DataSeriesColors
 
     public Color transferalsAccumulatedColor()
     {
-        return transferalsAccumulatedColor;
+        return requireConfigured(transferalsAccumulatedColor, "DataSeries.transferals-accumulated-color"); //$NON-NLS-1$
     }
 
     public void setTransferalsAccumulatedColor(RGBA color)
@@ -101,7 +109,7 @@ public final class DataSeriesColors
 
     public Color taxesColor()
     {
-        return taxesColor;
+        return requireConfigured(taxesColor, "DataSeries.taxes-color"); //$NON-NLS-1$
     }
 
     public void setTaxesColor(RGBA color)
@@ -111,7 +119,7 @@ public final class DataSeriesColors
 
     public Color taxesAccumulatedColor()
     {
-        return taxesAccumulatedColor;
+        return requireConfigured(taxesAccumulatedColor, "DataSeries.taxes-accumulated-color"); //$NON-NLS-1$
     }
 
     public void setTaxesAccumulatedColor(RGBA color)
@@ -121,7 +129,7 @@ public final class DataSeriesColors
 
     public Color absoluteDeltaColor()
     {
-        return absoluteDeltaColor;
+        return requireConfigured(absoluteDeltaColor, "DataSeries.absolute-delta-color"); //$NON-NLS-1$
     }
 
     public void setAbsoluteDeltaColor(RGBA color)
@@ -131,7 +139,7 @@ public final class DataSeriesColors
 
     public Color absoluteDeltaAllRecordColor()
     {
-        return absoluteDeltaAllRecordColor;
+        return requireConfigured(absoluteDeltaAllRecordColor, "DataSeries.absolute-delta-all-record-color"); //$NON-NLS-1$
     }
 
     public void setAbsoluteDeltaAllRecordColor(RGBA color)
@@ -141,7 +149,7 @@ public final class DataSeriesColors
 
     public Color dividendsColor()
     {
-        return dividendsColor;
+        return requireConfigured(dividendsColor, "DataSeries.dividends-color"); //$NON-NLS-1$
     }
 
     public void setDividendsColor(RGBA color)
@@ -151,7 +159,7 @@ public final class DataSeriesColors
 
     public Color dividendsAccumulatedColor()
     {
-        return dividendsAccumulatedColor;
+        return requireConfigured(dividendsAccumulatedColor, "DataSeries.dividends-accumulated-color"); //$NON-NLS-1$
     }
 
     public void setDividendsAccumulatedColor(RGBA color)
@@ -161,7 +169,7 @@ public final class DataSeriesColors
 
     public Color interestColor()
     {
-        return interestColor;
+        return requireConfigured(interestColor, "DataSeries.interest-color"); //$NON-NLS-1$
     }
 
     public void setInterestColor(RGBA color)
@@ -171,7 +179,7 @@ public final class DataSeriesColors
 
     public Color interestAccumulatedColor()
     {
-        return interestAccumulatedColor;
+        return requireConfigured(interestAccumulatedColor, "DataSeries.interest-accumulated-color"); //$NON-NLS-1$
     }
 
     public void setInterestAccumulatedColor(RGBA color)
@@ -181,7 +189,7 @@ public final class DataSeriesColors
 
     public Color interestChargeColor()
     {
-        return interestChargeColor;
+        return requireConfigured(interestChargeColor, "DataSeries.interest-charge-color"); //$NON-NLS-1$
     }
 
     public void setInterestChargeColor(RGBA color)
@@ -191,7 +199,7 @@ public final class DataSeriesColors
 
     public Color interestChargeAccumulatedColor()
     {
-        return interestChargeAccumulatedColor;
+        return requireConfigured(interestChargeAccumulatedColor, "DataSeries.interest-charge-accumulated-color"); //$NON-NLS-1$
     }
 
     public void setInterestChargeAccumulatedColor(RGBA color)
@@ -201,7 +209,7 @@ public final class DataSeriesColors
 
     public Color earningsColor()
     {
-        return earningsColor;
+        return requireConfigured(earningsColor, "DataSeries.earnings-color"); //$NON-NLS-1$
     }
 
     public void setEarningsColor(RGBA color)
@@ -211,7 +219,7 @@ public final class DataSeriesColors
 
     public Color earningsAccumulatedColor()
     {
-        return earningsAccumulatedColor;
+        return requireConfigured(earningsAccumulatedColor, "DataSeries.earnings-accumulated-color"); //$NON-NLS-1$
     }
 
     public void setEarningsAccumulatedColor(RGBA color)
@@ -221,7 +229,7 @@ public final class DataSeriesColors
 
     public Color feesColor()
     {
-        return feesColor;
+        return requireConfigured(feesColor, "DataSeries.fees-color"); //$NON-NLS-1$
     }
 
     public void setFeesColor(RGBA color)
@@ -231,7 +239,7 @@ public final class DataSeriesColors
 
     public Color feesAccumulatedColor()
     {
-        return feesAccumulatedColor;
+        return requireConfigured(feesAccumulatedColor, "DataSeries.fees-accumulated-color"); //$NON-NLS-1$
     }
 
     public void setFeesAccumulatedColor(RGBA color)
@@ -241,7 +249,7 @@ public final class DataSeriesColors
 
     public Color performanceEntirePortfolioColor()
     {
-        return performanceEntirePortfolioColor;
+        return requireConfigured(performanceEntirePortfolioColor, "DataSeries.performance-entire-portfolio-color"); //$NON-NLS-1$
     }
 
     public void setPerformanceEntirePortfolioColor(RGBA color)
@@ -251,7 +259,7 @@ public final class DataSeriesColors
 
     public Color performancePositiveColor()
     {
-        return performancePositiveColor;
+        return requireConfigured(performancePositiveColor, "DataSeries.performance-positive-color"); //$NON-NLS-1$
     }
 
     public void setPerformancePositiveColor(RGBA color)
@@ -261,7 +269,7 @@ public final class DataSeriesColors
 
     public Color performanceNegativeColor()
     {
-        return performanceNegativeColor;
+        return requireConfigured(performanceNegativeColor, "DataSeries.performance-negative-color"); //$NON-NLS-1$
     }
 
     public void setPerformanceNegativeColor(RGBA color)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/DataSeriesColors.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/DataSeriesColors.java
@@ -1,0 +1,271 @@
+package name.abuchen.portfolio.ui.util;
+
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGBA;
+
+public final class DataSeriesColors
+{
+    private static final DataSeriesColors INSTANCE = new DataSeriesColors();
+
+    private Color totalsColor = Colors.BLACK;
+
+    private Color investedCapitalColor = Colors.GRAY;
+    private Color absoluteInvestedCapitalColor = Colors.GRAY;
+
+    private Color transferalsColor = Colors.GRAY;
+    private Color transferalsAccumulatedColor = Colors.LIGHT_GRAY;
+
+    private Color taxesColor = Colors.GRAY;
+    private Color taxesAccumulatedColor = Colors.GRAY;
+
+    private Color absoluteDeltaColor = Colors.GRAY;
+    private Color absoluteDeltaAllRecordColor = Colors.GRAY;
+
+    private Color dividendsColor = Colors.GRAY;
+    private Color dividendsAccumulatedColor = Colors.GRAY;
+
+    private Color interestColor = Colors.GRAY;
+    private Color interestAccumulatedColor = Colors.GRAY;
+
+    private Color interestChargeColor = Colors.GRAY;
+    private Color interestChargeAccumulatedColor = Colors.GRAY;
+
+    private Color earningsColor = Colors.GRAY;
+    private Color earningsAccumulatedColor = Colors.GRAY;
+
+    private Color feesColor = Colors.GRAY;
+    private Color feesAccumulatedColor = Colors.GRAY;
+
+    private Color performanceEntirePortfolioColor = Colors.BLACK;
+    private Color performancePositiveColor = Colors.GRAY;
+    private Color performanceNegativeColor = Colors.GRAY;
+
+    private DataSeriesColors()
+    {
+    }
+
+    public static DataSeriesColors instance()
+    {
+        return INSTANCE;
+    }
+
+    public Color totalsColor()
+    {
+        return totalsColor;
+    }
+
+    public void setTotalsColor(RGBA color)
+    {
+        this.totalsColor = Colors.getColor(color.rgb);
+    }
+
+    public Color investedCapitalColor()
+    {
+        return investedCapitalColor;
+    }
+
+    public void setInvestedCapitalColor(RGBA color)
+    {
+        this.investedCapitalColor = Colors.getColor(color.rgb);
+    }
+
+    public Color absoluteInvestedCapitalColor()
+    {
+        return absoluteInvestedCapitalColor;
+    }
+
+    public void setAbsoluteInvestedCapitalColor(RGBA color)
+    {
+        this.absoluteInvestedCapitalColor = Colors.getColor(color.rgb);
+    }
+
+    public Color transferalsColor()
+    {
+        return transferalsColor;
+    }
+
+    public void setTransferalsColor(RGBA color)
+    {
+        this.transferalsColor = Colors.getColor(color.rgb);
+    }
+
+    public Color transferalsAccumulatedColor()
+    {
+        return transferalsAccumulatedColor;
+    }
+
+    public void setTransferalsAccumulatedColor(RGBA color)
+    {
+        this.transferalsAccumulatedColor = Colors.getColor(color.rgb);
+    }
+
+    public Color taxesColor()
+    {
+        return taxesColor;
+    }
+
+    public void setTaxesColor(RGBA color)
+    {
+        this.taxesColor = Colors.getColor(color.rgb);
+    }
+
+    public Color taxesAccumulatedColor()
+    {
+        return taxesAccumulatedColor;
+    }
+
+    public void setTaxesAccumulatedColor(RGBA color)
+    {
+        this.taxesAccumulatedColor = Colors.getColor(color.rgb);
+    }
+
+    public Color absoluteDeltaColor()
+    {
+        return absoluteDeltaColor;
+    }
+
+    public void setAbsoluteDeltaColor(RGBA color)
+    {
+        this.absoluteDeltaColor = Colors.getColor(color.rgb);
+    }
+
+    public Color absoluteDeltaAllRecordColor()
+    {
+        return absoluteDeltaAllRecordColor;
+    }
+
+    public void setAbsoluteDeltaAllRecordColor(RGBA color)
+    {
+        this.absoluteDeltaAllRecordColor = Colors.getColor(color.rgb);
+    }
+
+    public Color dividendsColor()
+    {
+        return dividendsColor;
+    }
+
+    public void setDividendsColor(RGBA color)
+    {
+        this.dividendsColor = Colors.getColor(color.rgb);
+    }
+
+    public Color dividendsAccumulatedColor()
+    {
+        return dividendsAccumulatedColor;
+    }
+
+    public void setDividendsAccumulatedColor(RGBA color)
+    {
+        this.dividendsAccumulatedColor = Colors.getColor(color.rgb);
+    }
+
+    public Color interestColor()
+    {
+        return interestColor;
+    }
+
+    public void setInterestColor(RGBA color)
+    {
+        this.interestColor = Colors.getColor(color.rgb);
+    }
+
+    public Color interestAccumulatedColor()
+    {
+        return interestAccumulatedColor;
+    }
+
+    public void setInterestAccumulatedColor(RGBA color)
+    {
+        this.interestAccumulatedColor = Colors.getColor(color.rgb);
+    }
+
+    public Color interestChargeColor()
+    {
+        return interestChargeColor;
+    }
+
+    public void setInterestChargeColor(RGBA color)
+    {
+        this.interestChargeColor = Colors.getColor(color.rgb);
+    }
+
+    public Color interestChargeAccumulatedColor()
+    {
+        return interestChargeAccumulatedColor;
+    }
+
+    public void setInterestChargeAccumulatedColor(RGBA color)
+    {
+        this.interestChargeAccumulatedColor = Colors.getColor(color.rgb);
+    }
+
+    public Color earningsColor()
+    {
+        return earningsColor;
+    }
+
+    public void setEarningsColor(RGBA color)
+    {
+        this.earningsColor = Colors.getColor(color.rgb);
+    }
+
+    public Color earningsAccumulatedColor()
+    {
+        return earningsAccumulatedColor;
+    }
+
+    public void setEarningsAccumulatedColor(RGBA color)
+    {
+        this.earningsAccumulatedColor = Colors.getColor(color.rgb);
+    }
+
+    public Color feesColor()
+    {
+        return feesColor;
+    }
+
+    public void setFeesColor(RGBA color)
+    {
+        this.feesColor = Colors.getColor(color.rgb);
+    }
+
+    public Color feesAccumulatedColor()
+    {
+        return feesAccumulatedColor;
+    }
+
+    public void setFeesAccumulatedColor(RGBA color)
+    {
+        this.feesAccumulatedColor = Colors.getColor(color.rgb);
+    }
+
+    public Color performanceEntirePortfolioColor()
+    {
+        return performanceEntirePortfolioColor;
+    }
+
+    public void setPerformanceEntirePortfolioColor(RGBA color)
+    {
+        this.performanceEntirePortfolioColor = Colors.getColor(color.rgb);
+    }
+
+    public Color performancePositiveColor()
+    {
+        return performancePositiveColor;
+    }
+
+    public void setPerformancePositiveColor(RGBA color)
+    {
+        this.performancePositiveColor = Colors.getColor(color.rgb);
+    }
+
+    public Color performanceNegativeColor()
+    {
+        return performanceNegativeColor;
+    }
+
+    public void setPerformanceNegativeColor(RGBA color)
+    {
+        this.performanceNegativeColor = Colors.getColor(color.rgb);
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ColorArchitectureDebugView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ColorArchitectureDebugView.java
@@ -113,7 +113,6 @@ public class ColorArchitectureDebugView extends AbstractFinanceView
         createSecuritiesChartSection(content, securitiesSnapshot);
         createPortfolioBalanceSection(content, portfolioSnapshot);
         createRenderPreviewSection(content, securitiesSnapshot, portfolioSnapshot);
-        createRestSection(content);
 
         scrolled.setMinSize(content.computeSize(SWT.DEFAULT, SWT.DEFAULT));
         content.addListener(SWT.Resize, e -> scrolled.setMinSize(content.computeSize(SWT.DEFAULT, SWT.DEFAULT)));
@@ -214,7 +213,7 @@ public class ColorArchitectureDebugView extends AbstractFinanceView
         var palette = PaymentsPalette.instance();
         for (int ii = 0; ii < palette.size(); ii++)
         {
-            addTrackedColorRow(table, "PaymentsPalette", "color-" + ii, palette.get(ii), "Palette index " + ii); //$NON-NLS-1$ //$NON-NLS-2$
+            addTrackedColorRow(table, "PaymentsPalette", "color-" + ii, palette.get(ii), "Palette index " + ii); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         }
     }
 
@@ -285,10 +284,10 @@ public class ColorArchitectureDebugView extends AbstractFinanceView
     private void createRenderPreviewSection(Composite parent, SecuritiesChartSnapshot securitiesSnapshot,
                     PortfolioBalanceChartSnapshot portfolioSnapshot)
     {
-        var section = createSection(parent, "Echte Render-Beispiele"); //$NON-NLS-1$
+        var section = createSection(parent, "Echte Render-Beispiele aus CSS-/Domain-Farben"); //$NON-NLS-1$
 
         var lineTitle = new Label(section, SWT.NONE);
-        lineTitle.setText("LineSeries / Marker / Event-Farben"); //$NON-NLS-1$
+        lineTitle.setText("SecuritiesChart-nahe LineSeries / Marker / Event-Farben"); //$NON-NLS-1$
         GridDataFactory.fillDefaults().grab(true, false).applyTo(lineTitle);
 
         var lineChart = new TimelineChart(section);
@@ -306,21 +305,32 @@ public class ColorArchitectureDebugView extends AbstractFinanceView
         double[] quoteValues = new double[] { 100, 103, 102, 106, 108, 107, 111 };
         double[] holdingsValues = new double[] { 10, 10, 11, 11, 12, 12, 12 };
 
-        var quoteSeries = lineChart.addDateSeries("debug-quote", dates, quoteValues, //$NON-NLS-1$
-                        notNull(securitiesSnapshot.quoteColor, Colors.GRAY), "Quote"); //$NON-NLS-1$
-        quoteSeries.enableArea(true);
+        lineChart.addDateSeries("debug-quote", dates, quoteValues, //$NON-NLS-1$
+                        cssOrDomainFallback("SecuritiesChart", "quote-color", securitiesSnapshot.quoteColor), "Quote"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 
         lineChart.addDateSeries("debug-shares-held", dates, holdingsValues, //$NON-NLS-1$
-                        notNull(securitiesSnapshot.sharesHeldColor, Colors.BLUE), "Shares Held"); //$NON-NLS-1$
+                        cssOrDomainFallback("SecuritiesChart", "shares-held-color", securitiesSnapshot.sharesHeldColor), //$NON-NLS-1$ //$NON-NLS-2$
+                        "Shares Held"); //$NON-NLS-1$
 
-        lineChart.addMarkerLine(dates[1], notNull(securitiesSnapshot.purchaseEventColor, Colors.DARK_GREEN), "BUY"); //$NON-NLS-1$
-        lineChart.addMarkerLine(dates[3], notNull(securitiesSnapshot.dividendEventColor, Colors.BLUE), "DIV"); //$NON-NLS-1$
-        lineChart.addMarkerLine(dates[5], notNull(securitiesSnapshot.saleEventColor, Colors.DARK_RED), "SELL"); //$NON-NLS-1$
-        lineChart.addNonTradingDayMarker(dates[2], notNull(securitiesSnapshot.nonTradingColor, Colors.LIGHT_GRAY));
+        lineChart.addMarkerLine(dates[1],
+                        cssOrDomainFallback("SecuritiesChart", "purchase-event-color", //$NON-NLS-1$ //$NON-NLS-2$
+                                        securitiesSnapshot.purchaseEventColor),
+                        "BUY"); //$NON-NLS-1$
+        lineChart.addMarkerLine(dates[3],
+                        cssOrDomainFallback("SecuritiesChart", "dividend-event-color", //$NON-NLS-1$ //$NON-NLS-2$
+                                        snapshotFallback(securitiesSnapshot.dividendEventColor,
+                                                        PaymentsPalette.instance().get(0))), // $NON-NLS-1$
+                        "DIV"); //$NON-NLS-1$
+        lineChart.addMarkerLine(dates[5],
+                        cssOrDomainFallback("SecuritiesChart", "sale-event-color", securitiesSnapshot.saleEventColor), //$NON-NLS-1$ //$NON-NLS-2$
+                        "SELL"); //$NON-NLS-1$
+
+        lineChart.addNonTradingDayMarker(dates[2], cssOrDomainFallback("SecuritiesChart", "non-trading-color", //$NON-NLS-1$ //$NON-NLS-2$
+                        securitiesSnapshot.nonTradingColor));
         lineChart.adjustRange();
 
         var barTitle = new Label(section, SWT.NONE);
-        barTitle.setText("BarSeries / PortfolioBalanceChart-nahe Farben"); //$NON-NLS-1$
+        barTitle.setText("PortfolioBalanceChart-nahe BarSeries-Farben"); //$NON-NLS-1$
         GridDataFactory.fillDefaults().grab(true, false).applyTo(barTitle);
 
         var barChart = new BarChart(section, "Debug"); //$NON-NLS-1$
@@ -328,13 +338,16 @@ public class ColorArchitectureDebugView extends AbstractFinanceView
 
         barChart.setCategories(java.util.List.of("A", "B", "C", "D")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
         barChart.addSeries("totals", "Totals", new double[] { 50, 60, 55, 70 }, //$NON-NLS-1$ //$NON-NLS-2$
-                        notNull(portfolioSnapshot.totalsColor, Colors.BLACK), true);
+                        cssOrDomainFallback("PortfolioBalanceChart", "totals-color", portfolioSnapshot.totalsColor), //$NON-NLS-1$ //$NON-NLS-2$
+                        true);
         barChart.addSeries("delta", "Absolute Delta", new double[] { 5, -3, 4, -2 }, //$NON-NLS-1$ //$NON-NLS-2$
-                        notNull(portfolioSnapshot.absoluteDeltaColor, Colors.GRAY), true);
+                        cssOrDomainFallback("PortfolioBalanceChart", "absolute-delta-color", //$NON-NLS-1$ //$NON-NLS-2$
+                                        portfolioSnapshot.absoluteDeltaColor),
+                        true);
         barChart.adjustRange();
 
         var paletteTitle = new Label(section, SWT.NONE);
-        paletteTitle.setText("PaymentsPalette als Liste"); //$NON-NLS-1$
+        paletteTitle.setText("PaymentsPalette aus Runtime-Palette"); //$NON-NLS-1$
         GridDataFactory.fillDefaults().grab(true, false).applyTo(paletteTitle);
 
         var paletteComposite = new Composite(section, SWT.NONE);
@@ -345,7 +358,7 @@ public class ColorArchitectureDebugView extends AbstractFinanceView
             createSwatch(paletteComposite, PaymentsPalette.instance().get(ii));
 
         var gradientTitle = new Label(section, SWT.NONE);
-        gradientTitle.setText("Gradients als Vorschau"); //$NON-NLS-1$
+        gradientTitle.setText("Gradients aus ColorGradientDefinitions"); //$NON-NLS-1$
         GridDataFactory.fillDefaults().grab(true, false).applyTo(gradientTitle);
 
         createGradientPreview(section, ColorGradientDefinitions.redToGreen());
@@ -355,27 +368,17 @@ public class ColorArchitectureDebugView extends AbstractFinanceView
         createGradientPreview(section, ColorGradientDefinitions.yellowWhiteBlack());
     }
 
-    private void createRestSection(Composite parent)
+    private Color cssOrDomainFallback(String domain, String property, Color color)
     {
-        var section = createSection(parent, "Separate Reststellen-Sektion"); //$NON-NLS-1$
-        var table = new Composite(section, SWT.NONE);
-        GridDataFactory.fillDefaults().grab(true, false).applyTo(table);
-        GridLayoutFactory.fillDefaults().numColumns(3).spacing(10, 6).margins(0, 0).applyTo(table);
+        if (color != null)
+            return color;
 
-        createHeader(table, "Klasse"); //$NON-NLS-1$
-        createHeader(table, "Status"); //$NON-NLS-1$
-        createHeader(table, "Reale Einordnung"); //$NON-NLS-1$
+        return Colors.theme().defaultForeground();
+    }
 
-        addRestRow(table, "RebalancingChartWidget", STATUS_MIXED, //$NON-NLS-1$
-                        "actual/target nutzen feste RGB-Werte, diff nutzt Colors.theme().redForeground()"); //$NON-NLS-1$
-        addRestRow(table, "DrawdownChartWidget", STATUS_HARD_CODED, //$NON-NLS-1$
-                        "colorDrawdown = SWT.COLOR_RED"); //$NON-NLS-1$
-        addRestRow(table, "CSVImportDefinitionPage", STATUS_MIXED, //$NON-NLS-1$
-                        "GREEN/LIGHTGREEN/ERROR sind fest; warningBackground kommt aus Theme"); //$NON-NLS-1$
-        addRestRow(table, "CircularChart", STATUS_ALGORITHMIC, //$NON-NLS-1$
-                        "Slice-Farben werden per HSB/Schrittalgorithmus erzeugt; Text nutzt teils Theme"); //$NON-NLS-1$
-        addRestRow(table, "ColorSchema", STATUS_MIXED, //$NON-NLS-1$
-                        "teils HSB-Berechnung, teils Gradients, teils Theme-Hintergrund"); //$NON-NLS-1$
+    private Color snapshotFallback(Color preferred, Color fallback)
+    {
+        return preferred != null ? preferred : fallback;
     }
 
     private SecuritiesChartSnapshot buildSecuritiesChartSnapshot(Composite parent)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ColorArchitectureDebugView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ColorArchitectureDebugView.java
@@ -1,0 +1,634 @@
+package name.abuchen.portfolio.ui.views;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
+import org.eclipse.swt.events.PaintEvent;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Canvas;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+
+import name.abuchen.portfolio.money.CurrencyConverterImpl;
+import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
+import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
+import name.abuchen.portfolio.ui.util.ColorGradientDefinitions;
+import name.abuchen.portfolio.ui.util.ColorSourceTracker;
+import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.DataSeriesColors;
+import name.abuchen.portfolio.ui.util.ValueColorScheme;
+import name.abuchen.portfolio.ui.util.chart.BarChart;
+import name.abuchen.portfolio.ui.util.chart.TimelineChart;
+import name.abuchen.portfolio.ui.views.payments.PaymentsPalette;
+
+public class ColorArchitectureDebugView extends AbstractFinanceView
+{
+    private static final String STATUS_CSS_BACKED = "CSS-backed"; //$NON-NLS-1$
+    private static final String STATUS_FALLBACK = "fallback"; //$NON-NLS-1$
+    private static final String STATUS_HARD_CODED = "hard-coded"; //$NON-NLS-1$
+    private static final String STATUS_ALGORITHMIC = "algorithmic"; //$NON-NLS-1$
+    private static final String STATUS_MIXED = "mixed"; //$NON-NLS-1$
+
+    private static final class ColorEntry
+    {
+        private final String domain;
+        private final String property;
+        private final Color color;
+        private final String status;
+        private final String note;
+
+        private ColorEntry(String domain, String property, Color color, String status, String note)
+        {
+            this.domain = domain;
+            this.property = property;
+            this.color = color;
+            this.status = status;
+            this.note = note;
+        }
+    }
+
+    private static final class SecuritiesChartSnapshot
+    {
+        private Color quoteColor;
+        private Color quoteAreaPositiveColor;
+        private Color quoteAreaNegativeColor;
+        private Color purchaseEventColor;
+        private Color saleEventColor;
+        private Color dividendEventColor;
+        private Color extremeMarkerHighColor;
+        private Color extremeMarkerLowColor;
+        private Color nonTradingColor;
+        private Color sharesHeldColor;
+    }
+
+    private static final class PortfolioBalanceChartSnapshot
+    {
+        private Color totalsColor;
+        private Color investedCapitalColor;
+        private Color absoluteDeltaColor;
+        private Color taxesAccumulatedColor;
+        private Color feesAccumulatedColor;
+        private Color deltaAreaPositiveColor;
+        private Color deltaAreaNegativeColor;
+    }
+
+    @Override
+    protected String getDefaultTitle()
+    {
+        return "Color Architecture Debug"; //$NON-NLS-1$
+    }
+
+    @Override
+    protected Control createBody(Composite parent)
+    {
+        var scrolled = new ScrolledComposite(parent, SWT.V_SCROLL | SWT.H_SCROLL);
+        scrolled.setExpandHorizontal(true);
+        scrolled.setExpandVertical(true);
+
+        var content = new Composite(scrolled, SWT.NONE);
+        GridLayoutFactory.fillDefaults().numColumns(1).margins(10, 10).spacing(10, 10).applyTo(content);
+        scrolled.setContent(content);
+
+        createInfoBlock(content);
+
+        var hidden = new Composite(content, SWT.NONE);
+        hidden.setVisible(false);
+        GridDataFactory.fillDefaults().exclude(true).hint(0, 0).applyTo(hidden);
+        hidden.setLayout(new FillLayout());
+
+        var securitiesSnapshot = buildSecuritiesChartSnapshot(hidden);
+        var portfolioSnapshot = buildPortfolioBalanceChartSnapshot(hidden);
+
+        createThemeSection(content);
+        createValueColorSchemeSection(content);
+        createDataSeriesSection(content);
+        createPaymentsSection(content);
+        createGradientSection(content);
+        createSecuritiesChartSection(content, securitiesSnapshot);
+        createPortfolioBalanceSection(content, portfolioSnapshot);
+        createRenderPreviewSection(content, securitiesSnapshot, portfolioSnapshot);
+        createRestSection(content);
+
+        scrolled.setMinSize(content.computeSize(SWT.DEFAULT, SWT.DEFAULT));
+        content.addListener(SWT.Resize, e -> scrolled.setMinSize(content.computeSize(SWT.DEFAULT, SWT.DEFAULT)));
+
+        return scrolled;
+    }
+
+    private void createInfoBlock(Composite parent)
+    {
+        var section = createSection(parent, "Debug-Zugriff"); //$NON-NLS-1$
+
+        var text = new Label(section, SWT.WRAP);
+        text.setText("Diese View zeigt aktuelle Farbwerte und trennt bei instrumentierten Domänen zwischen CSS-backed und fallback. " //$NON-NLS-1$
+                        + "SecuritiesChart und PortfolioBalanceChart werden intern als gestylte Testinstanzen aufgebaut. " //$NON-NLS-1$
+                        + "Reststellen werden bewusst als hard-coded, algorithmic oder mixed markiert."); //$NON-NLS-1$
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(text);
+
+        var launch = new Label(section, SWT.WRAP);
+        launch.setText("VM-Argument für Eclipse Debug-Run: -Dname.abuchen.portfolio.debug=yes"); //$NON-NLS-1$
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(launch);
+    }
+
+    private void createThemeSection(Composite parent)
+    {
+        var section = createSection(parent, "CustomColors"); //$NON-NLS-1$
+        var table = createColorTable(section);
+
+        var theme = Colors.theme();
+        addTrackedColorRow(table, "CustomColors", "default-foreground", theme.defaultForeground(), "Colors.Theme"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        addTrackedColorRow(table, "CustomColors", "default-background", theme.defaultBackground(), "Colors.Theme"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        addTrackedColorRow(table, "CustomColors", "chip-background", theme.chipBackground(), "Colors.Theme"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        addTrackedColorRow(table, "CustomColors", "warning-background", theme.warningBackground(), "Colors.Theme"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        addTrackedColorRow(table, "CustomColors", "red-background", theme.redBackground(), "Colors.Theme"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        addTrackedColorRow(table, "CustomColors", "green-background", theme.greenBackground(), "Colors.Theme"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        addTrackedColorRow(table, "CustomColors", "red-foreground", theme.redForeground(), "Colors.Theme"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        addTrackedColorRow(table, "CustomColors", "green-foreground", theme.greenForeground(), "Colors.Theme"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        addTrackedColorRow(table, "CustomColors", "gray-foreground", theme.grayForeground(), "Colors.Theme"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        addTrackedColorRow(table, "CustomColors", "hyperlink", theme.hyperlink(), "Colors.Theme"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    private void createValueColorSchemeSection(Composite parent)
+    {
+        var section = createSection(parent, "ValueColorScheme"); //$NON-NLS-1$
+        var table = createColorTable(section);
+
+        for (var scheme : ValueColorScheme.getAvailableSchemes())
+        {
+            String domain = "ValueColorScheme." + scheme.getIdentifier(); //$NON-NLS-1$
+            String note = scheme == ValueColorScheme.current() ? "aktives Scheme" : "verfügbares Scheme"; //$NON-NLS-1$ //$NON-NLS-2$
+
+            addTrackedColorRow(table, domain, "positive-foreground", scheme.positiveForeground(), note); //$NON-NLS-1$
+            addTrackedColorRow(table, domain, "negative-foreground", scheme.negativeForeground(), note); //$NON-NLS-1$
+        }
+    }
+
+    private void createDataSeriesSection(Composite parent)
+    {
+        var section = createSection(parent, "DataSeries"); //$NON-NLS-1$
+        var table = createColorTable(section);
+
+        var colors = DataSeriesColors.instance();
+
+        addTrackedColorRow(table, "DataSeries", "totals-color", colors.totalsColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+        addTrackedColorRow(table, "DataSeries", "invested-capital-color", colors.investedCapitalColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+        addTrackedColorRow(table, "DataSeries", "absolute-invested-capital-color", //$NON-NLS-1$ //$NON-NLS-2$
+                        colors.absoluteInvestedCapitalColor(), null);
+        addTrackedColorRow(table, "DataSeries", "transferals-color", colors.transferalsColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+        addTrackedColorRow(table, "DataSeries", "transferals-accumulated-color", colors.transferalsAccumulatedColor(), //$NON-NLS-1$ //$NON-NLS-2$
+                        null);
+        addTrackedColorRow(table, "DataSeries", "taxes-color", colors.taxesColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+        addTrackedColorRow(table, "DataSeries", "taxes-accumulated-color", colors.taxesAccumulatedColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+        addTrackedColorRow(table, "DataSeries", "absolute-delta-color", colors.absoluteDeltaColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+        addTrackedColorRow(table, "DataSeries", "absolute-delta-all-record-color", colors.absoluteDeltaAllRecordColor(), //$NON-NLS-1$ //$NON-NLS-2$
+                        null);
+        addTrackedColorRow(table, "DataSeries", "dividends-color", colors.dividendsColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+        addTrackedColorRow(table, "DataSeries", "dividends-accumulated-color", colors.dividendsAccumulatedColor(), //$NON-NLS-1$ //$NON-NLS-2$
+                        null);
+        addTrackedColorRow(table, "DataSeries", "interest-color", colors.interestColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+        addTrackedColorRow(table, "DataSeries", "interest-accumulated-color", colors.interestAccumulatedColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+        addTrackedColorRow(table, "DataSeries", "interest-charge-color", colors.interestChargeColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+        addTrackedColorRow(table, "DataSeries", "interest-charge-accumulated-color", //$NON-NLS-1$ //$NON-NLS-2$
+                        colors.interestChargeAccumulatedColor(), null);
+        addTrackedColorRow(table, "DataSeries", "earnings-color", colors.earningsColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+        addTrackedColorRow(table, "DataSeries", "earnings-accumulated-color", colors.earningsAccumulatedColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+        addTrackedColorRow(table, "DataSeries", "fees-color", colors.feesColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+        addTrackedColorRow(table, "DataSeries", "fees-accumulated-color", colors.feesAccumulatedColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+        addTrackedColorRow(table, "DataSeries", "performance-entire-portfolio-color", //$NON-NLS-1$ //$NON-NLS-2$
+                        colors.performanceEntirePortfolioColor(), null);
+        addTrackedColorRow(table, "DataSeries", "performance-positive-color", colors.performancePositiveColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+        addTrackedColorRow(table, "DataSeries", "performance-negative-color", colors.performanceNegativeColor(), null); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    private void createPaymentsSection(Composite parent)
+    {
+        var section = createSection(parent, "PaymentsPalette"); //$NON-NLS-1$
+        var table = createColorTable(section);
+
+        var palette = PaymentsPalette.instance();
+        for (int ii = 0; ii < palette.size(); ii++)
+        {
+            addTrackedColorRow(table, "PaymentsPalette", "color-" + ii, palette.get(ii), "Palette index " + ii); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+    }
+
+    private void createGradientSection(Composite parent)
+    {
+        var section = createSection(parent, "ColorGradientDefinitions"); //$NON-NLS-1$
+        var table = createGradientTable(section);
+
+        addGradientRow(table, ColorGradientDefinitions.redToGreen(),
+                        isGradientCssBacked(ColorGradientDefinitions.redToGreen()));
+        addGradientRow(table, ColorGradientDefinitions.orangeToBlue(),
+                        isGradientCssBacked(ColorGradientDefinitions.orangeToBlue()));
+        addGradientRow(table, ColorGradientDefinitions.greenYellowRed(),
+                        isGradientCssBacked(ColorGradientDefinitions.greenYellowRed()));
+        addGradientRow(table, ColorGradientDefinitions.greenWhiteRed(),
+                        isGradientCssBacked(ColorGradientDefinitions.greenWhiteRed()));
+        addGradientRow(table, ColorGradientDefinitions.yellowWhiteBlack(),
+                        isGradientCssBacked(ColorGradientDefinitions.yellowWhiteBlack()));
+    }
+
+    private void createSecuritiesChartSection(Composite parent, SecuritiesChartSnapshot snapshot)
+    {
+        var section = createSection(parent, "SecuritiesChart"); //$NON-NLS-1$
+        var table = createColorTable(section);
+
+        addTrackedColorRow(table, "SecuritiesChart", "quote-color", snapshot.quoteColor, "gestylte Dummy-Instanz"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        addTrackedColorRow(table, "SecuritiesChart", "quote-area-positive-color", snapshot.quoteAreaPositiveColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+        addTrackedColorRow(table, "SecuritiesChart", "quote-area-negative-color", snapshot.quoteAreaNegativeColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+        addTrackedColorRow(table, "SecuritiesChart", "purchase-event-color", snapshot.purchaseEventColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+        addTrackedColorRow(table, "SecuritiesChart", "sale-event-color", snapshot.saleEventColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+        addTrackedColorRow(table, "SecuritiesChart", "dividend-event-color", snapshot.dividendEventColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+        addTrackedColorRow(table, "SecuritiesChart", "extreme-marker-high-color", snapshot.extremeMarkerHighColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+        addTrackedColorRow(table, "SecuritiesChart", "extreme-marker-low-color", snapshot.extremeMarkerLowColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+        addTrackedColorRow(table, "SecuritiesChart", "non-trading-color", snapshot.nonTradingColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+        addTrackedColorRow(table, "SecuritiesChart", "shares-held-color", snapshot.sharesHeldColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+    }
+
+    private void createPortfolioBalanceSection(Composite parent, PortfolioBalanceChartSnapshot snapshot)
+    {
+        var section = createSection(parent, "PortfolioBalanceChart"); //$NON-NLS-1$
+        var table = createColorTable(section);
+
+        addTrackedColorRow(table, "PortfolioBalanceChart", "totals-color", snapshot.totalsColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+        addTrackedColorRow(table, "PortfolioBalanceChart", "invested-capital-color", snapshot.investedCapitalColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+        addTrackedColorRow(table, "PortfolioBalanceChart", "absolute-delta-color", snapshot.absoluteDeltaColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+        addTrackedColorRow(table, "PortfolioBalanceChart", "taxes-accumulated-color", snapshot.taxesAccumulatedColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+        addTrackedColorRow(table, "PortfolioBalanceChart", "fees-accumulated-color", snapshot.feesAccumulatedColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+        addTrackedColorRow(table, "PortfolioBalanceChart", "delta-area-positive-color", snapshot.deltaAreaPositiveColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+        addTrackedColorRow(table, "PortfolioBalanceChart", "delta-area-negative-color", snapshot.deltaAreaNegativeColor, //$NON-NLS-1$ //$NON-NLS-2$
+                        "gestylte Dummy-Instanz"); //$NON-NLS-1$
+    }
+
+    private void createRenderPreviewSection(Composite parent, SecuritiesChartSnapshot securitiesSnapshot,
+                    PortfolioBalanceChartSnapshot portfolioSnapshot)
+    {
+        var section = createSection(parent, "Echte Render-Beispiele"); //$NON-NLS-1$
+
+        var lineTitle = new Label(section, SWT.NONE);
+        lineTitle.setText("LineSeries / Marker / Event-Farben"); //$NON-NLS-1$
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(lineTitle);
+
+        var lineChart = new TimelineChart(section);
+        GridDataFactory.fillDefaults().grab(true, false).hint(SWT.DEFAULT, 220).applyTo(lineChart);
+
+        LocalDate[] dates = new LocalDate[] { //
+                        LocalDate.now().minusDays(6), //
+                        LocalDate.now().minusDays(5), //
+                        LocalDate.now().minusDays(4), //
+                        LocalDate.now().minusDays(3), //
+                        LocalDate.now().minusDays(2), //
+                        LocalDate.now().minusDays(1), //
+                        LocalDate.now() };
+
+        double[] quoteValues = new double[] { 100, 103, 102, 106, 108, 107, 111 };
+        double[] holdingsValues = new double[] { 10, 10, 11, 11, 12, 12, 12 };
+
+        var quoteSeries = lineChart.addDateSeries("debug-quote", dates, quoteValues, //$NON-NLS-1$
+                        notNull(securitiesSnapshot.quoteColor, Colors.GRAY), "Quote"); //$NON-NLS-1$
+        quoteSeries.enableArea(true);
+
+        lineChart.addDateSeries("debug-shares-held", dates, holdingsValues, //$NON-NLS-1$
+                        notNull(securitiesSnapshot.sharesHeldColor, Colors.BLUE), "Shares Held"); //$NON-NLS-1$
+
+        lineChart.addMarkerLine(dates[1], notNull(securitiesSnapshot.purchaseEventColor, Colors.DARK_GREEN), "BUY"); //$NON-NLS-1$
+        lineChart.addMarkerLine(dates[3], notNull(securitiesSnapshot.dividendEventColor, Colors.BLUE), "DIV"); //$NON-NLS-1$
+        lineChart.addMarkerLine(dates[5], notNull(securitiesSnapshot.saleEventColor, Colors.DARK_RED), "SELL"); //$NON-NLS-1$
+        lineChart.addNonTradingDayMarker(dates[2], notNull(securitiesSnapshot.nonTradingColor, Colors.LIGHT_GRAY));
+        lineChart.adjustRange();
+
+        var barTitle = new Label(section, SWT.NONE);
+        barTitle.setText("BarSeries / PortfolioBalanceChart-nahe Farben"); //$NON-NLS-1$
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(barTitle);
+
+        var barChart = new BarChart(section, "Debug"); //$NON-NLS-1$
+        GridDataFactory.fillDefaults().grab(true, false).hint(SWT.DEFAULT, 220).applyTo(barChart);
+
+        barChart.setCategories(java.util.List.of("A", "B", "C", "D")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        barChart.addSeries("totals", "Totals", new double[] { 50, 60, 55, 70 }, //$NON-NLS-1$ //$NON-NLS-2$
+                        notNull(portfolioSnapshot.totalsColor, Colors.BLACK), true);
+        barChart.addSeries("delta", "Absolute Delta", new double[] { 5, -3, 4, -2 }, //$NON-NLS-1$ //$NON-NLS-2$
+                        notNull(portfolioSnapshot.absoluteDeltaColor, Colors.GRAY), true);
+        barChart.adjustRange();
+
+        var paletteTitle = new Label(section, SWT.NONE);
+        paletteTitle.setText("PaymentsPalette als Liste"); //$NON-NLS-1$
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(paletteTitle);
+
+        var paletteComposite = new Composite(section, SWT.NONE);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(paletteComposite);
+        GridLayoutFactory.fillDefaults().numColumns(15).spacing(4, 4).margins(0, 0).applyTo(paletteComposite);
+
+        for (int ii = 0; ii < PaymentsPalette.instance().size(); ii++)
+            createSwatch(paletteComposite, PaymentsPalette.instance().get(ii));
+
+        var gradientTitle = new Label(section, SWT.NONE);
+        gradientTitle.setText("Gradients als Vorschau"); //$NON-NLS-1$
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(gradientTitle);
+
+        createGradientPreview(section, ColorGradientDefinitions.redToGreen());
+        createGradientPreview(section, ColorGradientDefinitions.orangeToBlue());
+        createGradientPreview(section, ColorGradientDefinitions.greenYellowRed());
+        createGradientPreview(section, ColorGradientDefinitions.greenWhiteRed());
+        createGradientPreview(section, ColorGradientDefinitions.yellowWhiteBlack());
+    }
+
+    private void createRestSection(Composite parent)
+    {
+        var section = createSection(parent, "Separate Reststellen-Sektion"); //$NON-NLS-1$
+        var table = new Composite(section, SWT.NONE);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(table);
+        GridLayoutFactory.fillDefaults().numColumns(3).spacing(10, 6).margins(0, 0).applyTo(table);
+
+        createHeader(table, "Klasse"); //$NON-NLS-1$
+        createHeader(table, "Status"); //$NON-NLS-1$
+        createHeader(table, "Reale Einordnung"); //$NON-NLS-1$
+
+        addRestRow(table, "RebalancingChartWidget", STATUS_MIXED, //$NON-NLS-1$
+                        "actual/target nutzen feste RGB-Werte, diff nutzt Colors.theme().redForeground()"); //$NON-NLS-1$
+        addRestRow(table, "DrawdownChartWidget", STATUS_HARD_CODED, //$NON-NLS-1$
+                        "colorDrawdown = SWT.COLOR_RED"); //$NON-NLS-1$
+        addRestRow(table, "CSVImportDefinitionPage", STATUS_MIXED, //$NON-NLS-1$
+                        "GREEN/LIGHTGREEN/ERROR sind fest; warningBackground kommt aus Theme"); //$NON-NLS-1$
+        addRestRow(table, "CircularChart", STATUS_ALGORITHMIC, //$NON-NLS-1$
+                        "Slice-Farben werden per HSB/Schrittalgorithmus erzeugt; Text nutzt teils Theme"); //$NON-NLS-1$
+        addRestRow(table, "ColorSchema", STATUS_MIXED, //$NON-NLS-1$
+                        "teils HSB-Berechnung, teils Gradients, teils Theme-Hintergrund"); //$NON-NLS-1$
+    }
+
+    private SecuritiesChartSnapshot buildSecuritiesChartSnapshot(Composite parent)
+    {
+        var snapshot = new SecuritiesChartSnapshot();
+
+        try
+        {
+            var factory = getFromContext(ExchangeRateProviderFactory.class);
+            if (factory == null || getClient() == null)
+                return snapshot;
+
+            var chart = new SecuritiesChart(parent, getClient(),
+                            new CurrencyConverterImpl(factory, getClient().getBaseCurrency()));
+            getStylingEngine().style(chart.getControl());
+            getStylingEngine().style(chart);
+
+            snapshot.quoteColor = readColorField(chart, "colorQuote"); //$NON-NLS-1$
+            snapshot.quoteAreaPositiveColor = readColorField(chart, "colorQuoteAreaPositive"); //$NON-NLS-1$
+            snapshot.quoteAreaNegativeColor = readColorField(chart, "colorQuoteAreaNegative"); //$NON-NLS-1$
+            snapshot.purchaseEventColor = readColorField(chart, "colorEventPurchase"); //$NON-NLS-1$
+            snapshot.saleEventColor = readColorField(chart, "colorEventSale"); //$NON-NLS-1$
+            snapshot.dividendEventColor = readColorField(chart, "colorEventDividend"); //$NON-NLS-1$
+            snapshot.extremeMarkerHighColor = readColorField(chart, "colorExtremeMarkerHigh"); //$NON-NLS-1$
+            snapshot.extremeMarkerLowColor = readColorField(chart, "colorExtremeMarkerLow"); //$NON-NLS-1$
+            snapshot.nonTradingColor = readColorField(chart, "colorNonTradingDay"); //$NON-NLS-1$
+            snapshot.sharesHeldColor = chart.getSharesHeldColor();
+        }
+        catch (RuntimeException e)
+        {
+            // Debug-View soll bei Teilfehlern trotzdem öffnen
+        }
+
+        return snapshot;
+    }
+
+    private PortfolioBalanceChartSnapshot buildPortfolioBalanceChartSnapshot(Composite parent)
+    {
+        var snapshot = new PortfolioBalanceChartSnapshot();
+
+        try
+        {
+            if (getClient() == null)
+                return snapshot;
+
+            var chart = new PortfolioBalanceChart(parent, getClient());
+            getStylingEngine().style(chart.getControl());
+            getStylingEngine().style(chart);
+
+            snapshot.totalsColor = readColorField(chart, "colorTotals"); //$NON-NLS-1$
+            snapshot.investedCapitalColor = readColorField(chart, "colorAbsoluteInvestedCapital"); //$NON-NLS-1$
+            snapshot.absoluteDeltaColor = readColorField(chart, "colorAbsoluteDelta"); //$NON-NLS-1$
+            snapshot.taxesAccumulatedColor = readColorField(chart, "colorTaxesAccumulated"); //$NON-NLS-1$
+            snapshot.feesAccumulatedColor = readColorField(chart, "colorFeesAccumulated"); //$NON-NLS-1$
+            snapshot.deltaAreaPositiveColor = readColorField(chart, "colorDeltaAreaPositive"); //$NON-NLS-1$
+            snapshot.deltaAreaNegativeColor = readColorField(chart, "colorDeltaAreaNegative"); //$NON-NLS-1$
+        }
+        catch (RuntimeException e)
+        {
+            // Debug-View soll bei Teilfehlern trotzdem öffnen
+        }
+
+        return snapshot;
+    }
+
+    private Composite createSection(Composite parent, String title)
+    {
+        var section = new Composite(parent, SWT.NONE);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(section);
+        GridLayoutFactory.fillDefaults().numColumns(1).margins(8, 8).spacing(6, 6).applyTo(section);
+
+        var label = new Label(section, SWT.NONE);
+        label.setText(title);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(label);
+
+        return section;
+    }
+
+    private Composite createColorTable(Composite parent)
+    {
+        var table = new Composite(parent, SWT.NONE);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(table);
+        GridLayoutFactory.fillDefaults().numColumns(5).spacing(10, 6).margins(0, 0).applyTo(table);
+
+        createHeader(table, "Domain"); //$NON-NLS-1$
+        createHeader(table, "Property"); //$NON-NLS-1$
+        createHeader(table, "Aktueller Wert"); //$NON-NLS-1$
+        createHeader(table, "Farbbox"); //$NON-NLS-1$
+        createHeader(table, "Status"); //$NON-NLS-1$
+
+        return table;
+    }
+
+    private Composite createGradientTable(Composite parent)
+    {
+        var table = new Composite(parent, SWT.NONE);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(table);
+        GridLayoutFactory.fillDefaults().numColumns(5).spacing(10, 6).margins(0, 0).applyTo(table);
+
+        createHeader(table, "Domain"); //$NON-NLS-1$
+        createHeader(table, "Property"); //$NON-NLS-1$
+        createHeader(table, "Aktueller Wert"); //$NON-NLS-1$
+        createHeader(table, "Vorschau"); //$NON-NLS-1$
+        createHeader(table, "Status"); //$NON-NLS-1$
+
+        return table;
+    }
+
+    private void createHeader(Composite parent, String text)
+    {
+        var label = new Label(parent, SWT.NONE);
+        label.setText(text);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(label);
+    }
+
+    private void addTrackedColorRow(Composite parent, String domain, String property, Color color, String note)
+    {
+        addColorRow(parent, new ColorEntry(domain, property, color, trackedStatus(domain, property), note));
+    }
+
+    private void addColorRow(Composite parent, ColorEntry entry)
+    {
+        var domain = new Label(parent, SWT.WRAP);
+        domain.setText(entry.domain);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(domain);
+
+        var property = new Label(parent, SWT.WRAP);
+        property.setText(entry.property);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(property);
+
+        var value = new Label(parent, SWT.WRAP);
+        value.setText(toHex(entry.color) + (entry.note != null ? " | " + entry.note : "")); //$NON-NLS-1$ //$NON-NLS-2$
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(value);
+
+        createSwatch(parent, entry.color);
+
+        var status = new Label(parent, SWT.WRAP);
+        status.setText(entry.status);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(status);
+    }
+
+    private void addGradientRow(Composite parent, ColorGradientDefinitions.Definition definition, String status)
+    {
+        String domain = "ColorGradientDefinitions." + definition.getCssClass(); //$NON-NLS-1$
+
+        var domainLabel = new Label(parent, SWT.WRAP);
+        domainLabel.setText(domain);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(domainLabel);
+
+        var propertyLabel = new Label(parent, SWT.WRAP);
+        propertyLabel.setText("color-0 .. color-n"); //$NON-NLS-1$
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(propertyLabel);
+
+        var valueLabel = new Label(parent, SWT.WRAP);
+        valueLabel.setText(sampleGradientText(definition));
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(valueLabel);
+
+        var preview = new Composite(parent, SWT.NONE);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(preview);
+        GridLayoutFactory.fillDefaults().numColumns(9).spacing(1, 1).margins(0, 0).applyTo(preview);
+
+        for (int ii = 0; ii < 9; ii++)
+            createSwatch(preview, definition.getGradient().getColorAt(ii / 8f));
+
+        var statusLabel = new Label(parent, SWT.WRAP);
+        statusLabel.setText(status);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(statusLabel);
+    }
+
+    private void createGradientPreview(Composite parent, ColorGradientDefinitions.Definition definition)
+    {
+        var row = new Composite(parent, SWT.NONE);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(row);
+        GridLayoutFactory.fillDefaults().numColumns(10).spacing(2, 2).margins(0, 0).applyTo(row);
+
+        var name = new Label(row, SWT.NONE);
+        name.setText(definition.getCssClass());
+        GridDataFactory.fillDefaults().hint(160, SWT.DEFAULT).applyTo(name);
+
+        for (int ii = 0; ii < 9; ii++)
+            createSwatch(row, definition.getGradient().getColorAt(ii / 8f));
+    }
+
+    private void addRestRow(Composite parent, String name, String status, String note)
+    {
+        var nameLabel = new Label(parent, SWT.WRAP);
+        nameLabel.setText(name);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(nameLabel);
+
+        var statusLabel = new Label(parent, SWT.WRAP);
+        statusLabel.setText(status);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(statusLabel);
+
+        var noteLabel = new Label(parent, SWT.WRAP);
+        noteLabel.setText(note);
+        GridDataFactory.fillDefaults().grab(true, false).applyTo(noteLabel);
+    }
+
+    private void createSwatch(Composite parent, Color color)
+    {
+        Color swatchColor = notNull(color, Colors.LIGHT_GRAY);
+
+        var swatch = new Canvas(parent, SWT.BORDER);
+        GridDataFactory.fillDefaults().hint(26, 14).applyTo(swatch);
+
+        swatch.addPaintListener((PaintEvent e) -> {
+            var area = swatch.getClientArea();
+            e.gc.setBackground(swatchColor);
+            e.gc.fillRectangle(area);
+        });
+    }
+
+    private String sampleGradientText(ColorGradientDefinitions.Definition definition)
+    {
+        var start = definition.getGradient().getColorAt(0f);
+        var mid = definition.getGradient().getColorAt(0.5f);
+        var end = definition.getGradient().getColorAt(1f);
+
+        return toHex(start) + " … " + toHex(mid) + " … " + toHex(end); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    private String trackedStatus(String domain, String property)
+    {
+        return ColorSourceTracker.isCssApplied(domain, property) ? STATUS_CSS_BACKED : STATUS_FALLBACK;
+    }
+
+    private String isGradientCssBacked(ColorGradientDefinitions.Definition definition)
+    {
+        String domain = "ColorGradientDefinitions." + definition.getCssClass(); //$NON-NLS-1$
+        return ColorSourceTracker.isCssApplied(domain, "color-0") ? STATUS_CSS_BACKED : STATUS_FALLBACK; //$NON-NLS-1$
+    }
+
+    private String toHex(Color color)
+    {
+        return color != null ? Colors.toHex(color) : "<null>"; //$NON-NLS-1$
+    }
+
+    private Color notNull(Color color, Color fallback)
+    {
+        return color != null ? color : fallback;
+    }
+
+    private Color readColorField(Object target, String fieldName)
+    {
+        try
+        {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return (Color) field.get(target);
+        }
+        catch (ReflectiveOperationException e)
+        {
+            return null;
+        }
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioBalanceChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioBalanceChart.java
@@ -70,12 +70,13 @@ public class PortfolioBalanceChart
     private EnumSet<ChartDetails> chartConfig = EnumSet.of(ChartDetails.ABSOLUTE_INVESTED_CAPITAL,
                     ChartDetails.ABSOLUTE_DELTA);
 
-    private Color colorAbsoluteInvestedCapital = Colors.getColor(235, 201, 52); // #EBC934
-    private Color colorAbsoluteDelta = Colors.getColor(90, 114, 226); // #5A72E2
-    private static final Color colorTaxesAccumulated = Display.getDefault().getSystemColor(SWT.COLOR_RED);
-    private static final Color colorFeesAccumulated = Display.getDefault().getSystemColor(SWT.COLOR_GRAY);
-    private Color colorDeltaAreaPositive = Colors.getColor(90, 114, 226); // #5A72E2
-    private Color colorDeltaAreaNegative = Colors.getColor(226, 91, 90); // #E25B5A
+    private Color colorTotals = Colors.BLACK;
+    private Color colorAbsoluteInvestedCapital = Colors.GRAY;
+    private Color colorAbsoluteDelta = Colors.GRAY;
+    private Color colorTaxesAccumulated = Colors.GRAY;
+    private Color colorFeesAccumulated = Colors.GRAY;
+    private Color colorDeltaAreaPositive = Colors.GRAY;
+    private Color colorDeltaAreaNegative = Colors.GRAY;
 
     public PortfolioBalanceChart(Composite parent, Client client)
     {
@@ -280,7 +281,7 @@ public class PortfolioBalanceChart
             // reverse the order
 
             var lineSeries = chart.addDateSeries(portfolioUUID, index.getDates(),
-                            toDouble(index.getTotals(), Values.Amount.divider()), Colors.CASH, portfolioName);
+                            toDouble(index.getTotals(), Values.Amount.divider()), colorTotals, portfolioName);
             lineSeries.setAntialias(swtAntialias);
 
             if (chartConfig.contains(ChartDetails.ABSOLUTE_INVESTED_CAPITAL))
@@ -302,6 +303,7 @@ public class PortfolioBalanceChart
             chart.suspendUpdate(false);
         }
     }
+
 
     public void addButtons(ToolBarManager toolBar)
     {
@@ -461,9 +463,24 @@ public class PortfolioBalanceChart
         this.colorAbsoluteDelta = color;
     }
 
+    public void setTotalsColor(Color color)
+    {
+        this.colorTotals = color;
+    }
+
     public void setAbsoluteInvestedCapitalColor(Color color)
     {
         this.colorAbsoluteInvestedCapital = color;
+    }
+
+    public void setTaxesAccumulatedColor(Color color)
+    {
+        this.colorTaxesAccumulated = color;
+    }
+
+    public void setFeesAccumulatedColor(Color color)
+    {
+        this.colorFeesAccumulated = color;
     }
 
     public void setDeltaAreaNegative(Color color)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioBalanceChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioBalanceChart.java
@@ -43,7 +43,6 @@ import name.abuchen.portfolio.snapshot.filter.ReadOnlyClient;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.ClientFilterMenu;
-import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.chart.TimelineChart;
@@ -70,13 +69,13 @@ public class PortfolioBalanceChart
     private EnumSet<ChartDetails> chartConfig = EnumSet.of(ChartDetails.ABSOLUTE_INVESTED_CAPITAL,
                     ChartDetails.ABSOLUTE_DELTA);
 
-    private Color colorTotals = Colors.BLACK;
-    private Color colorAbsoluteInvestedCapital = Colors.GRAY;
-    private Color colorAbsoluteDelta = Colors.GRAY;
-    private Color colorTaxesAccumulated = Colors.GRAY;
-    private Color colorFeesAccumulated = Colors.GRAY;
-    private Color colorDeltaAreaPositive = Colors.GRAY;
-    private Color colorDeltaAreaNegative = Colors.GRAY;
+    private Color colorTotals;
+    private Color colorAbsoluteInvestedCapital;
+    private Color colorAbsoluteDelta;
+    private Color colorTaxesAccumulated;
+    private Color colorFeesAccumulated;
+    private Color colorDeltaAreaPositive;
+    private Color colorDeltaAreaNegative;
 
     public PortfolioBalanceChart(Composite parent, Client client)
     {
@@ -281,7 +280,8 @@ public class PortfolioBalanceChart
             // reverse the order
 
             var lineSeries = chart.addDateSeries(portfolioUUID, index.getDates(),
-                            toDouble(index.getTotals(), Values.Amount.divider()), colorTotals, portfolioName);
+                            toDouble(index.getTotals(), Values.Amount.divider()),
+                            requireConfigured(colorTotals, "PortfolioBalanceChart.totals-color"), portfolioName); //$NON-NLS-1$
             lineSeries.setAntialias(swtAntialias);
 
             if (chartConfig.contains(ChartDetails.ABSOLUTE_INVESTED_CAPITAL))
@@ -365,7 +365,9 @@ public class PortfolioBalanceChart
         double[] values = toDouble(index.calculateAbsoluteInvestedCapital(), Values.Amount.divider());
         String lineID = Messages.LabelAbsoluteInvestedCapital;
 
-        var lineSeries = chart.addDateSeries(lineID, index.getDates(), values, colorAbsoluteInvestedCapital, lineID);
+        var lineSeries = chart.addDateSeries(lineID, index.getDates(), values,
+                        requireConfigured(colorAbsoluteInvestedCapital, "PortfolioBalanceChart.invested-capital-color"), //$NON-NLS-1$
+                        lineID);
         lineSeries.enableArea(true);
         lineSeries.setAntialias(swtAntialias);
     }
@@ -393,14 +395,16 @@ public class PortfolioBalanceChart
         String lineIDPos = Messages.LabelAbsoluteDelta + "Positive"; //$NON-NLS-1$
 
         var lineSeries2ndNegative = chart.addDateSeries(lineIDNeg, index.getDates(), valuesRelativeNegative,
-                        colorDeltaAreaNegative, lineIDNeg);
+                        requireConfigured(colorDeltaAreaNegative, "PortfolioBalanceChart.delta-area-negative-color"), //$NON-NLS-1$
+                        lineIDNeg);
         lineSeries2ndNegative.setAntialias(swtAntialias);
         lineSeries2ndNegative.enableArea(true);
         lineSeries2ndNegative.setVisibleInLegend(false);
         lineSeries2ndNegative.setLineWidth(1);
 
         var lineSeries2ndPositive = chart.addDateSeries(lineIDPos, index.getDates(), valuesRelativePositive,
-                        colorDeltaAreaPositive, lineIDPos);
+                        requireConfigured(colorDeltaAreaPositive, "PortfolioBalanceChart.delta-area-positive-color"), //$NON-NLS-1$
+                        lineIDPos);
         lineSeries2ndPositive.setAntialias(swtAntialias);
         lineSeries2ndPositive.enableArea(true);
         lineSeries2ndPositive.setVisibleInLegend(false);
@@ -408,7 +412,9 @@ public class PortfolioBalanceChart
 
         String lineID = Messages.LabelAbsoluteDelta;
 
-        var lineSeries = chart.addDateSeries(lineID, index.getDates(), values, colorAbsoluteDelta, lineID);
+        var lineSeries = chart.addDateSeries(lineID, index.getDates(), values,
+                        requireConfigured(colorAbsoluteDelta, "PortfolioBalanceChart.absolute-delta-color"), //$NON-NLS-1$
+                        lineID);
         lineSeries.setAntialias(swtAntialias);
     }
 
@@ -417,7 +423,9 @@ public class PortfolioBalanceChart
         double[] values = accumulateAndToDouble(index.getTaxes(), Values.Amount.divider());
         String lineID = Messages.LabelAccumulatedTaxes;
 
-        var lineSeries = chart.addDateSeries(lineID, index.getDates(), values, colorTaxesAccumulated, lineID);
+        var lineSeries = chart.addDateSeries(lineID, index.getDates(), values,
+                        requireConfigured(colorTaxesAccumulated, "PortfolioBalanceChart.taxes-accumulated-color"), //$NON-NLS-1$
+                        lineID);
         lineSeries.setAntialias(swtAntialias);
     }
 
@@ -426,8 +434,18 @@ public class PortfolioBalanceChart
         double[] values = accumulateAndToDouble(index.getFees(), Values.Amount.divider());
         String lineID = Messages.LabelFeesAccumulated;
 
-        var lineSeries = chart.addDateSeries(lineID, index.getDates(), values, colorFeesAccumulated, lineID);
+        var lineSeries = chart.addDateSeries(lineID, index.getDates(), values,
+                        requireConfigured(colorFeesAccumulated, "PortfolioBalanceChart.fees-accumulated-color"), //$NON-NLS-1$
+                        lineID);
         lineSeries.setAntialias(swtAntialias);
+    }
+
+    private Color requireConfigured(Color color, String property)
+    {
+        if (color == null)
+            throw new IllegalStateException("CSS portfolio balance chart color not configured: " + property); //$NON-NLS-1$
+
+        return color;
     }
 
     private enum ChartDetails

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -352,41 +352,41 @@ public class SecuritiesChart
         }
     }
 
-    private Color colorQuote = Colors.GRAY;
-    private Color colorQuoteAreaPositive = Colors.GRAY;
-    private Color colorQuoteAreaNegative = Colors.GRAY;
+    private Color colorQuote;
+    private Color colorQuoteAreaPositive;
+    private Color colorQuoteAreaNegative;
 
-    private Color colorEventPurchase = Colors.GRAY;
-    private Color colorEventSale = Colors.GRAY;
-    private Color colorEventDividend = Colors.GRAY;
+    private Color colorEventPurchase;
+    private Color colorEventSale;
+    private Color colorEventDividend;
 
-    private Color colorExtremeMarkerHigh = Colors.GRAY;
-    private Color colorExtremeMarkerLow = Colors.GRAY;
+    private Color colorExtremeMarkerHigh;
+    private Color colorExtremeMarkerLow;
 
-    private Color colorNonTradingDay = Colors.GRAY;
+    private Color colorNonTradingDay;
 
-    private Color colorSharesHeld = Colors.GRAY;
+    private Color colorSharesHeld;
 
-    private Color colorFifoPurchasePrice = Colors.GRAY;
-    private Color colorMovingAveragePurchasePrice = Colors.GRAY;
-    private Color colorBollingerBands = Colors.GRAY;
-    private Color colorMACD = Colors.GRAY;
+    private Color colorFifoPurchasePrice;
+    private Color colorMovingAveragePurchasePrice;
+    private Color colorBollingerBands;
+    private Color colorMACD;
 
-    private Color colorSMA1 = Colors.GRAY;
-    private Color colorSMA2 = Colors.GRAY;
-    private Color colorSMA3 = Colors.GRAY;
-    private Color colorSMA4 = Colors.GRAY;
-    private Color colorSMA5 = Colors.GRAY;
-    private Color colorSMA6 = Colors.GRAY;
-    private Color colorSMA7 = Colors.GRAY;
+    private Color colorSMA1;
+    private Color colorSMA2;
+    private Color colorSMA3;
+    private Color colorSMA4;
+    private Color colorSMA5;
+    private Color colorSMA6;
+    private Color colorSMA7;
 
-    private Color colorEMA1 = Colors.GRAY;
-    private Color colorEMA2 = Colors.GRAY;
-    private Color colorEMA3 = Colors.GRAY;
-    private Color colorEMA4 = Colors.GRAY;
-    private Color colorEMA5 = Colors.GRAY;
-    private Color colorEMA6 = Colors.GRAY;
-    private Color colorEMA7 = Colors.GRAY;
+    private Color colorEMA1;
+    private Color colorEMA2;
+    private Color colorEMA3;
+    private Color colorEMA4;
+    private Color colorEMA5;
+    private Color colorEMA6;
+    private Color colorEMA7;
 
     private static final String PREF_KEY = "security-chart-details"; //$NON-NLS-1$
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -352,41 +352,41 @@ public class SecuritiesChart
         }
     }
 
-    private Color colorQuote = Colors.getColor(77, 52, 235); // #4D34EB
-    private Color colorQuoteAreaPositive = Colors.getColor(90, 114, 226); // #5A72E2
-    private Color colorQuoteAreaNegative = Colors.getColor(226, 91, 90); // #E25B5A
+    private Color colorQuote = Colors.GRAY;
+    private Color colorQuoteAreaPositive = Colors.GRAY;
+    private Color colorQuoteAreaNegative = Colors.GRAY;
 
-    private Color colorEventPurchase = Colors.getColor(26, 173, 33); // #1AAD21
-    private Color colorEventSale = Colors.getColor(255, 43, 48); // #FF2B30
-    private Color colorEventDividend = Colors.getColor(128, 99, 168); // #8063A8
+    private Color colorEventPurchase = Colors.GRAY;
+    private Color colorEventSale = Colors.GRAY;
+    private Color colorEventDividend = Colors.GRAY;
 
-    private Color colorExtremeMarkerHigh = Colors.getColor(0, 147, 15); // #00930F
-    private Color colorExtremeMarkerLow = Colors.getColor(168, 39, 42); // #A8272A
+    private Color colorExtremeMarkerHigh = Colors.GRAY;
+    private Color colorExtremeMarkerLow = Colors.GRAY;
 
-    private Color colorNonTradingDay = Colors.getColor(255, 137, 89); // #FF8959
+    private Color colorNonTradingDay = Colors.GRAY;
 
-    private Color colorSharesHeld = Colors.getColor(235, 201, 52); // #EBC934
+    private Color colorSharesHeld = Colors.GRAY;
 
-    private static final Color colorFifoPurchasePrice = Colors.getColor(226, 122, 121); // #E27A79
-    private static final Color colorMovingAveragePurchasePrice = Colors.getColor(150, 82, 81); // #965251
-    private static final Color colorBollingerBands = Colors.getColor(201, 141, 68); // #C98D44
-    private static final Color colorMACD = Colors.getColor(226, 155, 200); // #E29BC8
+    private Color colorFifoPurchasePrice = Colors.GRAY;
+    private Color colorMovingAveragePurchasePrice = Colors.GRAY;
+    private Color colorBollingerBands = Colors.GRAY;
+    private Color colorMACD = Colors.GRAY;
 
-    private static final Color colorSMA1 = Colors.getColor(179, 107, 107); // #B36B6B
-    private static final Color colorSMA2 = Colors.getColor(179, 167, 107); // #B3A76B
-    private static final Color colorSMA3 = Colors.getColor(131, 179, 107); // #83B36B
-    private static final Color colorSMA4 = Colors.getColor(107, 179, 143); // #6BB38F
-    private static final Color colorSMA5 = Colors.getColor(107, 155, 179); // #6B9BB3
-    private static final Color colorSMA6 = Colors.getColor(119, 107, 179); // #776BB3
-    private static final Color colorSMA7 = Colors.getColor(179, 107, 179); // #B36BB3
+    private Color colorSMA1 = Colors.GRAY;
+    private Color colorSMA2 = Colors.GRAY;
+    private Color colorSMA3 = Colors.GRAY;
+    private Color colorSMA4 = Colors.GRAY;
+    private Color colorSMA5 = Colors.GRAY;
+    private Color colorSMA6 = Colors.GRAY;
+    private Color colorSMA7 = Colors.GRAY;
 
-    private static final Color colorEMA1 = Colors.getColor(200, 107, 107); // #C86B6B
-    private static final Color colorEMA2 = Colors.getColor(200, 167, 107); // #C8A76B
-    private static final Color colorEMA3 = Colors.getColor(131, 200, 107); // #83C86B
-    private static final Color colorEMA4 = Colors.getColor(107, 200, 143); // #6BC88F
-    private static final Color colorEMA5 = Colors.getColor(107, 155, 200); // #6B9BC8
-    private static final Color colorEMA6 = Colors.getColor(119, 107, 200); // #776BC8
-    private static final Color colorEMA7 = Colors.getColor(200, 107, 200); // #C86BB3
+    private Color colorEMA1 = Colors.GRAY;
+    private Color colorEMA2 = Colors.GRAY;
+    private Color colorEMA3 = Colors.GRAY;
+    private Color colorEMA4 = Colors.GRAY;
+    private Color colorEMA5 = Colors.GRAY;
+    private Color colorEMA6 = Colors.GRAY;
+    private Color colorEMA7 = Colors.GRAY;
 
     private static final String PREF_KEY = "security-chart-details"; //$NON-NLS-1$
 
@@ -524,6 +524,96 @@ public class SecuritiesChart
     public void setSharesHeldColor(Color color)
     {
         this.colorSharesHeld = color;
+    }
+
+    public void setFifoPurchasePriceColor(Color color)
+    {
+        this.colorFifoPurchasePrice = color;
+    }
+
+    public void setMovingAveragePurchasePriceColor(Color color)
+    {
+        this.colorMovingAveragePurchasePrice = color;
+    }
+
+    public void setBollingerBandsColor(Color color)
+    {
+        this.colorBollingerBands = color;
+    }
+
+    public void setMacdColor(Color color)
+    {
+        this.colorMACD = color;
+    }
+
+    public void setSma1Color(Color color)
+    {
+        this.colorSMA1 = color;
+    }
+
+    public void setSma2Color(Color color)
+    {
+        this.colorSMA2 = color;
+    }
+
+    public void setSma3Color(Color color)
+    {
+        this.colorSMA3 = color;
+    }
+
+    public void setSma4Color(Color color)
+    {
+        this.colorSMA4 = color;
+    }
+
+    public void setSma5Color(Color color)
+    {
+        this.colorSMA5 = color;
+    }
+
+    public void setSma6Color(Color color)
+    {
+        this.colorSMA6 = color;
+    }
+
+    public void setSma7Color(Color color)
+    {
+        this.colorSMA7 = color;
+    }
+
+    public void setEma1Color(Color color)
+    {
+        this.colorEMA1 = color;
+    }
+
+    public void setEma2Color(Color color)
+    {
+        this.colorEMA2 = color;
+    }
+
+    public void setEma3Color(Color color)
+    {
+        this.colorEMA3 = color;
+    }
+
+    public void setEma4Color(Color color)
+    {
+        this.colorEMA4 = color;
+    }
+
+    public void setEma5Color(Color color)
+    {
+        this.colorEMA5 = color;
+    }
+
+    public void setEma6Color(Color color)
+    {
+        this.colorEMA6 = color;
+    }
+
+    public void setEma7Color(Color color)
+    {
+        this.colorEMA7 = color;
     }
 
     public Client getClient()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/ClientDataSeriesChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/ClientDataSeriesChartWidget.java
@@ -13,7 +13,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 
 import name.abuchen.portfolio.model.Dashboard;
@@ -21,7 +20,7 @@ import name.abuchen.portfolio.model.Dashboard.Widget;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;
 import name.abuchen.portfolio.ui.Messages;
-import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.DataSeriesColors;
 import name.abuchen.portfolio.ui.util.chart.TimelineChart;
 import name.abuchen.portfolio.ui.util.format.AmountNumberFormat;
 import name.abuchen.portfolio.ui.util.format.ThousandsNumberFormat;
@@ -40,25 +39,7 @@ import name.abuchen.portfolio.util.TextUtil;
 
 public class ClientDataSeriesChartWidget extends WidgetDelegate<PerformanceIndex>
 {
-    private static final Color colorTotals = Colors.BLACK;
-    private static final Color colorInvestedCapital = Colors.getColor(235, 201, 52); // #EBC934
-    private static final Color colorAbsoluteInvestedCapital = Colors.getColor(235, 201, 52); // #EBC934
-    private static final Color colorTransferals = Colors.DARK_GRAY;
-    private static final Color colorTransferalsAccumulated = Display.getDefault().getSystemColor(SWT.COLOR_YELLOW);
-    private static final Color colorTaxes = Colors.RED;
-    private static final Color colorTaxesAccumulated = Colors.RED;
-    private static final Color colorAbsoluteDelta = Display.getDefault().getSystemColor(SWT.COLOR_BLUE);
-    private static final Color colorAbsoluteDeltaAllRecord = Display.getDefault().getSystemColor(SWT.COLOR_BLUE);
-    private static final Color colorDividends = Display.getDefault().getSystemColor(SWT.COLOR_DARK_MAGENTA);
-    private static final Color colorDividendsAccumulated = Display.getDefault().getSystemColor(SWT.COLOR_DARK_MAGENTA);
-    private static final Color colorInterest = Colors.DARK_GREEN;
-    private static final Color colorInterestAccumulated = Colors.DARK_GREEN;
-    private static final Color colorInterestCharge = Colors.DARK_GREEN;
-    private static final Color colorInterestChargeAccumulated = Colors.DARK_GREEN;
-    private static final Color colorEarnings = Colors.DARK_GREEN;
-    private static final Color colorEarningsAccumulated = Colors.DARK_GREEN;
-    private static final Color colorFees = Colors.GRAY;
-    private static final Color colorFeesAccumulated = Colors.GRAY;
+    private final DataSeriesColors colors = DataSeriesColors.instance();
 
     private Label title;
     private TimelineChart chart;
@@ -195,120 +176,126 @@ public class ClientDataSeriesChartWidget extends WidgetDelegate<PerformanceIndex
             if (metrics.contains(ClientDataSeriesType.INVESTED_CAPITAL))
             {
                 double[] values = toDouble(index.calculateInvestedCapital(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorInvestedCapital, Messages.LabelInvestedCapital, true);
+                addLineSerie(values, index.getDates(), colors.investedCapitalColor(), Messages.LabelInvestedCapital,
+                                true);
             }
 
             if (metrics.contains(ClientDataSeriesType.ABSOLUTE_INVESTED_CAPITAL))
             {
                 double[] values = toDouble(index.calculateAbsoluteInvestedCapital(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorAbsoluteInvestedCapital,
+                addLineSerie(values, index.getDates(), colors.absoluteInvestedCapitalColor(),
                                 Messages.LabelAbsoluteInvestedCapital, true);
             }
 
             if (metrics.contains(ClientDataSeriesType.TRANSFERALS))
             {
                 double[] values = toDouble(index.getTransferals(), Values.Amount.divider());
-                addBarSerie(values, index.getDates(), colorTransferals, Messages.LabelTransferals);
+                addBarSerie(values, index.getDates(), colors.transferalsColor(), Messages.LabelTransferals);
             }
 
             if (metrics.contains(ClientDataSeriesType.TRANSFERALS_ACCUMULATED))
             {
                 double[] values = accumulateAndToDouble(index.getTransferals(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorTransferalsAccumulated,
+                addLineSerie(values, index.getDates(), colors.transferalsAccumulatedColor(),
                                 Messages.LabelAccumulatedTransferals, true);
             }
 
             if (metrics.contains(ClientDataSeriesType.TAXES))
             {
                 double[] values = toDouble(index.getTaxes(), Values.Amount.divider());
-                addBarSerie(values, index.getDates(), colorTaxes, Messages.ColumnTaxes);
+                addBarSerie(values, index.getDates(), colors.taxesColor(), Messages.ColumnTaxes);
             }
 
             if (metrics.contains(ClientDataSeriesType.TAXES_ACCUMULATED))
             {
                 double[] values = accumulateAndToDouble(index.getTaxes(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorTaxesAccumulated, Messages.LabelAccumulatedTaxes, true);
+                addLineSerie(values, index.getDates(), colors.taxesAccumulatedColor(), Messages.LabelAccumulatedTaxes,
+                                true);
             }
 
             if (metrics.contains(ClientDataSeriesType.ABSOLUTE_DELTA))
             {
                 double[] values = toDouble(index.calculateDelta(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorAbsoluteDelta, Messages.LabelDelta);
+                addLineSerie(values, index.getDates(), colors.absoluteDeltaColor(), Messages.LabelDelta);
             }
 
             if (metrics.contains(ClientDataSeriesType.ABSOLUTE_DELTA_ALL_RECORDS))
             {
                 double[] values = toDouble(index.calculateAbsoluteDelta(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorAbsoluteDeltaAllRecord, Messages.LabelAbsoluteDelta);
+                addLineSerie(values, index.getDates(), colors.absoluteDeltaAllRecordColor(),
+                                Messages.LabelAbsoluteDelta);
             }
 
             if (metrics.contains(ClientDataSeriesType.DIVIDENDS))
             {
                 double[] values = toDouble(index.getDividends(), Values.Amount.divider());
-                addBarSerie(values, index.getDates(), colorDividends, Messages.LabelDividends);
+                addBarSerie(values, index.getDates(), colors.dividendsColor(), Messages.LabelDividends);
             }
 
             if (metrics.contains(ClientDataSeriesType.DIVIDENDS_ACCUMULATED))
             {
                 double[] values = accumulateAndToDouble(index.getDividends(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorDividendsAccumulated, Messages.LabelAccumulatedDividends);
+                addLineSerie(values, index.getDates(), colors.dividendsAccumulatedColor(),
+                                Messages.LabelAccumulatedDividends);
             }
 
             if (metrics.contains(ClientDataSeriesType.INTEREST))
             {
                 double[] values = toDouble(index.getInterest(), Values.Amount.divider());
-                addBarSerie(values, index.getDates(), colorInterest, Messages.LabelInterest);
+                addBarSerie(values, index.getDates(), colors.interestColor(), Messages.LabelInterest);
             }
 
             if (metrics.contains(ClientDataSeriesType.INTEREST_ACCUMULATED))
             {
                 double[] values = accumulateAndToDouble(index.getInterest(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorInterestAccumulated, Messages.LabelAccumulatedInterest);
+                addLineSerie(values, index.getDates(), colors.interestAccumulatedColor(),
+                                Messages.LabelAccumulatedInterest);
             }
 
             if (metrics.contains(ClientDataSeriesType.INTEREST_CHARGE))
             {
                 double[] values = toDouble(index.getInterestCharge(), Values.Amount.divider());
-                addBarSerie(values, index.getDates(), colorInterestCharge, Messages.LabelInterestCharge);
+                addBarSerie(values, index.getDates(), colors.interestChargeColor(), Messages.LabelInterestCharge);
             }
 
             if (metrics.contains(ClientDataSeriesType.INTEREST_CHARGE_ACCUMULATED))
             {
                 double[] values = accumulateAndToDouble(index.getInterestCharge(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorInterestChargeAccumulated,
+                addLineSerie(values, index.getDates(), colors.interestChargeAccumulatedColor(),
                                 Messages.LabelAccumulatedInterestCharge);
             }
 
             if (metrics.contains(ClientDataSeriesType.EARNINGS))
             {
                 double[] values = toDouble(add(index.getDividends(), index.getInterest()), Values.Amount.divider());
-                addBarSerie(values, index.getDates(), colorEarnings, Messages.LabelEarnings);
+                addBarSerie(values, index.getDates(), colors.earningsColor(), Messages.LabelEarnings);
             }
 
             if (metrics.contains(ClientDataSeriesType.EARNINGS_ACCUMULATED))
             {
                 double[] values = accumulateAndToDouble(add(index.getDividends(), index.getInterest()),
                                 Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorEarningsAccumulated, Messages.LabelAccumulatedEarnings);
+                addLineSerie(values, index.getDates(), colors.earningsAccumulatedColor(),
+                                Messages.LabelAccumulatedEarnings);
             }
 
             if (metrics.contains(ClientDataSeriesType.FEES))
             {
                 double[] values = toDouble(index.getFees(), Values.Amount.divider());
-                addBarSerie(values, index.getDates(), colorFees, Messages.LabelFees);
+                addBarSerie(values, index.getDates(), colors.feesColor(), Messages.LabelFees);
             }
 
             if (metrics.contains(ClientDataSeriesType.FEES_ACCUMULATED))
             {
                 double[] values = accumulateAndToDouble(index.getFees(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorFeesAccumulated, Messages.LabelFeesAccumulated);
+                addLineSerie(values, index.getDates(), colors.feesAccumulatedColor(), Messages.LabelFeesAccumulated);
             }
 
             // Totals at the end to be plotted in front of all the other
             if (metrics.contains(ClientDataSeriesType.TOTALS))
             {
                 double[] values = toDouble(index.getTotals(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorTotals, Messages.LabelTotalSum);
+                addLineSerie(values, index.getDates(), colors.totalsColor(), Messages.LabelTotalSum);
             }
 
             chart.adjustRange();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesSet.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesSet.java
@@ -5,8 +5,6 @@ import java.util.EnumSet;
 import java.util.List;
 
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Display;
 
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.Classification;
@@ -16,7 +14,7 @@ import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Taxonomy;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.ClientFilterMenu;
-import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.DataSeriesColors;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeries.ClientDataSeries;
 import name.abuchen.portfolio.util.ColorConversion;
 
@@ -143,104 +141,106 @@ public class DataSeriesSet
 
     private void buildStatementOfAssetsDataSeries()
     {
+        var colors = DataSeriesColors.instance();
+
         availableSeries.add(new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TOTALS, Messages.LabelTotalSum,
-                        Colors.TOTALS.getRGB()));
+                        colors.totalsColor().getRGB()));
 
         DataSeries series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TRANSFERALS,
-                        Messages.LabelTransferals, Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY).getRGB());
+                        Messages.LabelTransferals, colors.transferalsColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TRANSFERALS_ACCUMULATED,
-                        Messages.LabelAccumulatedTransferals,
-                        Display.getDefault().getSystemColor(SWT.COLOR_YELLOW).getRGB());
+                        Messages.LabelAccumulatedTransferals, colors.transferalsAccumulatedColor().getRGB());
         series.setShowArea(true);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.INVESTED_CAPITAL,
-                        Messages.LabelInvestedCapital, Display.getDefault().getSystemColor(SWT.COLOR_GRAY).getRGB());
+                        Messages.LabelInvestedCapital, colors.investedCapitalColor().getRGB());
         series.setShowArea(true);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.ABSOLUTE_INVESTED_CAPITAL,
-                        Messages.LabelAbsoluteInvestedCapital,
-                        Display.getDefault().getSystemColor(SWT.COLOR_GRAY).getRGB());
+                        Messages.LabelAbsoluteInvestedCapital, colors.absoluteInvestedCapitalColor().getRGB());
         series.setShowArea(true);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.ABSOLUTE_DELTA, Messages.LabelDelta,
-                        Display.getDefault().getSystemColor(SWT.COLOR_GRAY).getRGB());
+                        colors.absoluteDeltaColor().getRGB());
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.ABSOLUTE_DELTA_ALL_RECORDS,
-                        Messages.LabelAbsoluteDelta, Display.getDefault().getSystemColor(SWT.COLOR_GRAY).getRGB());
+                        Messages.LabelAbsoluteDelta, colors.absoluteDeltaAllRecordColor().getRGB());
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TAXES, Messages.ColumnTaxes,
-                        Display.getDefault().getSystemColor(SWT.COLOR_RED).getRGB());
+                        colors.taxesColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TAXES_ACCUMULATED,
-                        Messages.LabelAccumulatedTaxes, Display.getDefault().getSystemColor(SWT.COLOR_RED).getRGB());
+                        Messages.LabelAccumulatedTaxes, colors.taxesAccumulatedColor().getRGB());
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.DIVIDENDS, Messages.LabelDividends,
-                        Display.getDefault().getSystemColor(SWT.COLOR_DARK_MAGENTA).getRGB());
+                        colors.dividendsColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.DIVIDENDS_ACCUMULATED,
-                        Messages.LabelAccumulatedDividends,
-                        Display.getDefault().getSystemColor(SWT.COLOR_DARK_MAGENTA).getRGB());
+                        Messages.LabelAccumulatedDividends, colors.dividendsAccumulatedColor().getRGB());
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.INTEREST, Messages.LabelInterest,
-                        Colors.DARK_GREEN.getRGB());
+                        colors.interestColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.INTEREST_ACCUMULATED,
-                        Messages.LabelAccumulatedInterest, Colors.DARK_GREEN.getRGB());
+                        Messages.LabelAccumulatedInterest, colors.interestAccumulatedColor().getRGB());
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.INTEREST_CHARGE, Messages.LabelInterestCharge,
-                        Colors.DARK_GREEN.getRGB());
+                        colors.interestChargeColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.INTEREST_CHARGE_ACCUMULATED,
-                        Messages.LabelAccumulatedInterestCharge, Colors.DARK_GREEN.getRGB());
+                        Messages.LabelAccumulatedInterestCharge, colors.interestChargeAccumulatedColor().getRGB());
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.EARNINGS, Messages.LabelEarnings,
-                        Colors.DARK_GREEN.getRGB());
+                        colors.earningsColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.EARNINGS_ACCUMULATED,
-                        Messages.LabelAccumulatedEarnings, Colors.DARK_GREEN.getRGB());
+                        Messages.LabelAccumulatedEarnings, colors.earningsAccumulatedColor().getRGB());
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.FEES, Messages.LabelFees,
-                        Colors.GRAY.getRGB());
+                        colors.feesColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.FEES_ACCUMULATED,
-                        Messages.LabelFeesAccumulated, Colors.GRAY.getRGB());
+                        Messages.LabelFeesAccumulated, colors.feesAccumulatedColor().getRGB());
         availableSeries.add(series);
     }
 
     private void buildPerformanceDataSeries(Client client, IPreferenceStore preferences, ColorWheel wheel)
     {
+        var colors = DataSeriesColors.instance();
+
         // accumulated performance
         availableSeries.add(new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TOTALS,
-                        Messages.PerformanceChartLabelEntirePortfolio, Colors.TOTALS.getRGB()));
+                        Messages.PerformanceChartLabelEntirePortfolio,
+                        colors.performanceEntirePortfolioColor().getRGB()));
 
         DataSeries series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.DELTA_PERCENTAGE,
-                        Messages.LabelAggregationDaily, Colors.getColor(60, 151, 218).getRGB());
-        series.setColorNegative(Colors.getColor(253, 156, 82).getRGB());
+                        Messages.LabelAggregationDaily, colors.performancePositiveColor().getRGB());
+        series.setColorNegative(colors.performanceNegativeColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
@@ -258,9 +258,12 @@ public class DataSeriesSet
 
     private void buildReturnVolatilitySeries(Client client, IPreferenceStore preferences, ColorWheel wheel)
     {
+        var colors = DataSeriesColors.instance();
+
         // accumulated performance
         availableSeries.add(new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TOTALS,
-                        Messages.PerformanceChartLabelEntirePortfolio, Colors.TOTALS.getRGB()));
+                        Messages.PerformanceChartLabelEntirePortfolio,
+                        colors.performanceEntirePortfolioColor().getRGB()));
 
         // securities as benchmark
         for (Security security : client.getSecurities())

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsColors.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsColors.java
@@ -2,33 +2,14 @@ package name.abuchen.portfolio.ui.views.payments;
 
 import org.eclipse.swt.graphics.Color;
 
-import name.abuchen.portfolio.ui.util.Colors;
-
 public class PaymentsColors
 {
-    private static final Color[] COLORS = new Color[] { //
-                    Colors.getColor(140, 86, 75), //
-                    Colors.getColor(227, 119, 194), //
-                    Colors.getColor(127, 127, 127), //
-                    Colors.getColor(188, 189, 34), //
-                    Colors.getColor(23, 190, 207), //
-                    Colors.getColor(114, 124, 201), //
-                    Colors.getColor(250, 115, 92), //
-                    Colors.getColor(253, 182, 103), //
-                    Colors.getColor(143, 207, 112), //
-                    Colors.getColor(87, 207, 253), //
-                    Colors.getColor(31, 119, 180), //
-                    Colors.getColor(255, 127, 14), //
-                    Colors.getColor(44, 160, 44), //
-                    Colors.getColor(214, 39, 40), //
-                    Colors.getColor(148, 103, 189) }; //
-
     private PaymentsColors()
     {
     }
 
     public static Color getColor(int year)
     {
-        return COLORS[year % COLORS.length];
+        return PaymentsPalette.instance().getCyclic(year);
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPalette.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPalette.java
@@ -1,0 +1,59 @@
+package name.abuchen.portfolio.ui.views.payments;
+
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGBA;
+
+import name.abuchen.portfolio.ui.util.Colors;
+
+public final class PaymentsPalette
+{
+    private static final int SIZE = 15;
+
+    private static final PaymentsPalette INSTANCE = new PaymentsPalette();
+
+    private final Color[] colors = new Color[] { //
+                    Colors.getColor(140, 86, 75), //
+                    Colors.getColor(227, 119, 194), //
+                    Colors.getColor(127, 127, 127), //
+                    Colors.getColor(188, 189, 34), //
+                    Colors.getColor(23, 190, 207), //
+                    Colors.getColor(114, 124, 201), //
+                    Colors.getColor(250, 115, 92), //
+                    Colors.getColor(253, 182, 103), //
+                    Colors.getColor(143, 207, 112), //
+                    Colors.getColor(87, 207, 253), //
+                    Colors.getColor(31, 119, 180), //
+                    Colors.getColor(255, 127, 14), //
+                    Colors.getColor(44, 160, 44), //
+                    Colors.getColor(214, 39, 40), //
+                    Colors.getColor(148, 103, 189) }; //
+
+    private PaymentsPalette()
+    {
+    }
+
+    public static PaymentsPalette instance()
+    {
+        return INSTANCE;
+    }
+
+    public int size()
+    {
+        return SIZE;
+    }
+
+    public Color get(int index)
+    {
+        return colors[index];
+    }
+
+    public Color getCyclic(int index)
+    {
+        return colors[index % colors.length];
+    }
+
+    public void setColor(int index, RGBA color)
+    {
+        colors[index] = Colors.getColor(color.rgb);
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPalette.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPalette.java
@@ -11,22 +11,7 @@ public final class PaymentsPalette
 
     private static final PaymentsPalette INSTANCE = new PaymentsPalette();
 
-    private final Color[] colors = new Color[] { //
-                    Colors.getColor(140, 86, 75), //
-                    Colors.getColor(227, 119, 194), //
-                    Colors.getColor(127, 127, 127), //
-                    Colors.getColor(188, 189, 34), //
-                    Colors.getColor(23, 190, 207), //
-                    Colors.getColor(114, 124, 201), //
-                    Colors.getColor(250, 115, 92), //
-                    Colors.getColor(253, 182, 103), //
-                    Colors.getColor(143, 207, 112), //
-                    Colors.getColor(87, 207, 253), //
-                    Colors.getColor(31, 119, 180), //
-                    Colors.getColor(255, 127, 14), //
-                    Colors.getColor(44, 160, 44), //
-                    Colors.getColor(214, 39, 40), //
-                    Colors.getColor(148, 103, 189) }; //
+    private final Color[] colors = new Color[SIZE];
 
     private PaymentsPalette()
     {
@@ -44,12 +29,21 @@ public final class PaymentsPalette
 
     public Color get(int index)
     {
-        return colors[index];
+        return requireConfigured(index);
     }
 
     public Color getCyclic(int index)
     {
-        return colors[index % colors.length];
+        return requireConfigured(index % colors.length);
+    }
+
+    private Color requireConfigured(int index)
+    {
+        if (colors[index] == null)
+            throw new IllegalStateException(
+                            "CSS payments palette color not configured: ColorPalette.payments.color-" + index); //$NON-NLS-1$
+
+        return colors[index];
     }
 
     public void setColor(int index, RGBA color)


### PR DESCRIPTION
## Summary

This PR moves the core chart and palette colors from hard-coded Java values to CSS-based theme definitions.

The goal is to make theme color changes easier and more consistent, without changing the existing chart behavior.

This change focuses on the main chart and palette color domains only.

## What was changed

### CSS theme definitions
Added or extended color definitions in:

- `name.abuchen.portfolio.ui/css/shared/light.css`
- `name.abuchen.portfolio.ui/css/shared/dark.css`

This includes theme entries for:

- `CustomColors`
- `ValueColorScheme`
- `SecuritiesChart`
- `PortfolioBalanceChart`
- `DataSeries`
- `ColorPalette.payments`
- `ColorGradient.*`

### New CSS integration for Java target objects
Added CSS adapters and handlers for objects that need runtime color injection:

- `DataSeriesColors`
- `PaymentsPalette`
- `ColorGradientDefinitions.Definition`

### Theme registration
Updated the theme integration so these objects are styled by the CSS engine:

- `plugin.xml`
- `ElementProvider`
- `ThemeAddon`

### Active color migration in chart code
Replaced active hard-coded chart color usage with CSS-populated runtime values in:

- `SecuritiesChart`
- `PortfolioBalanceChart`
- `ClientDataSeriesChartWidget`
- `DataSeriesSet`
- `PaymentsColors`

## Important design note

The CSS engine does not color a chart series directly.

Instead, CSS writes color values into a Java target object first (for example `SecuritiesChart` or `PaymentsPalette`).

The chart code then uses these values when it creates the actual graphical series (for example a `LineSeries`).

This keeps the rendering logic in Java, but moves the theme color source into CSS.

## Why some fallback colors stay in Java

Some neutral fallback colors (for example black, gray, or white) remain in Java on purpose.

Reason:

- the object can exist before CSS is applied
- theme styling is applied later at runtime
- without a safe fallback, the code could hit `null` values or unstable rendering during initialization

These fallback values are **not** the intended design source anymore.

They are only a safe technical default until CSS is applied.

## Scope

This PR covers the **core chart and palette migration**.

It does **not** try to remove all remaining color logic from Java.

Some direct color logic outside this scope is intentionally left unchanged for now, for example:

- algorithmic palettes
- widgets without their own CSS domain
- dynamic theme-dependent logic that is not a simple static color mapping

## Result

After this change, the main chart and palette colors are controlled by CSS theme definitions instead of active hard-coded Java values.

This makes future theme changes easier, more centralized, and less error-prone.