### PR TITLE
Fix comdirect PDF importer for new buy/tax-treatment format

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
@@ -977,7 +977,7 @@ public class ComdirectPDFExtractorTest
         assertThat(results, hasItem(purchase( //
                         hasDate("2026-05-04T00:00"), hasShares(0.193), //
                         hasSource("KaufMitSteuerbehandlung17.txt"), //
-                        hasNote("R.-Nr.: 705006160048DB25"), //
+                        hasNote("Ord.-Nr.: 119817162670 | R.-Nr.: 705006160048DB25"), //
                         hasAmount("EUR", 25.00), hasGrossValue("EUR", 24.63), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.37))));
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
@@ -949,6 +949,40 @@ public class ComdirectPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierKaufMitSteuerbehandlung17()
+    {
+        var extractor = new ComdirectPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "KaufMitSteuerbehandlung17.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US69608A1088"), hasWkn("A2QA4J"), hasTicker(null), //
+                        hasName("Palantir Technologies Inc. Registered Shares o.N."), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-05-04T00:00"), hasShares(0.193), //
+                        hasSource("KaufMitSteuerbehandlung17.txt"), //
+                        hasNote("R.-Nr.: 705006160048DB25"), //
+                        hasAmount("EUR", 25.00), hasGrossValue("EUR", 24.63), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.37))));
+    }
+
+    @Test
     public void testWertpapierKaufSteuerbehandlung01()
     {
         var extractor = new ComdirectPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/KaufMitSteuerbehandlung17.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/KaufMitSteuerbehandlung17.txt
@@ -1,0 +1,84 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.83.2
+-----------------------------------------
+Ihren Auftrag haben wir gemäß unseren produktbezogenen
+Geschäftsbedingungen "Trading" wie nachstehend ausgeführt.
+Die Wertpapiere haben wir der Abrechnung entsprechend gebucht.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und
+Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.
+25449 Quickborn
+Telefon : 04106-708 25 00
+11111 111
+Depotnr.: 1111111 11
+BLZ: 111 111 11
+Vorname Nachname
+Straße 1
+11111 Stadt
+GESCHÄFTSABRECHNUNG VOM 04.05.2026
+*
+Wertpapierkauf
+Geschäftsnummer : 92 163657
+119817162670 Rechnungsnummer : 705006160048DB25
+Geschäftstag : 04.05.2026 Ausführungsplatz : TRADEGATE
+(Kommissionsgeschäft)
+Wertpapier-Bezeichnung WPKNR/ISIN
+Palantir Technologies Inc. A2QA4J
+Registered Shares o.N. US69608A1088
+Nennwert Zum Kurs von
+St. 0,193 EUR 127,62
+Kurswert : EUR 24,63
+--------------------------------------------------------------------------------
+Eigene Entgelte
+Provision : EUR 0,37
+--------------------------------------------------------------------------------
+IBAN Valuta Zu Ihren Lasten vor Steuern
+DE11 1111 1111 1111 1111 11 EUR 06.05.2026 EUR 25,00
+Verwahrungs-Art: GIROSAMMELDEPOT
+Informationen zur steuerlichen Behandlung dieses Geschäftsvorgangs und den auf
+Ihrem Konto gebuchten Endbetrag finden Sie auf der separaten Steuermitteilung.
+Ihre comdirect
+Diese Abrechnung wird von der Bank nicht unterschrieben
+Die Leistung ist gemäß §4 Nr.8 UStG umsatzsteuerfrei. USt-Id-Nr.: DE 114 103 514
+A113
+DO15DD/16/04/2010
+Kundennr. /BLZ Bezeichnung
+Vorname Nachname
+1111111
+Straße 1
+111 111 11 11111 Stadt
+abweichend wirtschaftlich Berechtigter
+----
+comdirect
+25451 Quickborn
+111 11111
+Telefon: 04106 - 708 25 00
+Herrn Datum: 04.05.2026
+Vorname Nachname Depotnummer: 1111111 11
+Straße 1
+11111 Stadt Referenz-Nummer: 2JINGAN3ZPQ003IE
+Steuerliche Behandlung: Wertpapierkauf Nr. 92163657 vom 04.05.2026
+Stk. 0,193 PALANTIR TECHNOLOGIES INC , WKN / ISIN: A2QA4J / US69608A1088
+Zu Ihren Lasten vor Steuern: EUR -25,00
+Steuerbemessungsgrundlage EUR 0,00
+Kapitalertragsteuer EUR 0,00
+Solidaritätszuschlag EUR 0,00
+Kirchensteuer E_U_R_______________0_,_0_0_
+abgeführte Steuern E_U_R_______________0_,_0_0_
+Zu Ihren Lasten nach Steuern: EUR -25,00
+Die Belastung erfolgt mit Valuta 06.05.2026 auf Konto EUR mit der IBAN DE11 1111 1111 1111 1111 11
+KEINE STEUERBESCHEINIGUNG ...
+Bisher einbehaltene bzw. angerechnete Steuer in EUR (4)
+in 2026 einbehaltene einbehaltener einbehaltene angerechnete
+Kapitalertragsteuer Solidaritätszuschlag Kirchensteuer ausländische Quellensteuer
+vor Ermittlung 79,95 4,32 6,30 52,34
+nach Ermittlung 79,95 4,32 6,30 52,34
+Verrechnungssalden in EUR (4)
+Gewinne / Verluste sonstige anrechenbare verfügbarer
+in 2026 aus Aktien Gewinne / Verluste ausländische Quellensteuer Freistellungsauftrag
+vor Ermittlung -22,03 535,50 0,00 0,00
+nach Ermittlung -22,03 535,50 0,00 0,00
+Ihre comdirect
+Diese Abrechnung ist maschinell erstellt und wird nicht unterschrieben.
+(4) Die ausgewiesenen EUR-Beträge spiegeln den Stand zum Abrechnungszeitpunkt wider.
+KEINE STEUERBESCHEINIGUNG

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
@@ -453,10 +453,11 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:off
                                         // Ordernummer       : 000117637940-001  Rechnungsnummer   : 508104401078D295
                                         //                     592581219254      Rechnungsnummer   : 878649826981vsP4
+                                        // 119817162670 Rechnungsnummer : 705006160048DB25
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("note") //
-                                                        .match("^.* (?<note>[\\-\\d]+)[\\s]{1,}Rechnungsnummer.*$") //
+                                                        .match("^(?:.* )?(?<note>[\\-\\d]+)[\\s]{1,}Rechnungsnummer.*$") //
                                                         .assign((t, v) -> t.setNote("Ord.-Nr.: " + v.get("note"))),
                                         // @formatter:off
                                         // Geschäftstag : 08.06.2015         Order-Nr.   : 71871368321 / 001
@@ -1053,13 +1054,16 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                         //
                                         // Stk.               8,544 ARERO-WELTFDS-ESG LC , WKN / ISIN: DWS26Y  / LU2114851830
                                         //  Zu  Ih r e n L a s te n  v o r  S te u e r n:
+                                        //
+                                        // Stk. 0,193 PALANTIR TECHNOLOGIES INC , WKN / ISIN: A2QA4J / US69608A1088
+                                        // Zu Ihren Lasten vor Steuern: EUR -25,00
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "wkn", "isin", "currency") //
                                                         .match("^Stk\\.[\\-\\s]{1,}[\\.,\\d]+ (?<name>.*), WKN \\/ ISIN: (?<wkn>[A-Z0-9]{6})[\\s]{1,}\\/[\\s]{1,}(?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]).*$") //
                                                         .match("^[\\s]*Z[\\s]*u[\\s]*I[\\s]*h[\\s]*r[\\s]*e[\\s]*n[\\s]*" //
                                                                         + "(G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n|L[\\s]*a[\\s]*s[\\s]*t[\\s]*e[\\s]*n)" //
-                                                                        + "[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?<currency>(?:[A-Z][\\s]*){3})[\\s]{1,}[\\.,\\d\\s]+.*$") //
+                                                                        + "[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?<currency>(?:[A-Z][\\s]*){3})[\\-\\s]{1,}[\\.,\\d\\s]+.*$") //
                                                         .assign((t, v) -> {
                                                             v.put("currency", stripBlanks(v.get("currency")));
                                                             v.put("name", trim(replaceMultipleBlanks(v.get("name"))));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
@@ -1041,7 +1041,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                                         .match("^Stk\\.[\\-\\s]{1,}[\\.,\\d]+ (?<name>.*), WKN \\/ ISIN: (?<wkn>[A-Z0-9]{6})[\\s]{1,}\\/[\\s]{1,}(?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]).*$") //
                                                         .match("^[\\s]*Z[\\s]*u[\\s]*I[\\s]*h[\\s]*r[\\s]*e[\\s]*n[\\s]*" //
                                                                         + "(G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n|L[\\s]*a[\\s]*s[\\s]*t[\\s]*e[\\s]*n)" //
-                                                                        + "[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?:[A-Z][\\s]*){3}[\\s]{1,}[\\.,\\d\\s]+[\\s]{1,}(?<currency>(?:[A-Z][\\s]*){3})[\\s]{1,}[\\.,\\d\\s]+.*$") //
+                                                                        + "[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?:[A-Z][\\s]*){3}[\\s]{1,}[\\.,\\d\\s]+[\\s]{1,}(?<currency>(?:[A-Z][\\s]*){3})[\\-\\s]{1,}[\\.,\\d\\s]+.*$") //
                                                         .assign((t, v) -> {
                                                             v.put("currency", stripBlanks(v.get("currency")));
                                                             v.put("name", trim(replaceMultipleBlanks(v.get("name"))));
@@ -1079,7 +1079,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                                         .match("^(?<currency>[A-Z]{3})[\\-\\s]{1,}(?<shares>[\\.,\\d]+) (?<name>.*), WKN \\/ ISIN: (?<wkn>[A-Z0-9]{6})[\\s]{1,}\\/[\\s]{1,}(?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]).*$") //
                                                         .match("^[\\s]*Z[\\s]*u[\\s]*I[\\s]*h[\\s]*r[\\s]*e[\\s]*n[\\s]*" //
                                                                         + "(G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n|L[\\s]*a[\\s]*s[\\s]*t[\\s]*e[\\s]*n)" //
-                                                                        + "[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?:[A-Z][\\s]*){3}[\\s]{1,}[\\.,\\d\\s]+.*$") //
+                                                                        + "[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?:[A-Z][\\s]*){3}[\\-\\s]{1,}[\\.,\\d\\s]+.*$") //
                                                         .assign((t, v) -> {
                                                             v.put("currency", stripBlanks(v.get("currency")));
                                                             v.put("name", trim(replaceMultipleBlanks(v.get("name"))));


### PR DESCRIPTION
Closes #5678

## Summary

The comdirect PDF layout for "Wertpapierkauf" with "Steuerliche Behandlung" has changed, causing imports to fail. Two regex relaxations:

1. **`Zu Ihren Lasten/Gunsten vor Steuern` line** — amounts are now rendered as `EUR -25,00` (no whitespace between currency and the leading `-`). The existing regex did not allow `-` between currency and the digit class, so the security/currency section in `addTaxesTreatmentTransaction` failed to match and the import was rejected.

   Fix: change the delimiter from `[\s]{1,}` to `[\-\s]{1,}` — the same pattern already used in the other tax regexes in the same file (lines 1219, 1298, …).

2. **`Ordernummer` line** — is now on the same line as `Rechnungsnummer` without leading whitespace (e.g. `119817162670 Rechnungsnummer : ...`). The existing note regex required a space before the digits, so it didn't match and the resulting note was missing `Ord.-Nr.:`.

   Fix: change `^.* ` to `^(?:.* )?` so the leading prefix is optional.

Both changes remain compatible with the older letter-spaced and whitespace-prefixed formats.

Verified that the fix also resolves the report in #5678 (same PDF structure, different security).

## Test plan

- [x] Added regression test `testWertpapierKaufMitSteuerbehandlung17` with a PDFBox 3.0.6 sample of the new format
- [x] All existing `ComdirectPDFExtractorTest` tests still pass locally