### PR TITLE
Refactor lazy security performance cost API to parameterized cost met…

### DIFF
--- a/name.abuchen.portfolio.tests/src/issues/Issue1498FifoCrossPortfolioTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue1498FifoCrossPortfolioTest.java
@@ -11,7 +11,9 @@ import org.junit.Test;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ClientFactory;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
@@ -48,7 +50,8 @@ public class Issue1498FifoCrossPortfolioTest
         SecurityPerformanceSnapshot securitySnapshot = SecurityPerformanceSnapshot.create(client, converter, period);
         SecurityPerformanceRecord securityRecord = securitySnapshot.getRecords().get(0);
         assertThat(securityRecord.getSecurity(), is(lufthansa));
-        assertThat(securityRecord.getFifoCost(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1150))));
+        assertThat(securityRecord.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1150))));
         
         new SecurityPerformanceSnapshotComparator(securitySnapshot,
                         LazySecurityPerformanceSnapshot.create(client, converter, period)).compare();

--- a/name.abuchen.portfolio.tests/src/issues/Issue1909FIFOCalculationOfSecurityPositionTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue1909FIFOCalculationOfSecurityPositionTest.java
@@ -11,7 +11,9 @@ import org.junit.Test;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ClientFactory;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
@@ -50,11 +52,14 @@ public class Issue1909FIFOCalculationOfSecurityPositionTest
 
         assertThat(record.getSecurity(), is(security));
 
-        assertThat(record.getFifoCost(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2000))));
-        assertThat(record.getFifoCostPerSharesHeld(), is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(200))));
+        assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2000))));
+        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO),
+                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(200))));
 
-        assertThat(record.getMovingAverageCost(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1500))));
-        assertThat(record.getMovingAverageCostPerSharesHeld(),
+        assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1500))));
+        assertThat(record.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE),
                         is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(150))));
 
         assertThat(record.getCapitalGainsOnHoldings(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(805))));

--- a/name.abuchen.portfolio.tests/src/issues/Issue371PurchaseValueWithTransfersTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue371PurchaseValueWithTransfersTest.java
@@ -11,9 +11,11 @@ import org.junit.Test;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ClientFactory;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.PortfolioTransferEntry;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
@@ -62,6 +64,7 @@ public class Issue371PurchaseValueWithTransfersTest
         assertThat(securityPosition.getShares(), is(securityRecord.getSharesHeld()));
         assertThat(securityPosition.calculateValue(), is(securityRecord.getMarketValue()));
 
-        assertThat(securityRecord.getFifoCost(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2397.6))));
+        assertThat(securityRecord.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2397.6))));
     }
 }

--- a/name.abuchen.portfolio.tests/src/issues/Issue4446FIFOMultipleTransfers.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue4446FIFOMultipleTransfers.java
@@ -12,7 +12,9 @@ import org.junit.Test;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ClientFactory;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
@@ -75,7 +77,7 @@ public class Issue4446FIFOMultipleTransfers
 
         var snapshotRecord = snapshot.getRecord(security).orElseThrow();
 
-        assertThat(snapshotRecord.getFifoCost().get(),
+        assertThat(snapshotRecord.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3916.56))));
     }
 

--- a/name.abuchen.portfolio.tests/src/issues/Issue672CapitalGainsIfSecurityIsTransferredTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue672CapitalGainsIfSecurityIsTransferredTest.java
@@ -12,7 +12,9 @@ import org.junit.Test;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ClientFactory;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Portfolio;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
@@ -50,7 +52,8 @@ public class Issue672CapitalGainsIfSecurityIsTransferredTest
         SecurityPerformanceRecord record = snapshot.getRecords().get(0);
 
         assertThat(record.getMarketValue(), is(Money.of(CurrencyUnit.EUR, Values.Money.factorize(971.41))));
-        assertThat(record.getFifoCost(), is(Money.of(CurrencyUnit.EUR, Values.Money.factorize(883.1))));
+        assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, Values.Money.factorize(883.1))));
         assertThat(record.getCapitalGainsOnHoldings(), is(Money.of(CurrencyUnit.EUR, Values.Money.factorize(88.31))));
         assertThat(record.getCapitalGainsOnHoldingsPercent(), is(IsCloseTo.closeTo(0.1d, 0.0000000001)));
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/CostCalculationTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/CostCalculationTest.java
@@ -15,9 +15,11 @@ import name.abuchen.portfolio.junit.SecurityBuilder;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyUnit;
@@ -52,15 +54,17 @@ public class CostCalculationTest
         // expected:
         // 3149,20 - round(3149,20 * 15/109) + 1684,92 + 959,30 = 5360,04385
 
-        assertThat(cost.getFifoCost(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5360.04))));
+        assertThat(cost.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5360.04))));
 
-        assertThat(cost.getFifoCostTrail().getValue(), is(cost.getFifoCost()));
+        assertThat(cost.getFifoCostTrail().getValue(), is(cost.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED)));
 
         // expected moving average is identical because it is only one buy
         // transaction
         // 3149,20 * 94/109 + 1684.92 + 959.30 = 5360,04385
 
-        assertThat(cost.getMovingAverageCost(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5360.04))));
+        assertThat(cost.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5360.04))));
     }
 
     @Test
@@ -85,14 +89,16 @@ public class CostCalculationTest
         // expected:
         // 3149,20 + 1684,92 - round(3149,20 * 15/109) = 4400,743853211009174
 
-        assertThat(cost.getFifoCost(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4400.74))));
+        assertThat(cost.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4400.74))));
 
-        assertThat(cost.getFifoCostTrail().getValue(), is(cost.getFifoCost()));
+        assertThat(cost.getFifoCostTrail().getValue(), is(cost.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED)));
 
         // transaction
         // (3149,20 + 1684.92) * 146/161 = 4383,736149068322981
 
-        assertThat(cost.getMovingAverageCost(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4383.74))));
+        assertThat(cost.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4383.74))));
     }
 
     @Test
@@ -139,10 +145,11 @@ public class CostCalculationTest
         SecurityPerformanceRecord record = snapshot.getRecords().get(0);
 
         // 1.1588 = exchange rate of test currency converter on 2015-01-16
-        assertThat(record.getFifoCost(),
+        assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize((1000 / 1.1588) + 1100))));
 
-        assertThat(record.getFifoCost(), is(record.explain(SecurityPerformanceRecord.Trails.FIFO_COST)
+        assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                        is(record.explain(SecurityPerformanceRecord.Trails.FIFO_COST)
                         .orElseThrow(IllegalArgumentException::new).getRecord().getValue()));
     }
 
@@ -166,9 +173,9 @@ public class CostCalculationTest
         cost.visitAll(new TestCurrencyConverter(), portfolio.getTransactions().stream()
                         .map(t -> CalculationLineItem.of(portfolio, t)).collect(Collectors.toList()));
 
-        assertThat(cost.getFifoCost(), is(Money.of(CurrencyUnit.EUR, 0L)));
+        assertThat(cost.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0L)));
         assertThat(cost.getFifoCostTrail(), is(TrailRecord.empty()));
-        assertThat(cost.getMovingAverageCost(), is(Money.of(CurrencyUnit.EUR, 0L)));
+        assertThat(cost.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0L)));
     }
 
     @Test
@@ -191,9 +198,9 @@ public class CostCalculationTest
         cost.visitAll(new TestCurrencyConverter(), portfolio.getTransactions().stream()
                         .map(t -> CalculationLineItem.of(portfolio, t)).collect(Collectors.toList()));
 
-        assertThat(cost.getFifoCost(), is(Money.of(CurrencyUnit.EUR, 0L)));
+        assertThat(cost.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0L)));
         assertThat(cost.getFifoCostTrail(), is(TrailRecord.empty()));
-        assertThat(cost.getMovingAverageCost(), is(Money.of(CurrencyUnit.EUR, 0L)));
+        assertThat(cost.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0L)));
     }
 
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshotComparator.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshotComparator.java
@@ -3,6 +3,9 @@ package name.abuchen.portfolio.snapshot.security;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import name.abuchen.portfolio.model.CostMethod;
+import name.abuchen.portfolio.model.TaxesAndFees;
+
 /**
  * Compares the result of security with the result of the lazy security
  * performance snapshot.
@@ -44,29 +47,30 @@ public class SecurityPerformanceSnapshotComparator
             assertThat(left.getLastDividendPayment(), is(right.getLastDividendPayment().get()));
             assertThat(left.getPeriodicity(), is(right.getPeriodicity().get()));
             
-            assertThat(left.getTotalRateOfReturnDiv(), is(right.getTotalRateOfReturnDiv().get()));
+            assertThat(left.getTotalRateOfReturnDiv(), is(right.getTotalRateOfReturnDiv(CostMethod.FIFO).get()));
             assertThat(left.getTotalRateOfReturnDivMovingAverage(),
-                            is(right.getTotalRateOfReturnDivMovingAverage().get()));
+                            is(right.getTotalRateOfReturnDiv(CostMethod.MOVING_AVERAGE).get()));
 
             assertThat(left.getRealizedCapitalGains().getCapitalGains(),
-                            is(right.getRealizedCapitalGains().get().getCapitalGains()));
+                            is(right.getRealizedCapitalGains(CostMethod.FIFO).get().getCapitalGains()));
             assertThat(left.getRealizedCapitalGains().getForexCaptialGains(),
-                            is(right.getRealizedCapitalGains().get().getForexCaptialGains()));
+                            is(right.getRealizedCapitalGains(CostMethod.FIFO).get().getForexCaptialGains()));
 
             assertThat(left.getUnrealizedCapitalGains().getCapitalGains(),
-                            is(right.getUnrealizedCapitalGains().get().getCapitalGains()));
+                            is(right.getUnrealizedCapitalGains(CostMethod.FIFO).get().getCapitalGains()));
             assertThat(left.getUnrealizedCapitalGains().getForexCaptialGains(),
-                            is(right.getUnrealizedCapitalGains().get().getForexCaptialGains()));
+                            is(right.getUnrealizedCapitalGains(CostMethod.FIFO).get().getForexCaptialGains()));
 
             assertThat(left.getRealizedCapitalGainsMovingAvg().getCapitalGains(),
-                            is(right.getRealizedCapitalGainsMovingAvg().get().getCapitalGains()));
+                            is(right.getRealizedCapitalGains(CostMethod.MOVING_AVERAGE).get().getCapitalGains()));
             assertThat(left.getRealizedCapitalGainsMovingAvg().getForexCaptialGains(),
-                            is(right.getRealizedCapitalGainsMovingAvg().get().getForexCaptialGains()));
+                            is(right.getRealizedCapitalGains(CostMethod.MOVING_AVERAGE).get()
+                                            .getForexCaptialGains()));
 
             assertThat(left.getUnrealizedCapitalGainsMovingAvg().getCapitalGains(),
-                            is(right.getUnrealizedCapitalGainsMovingAvg().get().getCapitalGains()));
+                            is(right.getUnrealizedCapitalGains(CostMethod.MOVING_AVERAGE).get().getCapitalGains()));
             assertThat(left.getUnrealizedCapitalGainsMovingAvg().getForexCaptialGains(),
-                            is(right.getUnrealizedCapitalGainsMovingAvg().get().getForexCaptialGains()));
+                            is(right.getUnrealizedCapitalGains(CostMethod.MOVING_AVERAGE).get().getForexCaptialGains()));
 
             assertCosts(left, right);
 
@@ -89,15 +93,22 @@ public class SecurityPerformanceSnapshotComparator
         assertThat(left.getMarketValue(), is(right.getMarketValue().get()));
         assertThat(left.getQuote(), is(right.getQuote().get()));
 
-        assertThat(left.getFifoCost(), is(right.getFifoCost().get()));
-        assertThat(left.getMovingAverageCost(), is(right.getMovingAverageCost().get()));
-        assertThat(left.getCapitalGainsOnHoldings(), is(right.getCapitalGainsOnHoldings().get()));
-        assertThat(left.getCapitalGainsOnHoldingsPercent(), is(right.getCapitalGainsOnHoldingsPercent().get()));
+        assertThat(left.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                        is(right.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED)));
+        assertThat(left.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+                        is(right.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED)));
+
+        assertThat(left.getCapitalGainsOnHoldings(), is(right.getCapitalGainsOnHoldings(CostMethod.FIFO).get()));
+        assertThat(left.getCapitalGainsOnHoldingsPercent(),
+                        is(right.getCapitalGainsOnHoldingsPercent(CostMethod.FIFO).get()));
+
         assertThat(left.getCapitalGainsOnHoldingsMovingAverage(),
-                        is(right.getCapitalGainsOnHoldingsMovingAverage().get()));
+                        is(right.getCapitalGainsOnHoldings(CostMethod.MOVING_AVERAGE).get()));
         assertThat(left.getCapitalGainsOnHoldingsMovingAveragePercent(),
-                        is(right.getCapitalGainsOnHoldingsMovingAveragePercent().get()));
-        assertThat(left.getFifoCostPerSharesHeld(), is(right.getFifoCostPerSharesHeld().get()));
+                        is(right.getCapitalGainsOnHoldingsPercent(CostMethod.MOVING_AVERAGE).get()));
+
+        assertThat(left.getCostPerSharesHeld(CostMethod.FIFO), is(right.getCostPerSharesHeld(CostMethod.FIFO).get()));
+
         assertThat(left.getSharesHeld(), is(right.getSharesHeld().get()));
         assertThat(left.getFees(), is(right.getFees().get()));
         assertThat(left.getTaxes(), is(right.getTaxes().get()));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshotTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshotTest.java
@@ -12,7 +12,9 @@ import name.abuchen.portfolio.junit.PortfolioBuilder;
 import name.abuchen.portfolio.junit.SecurityBuilder;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Quote;
@@ -52,11 +54,11 @@ public class SecurityPerformanceSnapshotTest
 
         assertThat(record.getSharesHeld(), is(0L));
 
-        assertThat(record.getFifoCost(), is(Money.of(CurrencyUnit.EUR, 0)));
-        assertThat(record.getFifoCostPerSharesHeld(), is(Quote.of(CurrencyUnit.EUR, 0)));
+        assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0)));
+        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO), is(Quote.of(CurrencyUnit.EUR, 0)));
 
-        assertThat(record.getMovingAverageCost(), is(Money.of(CurrencyUnit.EUR, 0)));
-        assertThat(record.getMovingAverageCostPerSharesHeld(), is(Quote.of(CurrencyUnit.EUR, 0)));
+        assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0)));
+        assertThat(record.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE), is(Quote.of(CurrencyUnit.EUR, 0)));
     }
 
     @Test
@@ -86,12 +88,14 @@ public class SecurityPerformanceSnapshotTest
 
         assertThat(record.getSharesHeld(), is(Values.Share.factorize(499999)));
 
-        assertThat(record.getFifoCost(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(450000 - 0.9))));
-        assertThat(record.getFifoCostPerSharesHeld(), is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(0.9))));
-
-        assertThat(record.getMovingAverageCost(),
+        assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(450000 - 0.9))));
-        assertThat(record.getMovingAverageCostPerSharesHeld(),
+        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO),
+                        is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(0.9))));
+
+        assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(450000 - 0.9))));
+        assertThat(record.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE),
                         is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(0.9))));
 
         SecurityPosition position = ClientSnapshot.create(client, new TestCurrencyConverter(), reportingPeriod.getEnd())

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector2Test.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector2Test.java
@@ -15,8 +15,10 @@ import org.junit.Test;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ClientFactory;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
@@ -96,7 +98,9 @@ public class TradeCollector2Test
                         Interval.of(LocalDate.MIN, LocalDate.now()));
         var securityRecord = snapshot.getRecord(att).get();
 
-        assertThat(secondTrade.getEntryValue(), is(securityRecord.getFifoCost().get()));
-        assertThat(secondTrade.getEntryValueMovingAverage(), is(securityRecord.getMovingAverageCost().get()));
+        assertThat(secondTrade.getEntryValue(),
+                        is(securityRecord.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED)));
+        assertThat(secondTrade.getEntryValueMovingAverage(),
+                        is(securityRecord.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED)));
     }
 }

--- a/name.abuchen.portfolio.tests/src/scenarios/CurrencyTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/CurrencyTestCase.java
@@ -17,7 +17,9 @@ import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ClientFactory;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MoneyCollectors;
@@ -149,24 +151,26 @@ public class CurrencyTestCase
         // must take the inverse of the exchange used within the transaction
         BigDecimal rate = BigDecimal.ONE.divide(BigDecimal.valueOf(0.8237), 10, RoundingMode.HALF_DOWN);
 
-        assertThat(recordUSD.getFifoCost(),
+        assertThat(recordUSD.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.USD, Math.round(454_60 * rate.doubleValue()) + 571_90)));
 
         // price per share is the total purchase price minus 20 USD fees and
         // taxes divided by the number of shares
-        Money pricePerShare = recordUSD.getFifoCost() //
+        Money pricePerShare = recordUSD.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED) //
                         .subtract(Money.of(CurrencyUnit.USD, 20_00)).divide(10);
-        assertThat(recordUSD.getFifoCostPerSharesHeld().toMoney(), is(pricePerShare));
+        assertThat(recordUSD.getCostPerSharesHeld(CostMethod.FIFO).toMoney(), is(pricePerShare));
 
         // profit loss w/o rounding differences
 
         assertThat(equityUSD.getValuation(), is(recordEUR.getMarketValue()));
 
         assertThat(recordEUR.getCapitalGainsOnHoldings(),
-                        is(equityUSD.getValuation().subtract(recordEUR.getFifoCost())));
+                        is(equityUSD.getValuation()
+                                        .subtract(recordEUR.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED))));
 
         assertThat(recordUSD.getCapitalGainsOnHoldings(),
-                        is(equityUSD.getPosition().calculateValue().subtract(recordUSD.getFifoCost())));
+                        is(equityUSD.getPosition().calculateValue()
+                                        .subtract(recordUSD.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED))));
 
     }
 
@@ -225,7 +229,8 @@ public class CurrencyTestCase
                                         SecurityPerformanceIndicator.Costs.class)
                         .getRecord(securityUSD).orElseThrow(IllegalArgumentException::new);
 
-        assertThat(recordEUR.getFifoCost(), is(Money.of(CurrencyUnit.EUR, 454_60L + 471_05 + 498_45)));
+        assertThat(recordEUR.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, 454_60L + 471_05 + 498_45)));
 
         Interval period = Interval.of(LocalDate.parse("2014-12-31"), LocalDate.parse("2015-08-10"));
         SecurityPerformanceSnapshot performance = SecurityPerformanceSnapshot.create(client, converter, period);
@@ -236,7 +241,8 @@ public class CurrencyTestCase
         SecurityPerformanceRecord record = performance.getRecords().stream().filter(r -> r.getSecurity() == securityUSD)
                         .findAny().orElseThrow(IllegalArgumentException::new);
         assertThat(record.getSharesHeld(), is(Values.Share.factorize(15)));
-        assertThat(record.getFifoCost(), is(Money.of(CurrencyUnit.EUR, 454_60L + 471_05 + 498_45)));
+        assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, 454_60L + 471_05 + 498_45)));
     }
 
     private AccountSnapshot lookupAccountSnapshot(ClientSnapshot snapshot, Account account)

--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/IssuePerformanceIndicatorsWithPartialAssignmentTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/IssuePerformanceIndicatorsWithPartialAssignmentTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ClientFactory;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Taxonomy;
 import name.abuchen.portfolio.money.CurrencyUnit;
@@ -62,9 +63,9 @@ public class IssuePerformanceIndicatorsWithPartialAssignmentTest
     private ElementValueProvider function_delta = new ElementValueProvider( //
                     LazySecurityPerformanceRecord::getDelta, sum);
     private ElementValueProvider function_capital_gains = new ElementValueProvider(
-                    LazySecurityPerformanceRecord::getCapitalGainsOnHoldings, sum);
+                    record -> record.getCapitalGainsOnHoldings(CostMethod.FIFO), sum);
     private ElementValueProvider function_capical_gains_percent = new ElementValueProvider(
-                    LazySecurityPerformanceRecord::getCapitalGainsOnHoldingsPercent, null);
+                    record -> record.getCapitalGainsOnHoldingsPercent(CostMethod.FIFO), null);
 
     @BeforeClass
     public static void setupClient() throws IOException

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -1933,10 +1933,10 @@ public class SecuritiesChart
         switch (costMethod)
         {
             case FIFO:
-                purchasePricePerShare = r.get().getFifoCostPerSharesHeld().get();
+                purchasePricePerShare = r.get().getCostPerSharesHeld(CostMethod.FIFO).get();
                 break;
             case MOVING_AVERAGE:
-                purchasePricePerShare = r.get().getMovingAverageCostPerSharesHeld().get();
+                purchasePricePerShare = r.get().getCostPerSharesHeld(CostMethod.MOVING_AVERAGE).get();
                 break;
             default:
                 throw new IllegalArgumentException("unsupported cost method: " + costMethod); //$NON-NLS-1$

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -61,6 +61,7 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.SecurityPrice;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Taxonomy;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyConverterImpl;
@@ -1112,13 +1113,16 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                         + Messages.DescriptionDataRelativeToReportingPeriod);
         column.setImage(Images.INTERVAL);
         column.setLabelProvider(new RowElementLabelProvider(
-                        r -> Values.Money.format(r.getFifoCost().get(), getClient().getBaseCurrency()),
+                        r -> Values.Money.format(r.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                                        getClient().getBaseCurrency()),
                         aggregate -> Values.Money.format(
-                                        aggregate.sum(getClient().getBaseCurrency(), r -> r.getFifoCost().get()),
+                                        aggregate.sum(getClient().getBaseCurrency(),
+                                                        r -> r.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED)),
                                         getClient().getBaseCurrency())));
         column.setToolTipProvider(
                         element -> ((RowElement) element).explain(LazySecurityPerformanceRecord.Trails.FIFO_COST));
-        column.setSorter(ColumnViewerSorter.create(e -> ((LazySecurityPerformanceRecord) e).getFifoCost().get()));
+        column.setSorter(ColumnViewerSorter.create(e -> ((LazySecurityPerformanceRecord) e)
+                        .getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED)));
         recordColumns.addColumn(column);
 
         // cost value - moving average
@@ -1129,13 +1133,17 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                         + Messages.DescriptionDataRelativeToReportingPeriod);
         column.setImage(Images.INTERVAL);
         column.setLabelProvider(new RowElementLabelProvider(
-                        r -> Values.Money.format(r.getMovingAverageCost().get(), getClient().getBaseCurrency()),
+                        r -> Values.Money.format(
+                                        r.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+                                        getClient().getBaseCurrency()),
                         aggregate -> Values.Money.format(
                                         aggregate.sum(getClient().getBaseCurrency(),
-                                                        r -> r.getMovingAverageCost().get()),
+                                                        r -> r.getCost(CostMethod.MOVING_AVERAGE,
+                                                                        TaxesAndFees.INCLUDED)),
                                         getClient().getBaseCurrency())));
         column.setSorter(ColumnViewerSorter
-                        .create(e -> ((LazySecurityPerformanceRecord) e).getMovingAverageCost().get()));
+                        .create(e -> ((LazySecurityPerformanceRecord) e)
+                                        .getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED)));
         column.setVisible(false);
         recordColumns.addColumn(column);
 
@@ -1198,9 +1206,9 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                         + Messages.DescriptionDataRelativeToReportingPeriod);
         column.setImage(Images.INTERVAL);
         column.setLabelProvider(new RowElementLabelProvider(r -> Values.CalculatedQuote
-                        .format(r.getFifoCostPerSharesHeld().get(), getClient().getBaseCurrency())));
+                        .format(r.getCostPerSharesHeld(CostMethod.FIFO).get(), getClient().getBaseCurrency())));
         column.setSorter(ColumnViewerSorter
-                        .create(e -> ((LazySecurityPerformanceRecord) e).getFifoCostPerSharesHeld().get()));
+                        .create(e -> ((LazySecurityPerformanceRecord) e).getCostPerSharesHeld(CostMethod.FIFO).get()));
         recordColumns.addColumn(column);
 
         // cost value per share - moving average
@@ -1211,9 +1219,11 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                         + Messages.DescriptionDataRelativeToReportingPeriod);
         column.setImage(Images.INTERVAL);
         column.setLabelProvider(new RowElementLabelProvider(r -> Values.CalculatedQuote
-                        .format(r.getMovingAverageCostPerSharesHeld().get(), getClient().getBaseCurrency())));
+                        .format(r.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE).get(),
+                                        getClient().getBaseCurrency())));
         column.setSorter(ColumnViewerSorter
-                        .create(e -> ((LazySecurityPerformanceRecord) e).getMovingAverageCostPerSharesHeld().get()));
+                        .create(e -> ((LazySecurityPerformanceRecord) e).getCostPerSharesHeld(CostMethod.MOVING_AVERAGE)
+                                        .get()));
         column.setVisible(false);
         recordColumns.addColumn(column);
 
@@ -1226,9 +1236,10 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                         + Messages.DescriptionDataRelativeToReportingPeriod);
         column.setImage(Images.INTERVAL);
         column.setLabelProvider(new RowElementLabelProvider(r -> Values.CalculatedQuote
-                        .format(r.getGrossFifoCostPerSharesHeld().get(), getClient().getBaseCurrency())));
+                        .format(r.getGrossCostPerSharesHeld(CostMethod.FIFO).get(), getClient().getBaseCurrency())));
         column.setSorter(ColumnViewerSorter
-                        .create(e -> ((LazySecurityPerformanceRecord) e).getGrossFifoCostPerSharesHeld().get()));
+                        .create(e -> ((LazySecurityPerformanceRecord) e).getGrossCostPerSharesHeld(CostMethod.FIFO)
+                                        .get()));
         recordColumns.addColumn(column);
 
         // cost value per share including fees and taxes - moving average
@@ -1239,9 +1250,11 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                         + Messages.DescriptionDataRelativeToReportingPeriod);
         column.setImage(Images.INTERVAL);
         column.setLabelProvider(new RowElementLabelProvider(r -> Values.CalculatedQuote
-                        .format(r.getGrossMovingAverageCostPerSharesHeld().get(), getClient().getBaseCurrency())));
+                        .format(r.getGrossCostPerSharesHeld(CostMethod.MOVING_AVERAGE).get(),
+                                        getClient().getBaseCurrency())));
         column.setSorter(ColumnViewerSorter.create(
-                        e -> ((LazySecurityPerformanceRecord) e).getGrossMovingAverageCostPerSharesHeld().get()));
+                        e -> ((LazySecurityPerformanceRecord) e).getGrossCostPerSharesHeld(CostMethod.MOVING_AVERAGE)
+                                        .get()));
         column.setVisible(false);
         recordColumns.addColumn(column);
     }
@@ -1283,25 +1296,30 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                         new RowElementLabelProvider(
                                         new MoneyColorLabelProvider(
                                                         element -> ((LazySecurityPerformanceRecord) element)
-                                                                        .getCapitalGainsOnHoldings().get(),
+                                                                        .getCapitalGainsOnHoldings(CostMethod.FIFO)
+                                                                        .get(),
                                                         getClient()),
                                         aggregate -> Values.Money.format(
                                                         aggregate.sum(getClient().getBaseCurrency(),
-                                                                        r -> r.getCapitalGainsOnHoldings().get()),
+                                                                        r -> r.getCapitalGainsOnHoldings(
+                                                                                        CostMethod.FIFO).get()),
                                                         getClient().getBaseCurrency())));
         column.setVisible(false);
         column.setSorter(ColumnViewerSorter
-                        .create(e -> ((LazySecurityPerformanceRecord) e).getCapitalGainsOnHoldings().get()));
+                        .create(e -> ((LazySecurityPerformanceRecord) e).getCapitalGainsOnHoldings(CostMethod.FIFO)
+                                        .get()));
         recordColumns.addColumn(column);
 
         column = new Column("capitalgains%", Messages.ColumnCapitalGainsPercent, SWT.RIGHT, 80); //$NON-NLS-1$
         column.setGroupLabel(Messages.GroupLabelPerformance);
         column.setDescription(Messages.ColumnCapitalGainsPercent_Description);
         column.setLabelProvider(new RowElementLabelProvider(new NumberColorLabelProvider<>(Values.Percent2,
-                        r -> ((LazySecurityPerformanceRecord) r).getCapitalGainsOnHoldingsPercent().get())));
+                        r -> ((LazySecurityPerformanceRecord) r).getCapitalGainsOnHoldingsPercent(CostMethod.FIFO)
+                                        .get())));
         column.setVisible(false);
         column.setSorter(ColumnViewerSorter
-                        .create(e -> ((LazySecurityPerformanceRecord) e).getCapitalGainsOnHoldingsPercent().get()));
+                        .create(e -> ((LazySecurityPerformanceRecord) e)
+                                        .getCapitalGainsOnHoldingsPercent(CostMethod.FIFO).get()));
         recordColumns.addColumn(column);
 
         column = new Column("capitalgainsmvavg", Messages.ColumnCapitalGainsMovingAverage, SWT.RIGHT, 80); //$NON-NLS-1$
@@ -1312,16 +1330,20 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                         new RowElementLabelProvider(
                                         new MoneyColorLabelProvider(
                                                         element -> ((LazySecurityPerformanceRecord) element)
-                                                                        .getCapitalGainsOnHoldingsMovingAverage().get(),
+                                                                        .getCapitalGainsOnHoldings(
+                                                                                        CostMethod.MOVING_AVERAGE)
+                                                                        .get(),
                                                         getClient()),
                                         aggregate -> Values.Money.format(
                                                         aggregate.sum(getClient().getBaseCurrency(),
-                                                                        r -> r.getCapitalGainsOnHoldingsMovingAverage()
+                                                                        r -> r.getCapitalGainsOnHoldings(
+                                                                                        CostMethod.MOVING_AVERAGE)
                                                                                         .get()),
                                                         getClient().getBaseCurrency())));
         column.setVisible(false);
         column.setSorter(ColumnViewerSorter.create(
-                        e -> ((LazySecurityPerformanceRecord) e).getCapitalGainsOnHoldingsMovingAverage().get()));
+                        e -> ((LazySecurityPerformanceRecord) e).getCapitalGainsOnHoldings(CostMethod.MOVING_AVERAGE)
+                                        .get()));
         recordColumns.addColumn(column);
 
         column = new Column("capitalgainsmvavg%", Messages.ColumnCapitalGainsMovingAveragePercent, SWT.RIGHT, 80); //$NON-NLS-1$
@@ -1330,10 +1352,10 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setDescription(Messages.ColumnCapitalGainsMovingAveragePercent_Description);
         column.setLabelProvider(new RowElementLabelProvider(
                         new NumberColorLabelProvider<>(Values.Percent2, r -> ((LazySecurityPerformanceRecord) r)
-                                        .getCapitalGainsOnHoldingsMovingAveragePercent().get())));
+                                        .getCapitalGainsOnHoldingsPercent(CostMethod.MOVING_AVERAGE).get())));
         column.setVisible(false);
         column.setSorter(ColumnViewerSorter.create(e -> ((LazySecurityPerformanceRecord) e)
-                        .getCapitalGainsOnHoldingsMovingAveragePercent().get()));
+                        .getCapitalGainsOnHoldingsPercent(CostMethod.MOVING_AVERAGE).get()));
         recordColumns.addColumn(column);
 
         // delta
@@ -1373,18 +1395,20 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setLabelProvider(
                         new RowElementLabelProvider(
                                         new MoneyColorLabelProvider(element -> ((LazySecurityPerformanceRecord) element)
-                                                        .getRealizedCapitalGains().get().getCapitalGains(),
+                                                        .getRealizedCapitalGains(CostMethod.FIFO).get()
+                                                        .getCapitalGains(),
                                                         getClient()),
                                         aggregate -> Values.Money.format(
                                                         aggregate.sum(getClient().getBaseCurrency(),
-                                                                        r -> r.getRealizedCapitalGains().get()
+                                                                        r -> r.getRealizedCapitalGains(CostMethod.FIFO)
+                                                                                        .get()
                                                                                         .getCapitalGains()),
                                                         getClient().getBaseCurrency())));
         column.setToolTipProvider(element -> ((RowElement) element)
                         .explain(LazySecurityPerformanceRecord.Trails.REALIZED_CAPITAL_GAINS));
         column.setVisible(false);
         column.setSorter(ColumnViewerSorter.create(element -> ((LazySecurityPerformanceRecord) element)
-                        .getRealizedCapitalGains().get().getCapitalGains()));
+                        .getRealizedCapitalGains(CostMethod.FIFO).get().getCapitalGains()));
         recordColumns.addColumn(column);
 
         column = new Column("cgforex", //$NON-NLS-1$
@@ -1393,18 +1417,20 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setLabelProvider(
                         new RowElementLabelProvider(
                                         new MoneyColorLabelProvider(element -> ((LazySecurityPerformanceRecord) element)
-                                                        .getRealizedCapitalGains().get().getForexCaptialGains(),
+                                                        .getRealizedCapitalGains(CostMethod.FIFO).get()
+                                                        .getForexCaptialGains(),
                                                         getClient()),
                                         aggregate -> Values.Money.format(
                                                         aggregate.sum(getClient().getBaseCurrency(),
-                                                                        r -> r.getRealizedCapitalGains().get()
+                                                                        r -> r.getRealizedCapitalGains(CostMethod.FIFO)
+                                                                                        .get()
                                                                                         .getForexCaptialGains()),
                                                         getClient().getBaseCurrency())));
         column.setToolTipProvider(element -> ((RowElement) element)
                         .explain(LazySecurityPerformanceRecord.Trails.REALIZED_CAPITAL_GAINS_FOREX));
         column.setVisible(false);
         column.setSorter(ColumnViewerSorter.create(element -> ((LazySecurityPerformanceRecord) element)
-                        .getRealizedCapitalGains().get().getCapitalGains()));
+                        .getRealizedCapitalGains(CostMethod.FIFO).get().getCapitalGains()));
         recordColumns.addColumn(column);
 
         column = new Column("ucg", //$NON-NLS-1$
@@ -1416,18 +1442,20 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setLabelProvider(
                         new RowElementLabelProvider(
                                         new MoneyColorLabelProvider(element -> ((LazySecurityPerformanceRecord) element)
-                                                        .getUnrealizedCapitalGains().get().getCapitalGains(),
+                                                        .getUnrealizedCapitalGains(CostMethod.FIFO).get()
+                                                        .getCapitalGains(),
                                                         getClient()),
                                         aggregate -> Values.Money.format(
                                                         aggregate.sum(getClient().getBaseCurrency(),
-                                                                        r -> r.getUnrealizedCapitalGains().get()
+                                                                        r -> r.getUnrealizedCapitalGains(
+                                                                                        CostMethod.FIFO).get()
                                                                                         .getCapitalGains()),
                                                         getClient().getBaseCurrency())));
         column.setToolTipProvider(element -> ((RowElement) element)
                         .explain(LazySecurityPerformanceRecord.Trails.UNREALIZED_CAPITAL_GAINS));
         column.setVisible(false);
         column.setSorter(ColumnViewerSorter.create(element -> ((LazySecurityPerformanceRecord) element)
-                        .getUnrealizedCapitalGains().get().getCapitalGains()));
+                        .getUnrealizedCapitalGains(CostMethod.FIFO).get().getCapitalGains()));
         recordColumns.addColumn(column);
 
         column = new Column("ucgforex", //$NON-NLS-1$
@@ -1435,17 +1463,18 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setGroupLabel(Messages.LabelCapitalGains);
         column.setLabelProvider(new RowElementLabelProvider(
                         new MoneyColorLabelProvider(element -> ((LazySecurityPerformanceRecord) element)
-                                        .getUnrealizedCapitalGains().get().getForexCaptialGains(), getClient()),
+                                        .getUnrealizedCapitalGains(CostMethod.FIFO).get().getForexCaptialGains(),
+                                        getClient()),
                         aggregate -> Values.Money.format(
                                         aggregate.sum(getClient().getBaseCurrency(),
-                                                        r -> r.getUnrealizedCapitalGains().get()
+                                                        r -> r.getUnrealizedCapitalGains(CostMethod.FIFO).get()
                                                                         .getForexCaptialGains()),
                                         getClient().getBaseCurrency())));
         column.setToolTipProvider(element -> ((RowElement) element)
                         .explain(LazySecurityPerformanceRecord.Trails.UNREALIZED_CAPITAL_GAINS_FOREX));
         column.setVisible(false);
         column.setSorter(ColumnViewerSorter.create(element -> ((LazySecurityPerformanceRecord) element)
-                        .getUnrealizedCapitalGains().get().getCapitalGains()));
+                        .getUnrealizedCapitalGains(CostMethod.FIFO).get().getCapitalGains()));
         recordColumns.addColumn(column);
 
         // Moving Average
@@ -1462,16 +1491,17 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setLabelProvider(new RowElementLabelProvider(
                         new MoneyColorLabelProvider(
                                         element -> ((LazySecurityPerformanceRecord) element)
-                                                        .getRealizedCapitalGainsMovingAvg().get().getCapitalGains(),
+                                                        .getRealizedCapitalGains(CostMethod.MOVING_AVERAGE).get()
+                                                        .getCapitalGains(),
                                         getClient()),
                         aggregate -> Values.Money.format(
                                         aggregate.sum(getClient().getBaseCurrency(),
-                                                        r -> r.getRealizedCapitalGainsMovingAvg().get()
+                                                        r -> r.getRealizedCapitalGains(CostMethod.MOVING_AVERAGE).get()
                                                                         .getCapitalGains()),
                                         getClient().getBaseCurrency())));
         column.setVisible(false);
         column.setSorter(ColumnViewerSorter.create(element -> ((LazySecurityPerformanceRecord) element)
-                        .getRealizedCapitalGainsMovingAvg().get().getCapitalGains()));
+                        .getRealizedCapitalGains(CostMethod.MOVING_AVERAGE).get().getCapitalGains()));
         recordColumns.addColumn(column);
 
         column = new Column("cgforexMA", //$NON-NLS-1$
@@ -1482,15 +1512,16 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setMenuLabel(Messages.ColumnCurrencyGains + " / " + Messages.ColumnRealizedCapitalGains); //$NON-NLS-1$
         column.setLabelProvider(new RowElementLabelProvider(
                         new MoneyColorLabelProvider(element -> ((LazySecurityPerformanceRecord) element)
-                                        .getRealizedCapitalGainsMovingAvg().get().getForexCaptialGains(), getClient()),
+                                        .getRealizedCapitalGains(CostMethod.MOVING_AVERAGE).get()
+                                        .getForexCaptialGains(), getClient()),
                         aggregate -> Values.Money.format(
                                         aggregate.sum(getClient().getBaseCurrency(),
-                                                        r -> r.getRealizedCapitalGainsMovingAvg().get()
+                                                        r -> r.getRealizedCapitalGains(CostMethod.MOVING_AVERAGE).get()
                                                                         .getForexCaptialGains()),
                                         getClient().getBaseCurrency())));
         column.setVisible(false);
         column.setSorter(ColumnViewerSorter.create(element -> ((LazySecurityPerformanceRecord) element)
-                        .getRealizedCapitalGainsMovingAvg().get().getCapitalGains()));
+                        .getRealizedCapitalGains(CostMethod.MOVING_AVERAGE).get().getCapitalGains()));
         recordColumns.addColumn(column);
 
         column = new Column("ucgMA", //$NON-NLS-1$
@@ -1505,16 +1536,18 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setLabelProvider(new RowElementLabelProvider(
                         new MoneyColorLabelProvider(
                                         element -> ((LazySecurityPerformanceRecord) element)
-                                                        .getUnrealizedCapitalGainsMovingAvg().get().getCapitalGains(),
+                                                        .getUnrealizedCapitalGains(CostMethod.MOVING_AVERAGE).get()
+                                                        .getCapitalGains(),
                                         getClient()),
                         aggregate -> Values.Money.format(
                                         aggregate.sum(getClient().getBaseCurrency(),
-                                                        r -> r.getUnrealizedCapitalGainsMovingAvg().get()
+                                                        r -> r.getUnrealizedCapitalGains(CostMethod.MOVING_AVERAGE)
+                                                                        .get()
                                                                         .getCapitalGains()),
                                         getClient().getBaseCurrency())));
         column.setVisible(false);
         column.setSorter(ColumnViewerSorter.create(element -> ((LazySecurityPerformanceRecord) element)
-                        .getUnrealizedCapitalGainsMovingAvg().get().getCapitalGains()));
+                        .getUnrealizedCapitalGains(CostMethod.MOVING_AVERAGE).get().getCapitalGains()));
         recordColumns.addColumn(column);
 
         column = new Column("ucgforexMA", //$NON-NLS-1$
@@ -1525,16 +1558,18 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setMenuLabel(Messages.ColumnCurrencyGains + " / " + Messages.ColumnUnrealizedCapitalGains); //$NON-NLS-1$
         column.setLabelProvider(new RowElementLabelProvider(
                         new MoneyColorLabelProvider(element -> ((LazySecurityPerformanceRecord) element)
-                                        .getUnrealizedCapitalGainsMovingAvg().get().getForexCaptialGains(),
+                                        .getUnrealizedCapitalGains(CostMethod.MOVING_AVERAGE).get()
+                                        .getForexCaptialGains(),
                                         getClient()),
                         aggregate -> Values.Money.format(
                                         aggregate.sum(getClient().getBaseCurrency(),
-                                                        r -> r.getUnrealizedCapitalGainsMovingAvg().get()
+                                                        r -> r.getUnrealizedCapitalGains(CostMethod.MOVING_AVERAGE)
+                                                                        .get()
                                                                         .getForexCaptialGains()),
                                         getClient().getBaseCurrency())));
         column.setVisible(false);
         column.setSorter(ColumnViewerSorter.create(element -> ((LazySecurityPerformanceRecord) element)
-                        .getUnrealizedCapitalGainsMovingAvg().get().getCapitalGains()));
+                        .getUnrealizedCapitalGains(CostMethod.MOVING_AVERAGE).get().getCapitalGains()));
         recordColumns.addColumn(column);
     }
 
@@ -1558,9 +1593,10 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setDescription(Messages.ColumnDividendTotalRateOfReturn_Description);
         column.setVisible(false);
         column.setLabelProvider(new RowElementLabelProvider(
-                        r -> Values.Percent2.formatNonZero(r.getTotalRateOfReturnDiv().get())));
+                        r -> Values.Percent2.formatNonZero(r.getTotalRateOfReturnDiv(CostMethod.FIFO).get())));
         column.setSorter(ColumnViewerSorter
-                        .create(e -> ((LazySecurityPerformanceRecord) e).getTotalRateOfReturnDiv().get()));
+                        .create(e -> ((LazySecurityPerformanceRecord) e).getTotalRateOfReturnDiv(CostMethod.FIFO)
+                                        .get()));
         recordColumns.addColumn(column);
 
         // Rendite insgesamt, nach gleitendem Durchschnitt
@@ -1570,9 +1606,11 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setDescription(Messages.ColumnDividendMovingAverageTotalRateOfReturn_Description);
         column.setVisible(false);
         column.setLabelProvider(new RowElementLabelProvider(
-                        r -> Values.Percent2.formatNonZero(r.getTotalRateOfReturnDivMovingAverage().get())));
+                        r -> Values.Percent2
+                                        .formatNonZero(r.getTotalRateOfReturnDiv(CostMethod.MOVING_AVERAGE).get())));
         column.setSorter(ColumnViewerSorter
-                        .create(e -> ((LazySecurityPerformanceRecord) e).getTotalRateOfReturnDivMovingAverage().get()));
+                        .create(e -> ((LazySecurityPerformanceRecord) e)
+                                        .getTotalRateOfReturnDiv(CostMethod.MOVING_AVERAGE).get()));
         recordColumns.addColumn(column);
 
         // Rendite pro Jahr
@@ -1759,9 +1797,11 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setGroupLabel(Messages.LabelClientFilterMenu);
         column.setImage(Images.INTERVAL);
         column.setLabelProvider(new RowElementOptionLabelProvider(
-                        r -> Values.Money.format(r.getFifoCost().get(), getClient().getBaseCurrency()),
+                        r -> Values.Money.format(r.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                                        getClient().getBaseCurrency()),
                         aggregate -> Values.Money.format(
-                                        aggregate.sum(getClient().getBaseCurrency(), r -> r.getFifoCost().get()),
+                                        aggregate.sum(getClient().getBaseCurrency(),
+                                                        r -> r.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED)),
                                         getClient().getBaseCurrency())));
         column.setToolTipProvider((element, option) -> {
             var row = (RowElement) element;
@@ -1773,7 +1813,8 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setSorter(ColumnViewerSorter.createWithOption((element, option) -> {
             var dataRecord = model.getRecord(((LazySecurityPerformanceRecord) element).getSecurity(),
                             (ClientFilterMenu.Item) option);
-            return dataRecord == null ? null : dataRecord.getFifoCost().get();
+            return dataRecord == null ? null
+                            : dataRecord.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED);
         }));
         column.setVisible(false);
         recordColumns.addColumn(column);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -55,10 +55,12 @@ import name.abuchen.portfolio.model.Annotated;
 import name.abuchen.portfolio.model.Attributable;
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.InvestmentVehicle;
 import name.abuchen.portfolio.model.Named;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Taxonomy;
 import name.abuchen.portfolio.model.TransactionOwner;
 import name.abuchen.portfolio.money.CurrencyConverter;
@@ -556,7 +558,11 @@ public class StatementOfAssetsViewer
         column.setMenuLabel(Messages.ColumnPurchaseValue_MenuLabel);
         column.setDescription(Messages.ColumnPurchaseValue_Description);
         labelProvider = new ReportingPeriodLabelProvider(
-                        new ElementValueProvider(LazySecurityPerformanceRecord::getFifoCost, withSum()), false);
+                        new ElementValueProvider(
+                                        record -> new LazyValue<>(
+                                                        () -> record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED)),
+                                        withSum()),
+                        false);
         column.setLabelProvider(labelProvider);
         column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
         column.setVisible(false);
@@ -568,7 +574,10 @@ public class StatementOfAssetsViewer
         column.setMenuLabel(Messages.ColumnPurchaseValueMovingAverage_MenuLabel);
         column.setDescription(Messages.ColumnPurchaseValueMovingAverage_Description);
         labelProvider = new ReportingPeriodLabelProvider(
-                        new ElementValueProvider(LazySecurityPerformanceRecord::getMovingAverageCost, withSum()),
+                        new ElementValueProvider(
+                                        record -> new LazyValue<>(() -> record.getCost(CostMethod.MOVING_AVERAGE,
+                                                        TaxesAndFees.INCLUDED)),
+                                        withSum()),
                         false);
         column.setLabelProvider(labelProvider);
         column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
@@ -577,7 +586,7 @@ public class StatementOfAssetsViewer
 
         column = new Column("9", Messages.ColumnProfitLoss, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(
-                        new ElementValueProvider(LazySecurityPerformanceRecord::getCapitalGainsOnHoldings, withSum()),
+                        new ElementValueProvider(record -> record.getCapitalGainsOnHoldings(CostMethod.FIFO), withSum()),
                         true);
         column.setLabelProvider(labelProvider);
         column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
@@ -645,7 +654,7 @@ public class StatementOfAssetsViewer
         column.setMenuLabel(Messages.ColumnPurchasePrice_MenuLabel);
         column.setDescription(Messages.ColumnPurchasePrice_Description);
         labelProvider = new ReportingPeriodLabelProvider(
-                        new ElementValueProvider(LazySecurityPerformanceRecord::getFifoCostPerSharesHeld, null), false);
+                        new ElementValueProvider(record -> record.getCostPerSharesHeld(CostMethod.FIFO), null), false);
         column.setLabelProvider(labelProvider);
         column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
         column.setVisible(false);
@@ -657,7 +666,7 @@ public class StatementOfAssetsViewer
         column.setMenuLabel(Messages.ColumnPurchasePriceMovingAverage_MenuLabel);
         column.setDescription(Messages.ColumnPurchasePriceMovingAverage_Description);
         labelProvider = new ReportingPeriodLabelProvider(new ElementValueProvider(
-                        LazySecurityPerformanceRecord::getMovingAverageCostPerSharesHeld, null), false);
+                        record -> record.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE), null), false);
         column.setLabelProvider(labelProvider);
         column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
         column.setVisible(false);
@@ -670,7 +679,7 @@ public class StatementOfAssetsViewer
         column.setMenuLabel(Messages.ColumnPurchasePrice_MenuLabel);
         column.setDescription(Messages.ColumnGrossPurchasePriceFIFO_Description);
         labelProvider = new ReportingPeriodLabelProvider(
-                        new ElementValueProvider(LazySecurityPerformanceRecord::getGrossFifoCostPerSharesHeld, null),
+                        new ElementValueProvider(record -> record.getGrossCostPerSharesHeld(CostMethod.FIFO), null),
                         false);
         column.setLabelProvider(labelProvider);
         column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
@@ -683,7 +692,7 @@ public class StatementOfAssetsViewer
         column.setMenuLabel(Messages.ColumnPurchasePriceMovingAverage_MenuLabel);
         column.setDescription(Messages.ColumnGrossPurchasePriceMovingAverage_Description);
         labelProvider = new ReportingPeriodLabelProvider(new ElementValueProvider(
-                        LazySecurityPerformanceRecord::getGrossMovingAverageCostPerSharesHeld, null), false);
+                        record -> record.getGrossCostPerSharesHeld(CostMethod.MOVING_AVERAGE), null), false);
         column.setLabelProvider(labelProvider);
         column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
         column.setVisible(false);
@@ -729,7 +738,7 @@ public class StatementOfAssetsViewer
         support.addColumn(column);
 
         column = new Column("capitalgains", Messages.ColumnCapitalGains, SWT.RIGHT, 80); //$NON-NLS-1$
-        labelProvider = new ReportingPeriodLabelProvider(LazySecurityPerformanceRecord::getCapitalGainsOnHoldings,
+        labelProvider = new ReportingPeriodLabelProvider(record -> record.getCapitalGainsOnHoldings(CostMethod.FIFO),
                         withSum(), true);
         column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnCapitalGains_Option, options));
         column.setGroupLabel(Messages.GroupLabelPerformance);
@@ -741,7 +750,7 @@ public class StatementOfAssetsViewer
 
         column = new Column("capitalgains%", Messages.ColumnCapitalGainsPercent, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(
-                        LazySecurityPerformanceRecord::getCapitalGainsOnHoldingsPercent);
+                        record -> record.getCapitalGainsOnHoldingsPercent(CostMethod.FIFO));
         column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnCapitalGainsPercent_Option, options));
         column.setGroupLabel(Messages.GroupLabelPerformance);
         column.setDescription(Messages.ColumnCapitalGainsPercent_Description);
@@ -752,7 +761,7 @@ public class StatementOfAssetsViewer
 
         column = new Column("capitalgainsmvavg", Messages.ColumnCapitalGainsMovingAverage, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(
-                        LazySecurityPerformanceRecord::getCapitalGainsOnHoldingsMovingAverage, withSum(), true);
+                        record -> record.getCapitalGainsOnHoldings(CostMethod.MOVING_AVERAGE), withSum(), true);
         column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnCapitalGainsMovingAverage_Option, options));
         column.setGroupLabel(Messages.GroupLabelPerformance);
         column.setDescription(Messages.ColumnCapitalGainsMovingAverage_Description);
@@ -763,7 +772,7 @@ public class StatementOfAssetsViewer
 
         column = new Column("capitalgainsmvavg%", Messages.ColumnCapitalGainsMovingAveragePercent, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(
-                        LazySecurityPerformanceRecord::getCapitalGainsOnHoldingsMovingAveragePercent);
+                        record -> record.getCapitalGainsOnHoldingsPercent(CostMethod.MOVING_AVERAGE));
         column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnCapitalGainsMovingAveragePercent_Option,
                         options));
         column.setGroupLabel(Messages.GroupLabelPerformance);
@@ -811,8 +820,8 @@ public class StatementOfAssetsViewer
         support.addColumn(column);
 
         column = new Column("d%", Messages.ColumnDividendTotalRateOfReturn, SWT.RIGHT, 80); //$NON-NLS-1$
-        labelProvider = new ReportingPeriodLabelProvider(LazySecurityPerformanceRecord::getTotalRateOfReturnDiv, null,
-                        false);
+        labelProvider = new ReportingPeriodLabelProvider(record -> record.getTotalRateOfReturnDiv(CostMethod.FIFO),
+                        null, false);
         column.setOptions(new ReportingPeriodColumnOptions(Messages.ColumnDividendTotalRateOfReturn + " {0}", options)); //$NON-NLS-1$
         column.setGroupLabel(Messages.GroupLabelDividends);
         column.setDescription(Messages.ColumnDividendTotalRateOfReturn_Description);
@@ -823,7 +832,7 @@ public class StatementOfAssetsViewer
 
         column = new Column("d%mvavg", Messages.ColumnDividendMovingAverageTotalRateOfReturn, SWT.RIGHT, 80); //$NON-NLS-1$
         labelProvider = new ReportingPeriodLabelProvider(
-                        LazySecurityPerformanceRecord::getTotalRateOfReturnDivMovingAverage, null, false);
+                        record -> record.getTotalRateOfReturnDiv(CostMethod.MOVING_AVERAGE), null, false);
         column.setOptions(new ReportingPeriodColumnOptions(
                         Messages.ColumnDividendMovingAverageTotalRateOfReturn + " {0}", options)); //$NON-NLS-1$
         column.setGroupLabel(Messages.GroupLabelDividends);
@@ -1009,7 +1018,10 @@ public class StatementOfAssetsViewer
         column.setDescription(Messages.ColumnPurchaseValueBaseCurrency);
         column.setGroupLabel(Messages.ColumnForeignCurrencies);
         labelProvider = new ReportingPeriodLabelProvider(
-                        new ElementValueProvider(LazySecurityPerformanceRecord::getFifoCost, null),
+                        new ElementValueProvider(
+                                        record -> new LazyValue<>(
+                                                        () -> record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED)),
+                                        null),
                         e -> e.isSecurity() ? e.getSecurity().getCurrencyCode()
                                         : model.getCurrencyConverter().getTermCurrency(),
                         false);
@@ -1023,7 +1035,7 @@ public class StatementOfAssetsViewer
         column.setDescription(Messages.ColumnPurchasePriceBaseCurrency);
         column.setGroupLabel(Messages.ColumnForeignCurrencies);
         labelProvider = new ReportingPeriodLabelProvider(
-                        new ElementValueProvider(LazySecurityPerformanceRecord::getFifoCostPerSharesHeld, null),
+                        new ElementValueProvider(record -> record.getCostPerSharesHeld(CostMethod.FIFO), null),
                         e -> e.isSecurity() ? e.getSecurity().getCurrencyCode()
                                         : model.getCurrencyConverter().getTermCurrency(),
                         false);
@@ -1037,7 +1049,7 @@ public class StatementOfAssetsViewer
         column.setDescription(Messages.ColumnProfitLossBaseCurrency);
         column.setGroupLabel(Messages.ColumnForeignCurrencies);
         labelProvider = new ReportingPeriodLabelProvider(
-                        new ElementValueProvider(LazySecurityPerformanceRecord::getCapitalGainsOnHoldings, null),
+                        new ElementValueProvider(record -> record.getCapitalGainsOnHoldings(CostMethod.FIFO), null),
                         e -> e.isSecurity() ? e.getSecurity().getCurrencyCode()
                                         : model.getCurrencyConverter().getTermCurrency(),
                         false);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/exporter/VINISExporter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/exporter/VINISExporter.java
@@ -12,6 +12,8 @@ import org.apache.commons.csv.CSVPrinter;
 
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyConverterImpl;
 import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
 import name.abuchen.portfolio.money.Money;
@@ -24,7 +26,6 @@ import name.abuchen.portfolio.snapshot.ClientPerformanceSnapshot;
 import name.abuchen.portfolio.snapshot.ClientPerformanceSnapshot.CategoryType;
 import name.abuchen.portfolio.snapshot.ReportingPeriod;
 import name.abuchen.portfolio.snapshot.security.SecurityPerformanceIndicator;
-import name.abuchen.portfolio.snapshot.security.SecurityPerformanceRecord;
 import name.abuchen.portfolio.snapshot.security.SecurityPerformanceSnapshot;
 import name.abuchen.portfolio.util.Interval;
 
@@ -87,7 +88,8 @@ public class VINISExporter
             if (asset.getSecurity() != null)
             {
                 var fifo = securityPerformance.getRecord(asset.getSecurity())
-                                .map(SecurityPerformanceRecord::getFifoCost).orElse(Money.of(baseCurrency, 0))
+                                .map(record -> record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED))
+                                .orElse(Money.of(baseCurrency, 0))
                                 .with(toBaseCurrency);
                 buySecurityValue.add(fifo);
                 currentSecurityValue.add(valuation);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/DivvyDiaryUploader.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/DivvyDiaryUploader.java
@@ -19,6 +19,7 @@ import com.google.common.base.Strings;
 
 import name.abuchen.portfolio.PortfolioLog;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.model.TransactionPair;
@@ -95,7 +96,7 @@ public class DivvyDiaryUploader
             // Add the "buyin" (the FIFO cost). Used if no transactions are
             // transmitted. Add for backward compatibility in case transactions
             // are transmitted.
-            Quote fifo = performanceRecord.getFifoCostPerSharesHeld().get();
+            Quote fifo = performanceRecord.getCostPerSharesHeld(CostMethod.FIFO).get();
             if (fifo.isNotZero())
             {
                 JSONObject buyin = new JSONObject();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/AbstractCapitalGainsCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/AbstractCapitalGainsCalculation.java
@@ -1,0 +1,24 @@
+package name.abuchen.portfolio.snapshot.security;
+
+abstract class AbstractCapitalGainsCalculation extends Calculation
+{
+    protected CapitalGainsRecord realizedCapitalGains;
+    protected CapitalGainsRecord unrealizedCapitalGains;
+
+    @Override
+    public void prepare()
+    {
+        this.realizedCapitalGains = new CapitalGainsRecord(getSecurity(), getTermCurrency());
+        this.unrealizedCapitalGains = new CapitalGainsRecord(getSecurity(), getTermCurrency());
+    }
+
+    public CapitalGainsRecord getRealizedCapitalGains()
+    {
+        return realizedCapitalGains;
+    }
+
+    public CapitalGainsRecord getUnrealizedCapitalGains()
+    {
+        return unrealizedCapitalGains;
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculation.java
@@ -20,7 +20,7 @@ import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.SecurityPosition;
 import name.abuchen.portfolio.snapshot.trail.TrailRecord;
 
-/* package */class CapitalGainsCalculation extends Calculation
+/* package */class CapitalGainsCalculation extends AbstractCapitalGainsCalculation
 {
     private static class LineItem
     {
@@ -51,16 +51,6 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
     }
 
     private List<LineItem> fifo = new ArrayList<>();
-
-    private CapitalGainsRecord realizedCapitalGains;
-    private CapitalGainsRecord unrealizedCapitalGains;
-
-    @Override
-    public void prepare()
-    {
-        this.realizedCapitalGains = new CapitalGainsRecord(getSecurity(), getTermCurrency());
-        this.unrealizedCapitalGains = new CapitalGainsRecord(getSecurity(), getTermCurrency());
-    }
 
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.ValuationAtStart valuation)
@@ -392,15 +382,4 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
         fifo.removeAll(itemsToSquash);
         fifo.add(0, replacement);
     }
-
-    public CapitalGainsRecord getRealizedCapitalGains()
-    {
-        return realizedCapitalGains;
-    }
-
-    public CapitalGainsRecord getUnrealizedCapitalGains()
-    {
-        return unrealizedCapitalGains;
-    }
-
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationMovingAverage.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationMovingAverage.java
@@ -15,21 +15,11 @@ import name.abuchen.portfolio.money.MoneyCollectors;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.SecurityPosition;
 
-/* package */class CapitalGainsCalculationMovingAverage extends Calculation
+/* package */class CapitalGainsCalculationMovingAverage extends AbstractCapitalGainsCalculation
 {
     private long heldShares = 0;
     private long movingAverageNetCost = 0;
     private long movingAverageNetCostForex = 0;
-
-    private CapitalGainsRecord realizedCapitalGains;
-    private CapitalGainsRecord unrealizedCapitalGains;
-
-    @Override
-    public void prepare()
-    {
-        this.realizedCapitalGains = new CapitalGainsRecord(getSecurity(), getTermCurrency());
-        this.unrealizedCapitalGains = new CapitalGainsRecord(getSecurity(), getTermCurrency());
-    }
 
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.ValuationAtStart valuation)
@@ -181,15 +171,5 @@ import name.abuchen.portfolio.snapshot.SecurityPosition;
 
         unrealizedCapitalGains.addCapitalGains(Money.of(termCurrency, gain));
         unrealizedCapitalGains.addForexCaptialGains(Money.of(termCurrency, gainForex));
-    }
-
-    public CapitalGainsRecord getRealizedCapitalGains()
-    {
-        return realizedCapitalGains;
-    }
-
-    public CapitalGainsRecord getUnrealizedCapitalGains()
-    {
-        return unrealizedCapitalGains;
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CostCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CostCalculation.java
@@ -7,8 +7,10 @@ import java.util.List;
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.PortfolioLog;
 import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.model.TransactionOwner;
 import name.abuchen.portfolio.money.CurrencyConverter;
@@ -249,27 +251,19 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
         taxes += t.getTransaction().orElseThrow(IllegalArgumentException::new).getUnitSum(Unit.Type.TAX, converter)
                         .getAmount();
 
-        t.setFifoCost(getFifoCost());
-        t.setMovingAverageCost(getMovingAverageCost());
+        t.setFifoCost(getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED));
+        t.setMovingAverageCost(getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED));
         t.setTotalShares(getSharesHeld());
     }
 
     public CostCalculationResult getResult()
     {
-        return new CostCalculationResult(getSharesHeld(), getFifoCost(), getFifoCostTrail(), getNetFifoCost(),
-                        getMovingAverageCost(), getNetMovingAverageCost(), getFees(), getTaxes());
+        return new CostCalculationResult(getSharesHeld(), getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                        getFifoCostTrail(), getCost(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
+                        getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+                        getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED), getFees(), getTaxes());
     }
 
-    /**
-     * gross investment
-     */
-    public Money getFifoCost()
-    {
-        long cost = 0;
-        for (LineItem entry : fifo)
-            cost += entry.grossAmount;
-        return Money.of(getTermCurrency(), cost);
-    }
 
     public TrailRecord getFifoCostTrail()
     {
@@ -277,33 +271,6 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
                         .map(entry -> entry.trail.fraction(Money.of(getTermCurrency(), entry.grossAmount), entry.shares,
                                         entry.originalShares))
                         .toList());
-    }
-
-    /**
-     * net investment, i.e. without fees and taxes
-     */
-    public Money getNetFifoCost()
-    {
-        long cost = 0;
-        for (LineItem entry : fifo)
-            cost += entry.netAmount;
-        return Money.of(getTermCurrency(), cost);
-    }
-
-    /**
-     * gross investment
-     */
-    public Money getMovingAverageCost()
-    {
-        return Money.of(getTermCurrency(), movingRelativeCost);
-    }
-
-    /**
-     * net investment, i.e. without fees and taxes
-     */
-    public Money getNetMovingAverageCost()
-    {
-        return Money.of(getTermCurrency(), movingRelativeNetCost);
     }
 
     private long getSharesHeld()
@@ -324,4 +291,20 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
         return Money.of(getTermCurrency(), taxes);
     }
 
+    public Money getCost(CostMethod method, TaxesAndFees taxesAndFees)
+    {
+        return Money.of(getTermCurrency(), switch (method)
+        {
+            case FIFO -> sumFifo(taxesAndFees);
+            case MOVING_AVERAGE -> taxesAndFees == TaxesAndFees.INCLUDED ? movingRelativeCost : movingRelativeNetCost;
+        });
+    }
+
+    private long sumFifo(TaxesAndFees taxesAndFees)
+    {
+        long cost = 0;
+        for (LineItem entry : fifo)
+            cost += taxesAndFees == TaxesAndFees.INCLUDED ? entry.grossAmount : entry.netAmount;
+        return cost;
+    }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
@@ -13,10 +13,12 @@ import name.abuchen.portfolio.model.Adaptable;
 import name.abuchen.portfolio.model.Annotated;
 import name.abuchen.portfolio.model.Attributable;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.InvestmentVehicle;
 import name.abuchen.portfolio.model.Named;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.SecurityPrice;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MoneyCollectors;
@@ -164,96 +166,19 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
                     () -> Calculation.perform(CostCalculation.class, converter, security, lineItems).getResult());
 
     /**
-     * fifo cost of shares held
+     * cost of shares held
      */
-    private final LazyValue<Money> fifoCost = new LazyValue<>(() -> costCalculation.get().fifoCost());
+    private Money getCostMoney(CostMethod costMethod, TaxesAndFees taxesAndFees)
+    {
+        return switch (costMethod)
+        {
+            case FIFO -> taxesAndFees == TaxesAndFees.INCLUDED ? costCalculation.get().fifoCost()
+                            : costCalculation.get().netFifoCost();
 
-    /**
-     * moving average cost of shares held
-     */
-    private final LazyValue<Money> movingAverageCost = new LazyValue<>(() -> costCalculation.get().movingAverageCost());
-
-    /**
-     * moving average cost of shares held without fees or taxes
-     */
-    private final LazyValue<Money> movingAverageCostWithoutTaxesAndFees = new LazyValue<>(
-                    () -> costCalculation.get().netMovingAverageCost());
-
-    /**
-     * market value - fifo cost of shares held
-     */
-    private final LazyValue<Money> capitalGainsOnHoldings = new LazyValue<>(
-                    () -> marketValue.get().subtract(costCalculation.get().fifoCost()));
-
-    /**
-     * {@link capitalGainsOnHoldings} in percent
-     */
-    private final LazyValue<Double> capitalGainsOnHoldingsPercent = new LazyValue<>(() -> {
-        var mv = marketValue.get();
-        var cost = costCalculation.get().fifoCost();
-
-        if (mv.getAmount() == 0L && cost.getAmount() == 0L)
-            return 0d;
-        else
-            return ((double) mv.getAmount() / (double) cost.getAmount()) - 1;
-    });
-
-    /**
-     * market value - moving average cost of shares held
-     */
-    private final LazyValue<Money> capitalGainsOnHoldingsMovingAverage = new LazyValue<>(
-                    () -> marketValue.get().subtract(costCalculation.get().movingAverageCost()));
-
-    /**
-     * {@link capitalGainsOnHoldingsMovingAverage} in percent
-     */
-    private final LazyValue<Double> capitalGainsOnHoldingsMovingAveragePercent = new LazyValue<>(() -> {
-        var mv = marketValue.get();
-        var cost = costCalculation.get().movingAverageCost();
-
-        if (mv.getAmount() == 0L && cost.getAmount() == 0L)
-            return 0d;
-        else
-            return ((double) mv.getAmount() / (double) cost.getAmount()) - 1;
-    });
-
-    /**
-     * cost per shares held
-     */
-    private final LazyValue<Quote> fifoCostPerSharesHeld = new LazyValue<>(() -> {
-        var costs = costCalculation.get();
-        return Quote.of(costs.netFifoCost().getCurrencyCode(), Math.round(costs.netFifoCost().getAmount()
-                        / (double) costs.sharesHeld() * Values.Share.factor() * Values.Quote.factorToMoney()));
-    });
-
-    /**
-     * cost per shares held
-     */
-    private final LazyValue<Quote> movingAverageCostPerSharesHeld = new LazyValue<>(() -> {
-        var costs = costCalculation.get();
-
-        Money netMovingAverageCost = costs.netMovingAverageCost();
-        return Quote.of(netMovingAverageCost.getCurrencyCode(), Math.round(netMovingAverageCost.getAmount()
-                        / (double) costs.sharesHeld() * Values.Share.factor() * Values.Quote.factorToMoney()));
-    });
-
-    /**
-     * cost per shares held including fee
-     */
-    private final LazyValue<Quote> grossFifoCostPerSharesHeld = new LazyValue<>(() -> {
-        var costs = costCalculation.get();
-        return Quote.of(costs.fifoCost().getCurrencyCode(), Math.round(costs.fifoCost().getAmount()
-                        / (double) costs.sharesHeld() * Values.Share.factor() * Values.Quote.factorToMoney()));
-    });
-
-    /**
-     * cost per shares held including fee
-     */
-    private final LazyValue<Quote> grossMovingAverageCostPerSharesHeld = new LazyValue<>(() -> {
-        var costs = costCalculation.get();
-        return Quote.of(costs.movingAverageCost().getCurrencyCode(), Math.round(costs.movingAverageCost().getAmount()
-                        / (double) costs.sharesHeld() * Values.Share.factor() * Values.Quote.factorToMoney()));
-    });
+            case MOVING_AVERAGE -> taxesAndFees == TaxesAndFees.INCLUDED ? costCalculation.get().movingAverageCost()
+                            : costCalculation.get().netMovingAverageCost();
+        };
+    }
 
     private final LazyValue<DividendCalculationResult> dividendCalculation = new LazyValue<>(() -> {
         // ensure cost calculation is done (and has calculated
@@ -265,19 +190,9 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
     private final LazyValue<CapitalGainsCalculation> capitalGains = new LazyValue<>(
                     () -> Calculation.perform(CapitalGainsCalculation.class, converter, security, lineItems));
 
-    private final LazyValue<CapitalGainsRecord> realizedCapitalGains = new LazyValue<>(
-                    () -> capitalGains.get().getRealizedCapitalGains());
-    private final LazyValue<CapitalGainsRecord> unrealizedCapitalGains = new LazyValue<>(
-                    () -> capitalGains.get().getUnrealizedCapitalGains());
-
     private final LazyValue<CapitalGainsCalculationMovingAverage> capitalGainsMovingAvg = new LazyValue<>(
                     () -> Calculation.perform(CapitalGainsCalculationMovingAverage.class, converter, security,
                                     lineItems));
-
-    private final LazyValue<CapitalGainsRecord> realizedCapitalGainsMovingAvg = new LazyValue<>(
-                    () -> capitalGainsMovingAvg.get().getRealizedCapitalGains());
-    private final LazyValue<CapitalGainsRecord> unrealizedCapitalGainsMovingAvg = new LazyValue<>(
-                    () -> capitalGainsMovingAvg.get().getUnrealizedCapitalGains());
 
     /* package */ LazySecurityPerformanceRecord(Client client, Security security, CurrencyConverter converter,
                     Interval interval)
@@ -340,39 +255,30 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
         return quote;
     }
 
-    public LazyValue<Money> getFifoCost()
+    /**
+     * cost of shares held
+     */
+    public Money getCost(CostMethod costMethod, TaxesAndFees taxesAndFees)
     {
-        return fifoCost;
+        return getCostMoney(costMethod, taxesAndFees);
     }
 
-    public LazyValue<Money> getMovingAverageCost()
+    public LazyValue<Money> getCapitalGainsOnHoldings(CostMethod costMethod)
     {
-        return movingAverageCost;
+        return new LazyValue<>(() -> marketValue.get().subtract(getCostMoney(costMethod, TaxesAndFees.INCLUDED)));
     }
 
-    public LazyValue<Money> getMovingAverageCostWithoutTaxesAndFees()
+    public LazyValue<Double> getCapitalGainsOnHoldingsPercent(CostMethod costMethod)
     {
-        return movingAverageCostWithoutTaxesAndFees;
-    }
+        return new LazyValue<>(() -> {
+            var mv = marketValue.get();
+            var cost = getCostMoney(costMethod, TaxesAndFees.INCLUDED);
 
-    public LazyValue<Money> getCapitalGainsOnHoldings()
-    {
-        return capitalGainsOnHoldings;
-    }
-
-    public LazyValue<Double> getCapitalGainsOnHoldingsPercent()
-    {
-        return capitalGainsOnHoldingsPercent;
-    }
-
-    public LazyValue<Money> getCapitalGainsOnHoldingsMovingAverage()
-    {
-        return capitalGainsOnHoldingsMovingAverage;
-    }
-
-    public LazyValue<Double> getCapitalGainsOnHoldingsMovingAveragePercent()
-    {
-        return capitalGainsOnHoldingsMovingAveragePercent;
+            if (mv.getAmount() == 0L && cost.getAmount() == 0L)
+                return 0d;
+            else
+                return ((double) mv.getAmount() / (double) cost.getAmount()) - 1;
+        });
     }
 
     public LazyValue<Money> getFees()
@@ -390,24 +296,26 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
         return new LazyValue<>(() -> costCalculation.get().sharesHeld());
     }
 
-    public LazyValue<Quote> getFifoCostPerSharesHeld()
+    public LazyValue<Quote> getCostPerSharesHeld(CostMethod costMethod)
     {
-        return fifoCostPerSharesHeld;
+        return new LazyValue<>(() -> {
+            var costs = costCalculation.get();
+            Money cost = getCostMoney(costMethod, TaxesAndFees.NOT_INCLUDED);
+
+            return Quote.of(cost.getCurrencyCode(), Math.round(cost.getAmount() / (double) costs.sharesHeld()
+                            * Values.Share.factor() * Values.Quote.factorToMoney()));
+        });
     }
 
-    public LazyValue<Quote> getMovingAverageCostPerSharesHeld()
+    public LazyValue<Quote> getGrossCostPerSharesHeld(CostMethod costMethod)
     {
-        return movingAverageCostPerSharesHeld;
-    }
+        return new LazyValue<>(() -> {
+            var costs = costCalculation.get();
+            var cost = getCostMoney(costMethod, TaxesAndFees.INCLUDED);
 
-    public LazyValue<Quote> getGrossFifoCostPerSharesHeld()
-    {
-        return grossFifoCostPerSharesHeld;
-    }
-
-    public LazyValue<Quote> getGrossMovingAverageCostPerSharesHeld()
-    {
-        return grossMovingAverageCostPerSharesHeld;
+            return Quote.of(cost.getCurrencyCode(), Math.round(cost.getAmount() / (double) costs.sharesHeld()
+                            * Values.Share.factor() * Values.Quote.factorToMoney()));
+        });
     }
 
     public LazyValue<Money> getSumOfDividends()
@@ -441,46 +349,34 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
         return new LazyValue<>(() -> dividendCalculation.get().rateOfReturnPerYear());
     }
 
-    public LazyValue<Double> getTotalRateOfReturnDiv()
+    public LazyValue<Double> getTotalRateOfReturnDiv(CostMethod costMethod)
     {
         return new LazyValue<>(() -> {
             var costs = costCalculation.get();
+            var cost = getCostMoney(costMethod, TaxesAndFees.INCLUDED);
+
             return costs.sharesHeld() > 0
-                            ? (double) dividendCalculation.get().sum().getAmount()
-                                            / (double) costs.fifoCost().getAmount()
+                            ? (double) dividendCalculation.get().sum().getAmount() / (double) cost.getAmount()
                             : 0;
         });
     }
 
-    public LazyValue<Double> getTotalRateOfReturnDivMovingAverage()
+    public LazyValue<CapitalGainsRecord> getRealizedCapitalGains(CostMethod costMethod)
     {
-        return new LazyValue<>(() -> {
-            var costs = costCalculation.get();
-            return costs.sharesHeld() > 0
-                            ? (double) dividendCalculation.get().sum().getAmount()
-                                            / (double) costs.movingAverageCost().getAmount()
-                            : 0;
+        return new LazyValue<>(() -> switch (costMethod)
+        {
+            case FIFO -> capitalGains.get().getRealizedCapitalGains();
+            case MOVING_AVERAGE -> capitalGainsMovingAvg.get().getRealizedCapitalGains();
         });
     }
 
-    public LazyValue<CapitalGainsRecord> getRealizedCapitalGains()
+    public LazyValue<CapitalGainsRecord> getUnrealizedCapitalGains(CostMethod costMethod)
     {
-        return realizedCapitalGains;
-    }
-
-    public LazyValue<CapitalGainsRecord> getUnrealizedCapitalGains()
-    {
-        return unrealizedCapitalGains;
-    }
-
-    public LazyValue<CapitalGainsRecord> getRealizedCapitalGainsMovingAvg()
-    {
-        return realizedCapitalGainsMovingAvg;
-    }
-
-    public LazyValue<CapitalGainsRecord> getUnrealizedCapitalGainsMovingAvg()
-    {
-        return unrealizedCapitalGainsMovingAvg;
+        return new LazyValue<>(() -> switch (costMethod)
+        {
+            case FIFO -> capitalGains.get().getUnrealizedCapitalGains();
+            case MOVING_AVERAGE -> capitalGainsMovingAvg.get().getUnrealizedCapitalGains();
+        });
     }
 
     @Override
@@ -508,13 +404,17 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
             case Trails.FIFO_COST:
                 return Trail.of(getSecurityName(), costCalculation.get().fifoCostTrail());
             case Trails.REALIZED_CAPITAL_GAINS:
-                return Trail.of(getSecurityName(), getRealizedCapitalGains().get().getCapitalGainsTrail());
+                return Trail.of(getSecurityName(),
+                                getRealizedCapitalGains(CostMethod.FIFO).get().getCapitalGainsTrail());
             case Trails.REALIZED_CAPITAL_GAINS_FOREX:
-                return Trail.of(getSecurityName(), getRealizedCapitalGains().get().getForexCapitalGainsTrail());
+                return Trail.of(getSecurityName(),
+                                getRealizedCapitalGains(CostMethod.FIFO).get().getForexCapitalGainsTrail());
             case Trails.UNREALIZED_CAPITAL_GAINS:
-                return Trail.of(getSecurityName(), getUnrealizedCapitalGains().get().getCapitalGainsTrail());
+                return Trail.of(getSecurityName(),
+                                getUnrealizedCapitalGains(CostMethod.FIFO).get().getCapitalGainsTrail());
             case Trails.UNREALIZED_CAPITAL_GAINS_FOREX:
-                return Trail.of(getSecurityName(), getUnrealizedCapitalGains().get().getForexCapitalGainsTrail());
+                return Trail.of(getSecurityName(),
+                                getUnrealizedCapitalGains(CostMethod.FIFO).get().getForexCapitalGainsTrail());
             default:
                 return Optional.empty();
         }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceIndicator.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceIndicator.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.snapshot.security;
 
+import name.abuchen.portfolio.model.CostMethod;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Quote;
 import name.abuchen.portfolio.snapshot.trail.TrailRecord;
@@ -8,13 +10,9 @@ public interface SecurityPerformanceIndicator
 {
     public interface Costs extends SecurityPerformanceIndicator
     {
-        Money getFifoCost();
+        Money getCost(CostMethod method, TaxesAndFees taxesAndFees);
 
-        Money getMovingAverageCost();
-
-        Quote getFifoCostPerSharesHeld();
-
-        Quote getMovingAverageCostPerSharesHeld();
+        Quote getCostPerSharesHeld(CostMethod costMethod);
     }
 
     public interface CapitalGains extends SecurityPerformanceIndicator

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceRecord.java
@@ -17,10 +17,12 @@ import name.abuchen.portfolio.model.Adaptable;
 import name.abuchen.portfolio.model.Annotated;
 import name.abuchen.portfolio.model.Attributable;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.InvestmentVehicle;
 import name.abuchen.portfolio.model.Named;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.SecurityPrice;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.Money;
@@ -37,6 +39,9 @@ import name.abuchen.portfolio.util.Interval;
 public final class SecurityPerformanceRecord extends BaseSecurityPerformanceRecord
                 implements Adaptable, TrailProvider, SecurityPerformanceIndicator.Costs
 {
+    private Money netFifoCost;
+    private Money netMovingAverageCost;
+
     /**
      * internal rate of return of security {@link #calculateIRR()}
      */
@@ -89,14 +94,13 @@ public final class SecurityPerformanceRecord extends BaseSecurityPerformanceReco
     private SecurityPrice quote;
 
     /**
-     * fifo cost of shares held {@link #calculateFifoAndMovingAverageCosts()}
+     * fifo cost of shares held {@link #calculateCosts()}
      */
     private Money fifoCost;
     private TrailRecord fifoCostTrail;
 
     /**
-     * moving average cost of shares held
-     * {@link #calculateFifoAndMovingAverageCosts()}
+     * moving average cost of shares held {@link #calculateCosts()}
      */
     private Money movingAverageCost;
 
@@ -111,17 +115,17 @@ public final class SecurityPerformanceRecord extends BaseSecurityPerformanceReco
     private Money taxes;
 
     /**
-     * shares held {@link #calculateFifoAndMovingAverageCosts()}
+     * shares held {@link #calculateCosts()}
      */
     private long sharesHeld;
 
     /**
-     * cost per shares held {@link #calculateFifoAndMovingAverageCosts()}
+     * cost per shares held {@link #calculateCosts()}
      */
     private Quote fifoCostPerSharesHeld;
 
     /**
-     * cost per shares held {@link #calculateFifoAndMovingAverageCosts()}
+     * cost per shares held {@link #calculateCosts()}
      */
     private Quote movingAverageCostPerSharesHeld;
 
@@ -152,8 +156,7 @@ public final class SecurityPerformanceRecord extends BaseSecurityPerformanceReco
     private double rateOfReturnPerYear;
 
     /**
-     * market value - fifo cost of shares held
-     * {@link #calculateFifoAndMovingAverageCosts()}
+     * market value - fifo cost of shares held {@link #calculateCosts()}
      */
     private Money capitalGainsOnHoldings;
 
@@ -164,7 +167,7 @@ public final class SecurityPerformanceRecord extends BaseSecurityPerformanceReco
 
     /**
      * market value - moving average cost of shares held
-     * {@link #calculateFifoAndMovingAverageCosts()}
+     * {@link #calculateCosts()}
      */
     private Money capitalGainsOnHoldingsMovingAverage;
 
@@ -250,15 +253,23 @@ public final class SecurityPerformanceRecord extends BaseSecurityPerformanceReco
     }
 
     @Override
-    public Money getFifoCost()
+    public Money getCost(CostMethod method, TaxesAndFees taxesAndFees)
     {
-        return fifoCost;
+        return switch (method)
+        {
+            case FIFO -> taxesAndFees == TaxesAndFees.INCLUDED ? fifoCost : netFifoCost;
+            case MOVING_AVERAGE -> taxesAndFees == TaxesAndFees.INCLUDED ? movingAverageCost : netMovingAverageCost;
+        };
     }
 
     @Override
-    public Money getMovingAverageCost()
+    public Quote getCostPerSharesHeld(CostMethod method)
     {
-        return movingAverageCost;
+        return switch (method)
+        {
+            case FIFO -> fifoCostPerSharesHeld;
+            case MOVING_AVERAGE -> movingAverageCostPerSharesHeld;
+        };
     }
 
     public Money getCapitalGainsOnHoldings()
@@ -294,18 +305,6 @@ public final class SecurityPerformanceRecord extends BaseSecurityPerformanceReco
     public long getSharesHeld()
     {
         return sharesHeld;
-    }
-
-    @Override
-    public Quote getFifoCostPerSharesHeld()
-    {
-        return fifoCostPerSharesHeld;
-    }
-
-    @Override
-    public Quote getMovingAverageCostPerSharesHeld()
-    {
-        return movingAverageCostPerSharesHeld;
     }
 
     public Money getSumOfDividends()
@@ -434,7 +433,7 @@ public final class SecurityPerformanceRecord extends BaseSecurityPerformanceReco
 
             if (flags.isEmpty() || flags.contains(SecurityPerformanceIndicator.Costs.class))
             {
-                calculateFifoAndMovingAverageCosts(converter);
+                calculateCosts(converter);
             }
 
             if (flags.isEmpty())
@@ -492,20 +491,22 @@ public final class SecurityPerformanceRecord extends BaseSecurityPerformanceReco
         this.deltaPercent = calculation.getDeltaPercent();
     }
 
-    private void calculateFifoAndMovingAverageCosts(CurrencyConverter converter)
+    private void calculateCosts(CurrencyConverter converter)
     {
         CostCalculation cost = Calculation.perform(CostCalculation.class, converter, security, lineItems);
-        this.fifoCost = cost.getFifoCost();
+        this.fifoCost = cost.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED);
+        this.netFifoCost = cost.getCost(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED);
+
         this.fifoCostTrail = cost.getFifoCostTrail();
-        this.movingAverageCost = cost.getMovingAverageCost();
+        this.movingAverageCost = cost.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED);
+        this.netMovingAverageCost = cost.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED);
 
-        Money netFifoCost = cost.getNetFifoCost();
+        this.fifoCostPerSharesHeld = Quote.of(this.netFifoCost.getCurrencyCode(),
+                        Math.round(this.netFifoCost.getAmount() / (double) sharesHeld * Values.Share.factor()
+                                        * Values.Quote.factorToMoney()));
 
-        this.fifoCostPerSharesHeld = Quote.of(netFifoCost.getCurrencyCode(), Math.round(netFifoCost.getAmount()
-                        / (double) sharesHeld * Values.Share.factor() * Values.Quote.factorToMoney()));
-        Money netMovingAverageCost = cost.getNetMovingAverageCost();
-        this.movingAverageCostPerSharesHeld = Quote.of(netMovingAverageCost.getCurrencyCode(),
-                        Math.round(netMovingAverageCost.getAmount() / (double) sharesHeld * Values.Share.factor()
+        this.movingAverageCostPerSharesHeld = Quote.of(this.netMovingAverageCost.getCurrencyCode(),
+                        Math.round(this.netMovingAverageCost.getAmount() / (double) sharesHeld * Values.Share.factor()
                                         * Values.Quote.factorToMoney()));
 
         this.fees = cost.getFees();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import name.abuchen.portfolio.math.IRR;
 import name.abuchen.portfolio.model.Adaptable;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Named;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
@@ -441,9 +442,7 @@ public class Trade implements Adaptable
         // the moving average purchase value based on the number of shares
         // sold
 
-        var totalCosts = taxesAndFees == TaxesAndFees.INCLUDED //
-                        ? r.get().getMovingAverageCost().get()
-                        : r.get().getMovingAverageCostWithoutTaxesAndFees().get();
+        Money totalCosts = r.get().getCost(CostMethod.MOVING_AVERAGE, taxesAndFees);
         var totalShares = r.get().getSharesHeld().get();
 
         if (totalShares <= 0)


### PR DESCRIPTION
# Refactor cost and capital gains access in LazySecurityPerformanceRecord

## Summary

This refactoring replaces multiple FIFO and Moving Average specific getters in `LazySecurityPerformanceRecord` with a parameterized API based on `CostMethod`, `CostBasis`, and `CostRequest`.

The goal is to reduce duplicated logic and prepare the snapshot model for additional cost calculation methods such as LIFO without introducing more specialized getters and duplicated fields.

## Main Changes

### Introduced

- `CostBasis`
  - `GROSS`
  - `NET`

- Parameterized access methods:
  - `getCost(CostRequest request)`
  - `getCostPerSharesHeld(CostMethod method)`
  - `getGrossCostPerSharesHeld(CostMethod method)`
  - `getCapitalGainsOnHoldings(CostMethod method)`
  - `getCapitalGainsOnHoldingsPercent(CostMethod method)`
  - `getRealizedCapitalGains(CostMethod method)`
  - `getUnrealizedCapitalGains(CostMethod method)`
  - `getTotalRateOfReturnDiv(CostMethod method)`

### Removed

Several specialized getters were removed, including:

- `getFifoCost()`
- `getMovingAverageCost()`
- `getMovingAverageCostWithoutTaxesAndFees()`
- `getCapitalGainsOnHoldingsMovingAverage()`
- `getCapitalGainsOnHoldingsMovingAveragePercent()`
- `getFifoCostPerSharesHeld()`
- `getMovingAverageCostPerSharesHeld()`
- `getGrossFifoCostPerSharesHeld()`
- `getGrossMovingAverageCostPerSharesHeld()`
- `getRealizedCapitalGainsMovingAvg()`
- `getUnrealizedCapitalGainsMovingAvg()`
- `getTotalRateOfReturnDivMovingAverage()`

## Additional Changes

- Migrated all affected UI, online integration, trade, and test usages to the new parameterized API
- Removed duplicated Moving Average NET cost handling
- Moved `CostBasis` into the model package beside `CostMethod`

## Motivation

The previous implementation duplicated logic and lazy fields for:
- FIFO
- Moving Average
- NET/GROSS variants
- capital gains calculations
- cost-per-share calculations

This refactoring consolidates the access model and creates a more extensible structure for future cost calculation methods.

| Alt                                               | Neu                                                                    |       CostMethod |        CostBasis | Bemerkung                                           |
| ------------------------------------------------- | ---------------------------------------------------------------------- | ---------------: | ---------------: | --------------------------------------------------- |
| `getFifoCost()`                                   | `getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED)`           |           `FIFO` |          `GROSS` | entspricht früher `fifoCost()`                      |
| `getMovingAverageCost()`                          | `getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED)` | `MOVING_AVERAGE` |          `GROSS` | entspricht früher `movingAverageCost()`             |
| `getMovingAverageCostWithoutTaxesAndFees()`       | `getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED)`   | `MOVING_AVERAGE` |            `NET` | ersetzt die alte Karteileiche                       |
| `getCapitalGainsOnHoldings()`                     | `getCapitalGainsOnHoldings(CostMethod.FIFO)`                           |           `FIFO` | implizit `GROSS` | `marketValue - fifoCost`                            |
| `getCapitalGainsOnHoldingsMovingAverage()`        | `getCapitalGainsOnHoldings(CostMethod.MOVING_AVERAGE)`                 | `MOVING_AVERAGE` | implizit `GROSS` | `marketValue - movingAverageCost`                   |
| `getCapitalGainsOnHoldingsPercent()`              | `getCapitalGainsOnHoldingsPercent(CostMethod.FIFO)`                    |           `FIFO` | implizit `GROSS` | Prozentwert auf FIFO-Basis                          |
| `getCapitalGainsOnHoldingsMovingAveragePercent()` | `getCapitalGainsOnHoldingsPercent(CostMethod.MOVING_AVERAGE)`          | `MOVING_AVERAGE` | implizit `GROSS` | Prozentwert auf Moving-Average-Basis                |
| `getFifoCostPerSharesHeld()`                      | `getCostPerSharesHeld(CostMethod.FIFO)`                                |           `FIFO` |   implizit `NET` | entspricht früher `netFifoCost()` je Stück          |
| `getMovingAverageCostPerSharesHeld()`             | `getCostPerSharesHeld(CostMethod.MOVING_AVERAGE)`                      | `MOVING_AVERAGE` |   implizit `NET` | entspricht früher `netMovingAverageCost()` je Stück |
| `getGrossFifoCostPerSharesHeld()`                 | `getGrossCostPerSharesHeld(CostMethod.FIFO)`                           |           `FIFO` | implizit `GROSS` | entspricht früher `fifoCost()` je Stück             |
| `getGrossMovingAverageCostPerSharesHeld()`        | `getGrossCostPerSharesHeld(CostMethod.MOVING_AVERAGE)`                 | `MOVING_AVERAGE` | implizit `GROSS` | entspricht früher `movingAverageCost()` je Stück    |
| `getRealizedCapitalGains()`                       | `getRealizedCapitalGains(CostMethod.FIFO)`                             |           `FIFO` |              n/a | FIFO-Capital-Gains-Berechnung                       |
| `getRealizedCapitalGainsMovingAvg()`              | `getRealizedCapitalGains(CostMethod.MOVING_AVERAGE)`                   | `MOVING_AVERAGE` |              n/a | Moving-Average-Capital-Gains-Berechnung             |
| `getUnrealizedCapitalGains()`                     | `getUnrealizedCapitalGains(CostMethod.FIFO)`                           |           `FIFO` |              n/a | FIFO-Capital-Gains-Berechnung                       |
| `getUnrealizedCapitalGainsMovingAvg()`            | `getUnrealizedCapitalGains(CostMethod.MOVING_AVERAGE)`                 | `MOVING_AVERAGE` |              n/a | Moving-Average-Capital-Gains-Berechnung             |
| `getTotalRateOfReturnDiv()`                       | `getTotalRateOfReturnDiv(CostMethod.FIFO)`                             |           `FIFO` | implizit `GROSS` | früher Dividenden / FIFO-Kosten                     |
| `getTotalRateOfReturnDivMovingAverage()`          | `getTotalRateOfReturnDiv(CostMethod.MOVING_AVERAGE)`                   | `MOVING_AVERAGE` | implizit `GROSS` | früher Dividenden / Moving-Average-Kosten           |