### PR TITLE
Fix #5623: colorize the profitLossBaseCurrency column

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -1041,7 +1041,7 @@ public class StatementOfAssetsViewer
                         new ElementValueProvider(record -> record.getCapitalGainsOnHoldings(CostMethod.FIFO), null),
                         e -> e.isSecurity() ? e.getSecurity().getCurrencyCode()
                                         : model.getCurrencyConverter().getTermCurrency(),
-                        false);
+                        true);
         column.setLabelProvider(labelProvider);
         column.setSorter(ColumnViewerSorter.create(new ElementComparator(labelProvider)));
         column.setVisible(false);


### PR DESCRIPTION
Fixes #5623.

`profitLossBaseCurrency` is the only profit/loss column in `StatementOfAssetsViewer` constructed with `showColorAndArrows=false`. The regular `profitloss` column passes `true`, which is why it shows red/green and an arrow. Same flag on the base-currency variant, same result.

Screenshots from the Kommer sample, rightmost column is "Profit / Loss\*\*":

Before:
<img width="700" src="https://raw.githubusercontent.com/armahnii2000/pp-issue-5623-screenshots/master/BEFORE.png" />

After:
<img width="700" src="https://raw.githubusercontent.com/armahnii2000/pp-issue-5623-screenshots/master/AFTER.png" />
