### PR TITLE
ING-DiBa Delivery Transfers

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
@@ -4166,6 +4166,68 @@ public class INGDiBaPDFExtractorTest
     }
 
     @Test
+    public void testUebertragAusgang01()
+    {
+        var extractor = new INGDiBaPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "UebertragAusgang01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("US3453708600"), hasWkn("502391"), hasTicker(null), //
+                        hasName("Ford Motor Co. Registered Shares DL -,01"), //
+                        hasCurrencyCode("USD"))));
+
+        assertThat(results, hasItem(outboundDelivery( //
+                        hasDate("2026-03-18T00:00"), hasShares(1.00), //
+                        hasSource("UebertragAusgang01.txt"), hasNote("Auftragsnummer 0027023852"), //
+                        hasAmount("USD", 0.00), hasGrossValue("USD", 0.00), //
+                        hasTaxes("USD", 0.00), hasFees("USD", 0.00))));
+    }
+
+    @Test
+    public void testWertpapierEingang01()
+    {
+        var extractor = new INGDiBaPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "WertpapierEingang01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("CA11271J1075"), hasWkn("A3D3EV"), hasTicker(null), //
+                        hasName("Brookfield Corp. Registered Shares Cl.A o.N."), //
+                        hasCurrencyCode("CAD"))));
+
+        assertThat(results, hasItem(inboundDelivery( //
+                        hasDate("2025-10-10T00:00"), hasShares(0.50), //
+                        hasSource("WertpapierEingang01.txt"), hasNote("Auftragsnummer 0025830418"), //
+                        hasAmount("CAD", 0.00), hasGrossValue("CAD", 0.00), //
+                        hasTaxes("CAD", 0.00), hasFees("CAD", 0.00))));
+    }
+
+    @Test
     public void testGiroKontoauszug01()
     {
         var extractor = new INGDiBaPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
@@ -4187,13 +4187,13 @@ public class INGDiBaPDFExtractorTest
         assertThat(results, hasItem(security( //
                         hasIsin("US3453708600"), hasWkn("502391"), hasTicker(null), //
                         hasName("Ford Motor Co. Registered Shares DL -,01"), //
-                        hasCurrencyCode("USD"))));
+                        hasCurrencyCode("EUR"))));
 
         assertThat(results, hasItem(outboundDelivery( //
                         hasDate("2026-03-18T00:00"), hasShares(1.00), //
                         hasSource("UebertragAusgang01.txt"), hasNote("Auftragsnummer 0027023852"), //
-                        hasAmount("USD", 0.00), hasGrossValue("USD", 0.00), //
-                        hasTaxes("USD", 0.00), hasFees("USD", 0.00))));
+                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -4210,7 +4210,7 @@ public class INGDiBaPDFExtractorTest
         assertThat(countBuySell(results), is(0L));
         assertThat(countAccountTransactions(results), is(1L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(1L));
         assertThat(countSkippedItems(results), is(0L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, "EUR");
@@ -4218,13 +4218,16 @@ public class INGDiBaPDFExtractorTest
         assertThat(results, hasItem(security( //
                         hasIsin("CA11271J1075"), hasWkn("A3D3EV"), hasTicker(null), //
                         hasName("Brookfield Corp. Registered Shares Cl.A o.N."), //
-                        hasCurrencyCode("CAD"))));
+                        hasCurrencyCode("EUR"))));
 
-        assertThat(results, hasItem(inboundDelivery( //
-                        hasDate("2025-10-10T00:00"), hasShares(0.50), //
-                        hasSource("WertpapierEingang01.txt"), hasNote("Auftragsnummer 0025830418"), //
-                        hasAmount("CAD", 0.00), hasGrossValue("CAD", 0.00), //
-                        hasTaxes("CAD", 0.00), hasFees("CAD", 0.00))));
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionSplitUnsupported, //
+                        inboundDelivery( //
+                                        hasDate("2025-10-10T00:00"), hasShares(0.50), //
+                                        hasSource("WertpapierEingang01.txt"), //
+                                        hasNote("Auftragsnummer 0025830418"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/UebertragAusgang01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/UebertragAusgang01.txt
@@ -1,0 +1,13 @@
+ING-DiBa AG
+Depotinhaber: Max Mustermann
+Direkt-Depot Nr.: 1234567890
+Datum: 19.03.2026
+Übertrag Ausgang
+Sehr geehrte Kundin, sehr geehrter Kunde,
+nachstehende Wertpapiere haben wir Ihrem Depot entnommen:
+Nominale / Stück Wertpapier-Informationen Schlusstag Auftragsnummer
+1,00 Stück Ford Motor Co. 18.03.2026 0027023852
+Registered Shares DL -,01
+ISIN (WKN): US3453708600 (502391)
+Girosammelverwahrung
+Taxbox-ID: 2026031800000384

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/WertpapierEingang01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/WertpapierEingang01.txt
@@ -1,0 +1,13 @@
+ING-DiBa AG
+Depotinhaber: Max Mustermann
+Direkt-Depot Nr.: 1234567890
+Datum: 15.10.2025
+Wertpapier Eingang
+Sehr geehrte Kundin, sehr geehrter Kunde,
+nachstehende Wertpapiere haben wir Ihrem Depot gutgeschrieben:
+Nominale / Stück Wertpapier-Informationen Schlusstag Auftragsnummer
+0,50 Stück Brookfield Corp. 10.10.2025 0025830418
+Registered Shares Cl.A o.N.
+ISIN (WKN): CA11271J1075 (A3D3EV)
+Wertpapierrechnung Kanada
+Die Gesellschaft hat einen Aktiensplit durchgeführt.

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
@@ -975,7 +975,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<nameContinued>.*)$") //
                         .match("^ISIN \\(WKN\\): (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\((?<wkn>[A-Z0-9]{6})\\)$") //
                         .assign((t, v) -> {
-                            v.put("currency", guessCurrencyCode(v.get("isin")));
+                            v.put("currency", getClient().getBaseCurrency());
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setShares(asShares(v.get("shares")));
@@ -985,21 +985,14 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                             t.setNote("Auftragsnummer " + v.get("note"));
                         })
 
+                        // @formatter:off
+                        // Die Gesellschaft hat einen Aktiensplit durchgeführt.
+                        // @formatter:on
+                        .section("stockSplit").optional() //
+                        .match("^(?<stockSplit>Die Gesellschaft hat einen Aktiensplit durchgef.hrt\\.)$") //
+                        .assign((t, v) -> v.markAsFailure(Messages.MsgErrorTransactionSplitUnsupported))
+
                         .wrap(TransactionItem::new);
-    }
-
-    private String guessCurrencyCode(String isin)
-    {
-        if (isin == null || isin.length() < 2)
-            return "EUR";
-
-        return switch (isin.substring(0, 2))
-        {
-            case "CA" -> "CAD";
-            case "GB" -> "GBP";
-            case "US" -> "USD";
-            default -> "EUR";
-        };
     }
 
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
@@ -52,6 +52,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
         addDividendeTransaction();
         addAdvanceTaxTransaction();
         addAccountStatementTransaction();
+        addDeliveryInOutTransaction();
         addNonImportableTransaction();
     }
 
@@ -937,6 +938,69 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> v.markAsFailure(Messages.MsgErrorTransactionSplitUnsupported))
 
                         .wrap(TransactionItem::new);
+    }
+
+    private void addDeliveryInOutTransaction()
+    {
+        addDeliveryTransaction("Übertrag Ausgang", PortfolioTransaction.Type.DELIVERY_OUTBOUND);
+        addDeliveryTransaction("Wertpapier Eingang", PortfolioTransaction.Type.DELIVERY_INBOUND);
+    }
+
+    private void addDeliveryTransaction(String label, PortfolioTransaction.Type transactionType)
+    {
+        final var type = new DocumentType(label);
+        this.addDocumentTyp(type);
+
+        var pdfTransaction = new Transaction<PortfolioTransaction>();
+
+        var firstRelevantLine = new Block("^[\\.,\\d]+ St.ck .* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+$");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
+
+        pdfTransaction //
+
+                        .subject(() -> {
+                            var portfolioTransaction = new PortfolioTransaction();
+                            portfolioTransaction.setType(transactionType);
+                            return portfolioTransaction;
+                        })
+
+                        // @formatter:off
+                        // 1,00 Stück Ford Motor Co. 18.03.2026 0027023852
+                        // Registered Shares DL -,01
+                        // ISIN (WKN): US3453708600 (502391)
+                        // @formatter:on
+                        .section("shares", "date", "note", "name", "nameContinued", "isin", "wkn") //
+                        .match("^(?<shares>[\\.,\\d]+) St.ck (?<name>.*) (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<note>[\\d]+)$") //
+                        .match("^(?<nameContinued>.*)$") //
+                        .match("^ISIN \\(WKN\\): (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\((?<wkn>[A-Z0-9]{6})\\)$") //
+                        .assign((t, v) -> {
+                            v.put("name", trim(v.get("name")) + " " + trim(v.get("nameContinued")));
+                            v.put("currency", guessCurrencyCode(v.get("isin")));
+
+                            t.setDateTime(asDate(v.get("date")));
+                            t.setShares(asShares(v.get("shares")));
+                            t.setSecurity(getOrCreateSecurity(v));
+                            t.setCurrencyCode(t.getSecurity().getCurrencyCode());
+                            t.setAmount(0L);
+                            t.setNote("Auftragsnummer " + v.get("note"));
+                        })
+
+                        .wrap(TransactionItem::new);
+    }
+
+    private String guessCurrencyCode(String isin)
+    {
+        if (isin == null || isin.length() < 2)
+            return "EUR";
+
+        return switch (isin.substring(0, 2))
+        {
+            case "CA" -> "CAD";
+            case "GB" -> "GBP";
+            case "US" -> "USD";
+            default -> "EUR";
+        };
     }
 
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
@@ -975,7 +975,6 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<nameContinued>.*)$") //
                         .match("^ISIN \\(WKN\\): (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\((?<wkn>[A-Z0-9]{6})\\)$") //
                         .assign((t, v) -> {
-                            v.put("name", trim(v.get("name")) + " " + trim(v.get("nameContinued")));
                             v.put("currency", guessCurrencyCode(v.get("isin")));
 
                             t.setDateTime(asDate(v.get("date")));


### PR DESCRIPTION
This extends the ING-DiBa PDF extractor with support for delivery transfer documents: `Übertrag Ausgang` and `Wertpapier Eingang`. 

It also adds sanitized regression fixtures based on real documents and fixes a name handling issue so the second security-name line is not duplicated for delivery transfers. 

The importer was validated through the headless import workflow from `codex/headless-pdf-import-tool`, which made it possible to repeatedly import, inspect, fix, and re-run batches against a large historical document archive. Transfers were especially     
important because the portfolio history includes multiple depot transfers. In the broader validation workflow, this was part of reconstructing a historical Portfolio Performance depot from roughly 2,000 real bank/broker documents.

For transparency: the real-life validation import also involved manual post-processing of the generated XML, outside these patches. In particular, I added ticker symbols resolved from ISINs, inferred cash deposits/transfers to avoid negative cash balances 
on buys, and a few transfer/account corrections because the reference cash account was also used as a normal bank account.                                                                                                                                        

Full disclosure: the implementation, fixture preparation, and validation workflow were prepared with help from Codex. Tests added/updated in this PR are in `INGDiBaPDFExtractorTest`. The combined branch passed `mvn -f portfolio-app/pom.xml clean verify`.