### PR TITLE
Fix line ending check on Windows for .properties files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,5 +8,9 @@
 *.csv text
 *.xml text
 
+# managed properties files must be checked out with LF on every platform
+# (the check-managed-bundles build step requires LF — see issue #5670)
+*.properties text eol=lf
+
 # some files are definitely not text:
 *.png binary


### PR DESCRIPTION
`.gitattributes` doesn't pin `*.properties` to LF, so on Windows (where `core.autocrlf=true` is the default) Git checks them out as CRLF and `check-managed-bundles` rejects them.

Verified on Windows 11 with `clean verify -Plocal-dev`.

Existing Windows clones will need to refresh after pulling:

```
git rm --cached -r .
git reset --hard
```

Closes #5670