### PR TITLE
Separate dashboard scope filtering from data series selection

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractIndicatorWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/AbstractIndicatorWidget.java
@@ -34,7 +34,25 @@ public abstract class AbstractIndicatorWidget<D> extends WidgetDelegate<D>
     {
         super(widget, dashboardData);
 
-        addConfig(new DataSeriesConfig(this, supportsBenchmarks, predicate));
+        addConfig(new ClientFilterConfig(this));
+        addConfig(new DataSeriesConfig(this, supportsBenchmarks, dataSeries -> {
+            if (predicate != null && !predicate.test(dataSeries))
+                return false;
+
+            switch (dataSeries.getType())
+            {
+                case CLIENT:
+                case CLIENT_PRETAX:
+                case SECURITY:
+                case CLASSIFICATION:
+                case SECURITY_BENCHMARK:
+                case DERIVED_DATA_SERIES:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }));
         addConfig(new ReportingPeriodConfig(this));
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MaxDrawdownDurationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/MaxDrawdownDurationWidget.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 import org.eclipse.swt.widgets.Composite;
 
 import name.abuchen.portfolio.math.Risk.Drawdown;
+import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Dashboard.Widget;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;
 import name.abuchen.portfolio.ui.Messages;
@@ -46,9 +47,14 @@ public class MaxDrawdownDurationWidget extends AbstractIndicatorWidget<Performan
     @Override
     public Supplier<PerformanceIndex> getUpdateTask()
     {
-        return () -> getDashboardData().getDataSeriesCache() //
-                        .lookup(get(DataSeriesConfig.class).getDataSeries(), get(ReportingPeriodConfig.class)
-                                        .getReportingPeriod().toInterval(LocalDate.now()));
+        return () -> {
+            var selectedFilter = get(ClientFilterConfig.class).getSelectedFilter();
+            Client filteredClient = selectedFilter.filter(getClient());
+
+            return getDashboardData().getDataSeriesCache().lookup(get(DataSeriesConfig.class).getDataSeries(),
+                            filteredClient, selectedFilter.toString(),
+                            get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now()));
+        };
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/ClientDataSeriesChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/ClientDataSeriesChartWidget.java
@@ -16,6 +16,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 
+import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Dashboard;
 import name.abuchen.portfolio.model.Dashboard.Widget;
 import name.abuchen.portfolio.money.Values;
@@ -27,6 +28,7 @@ import name.abuchen.portfolio.ui.util.format.AmountNumberFormat;
 import name.abuchen.portfolio.ui.util.format.ThousandsNumberFormat;
 import name.abuchen.portfolio.ui.views.dashboard.ChartHeightConfig;
 import name.abuchen.portfolio.ui.views.dashboard.ChartShowYAxisConfig;
+import name.abuchen.portfolio.ui.views.dashboard.ClientFilterConfig;
 import name.abuchen.portfolio.ui.views.dashboard.DashboardData;
 import name.abuchen.portfolio.ui.views.dashboard.DashboardResources;
 import name.abuchen.portfolio.ui.views.dashboard.DataSeriesConfig;
@@ -119,6 +121,7 @@ public class ClientDataSeriesChartWidget extends WidgetDelegate<PerformanceIndex
     {
         super(widget, dashboardData);
 
+        addConfig(new ClientFilterConfig(this));
         addConfig(new DataSeriesConfig(this, false));
         addConfig(new AspectConfig(this));
         addConfig(new ReportingPeriodConfig(this));
@@ -168,7 +171,12 @@ public class ClientDataSeriesChartWidget extends WidgetDelegate<PerformanceIndex
         DataSeries serie = get(DataSeriesConfig.class).getDataSeries();
         Interval interval = get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now());
 
-        return () -> cache.lookup(serie, interval);
+        return () -> {
+            var selectedFilter = get(ClientFilterConfig.class).getSelectedFilter();
+            Client filteredClient = selectedFilter.filter(getClient());
+
+            return cache.lookup(serie, filteredClient, selectedFilter.toString(), interval);
+        };
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/DrawdownChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/charts/DrawdownChartWidget.java
@@ -13,6 +13,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 
+import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Dashboard.Widget;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;
 import name.abuchen.portfolio.ui.Messages;
@@ -20,12 +21,12 @@ import name.abuchen.portfolio.ui.util.chart.TimelineChart;
 import name.abuchen.portfolio.ui.util.format.AxisTickPercentNumberFormat;
 import name.abuchen.portfolio.ui.views.dashboard.ChartHeightConfig;
 import name.abuchen.portfolio.ui.views.dashboard.ChartShowYAxisConfig;
+import name.abuchen.portfolio.ui.views.dashboard.ClientFilterConfig;
 import name.abuchen.portfolio.ui.views.dashboard.DashboardData;
 import name.abuchen.portfolio.ui.views.dashboard.DashboardResources;
 import name.abuchen.portfolio.ui.views.dashboard.DataSeriesConfig;
 import name.abuchen.portfolio.ui.views.dashboard.ReportingPeriodConfig;
 import name.abuchen.portfolio.ui.views.dashboard.WidgetDelegate;
-import name.abuchen.portfolio.ui.views.dataseries.DataSeries;
 import name.abuchen.portfolio.ui.views.dataseries.DataSeriesCache;
 import name.abuchen.portfolio.util.Interval;
 import name.abuchen.portfolio.util.TextUtil;
@@ -40,6 +41,7 @@ public class DrawdownChartWidget extends WidgetDelegate<Object>
     {
         super(widget, dashboardData);
 
+        addConfig(new ClientFilterConfig(this));
         addConfig(new DataSeriesConfig(this, true));
         addConfig(new ReportingPeriodConfig(this));
         addConfig(new ChartShowYAxisConfig(this, true));
@@ -87,12 +89,14 @@ public class DrawdownChartWidget extends WidgetDelegate<Object>
 
         DataSeriesCache cache = getDashboardData().getDataSeriesCache();
 
-        DataSeries serie = get(DataSeriesConfig.class).getDataSeries();
         Interval interval = get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now());
 
         return () -> {
-            cache.lookup(serie, interval);
-            return null;
+            var selectedFilter = get(ClientFilterConfig.class).getSelectedFilter();
+            Client filteredClient = selectedFilter.filter(getClient());
+
+            return cache.lookup(get(DataSeriesConfig.class).getDataSeries(), filteredClient, selectedFilter.toString(),
+                            interval);
         };
     }
 
@@ -118,8 +122,12 @@ public class DrawdownChartWidget extends WidgetDelegate<Object>
             Interval reportingPeriod = get(ReportingPeriodConfig.class).getReportingPeriod()
                             .toInterval(LocalDate.now());
 
+            var selectedFilter = get(ClientFilterConfig.class).getSelectedFilter();
+            Client filteredClient = selectedFilter.filter(getClient());
+
             PerformanceIndex index = getDashboardData().getDataSeriesCache()
-                            .lookup(get(DataSeriesConfig.class).getDataSeries(), reportingPeriod);
+                            .lookup(get(DataSeriesConfig.class).getDataSeries(), filteredClient,
+                                            selectedFilter.toString(), reportingPeriod);
 
             addDrawdown(index);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/PerformanceHeatmapWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/PerformanceHeatmapWidget.java
@@ -7,10 +7,12 @@ import java.time.temporal.TemporalAdjusters;
 import java.util.function.DoubleBinaryOperator;
 import java.util.function.ToDoubleFunction;
 
+import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Dashboard.Widget;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;
 import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.views.dashboard.ClientFilterConfig;
 import name.abuchen.portfolio.ui.views.dashboard.DashboardData;
 import name.abuchen.portfolio.ui.views.dashboard.DataSeriesConfig;
 import name.abuchen.portfolio.ui.views.dashboard.ReportingPeriodConfig;
@@ -25,6 +27,7 @@ public class PerformanceHeatmapWidget extends AbstractHeatmapWidget<Double>
 
         addConfig(new ColorSchemaConfig(this));
         addConfig(new HeatmapOrnamentConfig(this));
+        addConfig(new ClientFilterConfig(this));
         addConfig(new DataSeriesConfig(this, true));
         addConfig(new ExcessReturnDataSeriesConfig(this));
         addConfig(new ExcessReturnOperatorConfig(this));
@@ -45,7 +48,12 @@ public class PerformanceHeatmapWidget extends AbstractHeatmapWidget<Double>
                         interval.getEnd().with(TemporalAdjusters.lastDayOfMonth()));
 
         DataSeries dataSeries = get(DataSeriesConfig.class).getDataSeries();
-        PerformanceIndex performanceIndex = getDashboardData().calculate(dataSeries, calcInterval);
+
+        var selectedFilter = get(ClientFilterConfig.class).getSelectedFilter();
+        Client filteredClient = selectedFilter.filter(getClient());
+
+        PerformanceIndex performanceIndex = getDashboardData().getDataSeriesCache().lookup(dataSeries, filteredClient,
+                        selectedFilter.toString(), interval);
 
         // build functions to calculate performance and sum values
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesCache.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dataseries/DataSeriesCache.java
@@ -74,6 +74,23 @@ public class DataSeriesCache
         return result;
     }
 
+    public PerformanceIndex lookup(DataSeries series, Client scopedClient, String scopeKey, Interval reportingPeriod)
+    {
+        if (scopedClient == null || scopedClient == client || scopeKey == null || scopeKey.isBlank())
+            return lookup(series, reportingPeriod);
+
+        String uuid = series.getType() == DataSeries.Type.CLIENT ? "$client$" : series.getUUID(); //$NON-NLS-1$
+        CacheKey key = new CacheKey(scopeKey + "::" + uuid, reportingPeriod); //$NON-NLS-1$
+
+        PerformanceIndex result = cache.get(key);
+        if (result != null)
+            return result;
+
+        result = calculate(series, scopedClient, reportingPeriod);
+        cache.put(key, result);
+
+        return result;
+    }
     private PerformanceIndex calculate(DataSeries series, Interval reportingPeriod)
     {
         List<Exception> warnings = new ArrayList<>();
@@ -143,6 +160,36 @@ public class DataSeriesCache
 
                 default:
                     throw new IllegalArgumentException(series.getType().name());
+            }
+        }
+        finally
+        {
+            if (!warnings.isEmpty())
+                PortfolioPlugin.log(warnings);
+        }
+    }
+
+    private PerformanceIndex calculate(DataSeries series, Client scopedClient, Interval reportingPeriod)
+    {
+        List<Exception> warnings = new ArrayList<>();
+
+        try
+        {
+            switch (series.getType())
+            {
+                case CLIENT:
+                    return PerformanceIndex.forClient(scopedClient, converter, reportingPeriod, warnings);
+
+                case CLIENT_PRETAX:
+                    return PerformanceIndex.forClient(new WithoutTaxesFilter().filter(scopedClient), converter,
+                                    reportingPeriod, warnings);
+
+                case SECURITY:
+                    return PerformanceIndex.forInvestment(scopedClient, converter, (Security) series.getInstance(),
+                                    reportingPeriod, warnings);
+
+                default:
+                    return lookup(series, reportingPeriod);
             }
         }
         finally


### PR DESCRIPTION
## Summary

Separate dashboard scope filtering from data series selection

## Description

This change separates dashboard scope filtering from the selected data series.

Previously, `DataSeriesConfig` mixed:

- account / portfolio selection
- grouped account filters
- security selection
- client-level data series

in one combined selection model.

Dashboard widgets can now apply:

1. a dedicated `ClientFilterConfig` as scope filter
2. a separate `DataSeriesConfig` for the actual data series

This allows widgets to evaluate:

- total portfolio
- grouped accounts
- individual ownership scopes

independently from:

- client performance
- securities
- selected data series

The implementation keeps the existing `DataSeriesCache.lookup(DataSeries, Interval)` behavior unchanged and introduces an additive scoped lookup path for dashboard widgets only.

Existing dashboard configurations remain compatible.