### PR TITLE
simplify securities chart 

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -1929,18 +1929,7 @@ public class SecuritiesChart
         if (r.isEmpty())
             return Optional.empty();
 
-        Quote purchasePricePerShare;
-        switch (costMethod)
-        {
-            case FIFO:
-                purchasePricePerShare = r.get().getCostPerSharesHeld(CostMethod.FIFO);
-                break;
-            case MOVING_AVERAGE:
-                purchasePricePerShare = r.get().getCostPerSharesHeld(CostMethod.MOVING_AVERAGE);
-                break;
-            default:
-                throw new IllegalArgumentException("unsupported cost method: " + costMethod); //$NON-NLS-1$
-        }
+        Quote purchasePricePerShare = r.get().getCostPerSharesHeld(costMethod);
 
         return purchasePricePerShare.isZero() ? Optional.empty()
                         : Optional.of(purchasePricePerShare.getAmount() / Values.Quote.divider());


### PR DESCRIPTION
From https://github.com/portfolio-performance/portfolio/pull/5677,  getFifoCostPerSharesHeld and getMovingAverageCostPerSharesHeld were replaced by a single function with CostMethod parameter input.

There is no longer need for a switch which was calling the different functions