### PR TITLE
[2/7] CSS :: Move data series chart colors to CSS

### DIFF
--- a/name.abuchen.portfolio.ui/css/shared/dark.css
+++ b/name.abuchen.portfolio.ui/css/shared/dark.css
@@ -142,6 +142,40 @@ PortfolioBalanceChart.asia {
 	delta-area-negative-color: #23b0d7;
 }
 
+DataSeries {
+	totals-color: #EEEEEE;
+
+	invested-capital-color: #ffaf4d;
+	absolute-invested-capital-color: #ffaf4d;
+
+	transferals-color: #A0A0A0;
+	transferals-accumulated-color: #ffd562;
+
+	taxes-color: #ff2b30;
+	taxes-accumulated-color: #ff2b30;
+
+	absolute-delta-color: #4ddaff;
+	absolute-delta-all-record-color: #4ddaff;
+
+	dividends-color: #8063A8;
+	dividends-accumulated-color: #8063A8;
+
+	interest-color: #02f500;
+	interest-accumulated-color: #02f500;
+
+	interest-charge-color: #02f500;
+	interest-charge-accumulated-color: #02f500;
+
+	earnings-color: #02f500;
+	earnings-accumulated-color: #02f500;
+
+	fees-color: #808080;
+	fees-accumulated-color: #808080;
+
+	performance-entire-portfolio-color: #EEEEEE;
+	performance-positive-color: #4DA6FF;
+	performance-negative-color: #FFB366;
+}
 * {
 	font-family: "#systemfont";
 }

--- a/name.abuchen.portfolio.ui/css/shared/light.css
+++ b/name.abuchen.portfolio.ui/css/shared/light.css
@@ -175,6 +175,40 @@ PortfolioBalanceChart.asia {
 	delta-area-negative-color: #8396f2;
 }
 
+DataSeries {
+	totals-color: #000000;
+
+	invested-capital-color: #EBC934;
+	absolute-invested-capital-color: #EBC934;
+
+	transferals-color: #A9A9A9;
+	transferals-accumulated-color: #FFFF00;
+
+	taxes-color: #FF0000;
+	taxes-accumulated-color: #FF0000;
+
+	absolute-delta-color: #0000FF;
+	absolute-delta-all-record-color: #0000FF;
+
+	dividends-color: #800080;
+	dividends-accumulated-color: #800080;
+
+	interest-color: #377500;
+	interest-accumulated-color: #377500;
+
+	interest-charge-color: #377500;
+	interest-charge-accumulated-color: #377500;
+
+	earnings-color: #377500;
+	earnings-accumulated-color: #377500;
+
+	fees-color: #808080;
+	fees-accumulated-color: #808080;
+
+	performance-entire-portfolio-color: #000000;
+	performance-positive-color: #3C97DA;
+	performance-negative-color: #FD9C52;
+}
 * {
 	font-family: "#systemfont";
 }

--- a/name.abuchen.portfolio.ui/plugin.xml
+++ b/name.abuchen.portfolio.ui/plugin.xml
@@ -185,6 +185,77 @@
                name="down-arrow">
          </property-name>
       </handler>
+
+      <handler
+            adapter="name.abuchen.portfolio.ui.theme.DataSeriesColorsCSS$ElementAdapter"
+            handler="name.abuchen.portfolio.ui.theme.DataSeriesColorsCSS$Handler">
+         <property-name
+               name="totals-color">
+         </property-name>
+         <property-name
+               name="invested-capital-color">
+         </property-name>
+         <property-name
+               name="absolute-invested-capital-color">
+         </property-name>
+         <property-name
+               name="transferals-color">
+         </property-name>
+         <property-name
+               name="transferals-accumulated-color">
+         </property-name>
+         <property-name
+               name="taxes-color">
+         </property-name>
+         <property-name
+               name="taxes-accumulated-color">
+         </property-name>
+         <property-name
+               name="absolute-delta-color">
+         </property-name>
+         <property-name
+               name="absolute-delta-all-record-color">
+         </property-name>
+         <property-name
+               name="dividends-color">
+         </property-name>
+         <property-name
+               name="dividends-accumulated-color">
+         </property-name>
+         <property-name
+               name="interest-color">
+         </property-name>
+         <property-name
+               name="interest-accumulated-color">
+         </property-name>
+         <property-name
+               name="interest-charge-color">
+         </property-name>
+         <property-name
+               name="interest-charge-accumulated-color">
+         </property-name>
+         <property-name
+               name="earnings-color">
+         </property-name>
+         <property-name
+               name="earnings-accumulated-color">
+         </property-name>
+         <property-name
+               name="fees-color">
+         </property-name>
+         <property-name
+               name="fees-accumulated-color">
+         </property-name>
+         <property-name
+               name="performance-entire-portfolio-color">
+         </property-name>
+         <property-name
+               name="performance-positive-color">
+         </property-name>
+         <property-name
+               name="performance-negative-color">
+         </property-name>
+      </handler>
    </extension>
    <extension
          point="org.eclipse.e4.ui.css.core.elementProvider">
@@ -222,6 +293,9 @@
          </widget>
          <widget
                class="name.abuchen.portfolio.ui.util.ValueColorScheme">
+         </widget>
+         <widget
+               class="name.abuchen.portfolio.ui.util.DataSeriesColors">
          </widget>
       </provider>
    </extension>

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/DataSeriesColorsCSS.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/DataSeriesColorsCSS.java
@@ -1,0 +1,171 @@
+package name.abuchen.portfolio.ui.theme;
+
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.eclipse.e4.ui.css.swt.helpers.CSSSWTColorHelper;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.css.CSSValue;
+
+import name.abuchen.portfolio.ui.util.DataSeriesColors;
+import name.abuchen.portfolio.ui.util.ValueColorScheme;
+
+public final class DataSeriesColorsCSS
+{
+    private DataSeriesColorsCSS()
+    {
+    }
+
+    @SuppressWarnings("restriction")
+    public static final class ElementAdapter extends org.eclipse.e4.ui.css.core.dom.ElementAdapter
+    {
+        public ElementAdapter(DataSeriesColors colors, CSSEngine engine)
+        {
+            super(colors, engine);
+        }
+
+        public DataSeriesColors getColors()
+        {
+            return (DataSeriesColors) getNativeWidget();
+        }
+
+        @Override
+        public String getCSSId()
+        {
+            return null;
+        }
+
+        @Override
+        public String getCSSClass()
+        {
+            return ValueColorScheme.current().getIdentifier();
+        }
+
+        @Override
+        public String getCSSStyle()
+        {
+            return null;
+        }
+
+        @Override
+        public Node getParentNode()
+        {
+            return null;
+        }
+
+        @Override
+        public NodeList getChildNodes()
+        {
+            return null;
+        }
+
+        @Override
+        public String getNamespaceURI()
+        {
+            return null;
+        }
+
+        @Override
+        public String getLocalName()
+        {
+            return "DataSeries"; //$NON-NLS-1$
+        }
+
+        @Override
+        public String getAttribute(String name)
+        {
+            return ""; //$NON-NLS-1$
+        }
+    }
+
+    @SuppressWarnings("restriction")
+    public static final class Handler implements org.eclipse.e4.ui.css.core.dom.properties.ICSSPropertyHandler
+    {
+        @Override
+        public boolean applyCSSProperty(Object element, String property, CSSValue value, String pseudo,
+                        CSSEngine engine) throws Exception
+        {
+            if (element instanceof DataSeriesColorsCSS.ElementAdapter adapter)
+            {
+                var colors = adapter.getColors();
+                return applyTo(colors, property, value);
+            }
+
+            return false;
+        }
+
+        private boolean applyTo(DataSeriesColors colors, String property, CSSValue value)
+        {
+            switch (property)
+            {
+                case "totals-color": //$NON-NLS-1$
+                    colors.setTotalsColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "invested-capital-color": //$NON-NLS-1$
+                    colors.setInvestedCapitalColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "absolute-invested-capital-color": //$NON-NLS-1$
+                    colors.setAbsoluteInvestedCapitalColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "transferals-color": //$NON-NLS-1$
+                    colors.setTransferalsColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "transferals-accumulated-color": //$NON-NLS-1$
+                    colors.setTransferalsAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "taxes-color": //$NON-NLS-1$
+                    colors.setTaxesColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "taxes-accumulated-color": //$NON-NLS-1$
+                    colors.setTaxesAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "absolute-delta-color": //$NON-NLS-1$
+                    colors.setAbsoluteDeltaColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "absolute-delta-all-record-color": //$NON-NLS-1$
+                    colors.setAbsoluteDeltaAllRecordColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "dividends-color": //$NON-NLS-1$
+                    colors.setDividendsColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "dividends-accumulated-color": //$NON-NLS-1$
+                    colors.setDividendsAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "interest-color": //$NON-NLS-1$
+                    colors.setInterestColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "interest-accumulated-color": //$NON-NLS-1$
+                    colors.setInterestAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "interest-charge-color": //$NON-NLS-1$
+                    colors.setInterestChargeColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "interest-charge-accumulated-color": //$NON-NLS-1$
+                    colors.setInterestChargeAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "earnings-color": //$NON-NLS-1$
+                    colors.setEarningsColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "earnings-accumulated-color": //$NON-NLS-1$
+                    colors.setEarningsAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "fees-color": //$NON-NLS-1$
+                    colors.setFeesColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "fees-accumulated-color": //$NON-NLS-1$
+                    colors.setFeesAccumulatedColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "performance-entire-portfolio-color": //$NON-NLS-1$
+                    colors.setPerformanceEntirePortfolioColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "performance-positive-color": //$NON-NLS-1$
+                    colors.setPerformancePositiveColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                case "performance-negative-color": //$NON-NLS-1$
+                    colors.setPerformanceNegativeColor(CSSSWTColorHelper.getRGBA(value));
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ElementProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ElementProvider.java
@@ -15,6 +15,7 @@ import org.w3c.dom.Element;
 
 import name.abuchen.portfolio.ui.editor.Sidebar;
 import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.DataSeriesColors;
 import name.abuchen.portfolio.ui.util.ValueColorScheme;
 import name.abuchen.portfolio.ui.views.PortfolioBalanceChart;
 import name.abuchen.portfolio.ui.views.SecuritiesChart;
@@ -37,6 +38,8 @@ public class ElementProvider implements IElementProvider
             return new ChartElementAdapter(chart, engine);
         if (element instanceof Colors.Theme colorsTheme)
             return new ColorsThemeElementAdapter(colorsTheme, engine);
+        if (element instanceof DataSeriesColors dataSeriesColors)
+            return new DataSeriesColorsCSS.ElementAdapter(dataSeriesColors, engine);
         if (element instanceof Table table)
             return new TableElementAdapter(table, engine);
         if (element instanceof Tree tree)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ThemeAddon.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ThemeAddon.java
@@ -10,6 +10,7 @@ import org.osgi.service.event.Event;
 
 import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.DataSeriesColors;
 import name.abuchen.portfolio.ui.util.ValueColorScheme;
 
 @SuppressWarnings("restriction")
@@ -24,6 +25,7 @@ public class ThemeAddon
     {
         IThemeEngine engine = (IThemeEngine) event.getProperty(IThemeEngine.Events.THEME_ENGINE);
         engine.applyStyles(Colors.theme(), false);
+        engine.applyStyles(DataSeriesColors.instance(), false);
 
         for (var scheme : ValueColorScheme.getAvailableSchemes())
             engine.applyStyles(scheme, false);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/DataSeriesColors.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/DataSeriesColors.java
@@ -1,0 +1,286 @@
+package name.abuchen.portfolio.ui.util;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGBA;
+import org.eclipse.swt.widgets.Display;
+
+/**
+ * Holds the default colors for the client data series shown in the dashboard
+ * and performance charts.
+ * <p>
+ * The field initializers below are fallback values only. The authoritative
+ * colors are defined in the CSS theme files (light.css / dark.css) under the
+ * {@code DataSeries} selector and are applied via
+ * {@code name.abuchen.portfolio.ui.theme.DataSeriesColorsCSS} when the theme
+ * engine runs (see {@code ThemeAddon}). Because the theme is
+ * always applied at startup, the CSS values - not these defaults - determine
+ * what is rendered. When changing a default color, update the CSS as well.
+ */
+public final class DataSeriesColors
+{
+    private static final DataSeriesColors INSTANCE = new DataSeriesColors();
+
+    private Color totalsColor = Colors.BLACK;
+
+    private Color investedCapitalColor = Colors.getColor(235, 201, 52); // #EBC934;
+    private Color absoluteInvestedCapitalColor = Colors.getColor(235, 201, 52); // #EBC934;
+
+    private Color transferalsColor = Colors.DARK_GRAY;
+    private Color transferalsAccumulatedColor = Display.getDefault().getSystemColor(SWT.COLOR_YELLOW);
+
+    private Color taxesColor = Colors.RED;
+    private Color taxesAccumulatedColor = Colors.RED;
+
+    private Color absoluteDeltaColor = Display.getDefault().getSystemColor(SWT.COLOR_BLUE);
+    private Color absoluteDeltaAllRecordColor = Display.getDefault().getSystemColor(SWT.COLOR_BLUE);
+
+    private Color dividendsColor = Display.getDefault().getSystemColor(SWT.COLOR_DARK_MAGENTA);
+    private Color dividendsAccumulatedColor = Display.getDefault().getSystemColor(SWT.COLOR_DARK_MAGENTA);
+
+    private Color interestColor = Colors.DARK_GREEN;
+    private Color interestAccumulatedColor = Colors.DARK_GREEN;
+
+    private Color interestChargeColor = Colors.DARK_GREEN;
+    private Color interestChargeAccumulatedColor = Colors.DARK_GREEN;
+
+    private Color earningsColor = Colors.DARK_GREEN;
+    private Color earningsAccumulatedColor = Colors.DARK_GREEN;
+
+    private Color feesColor = Colors.GRAY;
+    private Color feesAccumulatedColor = Colors.GRAY;
+
+    private Color performanceEntirePortfolioColor = Colors.BLACK;
+
+    private Color performancePositiveColor = Colors.BLACK;
+    private Color performanceNegativeColor = Colors.BLACK;
+
+    private DataSeriesColors()
+    {
+    }
+
+    public static DataSeriesColors instance()
+    {
+        return INSTANCE;
+    }
+
+    public Color totalsColor()
+    {
+        return totalsColor;
+    }
+
+    public void setTotalsColor(RGBA color)
+    {
+        this.totalsColor = Colors.getColor(color.rgb);
+    }
+
+    public Color investedCapitalColor()
+    {
+        return investedCapitalColor;
+    }
+
+    public void setInvestedCapitalColor(RGBA color)
+    {
+        this.investedCapitalColor = Colors.getColor(color.rgb);
+    }
+
+    public Color absoluteInvestedCapitalColor()
+    {
+        return absoluteInvestedCapitalColor;
+    }
+
+    public void setAbsoluteInvestedCapitalColor(RGBA color)
+    {
+        this.absoluteInvestedCapitalColor = Colors.getColor(color.rgb);
+    }
+
+    public Color transferalsColor()
+    {
+        return transferalsColor;
+    }
+
+    public void setTransferalsColor(RGBA color)
+    {
+        this.transferalsColor = Colors.getColor(color.rgb);
+    }
+
+    public Color transferalsAccumulatedColor()
+    {
+        return transferalsAccumulatedColor;
+    }
+
+    public void setTransferalsAccumulatedColor(RGBA color)
+    {
+        this.transferalsAccumulatedColor = Colors.getColor(color.rgb);
+    }
+
+    public Color taxesColor()
+    {
+        return taxesColor;
+    }
+
+    public void setTaxesColor(RGBA color)
+    {
+        this.taxesColor = Colors.getColor(color.rgb);
+    }
+
+    public Color taxesAccumulatedColor()
+    {
+        return taxesAccumulatedColor;
+    }
+
+    public void setTaxesAccumulatedColor(RGBA color)
+    {
+        this.taxesAccumulatedColor = Colors.getColor(color.rgb);
+    }
+
+    public Color absoluteDeltaColor()
+    {
+        return absoluteDeltaColor;
+    }
+
+    public void setAbsoluteDeltaColor(RGBA color)
+    {
+        this.absoluteDeltaColor = Colors.getColor(color.rgb);
+    }
+
+    public Color absoluteDeltaAllRecordColor()
+    {
+        return absoluteDeltaAllRecordColor;
+    }
+
+    public void setAbsoluteDeltaAllRecordColor(RGBA color)
+    {
+        this.absoluteDeltaAllRecordColor = Colors.getColor(color.rgb);
+    }
+
+    public Color dividendsColor()
+    {
+        return dividendsColor;
+    }
+
+    public void setDividendsColor(RGBA color)
+    {
+        this.dividendsColor = Colors.getColor(color.rgb);
+    }
+
+    public Color dividendsAccumulatedColor()
+    {
+        return dividendsAccumulatedColor;
+    }
+
+    public void setDividendsAccumulatedColor(RGBA color)
+    {
+        this.dividendsAccumulatedColor = Colors.getColor(color.rgb);
+    }
+
+    public Color interestColor()
+    {
+        return interestColor;
+    }
+
+    public void setInterestColor(RGBA color)
+    {
+        this.interestColor = Colors.getColor(color.rgb);
+    }
+
+    public Color interestAccumulatedColor()
+    {
+        return interestAccumulatedColor;
+    }
+
+    public void setInterestAccumulatedColor(RGBA color)
+    {
+        this.interestAccumulatedColor = Colors.getColor(color.rgb);
+    }
+
+    public Color interestChargeColor()
+    {
+        return interestChargeColor;
+    }
+
+    public void setInterestChargeColor(RGBA color)
+    {
+        this.interestChargeColor = Colors.getColor(color.rgb);
+    }
+
+    public Color interestChargeAccumulatedColor()
+    {
+        return interestChargeAccumulatedColor;
+    }
+
+    public void setInterestChargeAccumulatedColor(RGBA color)
+    {
+        this.interestChargeAccumulatedColor = Colors.getColor(color.rgb);
+    }
+
+    public Color earningsColor()
+    {
+        return earningsColor;
+    }
+
+    public void setEarningsColor(RGBA color)
+    {
+        this.earningsColor = Colors.getColor(color.rgb);
+    }
+
+    public Color earningsAccumulatedColor()
+    {
+        return earningsAccumulatedColor;
+    }
+
+    public void setEarningsAccumulatedColor(RGBA color)
+    {
+        this.earningsAccumulatedColor = Colors.getColor(color.rgb);
+    }
+
+    public Color feesColor()
+    {
+        return feesColor;
+    }
+
+    public void setFeesColor(RGBA color)
+    {
+        this.feesColor = Colors.getColor(color.rgb);
+    }
+
+    public Color feesAccumulatedColor()
+    {
+        return feesAccumulatedColor;
+    }
+
+    public void setFeesAccumulatedColor(RGBA color)
+    {
+        this.feesAccumulatedColor = Colors.getColor(color.rgb);
+    }
+
+    public Color performanceEntirePortfolioColor()
+    {
+        return performanceEntirePortfolioColor;
+    }
+
+    public void setPerformanceEntirePortfolioColor(RGBA color)
+    {
+        this.performanceEntirePortfolioColor = Colors.getColor(color.rgb);
+    }
+
+    public Color performancePositiveColor()
+    {
+        return performancePositiveColor;
+    }
+
+    public void setPerformancePositiveColor(RGBA color)
+    {
+        this.performancePositiveColor = Colors.getColor(color.rgb);
+    }
+
+    public Color performanceNegativeColor()
+    {
+        return performanceNegativeColor;
+    }
+
+    public void setPerformanceNegativeColor(RGBA color)
+    {
+        this.performanceNegativeColor = Colors.getColor(color.rgb);
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/ClientDataSeriesChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/ClientDataSeriesChartWidget.java
@@ -13,7 +13,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 
 import name.abuchen.portfolio.model.Dashboard;
@@ -21,7 +20,7 @@ import name.abuchen.portfolio.model.Dashboard.Widget;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;
 import name.abuchen.portfolio.ui.Messages;
-import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.DataSeriesColors;
 import name.abuchen.portfolio.ui.util.chart.TimelineChart;
 import name.abuchen.portfolio.ui.util.format.AmountNumberFormat;
 import name.abuchen.portfolio.ui.util.format.ThousandsNumberFormat;
@@ -40,25 +39,7 @@ import name.abuchen.portfolio.util.TextUtil;
 
 public class ClientDataSeriesChartWidget extends WidgetDelegate<PerformanceIndex>
 {
-    private static final Color colorTotals = Colors.BLACK;
-    private static final Color colorInvestedCapital = Colors.getColor(235, 201, 52); // #EBC934
-    private static final Color colorAbsoluteInvestedCapital = Colors.getColor(235, 201, 52); // #EBC934
-    private static final Color colorTransferals = Colors.DARK_GRAY;
-    private static final Color colorTransferalsAccumulated = Display.getDefault().getSystemColor(SWT.COLOR_YELLOW);
-    private static final Color colorTaxes = Colors.RED;
-    private static final Color colorTaxesAccumulated = Colors.RED;
-    private static final Color colorAbsoluteDelta = Display.getDefault().getSystemColor(SWT.COLOR_BLUE);
-    private static final Color colorAbsoluteDeltaAllRecord = Display.getDefault().getSystemColor(SWT.COLOR_BLUE);
-    private static final Color colorDividends = Display.getDefault().getSystemColor(SWT.COLOR_DARK_MAGENTA);
-    private static final Color colorDividendsAccumulated = Display.getDefault().getSystemColor(SWT.COLOR_DARK_MAGENTA);
-    private static final Color colorInterest = Colors.DARK_GREEN;
-    private static final Color colorInterestAccumulated = Colors.DARK_GREEN;
-    private static final Color colorInterestCharge = Colors.DARK_GREEN;
-    private static final Color colorInterestChargeAccumulated = Colors.DARK_GREEN;
-    private static final Color colorEarnings = Colors.DARK_GREEN;
-    private static final Color colorEarningsAccumulated = Colors.DARK_GREEN;
-    private static final Color colorFees = Colors.GRAY;
-    private static final Color colorFeesAccumulated = Colors.GRAY;
+    private final DataSeriesColors colors = DataSeriesColors.instance();
 
     private Label title;
     private TimelineChart chart;
@@ -195,120 +176,126 @@ public class ClientDataSeriesChartWidget extends WidgetDelegate<PerformanceIndex
             if (metrics.contains(ClientDataSeriesType.INVESTED_CAPITAL))
             {
                 double[] values = toDouble(index.calculateInvestedCapital(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorInvestedCapital, Messages.LabelInvestedCapital, true);
+                addLineSerie(values, index.getDates(), colors.investedCapitalColor(), Messages.LabelInvestedCapital,
+                                true);
             }
 
             if (metrics.contains(ClientDataSeriesType.ABSOLUTE_INVESTED_CAPITAL))
             {
                 double[] values = toDouble(index.calculateAbsoluteInvestedCapital(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorAbsoluteInvestedCapital,
+                addLineSerie(values, index.getDates(), colors.absoluteInvestedCapitalColor(),
                                 Messages.LabelAbsoluteInvestedCapital, true);
             }
 
             if (metrics.contains(ClientDataSeriesType.TRANSFERALS))
             {
                 double[] values = toDouble(index.getTransferals(), Values.Amount.divider());
-                addBarSerie(values, index.getDates(), colorTransferals, Messages.LabelTransferals);
+                addBarSerie(values, index.getDates(), colors.transferalsColor(), Messages.LabelTransferals);
             }
 
             if (metrics.contains(ClientDataSeriesType.TRANSFERALS_ACCUMULATED))
             {
                 double[] values = accumulateAndToDouble(index.getTransferals(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorTransferalsAccumulated,
+                addLineSerie(values, index.getDates(), colors.transferalsAccumulatedColor(),
                                 Messages.LabelAccumulatedTransferals, true);
             }
 
             if (metrics.contains(ClientDataSeriesType.TAXES))
             {
                 double[] values = toDouble(index.getTaxes(), Values.Amount.divider());
-                addBarSerie(values, index.getDates(), colorTaxes, Messages.ColumnTaxes);
+                addBarSerie(values, index.getDates(), colors.taxesColor(), Messages.ColumnTaxes);
             }
 
             if (metrics.contains(ClientDataSeriesType.TAXES_ACCUMULATED))
             {
                 double[] values = accumulateAndToDouble(index.getTaxes(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorTaxesAccumulated, Messages.LabelAccumulatedTaxes, true);
+                addLineSerie(values, index.getDates(), colors.taxesAccumulatedColor(), Messages.LabelAccumulatedTaxes,
+                                true);
             }
 
             if (metrics.contains(ClientDataSeriesType.ABSOLUTE_DELTA))
             {
                 double[] values = toDouble(index.calculateDelta(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorAbsoluteDelta, Messages.LabelDelta);
+                addLineSerie(values, index.getDates(), colors.absoluteDeltaColor(), Messages.LabelDelta);
             }
 
             if (metrics.contains(ClientDataSeriesType.ABSOLUTE_DELTA_ALL_RECORDS))
             {
                 double[] values = toDouble(index.calculateAbsoluteDelta(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorAbsoluteDeltaAllRecord, Messages.LabelAbsoluteDelta);
+                addLineSerie(values, index.getDates(), colors.absoluteDeltaAllRecordColor(),
+                                Messages.LabelAbsoluteDelta);
             }
 
             if (metrics.contains(ClientDataSeriesType.DIVIDENDS))
             {
                 double[] values = toDouble(index.getDividends(), Values.Amount.divider());
-                addBarSerie(values, index.getDates(), colorDividends, Messages.LabelDividends);
+                addBarSerie(values, index.getDates(), colors.dividendsColor(), Messages.LabelDividends);
             }
 
             if (metrics.contains(ClientDataSeriesType.DIVIDENDS_ACCUMULATED))
             {
                 double[] values = accumulateAndToDouble(index.getDividends(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorDividendsAccumulated, Messages.LabelAccumulatedDividends);
+                addLineSerie(values, index.getDates(), colors.dividendsAccumulatedColor(),
+                                Messages.LabelAccumulatedDividends);
             }
 
             if (metrics.contains(ClientDataSeriesType.INTEREST))
             {
                 double[] values = toDouble(index.getInterest(), Values.Amount.divider());
-                addBarSerie(values, index.getDates(), colorInterest, Messages.LabelInterest);
+                addBarSerie(values, index.getDates(), colors.interestColor(), Messages.LabelInterest);
             }
 
             if (metrics.contains(ClientDataSeriesType.INTEREST_ACCUMULATED))
             {
                 double[] values = accumulateAndToDouble(index.getInterest(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorInterestAccumulated, Messages.LabelAccumulatedInterest);
+                addLineSerie(values, index.getDates(), colors.interestAccumulatedColor(),
+                                Messages.LabelAccumulatedInterest);
             }
 
             if (metrics.contains(ClientDataSeriesType.INTEREST_CHARGE))
             {
                 double[] values = toDouble(index.getInterestCharge(), Values.Amount.divider());
-                addBarSerie(values, index.getDates(), colorInterestCharge, Messages.LabelInterestCharge);
+                addBarSerie(values, index.getDates(), colors.interestChargeColor(), Messages.LabelInterestCharge);
             }
 
             if (metrics.contains(ClientDataSeriesType.INTEREST_CHARGE_ACCUMULATED))
             {
                 double[] values = accumulateAndToDouble(index.getInterestCharge(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorInterestChargeAccumulated,
+                addLineSerie(values, index.getDates(), colors.interestChargeAccumulatedColor(),
                                 Messages.LabelAccumulatedInterestCharge);
             }
 
             if (metrics.contains(ClientDataSeriesType.EARNINGS))
             {
                 double[] values = toDouble(add(index.getDividends(), index.getInterest()), Values.Amount.divider());
-                addBarSerie(values, index.getDates(), colorEarnings, Messages.LabelEarnings);
+                addBarSerie(values, index.getDates(), colors.earningsColor(), Messages.LabelEarnings);
             }
 
             if (metrics.contains(ClientDataSeriesType.EARNINGS_ACCUMULATED))
             {
                 double[] values = accumulateAndToDouble(add(index.getDividends(), index.getInterest()),
                                 Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorEarningsAccumulated, Messages.LabelAccumulatedEarnings);
+                addLineSerie(values, index.getDates(), colors.earningsAccumulatedColor(),
+                                Messages.LabelAccumulatedEarnings);
             }
 
             if (metrics.contains(ClientDataSeriesType.FEES))
             {
                 double[] values = toDouble(index.getFees(), Values.Amount.divider());
-                addBarSerie(values, index.getDates(), colorFees, Messages.LabelFees);
+                addBarSerie(values, index.getDates(), colors.feesColor(), Messages.LabelFees);
             }
 
             if (metrics.contains(ClientDataSeriesType.FEES_ACCUMULATED))
             {
                 double[] values = accumulateAndToDouble(index.getFees(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorFeesAccumulated, Messages.LabelFeesAccumulated);
+                addLineSerie(values, index.getDates(), colors.feesAccumulatedColor(), Messages.LabelFeesAccumulated);
             }
 
             // Totals at the end to be plotted in front of all the other
             if (metrics.contains(ClientDataSeriesType.TOTALS))
             {
                 double[] values = toDouble(index.getTotals(), Values.Amount.divider());
-                addLineSerie(values, index.getDates(), colorTotals, Messages.LabelTotalSum);
+                addLineSerie(values, index.getDates(), colors.totalsColor(), Messages.LabelTotalSum);
             }
 
             chart.adjustRange();

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesSet.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesSet.java
@@ -5,8 +5,6 @@ import java.util.EnumSet;
 import java.util.List;
 
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Display;
 
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.Classification;
@@ -16,7 +14,7 @@ import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Taxonomy;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.ClientFilterMenu;
-import name.abuchen.portfolio.ui.util.Colors;
+import name.abuchen.portfolio.ui.util.DataSeriesColors;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeries.ClientDataSeries;
 import name.abuchen.portfolio.util.ColorConversion;
 
@@ -143,104 +141,106 @@ public class DataSeriesSet
 
     private void buildStatementOfAssetsDataSeries()
     {
+        var colors = DataSeriesColors.instance();
+
         availableSeries.add(new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TOTALS, Messages.LabelTotalSum,
-                        Colors.TOTALS.getRGB()));
+                        colors.totalsColor().getRGB()));
 
         DataSeries series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TRANSFERALS,
-                        Messages.LabelTransferals, Display.getDefault().getSystemColor(SWT.COLOR_DARK_GRAY).getRGB());
+                        Messages.LabelTransferals, colors.transferalsColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TRANSFERALS_ACCUMULATED,
-                        Messages.LabelAccumulatedTransferals,
-                        Display.getDefault().getSystemColor(SWT.COLOR_YELLOW).getRGB());
+                        Messages.LabelAccumulatedTransferals, colors.transferalsAccumulatedColor().getRGB());
         series.setShowArea(true);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.INVESTED_CAPITAL,
-                        Messages.LabelInvestedCapital, Display.getDefault().getSystemColor(SWT.COLOR_GRAY).getRGB());
+                        Messages.LabelInvestedCapital, colors.investedCapitalColor().getRGB());
         series.setShowArea(true);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.ABSOLUTE_INVESTED_CAPITAL,
-                        Messages.LabelAbsoluteInvestedCapital,
-                        Display.getDefault().getSystemColor(SWT.COLOR_GRAY).getRGB());
+                        Messages.LabelAbsoluteInvestedCapital, colors.absoluteInvestedCapitalColor().getRGB());
         series.setShowArea(true);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.ABSOLUTE_DELTA, Messages.LabelDelta,
-                        Display.getDefault().getSystemColor(SWT.COLOR_GRAY).getRGB());
+                        colors.absoluteDeltaColor().getRGB());
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.ABSOLUTE_DELTA_ALL_RECORDS,
-                        Messages.LabelAbsoluteDelta, Display.getDefault().getSystemColor(SWT.COLOR_GRAY).getRGB());
+                        Messages.LabelAbsoluteDelta, colors.absoluteDeltaAllRecordColor().getRGB());
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TAXES, Messages.ColumnTaxes,
-                        Display.getDefault().getSystemColor(SWT.COLOR_RED).getRGB());
+                        colors.taxesColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TAXES_ACCUMULATED,
-                        Messages.LabelAccumulatedTaxes, Display.getDefault().getSystemColor(SWT.COLOR_RED).getRGB());
+                        Messages.LabelAccumulatedTaxes, colors.taxesAccumulatedColor().getRGB());
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.DIVIDENDS, Messages.LabelDividends,
-                        Display.getDefault().getSystemColor(SWT.COLOR_DARK_MAGENTA).getRGB());
+                        colors.dividendsColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.DIVIDENDS_ACCUMULATED,
-                        Messages.LabelAccumulatedDividends,
-                        Display.getDefault().getSystemColor(SWT.COLOR_DARK_MAGENTA).getRGB());
+                        Messages.LabelAccumulatedDividends, colors.dividendsAccumulatedColor().getRGB());
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.INTEREST, Messages.LabelInterest,
-                        Colors.DARK_GREEN.getRGB());
+                        colors.interestColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.INTEREST_ACCUMULATED,
-                        Messages.LabelAccumulatedInterest, Colors.DARK_GREEN.getRGB());
+                        Messages.LabelAccumulatedInterest, colors.interestAccumulatedColor().getRGB());
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.INTEREST_CHARGE, Messages.LabelInterestCharge,
-                        Colors.DARK_GREEN.getRGB());
+                        colors.interestChargeColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.INTEREST_CHARGE_ACCUMULATED,
-                        Messages.LabelAccumulatedInterestCharge, Colors.DARK_GREEN.getRGB());
+                        Messages.LabelAccumulatedInterestCharge, colors.interestChargeAccumulatedColor().getRGB());
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.EARNINGS, Messages.LabelEarnings,
-                        Colors.DARK_GREEN.getRGB());
+                        colors.earningsColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.EARNINGS_ACCUMULATED,
-                        Messages.LabelAccumulatedEarnings, Colors.DARK_GREEN.getRGB());
+                        Messages.LabelAccumulatedEarnings, colors.earningsAccumulatedColor().getRGB());
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.FEES, Messages.LabelFees,
-                        Colors.GRAY.getRGB());
+                        colors.feesColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
         series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.FEES_ACCUMULATED,
-                        Messages.LabelFeesAccumulated, Colors.GRAY.getRGB());
+                        Messages.LabelFeesAccumulated, colors.feesAccumulatedColor().getRGB());
         availableSeries.add(series);
     }
 
     private void buildPerformanceDataSeries(Client client, IPreferenceStore preferences, ColorWheel wheel)
     {
+        var colors = DataSeriesColors.instance();
+
         // accumulated performance
         availableSeries.add(new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TOTALS,
-                        Messages.PerformanceChartLabelEntirePortfolio, Colors.TOTALS.getRGB()));
+                        Messages.PerformanceChartLabelEntirePortfolio,
+                        colors.performanceEntirePortfolioColor().getRGB()));
 
         DataSeries series = new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.DELTA_PERCENTAGE,
-                        Messages.LabelAggregationDaily, Colors.getColor(60, 151, 218).getRGB());
-        series.setColorNegative(Colors.getColor(253, 156, 82).getRGB());
+                        Messages.LabelAggregationDaily, colors.performancePositiveColor().getRGB());
+        series.setColorNegative(colors.performanceNegativeColor().getRGB());
         series.setLineChart(false);
         availableSeries.add(series);
 
@@ -258,9 +258,12 @@ public class DataSeriesSet
 
     private void buildReturnVolatilitySeries(Client client, IPreferenceStore preferences, ColorWheel wheel)
     {
+        var colors = DataSeriesColors.instance();
+
         // accumulated performance
         availableSeries.add(new DataSeries(DataSeries.Type.CLIENT, ClientDataSeries.TOTALS,
-                        Messages.PerformanceChartLabelEntirePortfolio, Colors.TOTALS.getRGB()));
+                        Messages.PerformanceChartLabelEntirePortfolio,
+                        colors.performanceEntirePortfolioColor().getRGB()));
 
         // securities as benchmark
         for (Security security : client.getSecurities())


### PR DESCRIPTION
This PR is part of a stacked CSS color migration series and should be reviewed in order.

Moves the default data series chart colors from hard-coded Java constants to CSS-backed configuration. This keeps the existing semantic data series names while making their default colors theme-configurable.

[#5644 – Add CSS-backed core theme color infrastructure](https://github.com/portfolio-performance/portfolio/pull/5644)
**[#5645 – Move data series chart colors to CSS](https://github.com/portfolio-performance/portfolio/pull/5645)**
[#5646 – Move portfolio balance chart colors to CSS](https://github.com/portfolio-performance/portfolio/pull/5646)
[#5647 – Move securities chart colors to CSS](https://github.com/portfolio-performance/portfolio/pull/5647)
[#5648 – Move payments palette colors to CSS](https://github.com/portfolio-performance/portfolio/pull/5648)
[#5649 – Move color gradient definitions to CSS](https://github.com/portfolio-performance/portfolio/pull/5649)
[#5650 – Add color architecture debug view](https://github.com/portfolio-performance/portfolio/pull/5650)

**Note:**
This series was split to make the review of each semantic color group easier.
Some later PRs may not build independently against master until the preceding PRs have been merged.

The split is artificial to some extent because shared files such as CSS files, plugin.xml, ThemeAddon and ElementProvider are touched by multiple steps. I tried to keep each PR focused and to show only the final intended change per semantic area, but minor merge follow-up may still be required after the series is reviewed.