### PR TITLE
Fix CSS theme switching artifacts caused by hardcoded background colors

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/AboutDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/AboutDialog.java
@@ -63,7 +63,7 @@ public class AboutDialog extends Dialog
     protected Control createDialogArea(Composite parent)
     {
         var container = new Composite(parent, SWT.NONE);
-        container.setBackground(Colors.WHITE);
+        container.setBackground(Colors.theme().defaultBackground());
         GridDataFactory.fillDefaults().grab(true, true).hint(700, 500).applyTo(container);
         GridLayoutFactory.fillDefaults().spacing(5, 5).margins(5, 5).applyTo(container);
 
@@ -108,7 +108,7 @@ public class AboutDialog extends Dialog
 
         var area = new Composite(parent, SWT.NONE);
 
-        area.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
+        area.setBackground(Colors.theme().defaultBackground());
         getShell().setText(Messages.LabelAbout);
 
         var imageLabel = new Label(area, SWT.NONE);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/DisplayTextDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/DisplayTextDialog.java
@@ -108,7 +108,7 @@ public class DisplayTextDialog extends Dialog
     protected final Control createDialogArea(Composite parent)
     {
         Composite container = new Composite(parent, SWT.None);
-        container.setBackground(Colors.WHITE);
+        container.setBackground(Colors.theme().defaultBackground());
         GridDataFactory.fillDefaults().grab(true, true).hint(800, 500).applyTo(container);
         GridLayoutFactory.fillDefaults().numColumns(1).applyTo(container);
 
@@ -118,7 +118,7 @@ public class DisplayTextDialog extends Dialog
         if (additionalText != null)
         {
             StyledLabel additionalTextBox = new StyledLabel(container, SWT.MULTI | SWT.WRAP | SWT.READ_ONLY);
-            additionalTextBox.setBackground(Colors.WHITE);
+            additionalTextBox.setBackground(Colors.theme().defaultBackground());
             additionalTextBox.setText(additionalText);
             GridDataFactory.fillDefaults().grab(true, false).align(SWT.FILL, SWT.TOP).indent(5, 5)
                             .applyTo(additionalTextBox);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/PortfolioReportNotificationPopup.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/PortfolioReportNotificationPopup.java
@@ -50,7 +50,7 @@ public class PortfolioReportNotificationPopup extends AbstractNotificationPopup
     protected void createContentArea(Composite parent)
     {
         var messageComposite = new Composite(parent, SWT.NONE);
-        messageComposite.setBackground(Colors.WHITE);
+        messageComposite.setBackground(Colors.theme().defaultBackground());
         messageComposite.setLayout(new GridLayout(1, false));
         messageComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
@@ -60,7 +60,7 @@ public class PortfolioReportNotificationPopup extends AbstractNotificationPopup
         GridDataFactory.fillDefaults().grab(true, false).hint(300, SWT.DEFAULT).applyTo(messageLabel);
 
         var actionLink = new Link(messageComposite, SWT.NONE);
-        actionLink.setBackground(Colors.WHITE);
+        actionLink.setBackground(Colors.theme().defaultBackground());
         actionLink.setText("<a>" + Messages.CmdMigratePortfolioReport + "</a>"); //$NON-NLS-1$ //$NON-NLS-2$
         actionLink.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
             close();
@@ -68,7 +68,7 @@ public class PortfolioReportNotificationPopup extends AbstractNotificationPopup
         }));
 
         var infoLink = new Link(messageComposite, SWT.NONE);
-        infoLink.setBackground(Colors.WHITE);
+        infoLink.setBackground(Colors.theme().defaultBackground());
         infoLink.setText("<a>" + Messages.LabelInfo + "</a>"); //$NON-NLS-1$ //$NON-NLS-2$
         infoLink.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
             DesktopAPI.browse(Messages.SiteInfoPortfolioReportMigration);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/AbstractFinanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/AbstractFinanceView.java
@@ -249,7 +249,7 @@ public abstract class AbstractFinanceView
     private final Control createHeader(Composite parent)
     {
         Composite header = new Composite(parent, SWT.NONE);
-        header.setBackground(Colors.WHITE);
+        header.setBackground(Colors.theme().defaultBackground());
 
         titleText = getDefaultTitle();
         title = new Label(header, SWT.NONE);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/PortfolioPart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/PortfolioPart.java
@@ -250,7 +250,7 @@ public class PortfolioPart implements ClientInputListener
         ProgressBar bar = null;
 
         container = new Composite(parent, SWT.NONE);
-        container.setBackground(Colors.WHITE);
+        container.setBackground(Colors.theme().defaultBackground());
         container.setLayout(new FormLayout());
 
         Label image = new Label(container, SWT.NONE);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/parts/WelcomePart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/parts/WelcomePart.java
@@ -74,7 +74,7 @@ public class WelcomePart
     public void createComposite(Composite parent)
     {
         container = new Composite(parent, SWT.NONE);
-        container.setBackground(Colors.WHITE);
+        container.setBackground(Colors.theme().defaultBackground());
         GridLayoutFactory.fillDefaults().margins(20, 20).applyTo(container);
 
         createHeader(container);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
@@ -21,7 +21,6 @@ import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtchart.ISeries;
 
@@ -35,6 +34,7 @@ import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.PortfolioPlugin;
 import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.util.AbstractCSVExporter;
+import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.chart.TimelineChart;
@@ -110,7 +110,7 @@ public class PerformanceChartView extends AbstractHistoricView
     protected Composite createBody(Composite parent)
     {
         Composite composite = new Composite(parent, SWT.NONE);
-        composite.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
+        composite.setBackground(Colors.theme().defaultBackground());
 
         chart = new TimelineChart(composite);
         chart.getTitle().setText(getTitle());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ReturnsVolatilityChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/ReturnsVolatilityChartView.java
@@ -36,6 +36,7 @@ import name.abuchen.portfolio.snapshot.PerformanceIndex;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.AbstractCSVExporter;
+import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.LabelOnly;
 import name.abuchen.portfolio.ui.util.SimpleAction;
@@ -200,7 +201,7 @@ public class ReturnsVolatilityChartView extends AbstractHistoricView
         cache = make(DataSeriesCache.class);
 
         Composite composite = new Composite(parent, SWT.NONE);
-        composite.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
+        composite.setBackground(Colors.theme().defaultBackground());
 
         resources = new LocalResourceManager(JFaceResources.getResources(), composite);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityDetailsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityDetailsViewer.java
@@ -381,7 +381,7 @@ public class SecurityDetailsViewer
         // and covers right edge (last digits of quotes, etc.) of the content
         // pane. With setAlwaysShowScrollBars(true) that issue doesn't happen.
         container.setAlwaysShowScrollBars(true);
-        container1.setBackground(Colors.WHITE);
+        container1.setBackground(Colors.theme().defaultBackground());
         container1.setBackgroundMode(SWT.INHERIT_FORCE);
 
         // facets

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityQuoteQualityMetricsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecurityQuoteQualityMetricsViewer.java
@@ -41,7 +41,7 @@ public class SecurityQuoteQualityMetricsViewer
     public Control createViewControl(Composite parent)
     {
         Composite container = new Composite(parent, SWT.NONE);
-        container.setBackground(Colors.WHITE);
+        container.setBackground(Colors.theme().defaultBackground());
         FormLayout layout = new FormLayout();
         layout.marginHeight = layout.marginWidth = 5;
         container.setLayout(layout);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsHistoryView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsHistoryView.java
@@ -16,7 +16,6 @@ import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Menu;
 
 import com.google.common.collect.Lists;
@@ -24,6 +23,7 @@ import com.google.common.collect.Lists;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.UIConstants;
+import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.chart.TimelineChart;
@@ -117,7 +117,7 @@ public class StatementOfAssetsHistoryView extends AbstractHistoricView
     protected Composite createBody(Composite parent)
     {
         Composite composite = new Composite(parent, SWT.NONE);
-        composite.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
+        composite.setBackground(Colors.theme().defaultBackground());
 
         chart = new TimelineChart(composite);
         chart.getTitle().setVisible(false);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/currency/CurrencyConverterTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/currency/CurrencyConverterTab.java
@@ -215,7 +215,7 @@ public class CurrencyConverterTab implements AbstractTabbedView.Tab
     public Composite createTab(Composite parent)
     {
         Composite container = new Composite(parent, SWT.NONE);
-        container.setBackground(Colors.WHITE);
+        container.setBackground(Colors.theme().defaultBackground());
 
         FormLayout layout = new FormLayout();
         layout.marginLeft = 20;
@@ -230,7 +230,8 @@ public class CurrencyConverterTab implements AbstractTabbedView.Tab
         bindings.bindCurrencyCodeCombo(editArea, Messages.ColumnBaseCurrency, "baseCurrency", false); //$NON-NLS-1$
         bindings.bindMandatoryAmountInput(editArea, Messages.ColumnConvertedAmount, "termValue", SWT.READ_ONLY, 10); //$NON-NLS-1$
         bindings.bindCurrencyCodeCombo(editArea, Messages.ColumnTermCurrency, "termCurrency", false); //$NON-NLS-1$
-        bindings.bindDatePicker(editArea, Messages.ColumnDate, "date").setBackground(Colors.WHITE); //$NON-NLS-1$
+        bindings.bindDatePicker(editArea, Messages.ColumnDate, "date") //$NON-NLS-1$
+                        .setBackground(Colors.theme().defaultBackground());
 
         new Label(editArea, SWT.NONE);
         Button b = new Button(editArea, SWT.PUSH | SWT.FLAT);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/HoverButton.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/HoverButton.java
@@ -80,12 +80,12 @@ public class HoverButton
         {
             hoverShell = new Shell(leadingControl.getShell(), SWT.MODELESS | SWT.SHADOW_OUT);
             hoverShell.setData(UIConstants.CSS.CLASS_NAME, "hoverbutton"); //$NON-NLS-1$
-            hoverShell.setBackground(Colors.WHITE);
+            hoverShell.setBackground(Colors.theme().defaultBackground());
             hoverShell.setLayout(new FillLayout());
             ImageHyperlink button = new ImageHyperlink(hoverShell, SWT.NONE);
             button.setImage(Images.VIEW_SHARE.image());
             button.setData(UIConstants.CSS.CLASS_NAME, "hoverbutton"); //$NON-NLS-1$
-            button.setBackground(Colors.WHITE);
+            button.setBackground(Colors.theme().defaultBackground());
             button.addHyperlinkListener(listener);
             hoverShell.pack();
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/HistoricalPricesDataQualityPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/HistoricalPricesDataQualityPane.java
@@ -71,7 +71,7 @@ public class HistoricalPricesDataQualityPane implements InformationPanePage
     public Control createViewControl(Composite parent)
     {
         Composite container = new Composite(parent, SWT.NONE);
-        container.setBackground(Colors.WHITE);
+        container.setBackground(Colors.theme().defaultBackground());
         FormLayout layout = new FormLayout();
         layout.marginHeight = layout.marginWidth = 5;
         container.setLayout(layout);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractStackedChartViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractStackedChartViewer.java
@@ -32,6 +32,7 @@ import name.abuchen.portfolio.snapshot.AssetPosition;
 import name.abuchen.portfolio.snapshot.ClientSnapshot;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.editor.PortfolioPart;
+import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.ReportingPeriodDropDown.ReportingPeriodListener;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.chart.StackedChartCSVExporter;
@@ -121,7 +122,7 @@ public abstract class AbstractStackedChartViewer extends AbstractChartPage imple
     public Control createControl(Composite container)
     {
         Composite composite = new Composite(container, SWT.NONE);
-        composite.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
+        composite.setBackground(Colors.theme().defaultBackground());
         composite.setLayout(new FillLayout());
 
         chart = new StackedTimelineChart(composite, getDates());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TreeMapViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TreeMapViewer.java
@@ -37,6 +37,7 @@ import de.engehausen.treemap.swt.TreeMap;
 import name.abuchen.portfolio.snapshot.ReportingPeriod;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
+import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.LabelOnly;
 import name.abuchen.portfolio.ui.util.SWTHelper;
 import name.abuchen.portfolio.ui.util.SimpleAction;
@@ -346,7 +347,7 @@ import name.abuchen.portfolio.ui.views.taxonomy.TaxonomyNodeRenderer.Performance
         sash.setLayout(new SashLayout(sash, SWT.HORIZONTAL | SWT.END));
 
         Composite container = new Composite(sash, SWT.NONE);
-        container.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
+        container.setBackground(Colors.theme().defaultBackground());
 
         treeMap = new XTreeMap(container);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/EditSecurityDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/security/EditSecurityDialog.java
@@ -142,7 +142,7 @@ public class EditSecurityDialog extends Dialog
     private void createUpperArea(Composite container)
     {
         Composite header = new Composite(container, SWT.NONE);
-        header.setBackground(container.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+        header.setBackground(Colors.theme().defaultBackground());
         header.setLayout(new FormLayout());
         GridDataFactory.fillDefaults().grab(true, false).applyTo(header);
 


### PR DESCRIPTION
Remove or reduce explicit background color assignments on UI containers to avoid stale SWT colors when switching between light and dark themes at runtime. Prefer CSS-driven backgrounds where possible.