### PR TITLE
[1/7] CSS :: Add CSS-backed core theme color infrastructure

### DIFF
--- a/name.abuchen.portfolio.ui/css/shared/light.css
+++ b/name.abuchen.portfolio.ui/css/shared/light.css
@@ -92,6 +92,8 @@ CustomColors {
 	red-foreground: #7f0000;
 	green-foreground: #377500;
 	gray-foreground: #707070;
+	
+	hyperlink: "#COLOR_LINK_FOREGROUND";
 }
 
 ValueColorScheme.standard {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ColorsThemeCSSHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ColorsThemeCSSHandler.java
@@ -14,47 +14,45 @@ public class ColorsThemeCSSHandler implements ICSSPropertyHandler
     public boolean applyCSSProperty(Object element, String property, CSSValue value, String pseudo, CSSEngine engine)
                     throws Exception
     {
-        if (element instanceof ColorsThemeElementAdapter colorsThemeAdapter)
+        if (!(element instanceof ColorsThemeElementAdapter colorsThemeAdapter))
+            return false;
+
+        Colors.Theme theme = colorsThemeAdapter.getColorsTheme();
+
+        switch (property)
         {
-            Colors.Theme theme = colorsThemeAdapter.getColorsTheme();
-
-            switch (property)
-            {
-                case "default-foreground": //$NON-NLS-1$
-                    theme.setDefaultForeground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "default-background": //$NON-NLS-1$
-                    theme.setDefaultBackground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "chip-background": //$NON-NLS-1$
-                    theme.setChipBackground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "warning-background": //$NON-NLS-1$
-                    theme.setWarningBackground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "red-background": //$NON-NLS-1$
-                    theme.setRedBackground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "green-background": //$NON-NLS-1$
-                    theme.setGreenBackground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "red-foreground": //$NON-NLS-1$
-                    theme.setRedForeground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "green-foreground": //$NON-NLS-1$
-                    theme.setGreenForeground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "gray-foreground": //$NON-NLS-1$
-                    theme.setGrayForeground(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                case "hyperlink": //$NON-NLS-1$
-                    theme.setHyperlink(CSSSWTColorHelper.getRGBA(value));
-                    break;
-                default:
-            }
+            case "default-foreground": //$NON-NLS-1$
+                theme.setDefaultForeground(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "default-background": //$NON-NLS-1$
+                theme.setDefaultBackground(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "chip-background": //$NON-NLS-1$
+                theme.setChipBackground(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "warning-background": //$NON-NLS-1$
+                theme.setWarningBackground(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "red-background": //$NON-NLS-1$
+                theme.setRedBackground(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "green-background": //$NON-NLS-1$
+                theme.setGreenBackground(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "red-foreground": //$NON-NLS-1$
+                theme.setRedForeground(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "green-foreground": //$NON-NLS-1$
+                theme.setGreenForeground(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "gray-foreground": //$NON-NLS-1$
+                theme.setGrayForeground(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            case "hyperlink": //$NON-NLS-1$
+                theme.setHyperlink(CSSSWTColorHelper.getRGBA(value));
+                return true;
+            default:
+                return false;
         }
-
-        return false;
     }
-
 }


### PR DESCRIPTION
This PR is part of a stacked CSS color migration series and should be reviewed in order.

Adds the core infrastructure for CSS-backed theme colors. This prepares shared UI color values for central configuration through the theme CSS files.

**[#5644 – Add CSS-backed core theme color infrastructure](https://github.com/portfolio-performance/portfolio/pull/5644)**
[#5645 – Move data series chart colors to CSS](https://github.com/portfolio-performance/portfolio/pull/5645)
[#5646 – Move portfolio balance chart colors to CSS](https://github.com/portfolio-performance/portfolio/pull/5646)
[#5647 – Move securities chart colors to CSS](https://github.com/portfolio-performance/portfolio/pull/5647)
[#5648 – Move payments palette colors to CSS](https://github.com/portfolio-performance/portfolio/pull/5648)
[#5649 – Move color gradient definitions to CSS](https://github.com/portfolio-performance/portfolio/pull/5649)
[#5650 – Add color architecture debug view](https://github.com/portfolio-performance/portfolio/pull/5650)

**Note:**
This series was split to make the review of each semantic color group easier.
Some later PRs may not build independently against master until the preceding PRs have been merged.

The split is artificial to some extent because shared files such as CSS files, plugin.xml, ThemeAddon and ElementProvider are touched by multiple steps. I tried to keep each PR focused and to show only the final intended change per semantic area, but minor merge follow-up may still be required after the series is reviewed.