### PR TITLE
Add English dividend notes for Scalable Capital

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/Dividende12.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/Dividende12.txt
@@ -1,0 +1,39 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.83.2
+System: macosx | aarch64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Scalable Capital Bank GmbH • Seitzstraße 8e • 80538 Munich • Germany
+dLzRZ XszyB
+taY cm NQkbKurlXhMK 40
+48123 JIhtuUy Date 27.04.2026
+France Page 1 / 2
+Dividend
+for period 01.01.2025 - 31.12.2025
+Entitled security E.ON SE
+ISIN DE000ENAG999
+Entitled quantity 17
+Ex day 24.04.2026
+Clearing account ix10185353971233341028 (OUYFdFAsDrh)
+Clearing account movement
+Booking Value date Type Amount / pcs. Entitled quantity Total amount
+27.04.2026 28.04.2026 Credit 0.57 EUR 17 9.69 EUR
+Taxes -2.55 EUR
+Total 7.14 EUR
+Please ensure your compliance with the German foreign trade reporting regulations to the German Bundesbank (AWV-Meldung).
+Please note that the income from capital assets are fully subject to income tax in Germany.
+Calculation of tax-relevant income
+Type Amount
+Profit or loss 9.69 EUR
+Taxable amount 9.69 EUR
+Scalable Capital Bank GmbH • Seitzstraße 8e, 80538 Munich, Germany • HRB 217778 • Amtsgericht München • VAT ID: DE300434774 Page
+Managing Directors: Florian Prucker, Martin Krebs, Dirk Franzmeyer, Dr. Andreas Schranzhofer 1 / 2
+Supervisory Board: Patrick Olson (Chairman)
+Dividend
+Taxes incurred
+Type Amount
+Capital gains tax 2.42 EUR
+Solidarity surcharge 0.13 EUR
+Taxes incurred 2.55 EUR
+Scalable Capital Bank GmbH • Seitzstraße 8e, 80538 Munich, Germany • HRB 217778 • Amtsgericht München • VAT ID: DE300434774 Page
+Managing Directors: Florian Prucker, Martin Krebs, Dirk Franzmeyer, Dr. Andreas Schranzhofer 2 / 2
+Supervisory Board: Patrick Olson (Chairman)

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/ScalableCapitalPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/ScalableCapitalPDFExtractorTest.java
@@ -1881,6 +1881,41 @@ public class ScalableCapitalPDFExtractorTest
     }
 
     @Test
+    public void testDividende12()
+    {
+        var extractor = new ScalableCapitalPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende12.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("DE000ENAG999"), hasWkn(null), hasTicker(null), //
+                        hasName("E.ON SE"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-04-28T00:00"), hasExDate("2026-04-24T00:00"), //
+                        hasShares(17), //
+                        hasSource("Dividende12.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 7.14), hasGrossValue("EUR", 9.69), //
+                        hasTaxes("EUR", 2.55), hasFees("EUR", 0.00))));
+    }
+
+    @Test
     public void testRechnungsabschluss01()
     {
         var extractor = new ScalableCapitalPDFExtractor(new Client());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
@@ -292,7 +292,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
 
         var pdfTransaction = new Transaction<AccountTransaction>();
 
-        var firstRelevantLine = new Block("^.*(Seite|Pagina) 1 \\/ [\\d]$");
+        var firstRelevantLine = new Block("^.*(Seite|Pagina|Page) 1 \\/ [\\d]$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -330,6 +330,17 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
                                                         .match("^Berechtigtes[\\s]*Wertpapier (?<name>.*)$") //
                                                         .match("^ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]).*$") //
                                                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Gutschrift [\\.,\\d]+ (?<currency>[A-Z]{3}).*$") //
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
+                                        // @formatter:off
+                                        // Entitled security E.ON SE
+                                        // ISIN DE000ENAG999
+                                        // 27.04.2026 28.04.2026 Credit 0.57 EUR 17 9.69 EUR
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("name", "isin", "currency") //
+                                                        .match("^Entitled security (?<name>.*)$") //
+                                                        .match("^ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]).*$") //
+                                                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Credit [\\.,\\d]+ (?<currency>[A-Z]{3}).*$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
 
                         .oneOf( //
@@ -343,12 +354,20 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
                                                                         asShares(v.get("shares"), "en", "US"))),
                                         // @formatter:off
                                         // Berechtigte Anzahl 0,663129
-                                        // Berechtigte Anzahl 1.200 
+                                        // Berechtigte Anzahl 1.200
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("shares") //
                                                         .match("^Berechtigte Anzahl (?<shares>[\\.,\\d]+).*$") //
-                                                        .assign((t, v) -> t.setShares(asShares(v.get("shares")))))
+                                                        .assign((t, v) -> t.setShares(asShares(v.get("shares")))),
+                                        // @formatter:off
+                                        // Entitled quantity 17
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares") //
+                                                        .match("^Entitled quantity (?<shares>[\\.,\\d]+).*$") //
+                                                        .assign((t, v) -> t.setShares(
+                                                                        asShares(v.get("shares"), "en", "US"))))
 
                         .oneOf( //
                                         // @formatter:off
@@ -364,25 +383,34 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("date") //
                                                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) Gutschrift [\\.,\\d]+ [A-Z]{3} [\\.,\\d]+ [\\.,\\d]+ [A-Z]{3}.*$")
+                                                        .assign((t, v) -> t.setDateTime(asDate(v.get("date")))),
+                                        // @formatter:off
+                                        // 27.04.2026 28.04.2026 Credit 0.57 EUR 17 9.69 EUR
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date") //
+                                                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) Credit [\\.,\\d]+ [A-Z]{3} [\\.,\\d]+ [\\.,\\d]+ [A-Z]{3}.*$")
                                                         .assign((t, v) -> t.setDateTime(asDate(v.get("date")))))
 
                         .optionalOneOf(//
                         // @formatter:off
-                                        // Ex Tag 12.12.2025 
-                                        // Ex-dag 04.06.2025 
+                                        // Ex Tag 12.12.2025
+                                        // Ex-dag 04.06.2025
+                                        // Ex day 24.04.2026
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("exDate") //
-                                                        .match("^(Ex Tag|Ex-dag) (?<exDate>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})[\\s]*$")
+                                                        .match("^(Ex Tag|Ex-dag|Ex day) (?<exDate>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})[\\s]*$")
                                                         .assign((t, v) -> t.setExDate(asDate(v.get("exDate")))))
                         .oneOf( //
                                         // @formatter:off
                                         // Gesamtbetrag 0,07 EUR
                                         // Totaal 2.12 EUR
+                                        // Total 7.14 EUR
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("amount", "currency") //
-                                                        .match("^(Gesamtbetrag|Totaal) (?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                                                        .match("^(Gesamtbetrag|Totaal|Total) (?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
                                                         .assign((t, v) -> {
                                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                                             t.setAmount(asAmount(v.get("amount")));


### PR DESCRIPTION
Closes #5657

## Summary

Scalable Capital sends dividend notes in three languages — German ("Berechtigtes Wertpapier" / "Gutschrift" / "Gesamtbetrag"), Dutch ("Effect met recht" / "Krediet" / "Totaal") and English. The English variant was not recognized, so imports failed with `Unbekannter oder nicht unterstützter Buchungstyp`.

This PR adds the missing English patterns to `addDividendTransaction`:

- Block trigger: extend `(Seite|Pagina)` to `(Seite|Pagina|Page)`
- Security section: add `Entitled security` + `Credit` row variant
- Shares section: add `Entitled quantity` (parsed with `en`/`US` locale for dot decimals)
- Date section: add `Credit` row variant
- Ex-date alternation: extend `(Ex Tag|Ex-dag)` to `(Ex Tag|Ex-dag|Ex day)`
- Total amount alternation: extend `(Gesamtbetrag|Totaal)` to `(Gesamtbetrag|Totaal|Total)`

`Capital gains tax` and `Solidarity surcharge` were already supported in `addTaxesSectionsTransaction`, so the tax breakdown works as-is.

## Test plan

- [x] Added `Dividende12.txt` fixture (real-world sample from #5657: E.ON SE dividend, EUR-only, 17 shares, 9.69 EUR gross, 2.55 EUR taxes, 7.14 EUR net)
- [x] Added `testDividende12()` covering security, ex-date, shares, gross, taxes
- [x] All existing `ScalableCapitalPDFExtractorTest` tests still pass locally