### PR TITLE
getCostPerSharesHeld can now use TaxesAndFees input parameter

### DIFF
--- a/name.abuchen.portfolio.tests/src/issues/Issue1498FifoCrossPortfolioTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue1498FifoCrossPortfolioTest.java
@@ -59,9 +59,9 @@ public class Issue1498FifoCrossPortfolioTest
         assertThat(record.getSharesHeld(), is(6000000000L));
         assertThat(record.getMarketValue(), is(Money.of("EUR", 60000L))); //$NON-NLS-1$
         assertThat(record.getQuote(), is(Quote.of("EUR", 1000000000L))); //$NON-NLS-1$
-        assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
-                        is(Money.of("EUR", 99345L))); //$NON-NLS-1$
-        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO), is(Quote.of("EUR", 1916666667L))); //$NON-NLS-1$
+        assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of("EUR", 99345L))); //$NON-NLS-1$
+        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
+                        is(Quote.of("EUR", 1916666667L))); //$NON-NLS-1$
         assertThat(record.getFees(), is(Money.of("EUR", 0L))); //$NON-NLS-1$
         assertThat(record.getTaxes(), is(Money.of("EUR", 0L))); //$NON-NLS-1$
         assertThat(record.getDelta(), is(Money.of("EUR", -53660L))); //$NON-NLS-1$

--- a/name.abuchen.portfolio.tests/src/issues/Issue1879DividendRateOfReturnPerYearWithSecurityInMultipleAccountsTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue1879DividendRateOfReturnPerYearWithSecurityInMultipleAccountsTest.java
@@ -54,9 +54,9 @@ public class Issue1879DividendRateOfReturnPerYearWithSecurityInMultipleAccountsT
         assertThat(record.getMarketValue(), is(Money.of("EUR", 80120L))); //$NON-NLS-1$
         assertThat(record.getQuote(), is(Quote.of("EUR", 400600000L))); //$NON-NLS-1$
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of("EUR", 82930L))); //$NON-NLS-1$
-        assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
-                        is(Money.of("EUR", 82930L))); //$NON-NLS-1$
-        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO), is(Quote.of("EUR", 414650000L))); //$NON-NLS-1$
+        assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of("EUR", 82930L))); //$NON-NLS-1$
+        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
+                        is(Quote.of("EUR", 414650000L))); //$NON-NLS-1$
         assertThat(record.getFees(), is(Money.of("EUR", 0L))); //$NON-NLS-1$
         assertThat(record.getTaxes(), is(Money.of("EUR", 0L))); //$NON-NLS-1$
         assertThat(record.getDelta(), is(Money.of("EUR", 5190L))); //$NON-NLS-1$

--- a/name.abuchen.portfolio.tests/src/issues/Issue1909FIFOCalculationOfSecurityPositionTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue1909FIFOCalculationOfSecurityPositionTest.java
@@ -49,12 +49,12 @@ public class Issue1909FIFOCalculationOfSecurityPositionTest
 
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2000))));
-        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO),
+        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
                         is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(200))));
 
         assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1500))));
-        assertThat(record.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE),
+        assertThat(record.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
                         is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(150))));
 
         assertThat(record.getCapitalGainsOnHoldings(CostMethod.FIFO),

--- a/name.abuchen.portfolio.tests/src/issues/Issue371PurchaseValueWithTransfersTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue371PurchaseValueWithTransfersTest.java
@@ -69,9 +69,9 @@ public class Issue371PurchaseValueWithTransfersTest
         // pinned values previously verified via SecurityPerformanceSnapshotComparator
         assertThat(record.getMarketValue(), is(Money.of("EUR", 414023L))); //$NON-NLS-1$
         assertThat(record.getQuote(), is(Quote.of("EUR", 8809000000L))); //$NON-NLS-1$
-        assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
-                        is(Money.of("EUR", 239760L))); //$NON-NLS-1$
-        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO), is(Quote.of("EUR", 5080000000L))); //$NON-NLS-1$
+        assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of("EUR", 239760L))); //$NON-NLS-1$
+        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
+                        is(Quote.of("EUR", 5080000000L))); //$NON-NLS-1$
         assertThat(record.getFees(), is(Money.of("EUR", 1000L))); //$NON-NLS-1$
         assertThat(record.getTaxes(), is(Money.of("EUR", 0L))); //$NON-NLS-1$
         assertThat(record.getDelta(), is(Money.of("EUR", 174263L))); //$NON-NLS-1$

--- a/name.abuchen.portfolio.tests/src/issues/Issue672CapitalGainsIfSecurityIsTransferredTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue672CapitalGainsIfSecurityIsTransferredTest.java
@@ -59,9 +59,9 @@ public class Issue672CapitalGainsIfSecurityIsTransferredTest
         // cash-flow series with an absurdly large IRR.
         assertThat(record.getSharesHeld(), is(1000000000L));
         assertThat(record.getQuote(), is(Quote.of("EUR", 9714100000L))); //$NON-NLS-1$
-        assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
-                        is(Money.of("EUR", 88310L))); //$NON-NLS-1$
-        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO), is(Quote.of("EUR", 8831000000L))); //$NON-NLS-1$
+        assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of("EUR", 88310L))); //$NON-NLS-1$
+        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
+                        is(Quote.of("EUR", 8831000000L))); //$NON-NLS-1$
         assertThat(record.getFees(), is(Money.of("EUR", 0L))); //$NON-NLS-1$
         assertThat(record.getTaxes(), is(Money.of("EUR", 0L))); //$NON-NLS-1$
         assertThat(record.getDelta(), is(Money.of("EUR", 8831L))); //$NON-NLS-1$

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshotTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshotTest.java
@@ -51,10 +51,12 @@ public class SecurityPerformanceSnapshotTest
         assertThat(record.getSharesHeld(), is(0L));
 
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0)));
-        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO), is(Quote.of(CurrencyUnit.EUR, 0)));
+        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
+                        is(Quote.of(CurrencyUnit.EUR, 0)));
 
         assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0)));
-        assertThat(record.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE), is(Quote.of(CurrencyUnit.EUR, 0)));
+        assertThat(record.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
+                        is(Quote.of(CurrencyUnit.EUR, 0)));
     }
 
     @Test
@@ -82,12 +84,12 @@ public class SecurityPerformanceSnapshotTest
 
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(450000 - 0.9))));
-        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO),
+        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
                         is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(0.9))));
 
         assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(450000 - 0.9))));
-        assertThat(record.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE),
+        assertThat(record.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
                         is(Quote.of(CurrencyUnit.EUR, Values.Quote.factorize(0.9))));
 
         SecurityPosition position = ClientSnapshot.create(client, new TestCurrencyConverter(), reportingPeriod.getEnd())

--- a/name.abuchen.portfolio.tests/src/scenarios/CurrencyTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/CurrencyTestCase.java
@@ -155,7 +155,8 @@ public class CurrencyTestCase
         // taxes divided by the number of shares
         Money pricePerShare = recordUSD.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED) //
                         .subtract(Money.of(CurrencyUnit.USD, 20_00)).divide(10);
-        assertThat(recordUSD.getCostPerSharesHeld(CostMethod.FIFO).toMoney(), is(pricePerShare));
+        assertThat(recordUSD.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED).toMoney(),
+                        is(pricePerShare));
 
         // profit loss w/o rounding differences
 
@@ -242,7 +243,8 @@ public class CurrencyTestCase
         assertThat(record.getMarketValue(), is(Money.of("EUR", 149534L)));
         assertThat(record.getQuote(), is(Quote.of("USD", 11552000000L)));
         assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of("EUR", 142410L)));
-        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO), is(Quote.of("EUR", 9384200000L)));
+        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
+                        is(Quote.of("EUR", 9384200000L)));
         assertThat(record.getFees(), is(Money.of("EUR", 824L)));
         assertThat(record.getTaxes(), is(Money.of("EUR", 824L)));
         assertThat(record.getDelta(), is(Money.of("EUR", 7124L)));

--- a/name.abuchen.portfolio.tests/src/scenarios/SecurityPerformanceTaxRefundTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/SecurityPerformanceTaxRefundTestCase.java
@@ -118,7 +118,8 @@ public class SecurityPerformanceTaxRefundTestCase
         assertThat(record.getQuote(), is(Quote.of("EUR", 7430000000L)));
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of("EUR", 765800L)));
         assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of("EUR", 765800L)));
-        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO), is(Quote.of("EUR", 7638000000L)));
+        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
+                        is(Quote.of("EUR", 7638000000L)));
         assertThat(record.getDelta(), is(Money.of("EUR", -22300L)));
         assertThat(record.getDeltaPercent(), closeTo(-0.029119874640898408, 0.0001));
         assertThat(record.getCapitalGainsOnHoldings(CostMethod.FIFO), is(Money.of("EUR", -22800L)));
@@ -201,7 +202,7 @@ public class SecurityPerformanceTaxRefundTestCase
         assertThat(record.getQuote(), is(Quote.of("EUR", 7430000000L)));
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of("EUR", 0L)));
         assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of("EUR", 0L)));
-        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO), is(Quote.of("EUR", 0L)));
+        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED), is(Quote.of("EUR", 0L)));
         assertThat(record.getDelta(), is(Money.of("EUR", -24300L)));
         assertThat(record.getDeltaPercent(), closeTo(-0.03173152259075477, 0.0001));
         assertThat(record.getCapitalGainsOnHoldings(CostMethod.FIFO), is(Money.of("EUR", 0L)));

--- a/name.abuchen.portfolio.tests/src/scenarios/SecurityTaxAndFeeAccountTransactionsTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/SecurityTaxAndFeeAccountTransactionsTestCase.java
@@ -143,7 +143,8 @@ public class SecurityTaxAndFeeAccountTransactionsTestCase
         assertThat(record.getQuote(), is(Quote.of("EUR", 14565000000L)));
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of("EUR", 153300L)));
         assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of("EUR", 153300L)));
-        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO), is(Quote.of("EUR", 15130000000L)));
+        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
+                        is(Quote.of("EUR", 15130000000L)));
         assertThat(record.getCapitalGainsOnHoldings(CostMethod.FIFO), is(Money.of("EUR", -7650L)));
         assertThat(record.getCapitalGainsOnHoldings(CostMethod.MOVING_AVERAGE), is(Money.of("EUR", -7650L)));
         assertThat(record.getCapitalGainsOnHoldingsPercent(CostMethod.FIFO), closeTo(-0.049902152641878694, 0.0001));

--- a/name.abuchen.portfolio.tests/src/scenarios/SecurityTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/SecurityTestCase.java
@@ -64,7 +64,8 @@ public class SecurityTestCase
         assertThat(record.getQuote(), is(Quote.of("EUR", 7288000000L)));
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of("EUR", 774800L)));
         assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of("EUR", 774800L)));
-        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO), is(Quote.of("EUR", 7748000000L)));
+        assertThat(record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
+                        is(Quote.of("EUR", 7748000000L)));
         assertThat(record.getFees(), is(Money.of("EUR", 0L)));
         assertThat(record.getTaxes(), is(Money.of("EUR", 0L)));
         assertThat(record.getDelta(), is(Money.of("EUR", -46000L)));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -57,6 +57,7 @@ import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.SecurityEvent;
 import name.abuchen.portfolio.model.SecurityPrice;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.model.TransactionPair;
@@ -1929,18 +1930,7 @@ public class SecuritiesChart
         if (r.isEmpty())
             return Optional.empty();
 
-        Quote purchasePricePerShare;
-        switch (costMethod)
-        {
-            case FIFO:
-                purchasePricePerShare = r.get().getCostPerSharesHeld(CostMethod.FIFO);
-                break;
-            case MOVING_AVERAGE:
-                purchasePricePerShare = r.get().getCostPerSharesHeld(CostMethod.MOVING_AVERAGE);
-                break;
-            default:
-                throw new IllegalArgumentException("unsupported cost method: " + costMethod); //$NON-NLS-1$
-        }
+        Quote purchasePricePerShare = r.get().getCostPerSharesHeld(costMethod, TaxesAndFees.NOT_INCLUDED);
 
         return purchasePricePerShare.isZero() ? Optional.empty()
                         : Optional.of(purchasePricePerShare.getAmount() / Values.Quote.divider());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -1204,10 +1204,11 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setDescription(Messages.ColumnPurchasePrice_Description + TextUtil.PARAGRAPH_BREAK
                         + Messages.DescriptionDataRelativeToReportingPeriod);
         column.setImage(Images.INTERVAL);
-        column.setLabelProvider(new RowElementLabelProvider(r -> Values.CalculatedQuote
-                        .format(r.getCostPerSharesHeld(CostMethod.FIFO), getClient().getBaseCurrency())));
-        column.setSorter(ColumnViewerSorter
-                        .create(e -> ((LazySecurityPerformanceRecord) e).getCostPerSharesHeld(CostMethod.FIFO)));
+        column.setLabelProvider(new RowElementLabelProvider(r -> Values.CalculatedQuote.format(
+                        r.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
+                        getClient().getBaseCurrency())));
+        column.setSorter(ColumnViewerSorter.create(e -> ((LazySecurityPerformanceRecord) e)
+                        .getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED)));
         recordColumns.addColumn(column);
 
         // cost value per share - moving average
@@ -1217,10 +1218,11 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setDescription(Messages.ColumnPurchasePriceMovingAverage_Description + TextUtil.PARAGRAPH_BREAK
                         + Messages.DescriptionDataRelativeToReportingPeriod);
         column.setImage(Images.INTERVAL);
-        column.setLabelProvider(new RowElementLabelProvider(r -> Values.CalculatedQuote
-                        .format(r.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE), getClient().getBaseCurrency())));
-        column.setSorter(ColumnViewerSorter.create(
-                        e -> ((LazySecurityPerformanceRecord) e).getCostPerSharesHeld(CostMethod.MOVING_AVERAGE)));
+        column.setLabelProvider(new RowElementLabelProvider(r -> Values.CalculatedQuote.format(
+                        r.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
+                        getClient().getBaseCurrency())));
+        column.setSorter(ColumnViewerSorter.create(e -> ((LazySecurityPerformanceRecord) e)
+                        .getCostPerSharesHeld(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED)));
         column.setVisible(false);
         recordColumns.addColumn(column);
 
@@ -1232,10 +1234,11 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setDescription(Messages.ColumnGrossPurchasePriceFIFO_Description + TextUtil.PARAGRAPH_BREAK
                         + Messages.DescriptionDataRelativeToReportingPeriod);
         column.setImage(Images.INTERVAL);
-        column.setLabelProvider(new RowElementLabelProvider(r -> Values.CalculatedQuote
-                        .format(r.getGrossCostPerSharesHeld(CostMethod.FIFO), getClient().getBaseCurrency())));
-        column.setSorter(ColumnViewerSorter
-                        .create(e -> ((LazySecurityPerformanceRecord) e).getGrossCostPerSharesHeld(CostMethod.FIFO)));
+        column.setLabelProvider(new RowElementLabelProvider(r -> Values.CalculatedQuote.format(
+                        r.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                        getClient().getBaseCurrency())));
+        column.setSorter(ColumnViewerSorter.create(e -> ((LazySecurityPerformanceRecord) e)
+                        .getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.INCLUDED)));
         recordColumns.addColumn(column);
 
         // cost value per share including fees and taxes - moving average
@@ -1246,9 +1249,10 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                         + Messages.DescriptionDataRelativeToReportingPeriod);
         column.setImage(Images.INTERVAL);
         column.setLabelProvider(new RowElementLabelProvider(r -> Values.CalculatedQuote.format(
-                        r.getGrossCostPerSharesHeld(CostMethod.MOVING_AVERAGE), getClient().getBaseCurrency())));
-        column.setSorter(ColumnViewerSorter.create(
-                        e -> ((LazySecurityPerformanceRecord) e).getGrossCostPerSharesHeld(CostMethod.MOVING_AVERAGE)));
+                        r.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+                        getClient().getBaseCurrency())));
+        column.setSorter(ColumnViewerSorter.create(e -> ((LazySecurityPerformanceRecord) e)
+                        .getCostPerSharesHeld(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED)));
         column.setVisible(false);
         recordColumns.addColumn(column);
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -644,8 +644,9 @@ public class StatementOfAssetsViewer
         column.setGroupLabel(Messages.LabelPurchasePrice);
         column.setMenuLabel(Messages.ColumnPurchasePrice_MenuLabel);
         column.setDescription(Messages.ColumnPurchasePrice_Description);
-        labelProvider = new ReportingPeriodLabelProvider(
-                        new ElementValueProvider(record -> record.getCostPerSharesHeld(CostMethod.FIFO), null), false);
+        labelProvider = new ReportingPeriodLabelProvider(new ElementValueProvider(
+                        record -> record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED), null),
+                        false);
         column.setLabelProvider(labelProvider);
         column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
         column.setVisible(false);
@@ -657,7 +658,8 @@ public class StatementOfAssetsViewer
         column.setMenuLabel(Messages.ColumnPurchasePriceMovingAverage_MenuLabel);
         column.setDescription(Messages.ColumnPurchasePriceMovingAverage_Description);
         labelProvider = new ReportingPeriodLabelProvider(new ElementValueProvider(
-                        record -> record.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE), null), false);
+                        record -> record.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
+                        null), false);
         column.setLabelProvider(labelProvider);
         column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
         column.setVisible(false);
@@ -669,9 +671,8 @@ public class StatementOfAssetsViewer
         column.setGroupLabel(Messages.LabelPurchasePrice);
         column.setMenuLabel(Messages.ColumnPurchasePrice_MenuLabel);
         column.setDescription(Messages.ColumnGrossPurchasePriceFIFO_Description);
-        labelProvider = new ReportingPeriodLabelProvider(
-                        new ElementValueProvider(record -> record.getGrossCostPerSharesHeld(CostMethod.FIFO), null),
-                        false);
+        labelProvider = new ReportingPeriodLabelProvider(new ElementValueProvider(
+                        record -> record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.INCLUDED), null), false);
         column.setLabelProvider(labelProvider);
         column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
         column.setVisible(false);
@@ -683,7 +684,8 @@ public class StatementOfAssetsViewer
         column.setMenuLabel(Messages.ColumnPurchasePriceMovingAverage_MenuLabel);
         column.setDescription(Messages.ColumnGrossPurchasePriceMovingAverage_Description);
         labelProvider = new ReportingPeriodLabelProvider(new ElementValueProvider(
-                        record -> record.getGrossCostPerSharesHeld(CostMethod.MOVING_AVERAGE), null), false);
+                        record -> record.getCostPerSharesHeld(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), null),
+                        false);
         column.setLabelProvider(labelProvider);
         column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
         column.setVisible(false);
@@ -1023,8 +1025,8 @@ public class StatementOfAssetsViewer
                         Messages.ColumnPurchasePrice + Messages.BaseCurrencyCue, SWT.RIGHT, 80);
         column.setDescription(Messages.ColumnPurchasePriceBaseCurrency);
         column.setGroupLabel(Messages.ColumnForeignCurrencies);
-        labelProvider = new ReportingPeriodLabelProvider(
-                        new ElementValueProvider(record -> record.getCostPerSharesHeld(CostMethod.FIFO), null),
+        labelProvider = new ReportingPeriodLabelProvider(new ElementValueProvider(
+                        record -> record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED), null),
                         e -> e.isSecurity() ? e.getSecurity().getCurrencyCode()
                                         : model.getCurrencyConverter().getTermCurrency(),
                         false);
@@ -1562,7 +1564,8 @@ public class StatementOfAssetsViewer
             // every value is retrieved from a LazySecurityPerformanceRecord
             // (the logic for that is inside the ElementValueProvider class)
 
-            // the LazySecurityPerformanceRecord are determined based on this logic:
+            // the LazySecurityPerformanceRecord are determined based on this
+            // logic:
             // - if given as an option to column (i.e. the user chooses an
             // interval explicitly), then this interval is used
             // - if no option is present, then the "global interval" is used,

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/DivvyDiaryUploader.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/DivvyDiaryUploader.java
@@ -21,6 +21,7 @@ import name.abuchen.portfolio.PortfolioLog;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.model.TransactionPair;
 import name.abuchen.portfolio.money.CurrencyConverter;
@@ -96,7 +97,7 @@ public class DivvyDiaryUploader
             // Add the "buyin" (the FIFO cost). Used if no transactions are
             // transmitted. Add for backward compatibility in case transactions
             // are transmitted.
-            Quote fifo = performanceRecord.getCostPerSharesHeld(CostMethod.FIFO);
+            Quote fifo = performanceRecord.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED);
             if (fifo.isNotZero())
             {
                 JSONObject buyin = new JSONObject();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
@@ -277,21 +277,12 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
         return costCalculation.get().sharesHeld();
     }
 
-    public Quote getCostPerSharesHeld(CostMethod costMethod)
+    public Quote getCostPerSharesHeld(CostMethod costMethod, TaxesAndFees taxesAndFees)
     {
-        var costs = costCalculation.get();
-        Money cost = getCostMoney(costMethod, TaxesAndFees.NOT_INCLUDED);
+        var sharesHeld = getSharesHeld();
+        Money cost = getCostMoney(costMethod, taxesAndFees);
 
-        return Quote.of(cost.getCurrencyCode(), Math.round(cost.getAmount() / (double) costs.sharesHeld()
-                        * Values.Share.factor() * Values.Quote.factorToMoney()));
-    }
-
-    public Quote getGrossCostPerSharesHeld(CostMethod costMethod)
-    {
-        var costs = costCalculation.get();
-        var cost = getCostMoney(costMethod, TaxesAndFees.INCLUDED);
-
-        return Quote.of(cost.getCurrencyCode(), Math.round(cost.getAmount() / (double) costs.sharesHeld()
+        return Quote.of(cost.getCurrencyCode(), Math.round(cost.getAmount() / (double) sharesHeld
                         * Values.Share.factor() * Values.Quote.factorToMoney()));
     }
 


### PR DESCRIPTION
From #5677, getFifoCostPerSharesHeld and getMovingAverageCostPerSharesHeld were replaced by a single function with CostMethod parameter input. And getCost by a single fonction with both CostMethod and TaxesAndFees as parameter.

This PR proposes to uses TaxesAndFees too as a parameter for getCostPerSharesHeld. , so to regroup the previous getCostPerSharesHeld and getGrossCostPerSharesHeld.