### PR TITLE
[5/7] CSS :: Move payments palette colors to CSS

### DIFF
--- a/name.abuchen.portfolio.ui/css/shared/dark.css
+++ b/name.abuchen.portfolio.ui/css/shared/dark.css
@@ -199,6 +199,25 @@ DataSeries {
 	performance-positive-color: #4DA6FF;
 	performance-negative-color: #FFB366;
 }
+
+ColorPalette {
+	color-0: #8C564B;
+	color-1: #E377C2;
+	color-2: #7F7F7F;
+	color-3: #BCBD22;
+	color-4: #17BECF;
+	color-5: #727CC9;
+	color-6: #FA735C;
+	color-7: #FDB667;
+	color-8: #8FCF70;
+	color-9: #57CFFD;
+	color-10: #1F77B4;
+	color-11: #FF7F0E;
+	color-12: #2CA02C;
+	color-13: #D62728;
+	color-14: #9467BD;
+}
+
 * {
 	font-family: "#systemfont";
 }

--- a/name.abuchen.portfolio.ui/css/shared/light.css
+++ b/name.abuchen.portfolio.ui/css/shared/light.css
@@ -232,6 +232,25 @@ DataSeries {
 	performance-positive-color: #3C97DA;
 	performance-negative-color: #FD9C52;
 }
+
+ColorPalette {
+	color-0: #8C564B;
+	color-1: #E377C2;
+	color-2: #7F7F7F;
+	color-3: #BCBD22;
+	color-4: #17BECF;
+	color-5: #727CC9;
+	color-6: #FA735C;
+	color-7: #FDB667;
+	color-8: #8FCF70;
+	color-9: #57CFFD;
+	color-10: #1F77B4;
+	color-11: #FF7F0E;
+	color-12: #2CA02C;
+	color-13: #D62728;
+	color-14: #9467BD;
+}
+
 * {
 	font-family: "#systemfont";
 }

--- a/name.abuchen.portfolio.ui/plugin.xml
+++ b/name.abuchen.portfolio.ui/plugin.xml
@@ -319,6 +319,55 @@
                name="performance-negative-color">
          </property-name>
       </handler>
+      <handler
+            adapter="name.abuchen.portfolio.ui.theme.PaymentsPaletteCSS$ElementAdapter"
+            handler="name.abuchen.portfolio.ui.theme.PaymentsPaletteCSS$Handler">
+         <property-name
+               name="color-0">
+         </property-name>
+         <property-name
+               name="color-1">
+         </property-name>
+         <property-name
+               name="color-2">
+         </property-name>
+         <property-name
+               name="color-3">
+         </property-name>
+         <property-name
+               name="color-4">
+         </property-name>
+         <property-name
+               name="color-5">
+         </property-name>
+         <property-name
+               name="color-6">
+         </property-name>
+         <property-name
+               name="color-7">
+         </property-name>
+         <property-name
+               name="color-8">
+         </property-name>
+         <property-name
+               name="color-9">
+         </property-name>
+         <property-name
+               name="color-10">
+         </property-name>
+         <property-name
+               name="color-11">
+         </property-name>
+         <property-name
+               name="color-12">
+         </property-name>
+         <property-name
+               name="color-13">
+         </property-name>
+         <property-name
+               name="color-14">
+         </property-name>
+      </handler>
    </extension>
    <extension
          point="org.eclipse.e4.ui.css.core.elementProvider">
@@ -359,6 +408,9 @@
          </widget>
          <widget
                class="name.abuchen.portfolio.ui.util.DataSeriesColors">
+         </widget>
+         <widget
+               class="name.abuchen.portfolio.ui.views.payments.PaymentsPalette">
          </widget>
       </provider>
    </extension>

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ElementProvider.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ElementProvider.java
@@ -19,6 +19,7 @@ import name.abuchen.portfolio.ui.util.DataSeriesColors;
 import name.abuchen.portfolio.ui.util.ValueColorScheme;
 import name.abuchen.portfolio.ui.views.PortfolioBalanceChart;
 import name.abuchen.portfolio.ui.views.SecuritiesChart;
+import name.abuchen.portfolio.ui.views.payments.PaymentsPalette;
 
 @SuppressWarnings("restriction")
 public class ElementProvider implements IElementProvider
@@ -50,6 +51,8 @@ public class ElementProvider implements IElementProvider
             return new PortfolioBalanceChartCSS.ElementAdapter(portfolioBalanceChart, engine);
         if (element instanceof ValueColorScheme scheme)
             return new ValueColorSchemeElementAdapter(scheme, engine);
+        if (element instanceof PaymentsPalette palette)
+            return new PaymentsPaletteCSS.ElementAdapter(palette, engine);
 
         return null;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/PaymentsPaletteCSS.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/PaymentsPaletteCSS.java
@@ -1,0 +1,159 @@
+package name.abuchen.portfolio.ui.theme;
+
+import org.eclipse.e4.ui.css.core.engine.CSSEngine;
+import org.eclipse.e4.ui.css.swt.helpers.CSSSWTColorHelper;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.css.CSSValue;
+
+import name.abuchen.portfolio.ui.util.ValueColorScheme;
+import name.abuchen.portfolio.ui.views.payments.PaymentsPalette;
+
+public final class PaymentsPaletteCSS
+{
+    private PaymentsPaletteCSS()
+    {
+    }
+
+    @SuppressWarnings("restriction")
+    public static final class ElementAdapter extends org.eclipse.e4.ui.css.core.dom.ElementAdapter
+    {
+        public ElementAdapter(PaymentsPalette palette, CSSEngine engine)
+        {
+            super(palette, engine);
+        }
+
+        public PaymentsPalette getPalette()
+        {
+            return (PaymentsPalette) getNativeWidget();
+        }
+
+        @Override
+        public String getCSSId()
+        {
+            return null;
+        }
+
+        @Override
+        public String getCSSClass()
+        {
+            return ValueColorScheme.current().getIdentifier();
+        }
+
+        @Override
+        public String getCSSStyle()
+        {
+            return null;
+        }
+
+        @Override
+        public Node getParentNode()
+        {
+            return null;
+        }
+
+        @Override
+        public NodeList getChildNodes()
+        {
+            return null;
+        }
+
+        @Override
+        public String getNamespaceURI()
+        {
+            return null;
+        }
+
+        @Override
+        public String getLocalName()
+        {
+            return "ColorPalette"; //$NON-NLS-1$
+        }
+
+        @Override
+        public String getAttribute(String name)
+        {
+            return ""; //$NON-NLS-1$
+        }
+    }
+
+    @SuppressWarnings("restriction")
+    public static final class Handler implements org.eclipse.e4.ui.css.core.dom.properties.ICSSPropertyHandler
+    {
+        @Override
+        public boolean applyCSSProperty(Object element, String property, CSSValue value, String pseudo,
+                        CSSEngine engine) throws Exception
+        {
+            if (!(element instanceof PaymentsPaletteCSS.ElementAdapter adapter))
+                return false;
+
+            PaymentsPalette palette = adapter.getPalette();
+
+            switch (property)
+            {
+                case "color-0": //$NON-NLS-1$
+                    palette.setColor(0, CSSSWTColorHelper.getRGBA(value));
+                    return true;
+
+                case "color-1": //$NON-NLS-1$
+                    palette.setColor(1, CSSSWTColorHelper.getRGBA(value));
+                    return true;
+
+                case "color-2": //$NON-NLS-1$
+                    palette.setColor(2, CSSSWTColorHelper.getRGBA(value));
+                    return true;
+
+                case "color-3": //$NON-NLS-1$
+                    palette.setColor(3, CSSSWTColorHelper.getRGBA(value));
+                    return true;
+
+                case "color-4": //$NON-NLS-1$
+                    palette.setColor(4, CSSSWTColorHelper.getRGBA(value));
+                    return true;
+
+                case "color-5": //$NON-NLS-1$
+                    palette.setColor(5, CSSSWTColorHelper.getRGBA(value));
+                    return true;
+
+                case "color-6": //$NON-NLS-1$
+                    palette.setColor(6, CSSSWTColorHelper.getRGBA(value));
+                    return true;
+
+                case "color-7": //$NON-NLS-1$
+                    palette.setColor(7, CSSSWTColorHelper.getRGBA(value));
+                    return true;
+
+                case "color-8": //$NON-NLS-1$
+                    palette.setColor(8, CSSSWTColorHelper.getRGBA(value));
+                    return true;
+
+                case "color-9": //$NON-NLS-1$
+                    palette.setColor(9, CSSSWTColorHelper.getRGBA(value));
+                    return true;
+
+                case "color-10": //$NON-NLS-1$
+                    palette.setColor(10, CSSSWTColorHelper.getRGBA(value));
+                    return true;
+
+                case "color-11": //$NON-NLS-1$
+                    palette.setColor(11, CSSSWTColorHelper.getRGBA(value));
+                    return true;
+
+                case "color-12": //$NON-NLS-1$
+                    palette.setColor(12, CSSSWTColorHelper.getRGBA(value));
+                    return true;
+
+                case "color-13": //$NON-NLS-1$
+                    palette.setColor(13, CSSSWTColorHelper.getRGBA(value));
+                    return true;
+
+                case "color-14": //$NON-NLS-1$
+                    palette.setColor(14, CSSSWTColorHelper.getRGBA(value));
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ThemeAddon.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ThemeAddon.java
@@ -12,6 +12,7 @@ import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.DataSeriesColors;
 import name.abuchen.portfolio.ui.util.ValueColorScheme;
+import name.abuchen.portfolio.ui.views.payments.PaymentsPalette;
 
 @SuppressWarnings("restriction")
 public class ThemeAddon
@@ -26,6 +27,7 @@ public class ThemeAddon
         IThemeEngine engine = (IThemeEngine) event.getProperty(IThemeEngine.Events.THEME_ENGINE);
         engine.applyStyles(Colors.theme(), false);
         engine.applyStyles(DataSeriesColors.instance(), false);
+        engine.applyStyles(PaymentsPalette.instance(), false);
 
         for (var scheme : ValueColorScheme.getAvailableSchemes())
             engine.applyStyles(scheme, false);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsColors.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsColors.java
@@ -2,33 +2,14 @@ package name.abuchen.portfolio.ui.views.payments;
 
 import org.eclipse.swt.graphics.Color;
 
-import name.abuchen.portfolio.ui.util.Colors;
-
 public class PaymentsColors
 {
-    private static final Color[] COLORS = new Color[] { //
-                    Colors.getColor(140, 86, 75), //
-                    Colors.getColor(227, 119, 194), //
-                    Colors.getColor(127, 127, 127), //
-                    Colors.getColor(188, 189, 34), //
-                    Colors.getColor(23, 190, 207), //
-                    Colors.getColor(114, 124, 201), //
-                    Colors.getColor(250, 115, 92), //
-                    Colors.getColor(253, 182, 103), //
-                    Colors.getColor(143, 207, 112), //
-                    Colors.getColor(87, 207, 253), //
-                    Colors.getColor(31, 119, 180), //
-                    Colors.getColor(255, 127, 14), //
-                    Colors.getColor(44, 160, 44), //
-                    Colors.getColor(214, 39, 40), //
-                    Colors.getColor(148, 103, 189) }; //
-
     private PaymentsColors()
     {
     }
 
     public static Color getColor(int year)
     {
-        return COLORS[year % COLORS.length];
+        return PaymentsPalette.instance().getCyclic(year);
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPalette.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsPalette.java
@@ -1,0 +1,50 @@
+package name.abuchen.portfolio.ui.views.payments;
+
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGBA;
+
+import name.abuchen.portfolio.ui.util.Colors;
+
+public final class PaymentsPalette
+{
+    private static final PaymentsPalette INSTANCE = new PaymentsPalette();
+
+    private final Color[] colors = new Color[] { //
+                    Colors.getColor(140, 86, 75), //
+                    Colors.getColor(227, 119, 194), //
+                    Colors.getColor(127, 127, 127), //
+                    Colors.getColor(188, 189, 34), //
+                    Colors.getColor(23, 190, 207), //
+                    Colors.getColor(114, 124, 201), //
+                    Colors.getColor(250, 115, 92), //
+                    Colors.getColor(253, 182, 103), //
+                    Colors.getColor(143, 207, 112), //
+                    Colors.getColor(87, 207, 253), //
+                    Colors.getColor(31, 119, 180), //
+                    Colors.getColor(255, 127, 14), //
+                    Colors.getColor(44, 160, 44), //
+                    Colors.getColor(214, 39, 40), //
+                    Colors.getColor(148, 103, 189) }; //
+
+    private PaymentsPalette()
+    {
+    }
+
+    public static PaymentsPalette instance()
+    {
+        return INSTANCE;
+    }
+
+    public Color getCyclic(int index)
+    {
+        return colors[index % colors.length];
+    }
+
+    public void setColor(int index, RGBA color)
+    {
+        if (color == null)
+            return;
+
+        colors[index] = Colors.getColor(color.rgb);
+    }
+}


### PR DESCRIPTION
This PR is part of a stacked CSS color migration series and should be reviewed in order.

Moves the payments color palette to CSS-backed configuration. The palette remains separate from generic UI colors because it is used as a semantic payment/year color palette.

[#5644 – Add CSS-backed core theme color infrastructure](https://github.com/portfolio-performance/portfolio/pull/5644)
[#5645 – Move data series chart colors to CSS](https://github.com/portfolio-performance/portfolio/pull/5645)
[#5646 – Move portfolio balance chart colors to CSS](https://github.com/portfolio-performance/portfolio/pull/5646)
[#5647 – Move securities chart colors to CSS](https://github.com/portfolio-performance/portfolio/pull/5647)
**[#5648 – Move payments palette colors to CSS](https://github.com/portfolio-performance/portfolio/pull/5648)**
[#5649 – Move color gradient definitions to CSS](https://github.com/portfolio-performance/portfolio/pull/5649)
[#5650 – Add color architecture debug view](https://github.com/portfolio-performance/portfolio/pull/5650)

**Note:**
This series was split to make the review of each semantic color group easier.
Some later PRs may not build independently against master until the preceding PRs have been merged.

The split is artificial to some extent because shared files such as CSS files, plugin.xml, ThemeAddon and ElementProvider are touched by multiple steps. I tried to keep each PR focused and to show only the final intended change per semantic area, but minor merge follow-up may still be required after the series is reviewed.