### PR TITLE
Fix annual dividend yield aggregation

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/CostCalculationTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/CostCalculationTest.java
@@ -135,22 +135,30 @@ public class CostCalculationTest
         CurrencyConverter converter = new TestCurrencyConverter().with(CurrencyUnit.EUR);
 
         var interval = Interval.of(LocalDate.parse("2015-01-16"), LocalDate.parse("2015-12-31"));
-        SecurityPerformanceSnapshot snapshot = SecurityPerformanceSnapshot.create(client, converter, interval);
-
-        new SecurityPerformanceSnapshotComparator(snapshot,
-                        LazySecurityPerformanceSnapshot.create(client, converter, interval)).compare();
+        LazySecurityPerformanceSnapshot snapshot = LazySecurityPerformanceSnapshot.create(client, converter, interval);
 
         assertThat(snapshot.getRecords().size(), is(1));
 
-        SecurityPerformanceRecord record = snapshot.getRecords().get(0);
+        LazySecurityPerformanceRecord record = snapshot.getRecords().get(0);
 
+<<<<<<< HEAD
         // 1.1588 = exchange rate of test currency converter on 2015-01-16
+=======
+        // Historic cost basis: the inbound delivery before the reporting period
+        // keeps its original EUR value instead of being revalued at the start
+        // date.
+>>>>>>> 109cdb01f (Fix annual dividend yield aggregation)
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize((1000 / 1.1588) + 1100))));
 
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+<<<<<<< HEAD
                         is(record.explain(SecurityPerformanceRecord.Trails.FIFO_COST)
                         .orElseThrow(IllegalArgumentException::new).getRecord().getValue()));
+=======
+                        is(record.explain(BaseSecurityPerformanceRecord.Trails.FIFO_COST)
+                                        .orElseThrow(IllegalArgumentException::new).getRecord().getValue()));
+>>>>>>> 109cdb01f (Fix annual dividend yield aggregation)
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendCalculationTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendCalculationTest.java
@@ -18,6 +18,7 @@ import name.abuchen.portfolio.model.PortfolioTransaction.Type;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.SecurityPrice;
 import name.abuchen.portfolio.money.CurrencyConverter;
+import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.security.BaseSecurityPerformanceRecord.Periodicity;
 
@@ -25,6 +26,7 @@ import name.abuchen.portfolio.snapshot.security.BaseSecurityPerformanceRecord.Pe
 public class DividendCalculationTest
 {
     Account account;
+    Portfolio portfolio;
     Security security;
     CurrencyConverter converter;
 
@@ -32,6 +34,7 @@ public class DividendCalculationTest
     public void setup()
     {
         this.account = new Account();
+        this.portfolio = new Portfolio();
         this.security = new Security("ADIDAS ORD", "EUR");
         this.converter = new TestCurrencyConverter();
     }
@@ -254,5 +257,219 @@ public class DividendCalculationTest
         // This test will FAIL with the buggy code (~0.0588) and PASS with the fix (~0.05)
         // Tolerance is tight (0.005) to catch the bug: 0.0588 - 0.05 = 0.0088 > 0.005
         assertEquals(0.05, dividends.getRateOfReturnPerYear(), 0.005);
+    }
+
+    @Test
+    public void rateOfReturnWithDividendCurrencyDifferentFromSecurityCurrency()
+    {
+        Security eurSecurity = new Security("EUR Security", CurrencyUnit.EUR);
+
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        transactions.add(CalculationLineItem.of(portfolio,
+                        new PortfolioTransaction(LocalDateTime.of(2015, 1, 14, 12, 0), eurSecurity.getCurrencyCode(),
+                                        Values.Amount.factorize(1000), eurSecurity, Values.Share.factorize(10),
+                                        Type.BUY, 0L, 0L)));
+
+        AccountTransaction dividend = new AccountTransaction();
+        dividend.setType(AccountTransaction.Type.DIVIDENDS);
+        dividend.setSecurity(eurSecurity);
+        dividend.setDateTime(LocalDateTime.of(2015, 1, 15, 12, 0));
+        dividend.setAmount(Values.Amount.factorize(50));
+        dividend.setShares(Values.Share.factorize(10));
+        dividend.setCurrencyCode(CurrencyUnit.USD);
+
+        transactions.add(CalculationLineItem.of(account, dividend));
+
+        CurrencyConverter eurConverter = new TestCurrencyConverter().with(CurrencyUnit.EUR);
+
+        Calculation.perform(CostCalculation.class, eurConverter, eurSecurity, transactions);
+        DividendCalculation dividends = Calculation.perform(DividendCalculation.class, eurConverter, eurSecurity,
+                        transactions);
+
+        /*
+         * Expected: dividend converted from USD to EUR at dividend date divided
+         * by EUR cost basis.
+         */
+        assertEquals(0.0427, dividends.getRateOfReturnPerYear(), 0.005);
+    }
+
+    private CalculationLineItem buy(LocalDateTime date, double amount, double shares)
+    {
+        return CalculationLineItem.of(portfolio, new PortfolioTransaction(date, security.getCurrencyCode(),
+                        Values.Amount.factorize(amount), security, Values.Share.factorize(shares), Type.BUY, 0L, 0L));
+    }
+
+    @SuppressWarnings("unused")
+    private CalculationLineItem buy(LocalDateTime date, double amount, double shares, double fees)
+    {
+        return CalculationLineItem.of(portfolio,
+                        new PortfolioTransaction(date, security.getCurrencyCode(), Values.Amount.factorize(amount),
+                                        security, Values.Share.factorize(shares), Type.BUY,
+                                        Values.Amount.factorize(fees), 0L));
+    }
+
+    private CalculationLineItem sell(LocalDateTime date, double amount, double shares)
+    {
+        return CalculationLineItem.of(portfolio, new PortfolioTransaction(date, security.getCurrencyCode(),
+                        Values.Amount.factorize(amount), security, Values.Share.factorize(shares), Type.SELL, 0L, 0L));
+    }
+
+    private CalculationLineItem dividend(LocalDateTime date, double amount, double shares)
+    {
+        return dividend(account, date, amount, shares);
+    }
+
+    private CalculationLineItem dividend(Account dividendAccount, LocalDateTime date, double amount, double shares)
+    {
+        AccountTransaction t = new AccountTransaction();
+        t.setType(AccountTransaction.Type.DIVIDENDS);
+        t.setSecurity(security);
+        t.setDateTime(date);
+        t.setAmount(Values.Amount.factorize(amount));
+        t.setShares(Values.Share.factorize(shares));
+        t.setCurrencyCode(security.getCurrencyCode());
+
+        return CalculationLineItem.of(dividendAccount, t);
+    }
+
+    private DividendCalculation calculate(List<CalculationLineItem> transactions)
+    {
+        Calculation.perform(CostCalculation.class, converter, security, transactions);
+        return Calculation.perform(DividendCalculation.class, converter, security, transactions);
+    }
+
+    @Test
+    public void rateOfReturnThreeYearsWithConstantPosition()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 7, 12, 0), 1330.25, 61));
+
+        transactions.add(dividend(LocalDateTime.of(2019, 6, 15, 12, 0), 17.49, 61));
+        transactions.add(dividend(LocalDateTime.of(2020, 6, 15, 12, 0), 17.49, 61));
+        transactions.add(dividend(LocalDateTime.of(2021, 6, 15, 12, 0), 17.49, 61));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals(52.47 / 1330.25 / 3, dividends.getRateOfReturnPerYear(), 0.00001);
+    }
+
+    @Test
+    public void rateOfReturnThreeYearsWithSavingsPlan()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 1, 12, 0), 1000, 10));
+        transactions.add(dividend(LocalDateTime.of(2019, 6, 15, 12, 0), 10, 10));
+
+        transactions.add(buy(LocalDateTime.of(2020, 1, 1, 12, 0), 1000, 10));
+        transactions.add(dividend(LocalDateTime.of(2020, 6, 15, 12, 0), 20, 20));
+
+        transactions.add(buy(LocalDateTime.of(2021, 1, 1, 12, 0), 1000, 10));
+        transactions.add(dividend(LocalDateTime.of(2021, 6, 15, 12, 0), 30, 30));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals(0.01, dividends.getRateOfReturnPerYear(), 0.00001);
+    }
+
+    @Test
+    public void rateOfReturnThreeYearsWithAdditionalPurchaseDuringPeriod()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 1, 12, 0), 1000, 10));
+        transactions.add(dividend(LocalDateTime.of(2019, 6, 15, 12, 0), 100, 10));
+
+        transactions.add(buy(LocalDateTime.of(2020, 1, 1, 12, 0), 1000, 10));
+        transactions.add(dividend(LocalDateTime.of(2020, 6, 15, 12, 0), 100, 20));
+        transactions.add(dividend(LocalDateTime.of(2021, 6, 15, 12, 0), 100, 20));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals((0.10 + 0.05 + 0.05) / 3, dividends.getRateOfReturnPerYear(), 0.00001);
+    }
+
+    @Test
+    public void rateOfReturnThreeYearsWithPartialSaleDuringPeriod()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 1, 12, 0), 1000, 100));
+        transactions.add(dividend(LocalDateTime.of(2019, 6, 15, 12, 0), 100, 100));
+
+        transactions.add(sell(LocalDateTime.of(2020, 1, 1, 12, 0), 500, 50));
+        transactions.add(dividend(LocalDateTime.of(2020, 6, 15, 12, 0), 50, 50));
+        transactions.add(dividend(LocalDateTime.of(2021, 6, 15, 12, 0), 50, 50));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals(0.10, dividends.getRateOfReturnPerYear(), 0.00001);
+    }
+
+    @Test
+    public void rateOfReturnThreeYearsWithFullSaleAfterLastDividend()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 1, 12, 0), 1000, 100));
+        transactions.add(dividend(LocalDateTime.of(2019, 6, 15, 12, 0), 100, 100));
+        transactions.add(dividend(LocalDateTime.of(2020, 6, 15, 12, 0), 100, 100));
+        transactions.add(dividend(LocalDateTime.of(2021, 6, 15, 12, 0), 100, 100));
+        transactions.add(sell(LocalDateTime.of(2021, 12, 31, 12, 0), 1000, 100));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals(0.10, dividends.getRateOfReturnPerYear(), 0.00001);
+    }
+
+    @Test
+    public void rateOfReturnThreeYearsWithSaleAndRepurchase()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 1, 12, 0), 1000, 100));
+        transactions.add(dividend(LocalDateTime.of(2019, 6, 15, 12, 0), 100, 100));
+
+        transactions.add(sell(LocalDateTime.of(2019, 12, 31, 12, 0), 1000, 100));
+
+        transactions.add(buy(LocalDateTime.of(2020, 1, 1, 12, 0), 2000, 100));
+        transactions.add(dividend(LocalDateTime.of(2020, 6, 15, 12, 0), 100, 100));
+        transactions.add(dividend(LocalDateTime.of(2021, 6, 15, 12, 0), 100, 100));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals((0.10 + 0.05 + 0.05) / 3, dividends.getRateOfReturnPerYear(), 0.00001);
+    }
+
+    @Test
+    public void rateOfReturnWithMultipleAccountsOnSameDividendDate()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        Account secondAccount = new Account();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 1, 12, 0), 1000, 100));
+
+        transactions.add(dividend(account, LocalDateTime.of(2019, 6, 15, 12, 0), 40, 40));
+        transactions.add(dividend(secondAccount, LocalDateTime.of(2019, 6, 15, 12, 0), 60, 60));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals(0.10, dividends.getRateOfReturnPerYear(), 0.00001);
+    }
+
+    @Test
+    public void rateOfReturnWithDividendForPartialPosition()
+    {
+        List<CalculationLineItem> transactions = new ArrayList<>();
+
+        transactions.add(buy(LocalDateTime.of(2019, 1, 1, 12, 0), 1000, 100));
+        transactions.add(dividend(LocalDateTime.of(2019, 6, 15, 12, 0), 40, 40));
+
+        DividendCalculation dividends = calculate(transactions);
+
+        assertEquals(0.04, dividends.getRateOfReturnPerYear(), 0.00001);
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/BaseSecurityPerformanceRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/BaseSecurityPerformanceRecord.java
@@ -42,6 +42,8 @@ public class BaseSecurityPerformanceRecord
 
     protected final List<CalculationLineItem> lineItems = new ArrayList<>();
 
+    protected final List<CalculationLineItem> prePeriodLineItems = new ArrayList<>();
+
     public BaseSecurityPerformanceRecord(Client client, Security security, CurrencyConverter converter,
                     Interval interval)
     {
@@ -72,4 +74,13 @@ public class BaseSecurityPerformanceRecord
         return lineItems;
     }
 
+    /* package */ void addPrePeriodLineItem(CalculationLineItem item)
+    {
+        this.prePeriodLineItems.add(item);
+    }
+
+    public List<CalculationLineItem> getPrePeriodLineItems()
+    {
+        return prePeriodLineItems;
+    }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/Calculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/Calculation.java
@@ -121,4 +121,28 @@ import name.abuchen.portfolio.money.CurrencyConverter;
             throw new UnsupportedOperationException(e);
         }
     }
+
+    public static <T extends Calculation> T perform(Class<T> type, CurrencyConverter converter, Security security,
+                    List<CalculationLineItem> lineItems, List<CalculationLineItem> prePeriodLineItems)
+    {
+        try
+        {
+            T calculation = type.getDeclaredConstructor().newInstance();
+            calculation.setSecurity(security);
+            calculation.setTermCurrency(converter.getTermCurrency());
+            calculation.prepare();
+            calculation.preload(converter, prePeriodLineItems);
+            calculation.visitAll(converter, lineItems);
+            calculation.finish(converter, lineItems);
+            return calculation;
+        }
+        catch (Exception e)
+        {
+            throw new UnsupportedOperationException(e);
+        }
+    }
+
+    public void preload(CurrencyConverter converter, List<CalculationLineItem> lineItems)
+    {
+    }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CostCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CostCalculation.java
@@ -62,9 +62,25 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
     private long fees;
     private long taxes;
 
+    private boolean useHistoricCostBasis = false;
+
+    @Override
+    public void preload(CurrencyConverter converter, List<CalculationLineItem> lineItems)
+    {
+        this.useHistoricCostBasis = true;
+
+        visitAll(converter, lineItems);
+
+        this.fees = 0;
+        this.taxes = 0;
+    }
+
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.ValuationAtStart item)
     {
+        if (useHistoricCostBasis)
+            return;
+
         Money valuation = item.getValue();
         SecurityPosition position = item.getSecurityPosition().orElseThrow(IllegalArgumentException::new);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
@@ -7,11 +7,9 @@ import java.util.Collections;
 import java.util.List;
 
 import name.abuchen.portfolio.model.Security;
-import name.abuchen.portfolio.model.SecurityPrice;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MutableMoney;
-import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.security.BaseSecurityPerformanceRecord.Periodicity;
 import name.abuchen.portfolio.util.Dates;
 
@@ -42,7 +40,7 @@ import name.abuchen.portfolio.util.Dates;
         /**
          * Rate of return for this payment.
          */
-        public final double rateOfReturn;
+        public final long costBaseAmount;
 
         /**
          * Constructs an instance.
@@ -54,49 +52,19 @@ import name.abuchen.portfolio.util.Dates;
          * @param security
          *            {@link Security}
          */
-        public Payment(CurrencyConverter converter, CalculationLineItem.DividendPayment t, Security security)
+        public Payment(CurrencyConverter converter, CalculationLineItem.DividendPayment t)
         {
             this.amount = t.getGrossValue().with(converter.at(t.getDateTime()));
+
             LocalDateTime time = t.getDateTime();
             this.year = time.getYear();
             this.date = time.toLocalDate();
 
-            // try to set rate of return, default is NaN
-            double rr = Double.NaN;
-            if (security != null)
-            {
-                // calculate the rate of return, but do NOT use the method on
-                // the DividendPayment class. Why? The DividendPayment looks
-                // only at the payment, but the payment might only be for a
-                // partial position (for example if the security is held in
-                // multiple accounts). The moving average cost is always the
-                // total costs.
+            Money movingAverageCost = t.getMovingAverageCost();
 
-                Money movingAverageCost = t.getMovingAverageCost();
-                if (movingAverageCost != null && !movingAverageCost.isZero())
-                {
-                    // Use converted amount (in term currency) instead of raw amount (in transaction currency)
-                    // to ensure both values are in the same currency for correct calculation
-                    rr = this.amount.getAmount() / (double) movingAverageCost.getAmount();
-                }
-
-                // check if it is valid (non 0)
-                if (rr == 0)
-                {
-                    // else use the security price at that date
-                    SecurityPrice p = security.getSecurityPrice(date);
-                    // getSecurityPrice may return an empty price value, so
-                    // check that
-                    long pValue = p.getValue();
-                    if (pValue != 0)
-                    {
-                        double sharePriceAmount = ((double) pValue) / Values.Quote.factor()
-                                        * Values.AmountFraction.factor();
-                        rr = t.getDividendPerShare() / sharePriceAmount;
-                    }
-                }
-            }
-            this.rateOfReturn = rr;
+            this.costBaseAmount = movingAverageCost != null && !movingAverageCost.isZero()
+                            ? movingAverageCost.getAmount()
+                            : 0;
         }
     }
 
@@ -127,22 +95,18 @@ import name.abuchen.portfolio.util.Dates;
 
         int significantCount = 0;
         int insignificantYears = 0;
-        double sumRateOfReturn = 0;
 
         // first calc total sum of all payments
         for (Payment p : payments)
         {
             // add to total sum
             sum.add(p.amount);
-            sumRateOfReturn += p.rateOfReturn;
         }
 
-        int years = 0;
 
         // now walk through individual years
         for (int year = firstPayment.getYear(); year <= lastPayment.getYear(); year++)
         {
-            years++;
             int countPerYear = 0;
             long sumPerYear = 0;
             LocalDate lastDate = null;
@@ -190,7 +154,7 @@ import name.abuchen.portfolio.util.Dates;
             }
         }
 
-        this.rateOfReturnPerYear = sumRateOfReturn / years;
+        this.rateOfReturnPerYear = calculateRateOfReturnPerYear(firstPayment.getYear(), lastPayment.getYear());
 
         // determine periodicity?
         if (significantCount > 0)
@@ -220,6 +184,64 @@ import name.abuchen.portfolio.util.Dates;
                 }
             }
         }
+    }
+
+    private double calculateRateOfReturnPerYear(int firstYear, int lastYear)
+    {
+        double sumYearlyRateOfReturn = 0;
+        int yearsWithValidRateOfReturn = 0;
+
+        for (int year = firstYear; year <= lastYear; year++)
+        {
+            double yearlyRateOfReturn = 0;
+            boolean hasValidRateOfReturn = false;
+
+            LocalDate currentDate = null;
+            long dividendAmountOnDate = 0;
+            long costBaseAmountOnDate = 0;
+
+            for (Payment p : payments)
+            {
+                if (p.year != year)
+                    continue;
+
+                if (currentDate == null)
+                {
+                    currentDate = p.date;
+                }
+                else if (!currentDate.equals(p.date))
+                {
+                    if (dividendAmountOnDate > 0 && costBaseAmountOnDate > 0)
+                    {
+                        yearlyRateOfReturn += dividendAmountOnDate / (double) costBaseAmountOnDate;
+                        hasValidRateOfReturn = true;
+                    }
+
+                    currentDate = p.date;
+                    dividendAmountOnDate = 0;
+                    costBaseAmountOnDate = 0;
+                }
+
+                dividendAmountOnDate += p.amount.getAmount();
+
+                if (p.costBaseAmount > 0)
+                    costBaseAmountOnDate = Math.max(costBaseAmountOnDate, p.costBaseAmount);
+            }
+
+            if (dividendAmountOnDate > 0 && costBaseAmountOnDate > 0)
+            {
+                yearlyRateOfReturn += dividendAmountOnDate / (double) costBaseAmountOnDate;
+                hasValidRateOfReturn = true;
+            }
+
+            if (hasValidRateOfReturn)
+            {
+                sumYearlyRateOfReturn += yearlyRateOfReturn;
+                yearsWithValidRateOfReturn++;
+            }
+        }
+
+        return yearsWithValidRateOfReturn > 0 ? sumYearlyRateOfReturn / yearsWithValidRateOfReturn : Double.NaN;
     }
 
     public DividendCalculationResult getResult()
@@ -269,6 +291,6 @@ import name.abuchen.portfolio.util.Dates;
     public void visit(CurrencyConverter converter, CalculationLineItem.DividendPayment t)
     {
         // construct new payment and add it to the list
-        payments.add(new Payment(converter, t, getSecurity()));
+        payments.add(new Payment(converter, t));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
@@ -148,6 +148,9 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
     private final LazyValue<CostCalculationResult> costCalculation = new LazyValue<>(
                     () -> Calculation.perform(CostCalculation.class, converter, security, lineItems).getResult());
 
+    private final LazyValue<CostCalculationResult> dividendCostCalculation = new LazyValue<>(() -> Calculation
+                    .perform(CostCalculation.class, converter, security, lineItems, prePeriodLineItems).getResult());
+
     /**
      * cost of shares held
      */
@@ -164,9 +167,7 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
     }
 
     private final LazyValue<DividendCalculationResult> dividendCalculation = new LazyValue<>(() -> {
-        // ensure cost calculation is done (and has calculated
-        // moving averages)
-        costCalculation.get();
+        dividendCostCalculation.get();
         return Calculation.perform(DividendCalculation.class, converter, security, lineItems).getResult();
     });
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshotBuilder.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshotBuilder.java
@@ -46,8 +46,10 @@ import name.abuchen.portfolio.util.Interval;
             addPseudoValuationTansactions(portfolio, transactions);
         }
 
-        transactions.values()
-                        .forEach(item -> Collections.sort(item.getLineItems(), new CalculationLineItemComparator()));
+        transactions.values().forEach(item -> {
+            Collections.sort(item.getPrePeriodLineItems(), new CalculationLineItemComparator());
+            Collections.sort(item.getLineItems(), new CalculationLineItemComparator());
+        });
 
         return transactions.values().stream().filter(item -> !item.getLineItems().isEmpty()).toList();
     }
@@ -80,8 +82,10 @@ import name.abuchen.portfolio.util.Interval;
             }
         }
 
-        transactions.values()
-                        .forEach(item -> Collections.sort(item.getLineItems(), new CalculationLineItemComparator()));
+        transactions.values().forEach(item -> {
+            Collections.sort(item.getPrePeriodLineItems(), new CalculationLineItemComparator());
+            Collections.sort(item.getLineItems(), new CalculationLineItemComparator());
+        });
 
         return transactions.values().stream().filter(item -> !item.getLineItems().isEmpty()).toList();
     }
@@ -135,29 +139,41 @@ import name.abuchen.portfolio.util.Interval;
     private void extractSecurityRelatedPortfolioTransactions(Class<T> type, Portfolio portfolio,
                     Map<Security, T> records)
     {
-        portfolio.getTransactions().stream() //
-                        .filter(t -> interval.contains(t.getDateTime())) //
-                        .forEach(t -> records.computeIfAbsent(t.getSecurity(), s -> {
+        for (var t : portfolio.getTransactions())
+        {
+            T record = records.computeIfAbsent(t.getSecurity(), s -> {
 
-                            // must not happen because the records map is filled
-                            // with _all_ securities of the client. However,
-                            // #1836 reports a NPE exception here. Create a
-                            // builder object to collect the transaction anyway.
+                // must not happen because the records map is filled
+                // with _all_ securities of the client. However,
+                // #1836 reports a NPE exception here. Create a
+                // builder object to collect the transaction anyway.
 
-                            PortfolioLog.warning(MessageFormat.format("Unidentified security ''{0}'' with UUID {1}", //$NON-NLS-1$
-                                            s.getName(), s.getUUID()));
+                PortfolioLog.warning(MessageFormat.format("Unidentified security ''{0}'' with UUID {1}", //$NON-NLS-1$
+                                s.getName(), s.getUUID()));
 
-                            try
-                            {
-                                var typeConstructor = type.getDeclaredConstructor(Client.class, Security.class,
-                                                CurrencyConverter.class, Interval.class);
-                                return typeConstructor.newInstance(client, s, converter, interval);
-                            }
-                            catch (ReflectiveOperationException e)
-                            {
-                                throw new IllegalArgumentException(e);
-                            }
-                        }).addLineItem(CalculationLineItem.of(portfolio, t)));
+                try
+                {
+                    var typeConstructor = type.getDeclaredConstructor(Client.class, Security.class,
+                                    CurrencyConverter.class, Interval.class);
+                    return typeConstructor.newInstance(client, s, converter, interval);
+                }
+                catch (ReflectiveOperationException e)
+                {
+                    throw new IllegalArgumentException(e);
+                }
+            });
+
+            CalculationLineItem item = CalculationLineItem.of(portfolio, t);
+
+            if (t.getDateTime().toLocalDate().isBefore(interval.getStart()))
+            {
+                record.addPrePeriodLineItem(item);
+            }
+            else if (interval.contains(t.getDateTime()))
+            {
+                record.addLineItem(item);
+            }
+        }
     }
 
     private void addPseudoValuationTansactions(Portfolio portfolio, Map<Security, T> records)


### PR DESCRIPTION
The previous implementation aggregated annual dividend yield using simplified cost-base handling.

This caused distorted values when positions changed over time, for example with:

* partial sales,
* repurchases,
* multiple dividend payments on the same date,
* and positions that already existed before the reporting period.

The calculation now evaluates dividend payments against the cost basis at the payment date and aggregates the resulting yields per year.

For dividend yield only, the cost basis is built from historical transactions before the reporting period. This avoids using the period-start valuation as dividend yield cost basis, while keeping the existing cost and capital-gains calculations unchanged.