### PR TITLE
Fix annual dividend yield aggregation

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendCalculationTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendCalculationTest.java
@@ -25,6 +25,7 @@ import name.abuchen.portfolio.snapshot.security.BaseSecurityPerformanceRecord.Pe
 public class DividendCalculationTest
 {
     Account account;
+    Portfolio portfolio;
     Security security;
     CurrencyConverter converter;
 
@@ -32,6 +33,7 @@ public class DividendCalculationTest
     public void setup()
     {
         this.account = new Account();
+        this.portfolio = new Portfolio();
         this.security = new Security("ADIDAS ORD", "EUR");
         this.converter = new TestCurrencyConverter();
     }
@@ -254,5 +256,184 @@ public class DividendCalculationTest
         // This test will FAIL with the buggy code (~0.0588) and PASS with the fix (~0.05)
         // Tolerance is tight (0.005) to catch the bug: 0.0588 - 0.05 = 0.0088 > 0.005
         assertEquals(0.05, dividends.getRateOfReturnPerYear(), 0.005);
+    }
+
+    private CalculationLineItem buy(LocalDateTime date, double amount, double shares)
+    {
+        return CalculationLineItem.of(portfolio, new PortfolioTransaction(date, security.getCurrencyCode(),
+                        Values.Amount.factorize(amount), security, Values.Share.factorize(shares), Type.BUY, 0L, 0L));
+    }
+
+    @SuppressWarnings("unused")
+    private CalculationLineItem buy(LocalDateTime date, double amount, double shares, double fees)
+    {
+        return CalculationLineItem.of(portfolio,
+                        new PortfolioTransaction(date, security.getCurrencyCode(), Values.Amount.factorize(amount),
+                                        security, Values.Share.factorize(shares), Type.BUY,
+                                        Values.Amount.factorize(fees), 0L));
+    }
+
+    private CalculationLineItem sell(LocalDateTime date, double amount, double shares)
+    {
+        return CalculationLineItem.of(portfolio, new PortfolioTransaction(date, security.getCurrencyCode(),
+                        Values.Amount.factorize(amount), security, Values.Share.factorize(shares), Type.SELL, 0L, 0L));
+    }
+
+    private CalculationLineItem dividend(LocalDateTime date, double amount, double shares)
+    {
+        return dividend(account, date, amount, shares);
+    }
+
+    private CalculationLineItem dividend(Account dividendAccount, LocalDateTime date, double amount, double shares)
+    {
+        AccountTransaction t = new AccountTransaction();
+        t.setType(AccountTransaction.Type.DIVIDENDS);
+        t.setSecurity(security);
+        t.setDateTime(date);
+        t.setAmount(Values.Amount.factorize(amount));
+        t.setShares(Values.Share.factorize(shares));
+        t.setCurrencyCode(security.getCurrencyCode());
+
+        return CalculationLineItem.of(dividendAccount, t);
+    }
+
+    private DividendCalculation calculate(List<CalculationLineItem> transactions)
+    {
+        Calculation.perform(CostCalculation.class, converter, security, transactions);
+        return Calculation.perform(DividendCalculation.class, converter, security, transactions);
+    }
+
+    @Test
+    public void rateOfReturnThreeYearsWithConstantPosition()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 7, 12, 0), 1330.25, 61));
+
+        transactions.add(dividend(LocalDateTime.of(2019, 6, 15, 12, 0), 17.49, 61));
+        transactions.add(dividend(LocalDateTime.of(2020, 6, 15, 12, 0), 17.49, 61));
+        transactions.add(dividend(LocalDateTime.of(2021, 6, 15, 12, 0), 17.49, 61));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals(52.47 / 1330.25 / 3, dividends.getRateOfReturnPerYear(), 0.00001);
+    }
+
+    @Test
+    public void rateOfReturnThreeYearsWithSavingsPlan()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 1, 12, 0), 1000, 10));
+        transactions.add(dividend(LocalDateTime.of(2019, 6, 15, 12, 0), 10, 10));
+
+        transactions.add(buy(LocalDateTime.of(2020, 1, 1, 12, 0), 1000, 10));
+        transactions.add(dividend(LocalDateTime.of(2020, 6, 15, 12, 0), 20, 20));
+
+        transactions.add(buy(LocalDateTime.of(2021, 1, 1, 12, 0), 1000, 10));
+        transactions.add(dividend(LocalDateTime.of(2021, 6, 15, 12, 0), 30, 30));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals(0.01, dividends.getRateOfReturnPerYear(), 0.00001);
+    }
+
+    @Test
+    public void rateOfReturnThreeYearsWithAdditionalPurchaseDuringPeriod()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 1, 12, 0), 1000, 10));
+        transactions.add(dividend(LocalDateTime.of(2019, 6, 15, 12, 0), 100, 10));
+
+        transactions.add(buy(LocalDateTime.of(2020, 1, 1, 12, 0), 1000, 10));
+        transactions.add(dividend(LocalDateTime.of(2020, 6, 15, 12, 0), 100, 20));
+        transactions.add(dividend(LocalDateTime.of(2021, 6, 15, 12, 0), 100, 20));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals((0.10 + 0.05 + 0.05) / 3, dividends.getRateOfReturnPerYear(), 0.00001);
+    }
+
+    @Test
+    public void rateOfReturnThreeYearsWithPartialSaleDuringPeriod()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 1, 12, 0), 1000, 100));
+        transactions.add(dividend(LocalDateTime.of(2019, 6, 15, 12, 0), 100, 100));
+
+        transactions.add(sell(LocalDateTime.of(2020, 1, 1, 12, 0), 500, 50));
+        transactions.add(dividend(LocalDateTime.of(2020, 6, 15, 12, 0), 50, 50));
+        transactions.add(dividend(LocalDateTime.of(2021, 6, 15, 12, 0), 50, 50));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals(0.10, dividends.getRateOfReturnPerYear(), 0.00001);
+    }
+
+    @Test
+    public void rateOfReturnThreeYearsWithFullSaleAfterLastDividend()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 1, 12, 0), 1000, 100));
+        transactions.add(dividend(LocalDateTime.of(2019, 6, 15, 12, 0), 100, 100));
+        transactions.add(dividend(LocalDateTime.of(2020, 6, 15, 12, 0), 100, 100));
+        transactions.add(dividend(LocalDateTime.of(2021, 6, 15, 12, 0), 100, 100));
+        transactions.add(sell(LocalDateTime.of(2021, 12, 31, 12, 0), 1000, 100));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals(0.10, dividends.getRateOfReturnPerYear(), 0.00001);
+    }
+
+    @Test
+    public void rateOfReturnThreeYearsWithSaleAndRepurchase()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 1, 12, 0), 1000, 100));
+        transactions.add(dividend(LocalDateTime.of(2019, 6, 15, 12, 0), 100, 100));
+
+        transactions.add(sell(LocalDateTime.of(2019, 12, 31, 12, 0), 1000, 100));
+
+        transactions.add(buy(LocalDateTime.of(2020, 1, 1, 12, 0), 2000, 100));
+        transactions.add(dividend(LocalDateTime.of(2020, 6, 15, 12, 0), 100, 100));
+        transactions.add(dividend(LocalDateTime.of(2021, 6, 15, 12, 0), 100, 100));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals((0.10 + 0.05 + 0.05) / 3, dividends.getRateOfReturnPerYear(), 0.00001);
+    }
+
+    @Test
+    public void rateOfReturnWithMultipleAccountsOnSameDividendDate()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        Account secondAccount = new Account();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 1, 12, 0), 1000, 100));
+
+        transactions.add(dividend(account, LocalDateTime.of(2019, 6, 15, 12, 0), 40, 40));
+        transactions.add(dividend(secondAccount, LocalDateTime.of(2019, 6, 15, 12, 0), 60, 60));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals(0.10, dividends.getRateOfReturnPerYear(), 0.00001);
+    }
+
+    @Test
+    public void rateOfReturnWithDividendForPartialPosition()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 1, 12, 0), 1000, 100));
+        transactions.add(dividend(LocalDateTime.of(2019, 6, 15, 12, 0), 40, 40));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals(0.10, dividends.getRateOfReturnPerYear(), 0.00001);
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CalculationLineItem.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CalculationLineItem.java
@@ -81,7 +81,7 @@ public interface CalculationLineItem
 
     public static class DividendPayment extends TransactionItem
     {
-        private long totalShares;
+        long totalShares;
         private Money fifoCost;
         private Money movingAverageCost;
 
@@ -130,6 +130,11 @@ public interface CalculationLineItem
         /* package */ void setTotalShares(long totalShares)
         {
             this.totalShares = totalShares;
+        }
+
+        /* package */ long getTotalShares()
+        {
+            return totalShares;
         }
 
         public double getPersonalDividendYield()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
@@ -7,11 +7,9 @@ import java.util.Collections;
 import java.util.List;
 
 import name.abuchen.portfolio.model.Security;
-import name.abuchen.portfolio.model.SecurityPrice;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MutableMoney;
-import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.security.BaseSecurityPerformanceRecord.Periodicity;
 import name.abuchen.portfolio.util.Dates;
 
@@ -42,7 +40,7 @@ import name.abuchen.portfolio.util.Dates;
         /**
          * Rate of return for this payment.
          */
-        public final double rateOfReturn;
+        public final long costBaseAmount;
 
         /**
          * Constructs an instance.
@@ -54,49 +52,32 @@ import name.abuchen.portfolio.util.Dates;
          * @param security
          *            {@link Security}
          */
-        public Payment(CurrencyConverter converter, CalculationLineItem.DividendPayment t, Security security)
+        public Payment(CurrencyConverter converter, CalculationLineItem.DividendPayment t)
         {
             this.amount = t.getGrossValue().with(converter.at(t.getDateTime()));
+
             LocalDateTime time = t.getDateTime();
             this.year = time.getYear();
             this.date = time.toLocalDate();
 
-            // try to set rate of return, default is NaN
-            double rr = Double.NaN;
-            if (security != null)
+            Money movingAverageCost = t.getMovingAverageCost();
+            long costBase = 0;
+
+            if (movingAverageCost != null && !movingAverageCost.isZero())
             {
-                // calculate the rate of return, but do NOT use the method on
-                // the DividendPayment class. Why? The DividendPayment looks
-                // only at the payment, but the payment might only be for a
-                // partial position (for example if the security is held in
-                // multiple accounts). The moving average cost is always the
-                // total costs.
+                costBase = movingAverageCost.getAmount();
 
-                Money movingAverageCost = t.getMovingAverageCost();
-                if (movingAverageCost != null && !movingAverageCost.isZero())
+                if (t.getTransaction().isPresent() //
+                                && t.getTransaction().get().getShares() > 0 //
+                                && t.getTotalShares() > 0 //
+                                && t.getTransaction().get().getShares() < t.getTotalShares())
                 {
-                    // Use converted amount (in term currency) instead of raw amount (in transaction currency)
-                    // to ensure both values are in the same currency for correct calculation
-                    rr = this.amount.getAmount() / (double) movingAverageCost.getAmount();
-                }
-
-                // check if it is valid (non 0)
-                if (rr == 0)
-                {
-                    // else use the security price at that date
-                    SecurityPrice p = security.getSecurityPrice(date);
-                    // getSecurityPrice may return an empty price value, so
-                    // check that
-                    long pValue = p.getValue();
-                    if (pValue != 0)
-                    {
-                        double sharePriceAmount = ((double) pValue) / Values.Quote.factor()
-                                        * Values.AmountFraction.factor();
-                        rr = t.getDividendPerShare() / sharePriceAmount;
-                    }
+                    costBase = Math.round(movingAverageCost.getAmount()
+                                    * (t.getTransaction().get().getShares() / (double) t.getTotalShares()));
                 }
             }
-            this.rateOfReturn = rr;
+
+            this.costBaseAmount = costBase;
         }
     }
 
@@ -127,22 +108,18 @@ import name.abuchen.portfolio.util.Dates;
 
         int significantCount = 0;
         int insignificantYears = 0;
-        double sumRateOfReturn = 0;
 
         // first calc total sum of all payments
         for (Payment p : payments)
         {
             // add to total sum
             sum.add(p.amount);
-            sumRateOfReturn += p.rateOfReturn;
         }
 
-        int years = 0;
 
         // now walk through individual years
         for (int year = firstPayment.getYear(); year <= lastPayment.getYear(); year++)
         {
-            years++;
             int countPerYear = 0;
             long sumPerYear = 0;
             LocalDate lastDate = null;
@@ -190,7 +167,7 @@ import name.abuchen.portfolio.util.Dates;
             }
         }
 
-        this.rateOfReturnPerYear = sumRateOfReturn / years;
+        this.rateOfReturnPerYear = calculateRateOfReturnPerYear(firstPayment.getYear(), lastPayment.getYear());
 
         // determine periodicity?
         if (significantCount > 0)
@@ -220,6 +197,64 @@ import name.abuchen.portfolio.util.Dates;
                 }
             }
         }
+    }
+
+    private double calculateRateOfReturnPerYear(int firstYear, int lastYear)
+    {
+        double sumYearlyRateOfReturn = 0;
+        int yearsWithValidRateOfReturn = 0;
+
+        for (int year = firstYear; year <= lastYear; year++)
+        {
+            double yearlyRateOfReturn = 0;
+            boolean hasValidRateOfReturn = false;
+
+            LocalDate currentDate = null;
+            long dividendAmountOnDate = 0;
+            long costBaseAmountOnDate = 0;
+
+            for (Payment p : payments)
+            {
+                if (p.year != year)
+                    continue;
+
+                if (currentDate == null)
+                {
+                    currentDate = p.date;
+                }
+                else if (!currentDate.equals(p.date))
+                {
+                    if (dividendAmountOnDate > 0 && costBaseAmountOnDate > 0)
+                    {
+                        yearlyRateOfReturn += dividendAmountOnDate / (double) costBaseAmountOnDate;
+                        hasValidRateOfReturn = true;
+                    }
+
+                    currentDate = p.date;
+                    dividendAmountOnDate = 0;
+                    costBaseAmountOnDate = 0;
+                }
+
+                dividendAmountOnDate += p.amount.getAmount();
+
+                if (p.costBaseAmount > 0)
+                    costBaseAmountOnDate += p.costBaseAmount;
+            }
+
+            if (dividendAmountOnDate > 0 && costBaseAmountOnDate > 0)
+            {
+                yearlyRateOfReturn += dividendAmountOnDate / (double) costBaseAmountOnDate;
+                hasValidRateOfReturn = true;
+            }
+
+            if (hasValidRateOfReturn)
+            {
+                sumYearlyRateOfReturn += yearlyRateOfReturn;
+                yearsWithValidRateOfReturn++;
+            }
+        }
+
+        return yearsWithValidRateOfReturn > 0 ? sumYearlyRateOfReturn / yearsWithValidRateOfReturn : Double.NaN;
     }
 
     public DividendCalculationResult getResult()
@@ -269,6 +304,6 @@ import name.abuchen.portfolio.util.Dates;
     public void visit(CurrencyConverter converter, CalculationLineItem.DividendPayment t)
     {
         // construct new payment and add it to the list
-        payments.add(new Payment(converter, t, getSecurity()));
+        payments.add(new Payment(converter, t));
     }
 }


### PR DESCRIPTION
The previous implementation aggregated dividend yield using a simplified cost base handling.
This caused distorted annual dividend yield values for scenarios with
- partial sales,
- repurchases,
- multiple dividend payments on the same date,
- and changing positions over time.

The calculation now aggregates dividend payments against the cost base at the payment date.