### PR TITLE
 Improve PDF-Importer use convenience constructors, normalize wrap blocks and ExtractorMatchers

### DIFF
--- a/.claude/rules/pdfextractors.md
+++ b/.claude/rules/pdfextractors.md
@@ -20,6 +20,84 @@ PDF importers extract transactions from bank and broker PDF statements.
   - Consistency in coding style between all extractors is more important than nice code.
   - Add comment-blocks with `@formatter:off` and `@formatter:on` before each section-block showing the format that is handled there.
 
+## Conventions
+
+**DocumentType declaration** — always `final`:
+```java
+final var type = new DocumentType("...");
+```
+
+**subject() lambda** — always use the single-argument convenience constructor or method reference, never the verbose 3-line form:
+```java
+// correct
+.subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
+.subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
+.subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
+.subject(AccountTransferEntry::new)   // no Type parameter — use method reference
+
+// wrong
+.subject(() -> {
+    var t = new AccountTransaction();
+    t.setType(AccountTransaction.Type.DIVIDENDS);
+    return t;
+})
+```
+
+**setCurrencyCode** — always use `asCurrencyCode()`, never `CurrencyUnit` constants:
+```java
+t.setCurrencyCode(asCurrencyCode("EUR"));   // correct
+t.setCurrencyCode(CurrencyUnit.EUR);         // wrong
+```
+
+**Fixed-currency extractors** — when an extractor always deals with one currency (e.g. a USD-only broker), declare a private String constant and use it with `asCurrencyCode()`. Keep `asCurrencyCode()` — it has normalization side-effects even for known codes:
+```java
+private static final String USD = "USD";
+
+v.put("currency", asCurrencyCode(USD));          // correct
+v.put("currency", CurrencyUnit.USD);              // wrong — CurrencyUnit object, not String
+v.put("currency", asCurrencyCode("USD"));         // works but prefer named constant
+```
+
+**DocumentContext currency** — when storing currency into the document context, always normalize with `asCurrencyCode()`. When the value is later read back via `.documentContext("currency")`, it is already normalized — do NOT wrap it with `asCurrencyCode()` again:
+```java
+// storing — always normalize
+.assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency"))))  // correct
+.assign((ctx, v) -> ctx.put("currency", v.get("currency")))                   // wrong
+
+// reading via documentContext — already normalized, no wrapping needed
+.section("tax").optional()
+.documentContext("currency")
+.assign((t, v) -> {
+    var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));             // correct
+    var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(...));      // wrong — redundant
+})
+
+// reading via local .section — currency is raw, asCurrencyCode() is required
+.section("tax", "currency").optional()
+.assign((t, v) -> {
+    var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));  // correct
+})
+```
+
+**wrap() block** — use the canonical `if/return SkippedItem` form; no ternary, no intermediate `item` variable, no unused `ctx` parameter. Always guard the amount check with a currency code null-check:
+```java
+// AccountTransaction
+.wrap(t -> {
+    if (t.getCurrencyCode() != null && t.getAmount() == 0)
+        return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+    return new TransactionItem(t);
+})
+
+// BuySellEntry
+.wrap(t -> {
+    if (t.getPortfolioTransaction().getCurrencyCode() != null && t.getPortfolioTransaction().getAmount() == 0)
+        return new SkippedItem(new BuySellEntryItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+    return new BuySellEntryItem(t);
+})
+```
+
 
 # Testing
 Test methods should be in following structure
@@ -61,8 +139,37 @@ public void testWertpapierKauf01()
 }
 ```
 
+`withFailureMessage(...)` assertions follow this structure — the `//` after the opening parenthesis is required:
+
+```java
+// check failure message
+assertThat(results, hasItem(withFailureMessage( //
+                Messages.MsgErrorTransactionOrderCancellationUnsupported, //
+                dividend( //
+                                hasDate("2022-06-13"), hasExDate(null), //
+                                hasShares(10.672), //
+                                hasSource("DividendeStorno01.txt"), //
+                                hasNote("Vorgangs-Nr.: XXXXX"), //
+                                hasAmount("EUR", 7.04), hasGrossValue("EUR", 7.04), //
+                                hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
+```
+`skippedItem(...)` assertions follow the same structure — the `//` after the opening parenthesis is required:
+
+```java
+// check skipped item
+assertThat(results, hasItem(skippedItem( //
+                Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                purchase( //
+                                hasDate("2012-07-02T00:00"), hasShares(0.00), //
+                                hasSource("Quartalsbericht06.txt"), //
+                                hasNote(null), //
+                                hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
+```
+
 - Each method has a starting `assertThat`-Block checking the counts. All 8 assertions need to be present.
 - Use `//` to enforce line-breaks when checking securities and transactions
 - Include time (hours, minutes, seconds) in `hasDate` when the source document provides it.
 - The `ExtractorMatchers`-class contains test assertion helpers
 - The fees and taxes could consist of multiple values, do not merge or consolidate them for better understanding
+- Every `dividend(...)` assertion must include `hasExDate(...)`. The correct value comes from the JUnit test failure message: look for `dividend with exDate = <value>` in the mismatch output. Use that exact value. If the extractor does not extract an ex-date, the actual value will be `null`.

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorMatchers.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorMatchers.java
@@ -95,7 +95,7 @@ public class ExtractorMatchers
         @Override
         protected boolean matchesSafely(Extractor.Item item, Description mismatchDescription)
         {
-            V tx = transaction.apply(item);
+            var tx = transaction.apply(item);
             if (tx == null)
             {
                 mismatchDescription.appendText("\n* not a '").appendText(label).appendText("' item"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -206,7 +206,7 @@ public class ExtractorMatchers
                 return false;
             }
 
-            boolean result = matcher.matches(item);
+            var result = matcher.matches(item);
             if (!result)
             {
                 matcher.describeMismatch(item, mismatchDescription);
@@ -369,7 +369,7 @@ public class ExtractorMatchers
     @SafeVarargs
     public static Matcher<Extractor.Item> inboundCash(Matcher<Transaction>... properties)
     {
-        return new ExtractorItemMatcher<Transaction>("cash transfer", //$NON-NLS-1$
+        return new ExtractorItemMatcher<>("cash transfer", //$NON-NLS-1$
                         item -> item instanceof AccountTransferItem transfer //
                                         && transfer.getSubject() instanceof AccountTransferEntry entry
                                                         ? entry.getTargetTransaction()
@@ -380,7 +380,7 @@ public class ExtractorMatchers
     @SafeVarargs
     public static Matcher<Extractor.Item> outboundCash(Matcher<Transaction>... properties)
     {
-        return new ExtractorItemMatcher<Transaction>("cash transfer", //$NON-NLS-1$
+        return new ExtractorItemMatcher<>("cash transfer", //$NON-NLS-1$
                         item -> item instanceof AccountTransferItem transfer //
                                         && transfer.getSubject() instanceof AccountTransferEntry entry
                                                         ? entry.getSourceTransaction()
@@ -391,7 +391,7 @@ public class ExtractorMatchers
     @SafeVarargs
     public static Matcher<Extractor.Item> purchase(Matcher<Transaction>... properties)
     {
-        return new ExtractorItemMatcher<Transaction>("purchase", //$NON-NLS-1$
+        return new ExtractorItemMatcher<>("purchase", //$NON-NLS-1$
                         item -> item instanceof BuySellEntryItem buysell //
                                         && buysell.getSubject() instanceof BuySellEntry entry
                                         && entry.getPortfolioTransaction().getType() == PortfolioTransaction.Type.BUY
@@ -403,7 +403,7 @@ public class ExtractorMatchers
     @SafeVarargs
     public static Matcher<Extractor.Item> sale(Matcher<Transaction>... properties)
     {
-        return new ExtractorItemMatcher<Transaction>("sale", //$NON-NLS-1$
+        return new ExtractorItemMatcher<>("sale", //$NON-NLS-1$
                         item -> item instanceof BuySellEntryItem buysell //
                                         && buysell.getSubject() instanceof BuySellEntry entry
                                         && entry.getPortfolioTransaction().getType() == PortfolioTransaction.Type.SELL
@@ -415,7 +415,7 @@ public class ExtractorMatchers
     @SafeVarargs
     public static Matcher<Extractor.Item> inboundDelivery(Matcher<Transaction>... properties)
     {
-        return new ExtractorItemMatcher<Transaction>("inbound delivery", //$NON-NLS-1$
+        return new ExtractorItemMatcher<>("inbound delivery", //$NON-NLS-1$
                         item -> item instanceof TransactionItem tItem //
                                         && tItem.getSubject() instanceof PortfolioTransaction tx
                                         && tx.getType() == PortfolioTransaction.Type.DELIVERY_INBOUND ? tx : null, //
@@ -425,7 +425,7 @@ public class ExtractorMatchers
     @SafeVarargs
     public static Matcher<Extractor.Item> outboundDelivery(Matcher<Transaction>... properties)
     {
-        return new ExtractorItemMatcher<Transaction>("outbound delivery", //$NON-NLS-1$
+        return new ExtractorItemMatcher<>("outbound delivery", //$NON-NLS-1$
                         item -> item instanceof TransactionItem tItem //
                                         && tItem.getSubject() instanceof PortfolioTransaction tx
                                         && tx.getType() == PortfolioTransaction.Type.DELIVERY_OUTBOUND ? tx : null, //
@@ -435,7 +435,7 @@ public class ExtractorMatchers
     @SafeVarargs
     public static Matcher<Extractor.Item> securityTransfer(Matcher<Transaction>... properties)
     {
-        return new ExtractorItemMatcher<Transaction>("securityTransfer", //$NON-NLS-1$
+        return new ExtractorItemMatcher<>("securityTransfer", //$NON-NLS-1$
                         item -> item instanceof PortfolioTransferItem transfer //
                                         && transfer.getSubject() instanceof PortfolioTransferEntry entry
                                                         ? entry.getSourceTransaction()
@@ -451,7 +451,7 @@ public class ExtractorMatchers
 
     public static Matcher<Transaction> hasDate(String dateString)
     {
-        LocalDateTime expectecd = dateString.contains("T") //$NON-NLS-1$
+        var expectecd = dateString.contains("T") //$NON-NLS-1$
                         ? LocalDateTime.parse(dateString)
                         : LocalDate.parse(dateString).atStartOfDay();
 
@@ -462,9 +462,10 @@ public class ExtractorMatchers
 
     public static Matcher<Transaction> hasExDate(String dateString)
     {
-        var expected = dateString.contains("T") //$NON-NLS-1$
-                        ? LocalDateTime.parse(dateString)
-                        : LocalDate.parse(dateString).atStartOfDay();
+        var expected = dateString == null ? null
+                        : dateString.contains("T") //$NON-NLS-1$
+                                        ? LocalDateTime.parse(dateString)
+                                        : LocalDate.parse(dateString).atStartOfDay();
 
         return new PropertyMatcher<>("exDate", //$NON-NLS-1$
                         expected, //
@@ -474,7 +475,7 @@ public class ExtractorMatchers
     public static Matcher<Transaction> hasShares(double value)
     {
         // work with BigDecimal to have better assertion failed messages
-        return new PropertyMatcher<Transaction, BigDecimal>("shares", //$NON-NLS-1$
+        return new PropertyMatcher<>("shares", //$NON-NLS-1$
                         BigDecimal.valueOf(value).setScale(Values.Share.precision(), Values.MC.getRoundingMode()), //
                         tx -> BigDecimal.valueOf(tx.getShares()).divide(Values.Share.getBigDecimalFactor(), Values.MC)
                                         .setScale(Values.Share.precision(), Values.MC.getRoundingMode()));
@@ -511,7 +512,7 @@ public class ExtractorMatchers
         return new PropertyMatcher<>("forexGrossValue", //$NON-NLS-1$
                         Money.of(currencyCode, Values.Amount.factorize(value)), //
                         tx -> {
-                            Unit grossValueUnit = tx.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(AssertionError::new);
+                            var grossValueUnit = tx.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(AssertionError::new);
                             return grossValueUnit.getForex();
                         });
     }
@@ -547,7 +548,7 @@ public class ExtractorMatchers
     @SafeVarargs
     public static Matcher<Extractor.Item> security(Matcher<Security>... properties)
     {
-        return new ExtractorItemMatcher<Security>("security", //$NON-NLS-1$
+        return new ExtractorItemMatcher<>("security", //$NON-NLS-1$
                         item -> item instanceof SecurityItem securityItem ? securityItem.getSecurity() : null,
                         properties);
     }
@@ -590,7 +591,7 @@ public class ExtractorMatchers
 
     public static Matcher<Security> hasFeedProperty(String name, String value)
     {
-        return new PropertyMatcher<Security, String>("feedProperty " + name, value, //$NON-NLS-1$
+        return new PropertyMatcher<>("feedProperty " + name, value, //$NON-NLS-1$
                         s -> s.getPropertyValue(SecurityProperty.Type.FEED, name).orElse(null));
     }
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorMatchersTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorMatchersTest.java
@@ -49,7 +49,7 @@ public class ExtractorMatchersTest
     @BeforeClass
     public static void setup()
     {
-        Security s = new Security();
+        var s = new Security();
         s.setName("test name");
         s.setIsin("DE01");
         s.setWkn("WKN");
@@ -58,7 +58,7 @@ public class ExtractorMatchersTest
 
         someSecurity = new SecurityItem(s);
 
-        AccountTransaction tx = new AccountTransaction();
+        var tx = new AccountTransaction();
         tx.setType(AccountTransaction.Type.DIVIDENDS);
         tx.setCurrencyCode(CurrencyUnit.EUR);
         tx.setAmount(Values.Amount.factorize(100));
@@ -87,7 +87,7 @@ public class ExtractorMatchersTest
     @Test(expected = AssertionError.class)
     public void testList()
     {
-        List<Extractor.Item> items = new ArrayList<Extractor.Item>();
+        List<Extractor.Item> items = new ArrayList<>();
 
         items.add(new Extractor.TransactionItem(new AccountTransaction()));
 
@@ -97,11 +97,11 @@ public class ExtractorMatchersTest
     @Test(expected = AssertionError.class)
     public void testDividend()
     {
-        List<Extractor.Item> items = new ArrayList<Extractor.Item>();
+        List<Extractor.Item> items = new ArrayList<>();
 
         items.add(someTransactionItem);
 
-        AccountTransaction tx = new AccountTransaction();
+        var tx = new AccountTransaction();
         tx.setType(AccountTransaction.Type.DIVIDENDS);
         tx.setCurrencyCode(CurrencyUnit.EUR);
         tx.setAmount(1000);
@@ -276,6 +276,24 @@ public class ExtractorMatchersTest
     public void testExDateSuccess()
     {
         assertThat(List.of(someTransactionItem), hasItem(dividend(hasExDate("2023-04-28"))));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testExDateNullFailure()
+    {
+        assertThat(List.of(someTransactionItem), hasItem(dividend(hasExDate(null))));
+    }
+
+    @Test
+    public void testExDateNullSuccess()
+    {
+        var tx = new AccountTransaction();
+        tx.setType(AccountTransaction.Type.DIVIDENDS);
+        tx.setCurrencyCode(CurrencyUnit.EUR);
+        tx.setAmount(Values.Amount.factorize(100));
+        tx.setDateTime(LocalDateTime.parse("2023-04-30T12:45"));
+
+        assertThat(List.of(new TransactionItem(tx)), hasItem(dividend(hasExDate(null))));
     }
 
     @Test(expected = AssertionError.class)

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractorTest.java
@@ -1,0 +1,82 @@
+package name.abuchen.portfolio.datatransfer.pdf;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.model.Client;
+
+@SuppressWarnings("nls")
+public class AbstractPDFExtractorTest
+{
+    private static class TestExtractor extends AbstractPDFExtractor
+    {
+        TestExtractor(Client client)
+        {
+            super(client);
+        }
+
+        @Override
+        public String getLabel()
+        {
+            return "Test";
+        }
+
+        public String currencyCode(String currency)
+        {
+            return asCurrencyCode(currency);
+        }
+    }
+
+    @Test
+    public void testAsCurrencyCode()
+    {
+        var extractor = new TestExtractor(new Client());
+
+        assertThat(extractor.currencyCode("EUR"), is("EUR"));
+        assertThat(extractor.currencyCode("USD"), is("USD"));
+        assertThat(extractor.currencyCode("GBP"), is("GBP"));
+        assertThat(extractor.currencyCode("CHF"), is("CHF"));
+    }
+
+    @Test
+    public void testAsCurrencyCodeTrimsNonBreakingSpace()
+    {
+        var extractor = new TestExtractor(new Client());
+
+        // U+00A0 non-breaking space: trimmed by TextUtil.trim() but not by String.trim()
+        var nbsp = String.valueOf((char) 0x00A0);
+        assertThat(extractor.currencyCode("USD" + nbsp), is("USD"));
+        assertThat(extractor.currencyCode(nbsp + "EUR"), is("EUR"));
+        assertThat(extractor.currencyCode(nbsp + "CHF" + nbsp), is("CHF"));
+    }
+
+    @Test
+    public void testAsCurrencyCodeTrimsRegularWhitespace()
+    {
+        var extractor = new TestExtractor(new Client());
+
+        assertThat(extractor.currencyCode(" EUR "), is("EUR"));
+        assertThat(extractor.currencyCode("\tUSD\t"), is("USD"));
+    }
+
+    @Test
+    public void testAsCurrencyCodeHandlesNull()
+    {
+        var client = new Client();
+        var extractor = new TestExtractor(client);
+
+        assertThat(extractor.currencyCode(null), is(client.getBaseCurrency()));
+    }
+
+    @Test
+    public void testAsCurrencyCodeFallsBackToBaseCurrency()
+    {
+        var client = new Client();
+        var extractor = new TestExtractor(client);
+
+        assertThat(extractor.currencyCode("UNKNOWN"), is(client.getBaseCurrency()));
+        assertThat(extractor.currencyCode("XYZ"), is(client.getBaseCurrency()));
+    }
+}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/ArkeaDirectBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/arkeadirectbank/ArkeaDirectBankPDFExtractorTest.java
@@ -5,6 +5,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasExDate;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasIsin;
@@ -639,7 +640,8 @@ public class ArkeaDirectBankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2023-12-04T00:00"), hasShares(450.00), //
+                        hasDate("2023-12-04T00:00"), hasExDate(null), //
+                        hasShares(450.00), //
                         hasSource("Dividende01.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 135.00), hasGrossValue("EUR", 135.00), //
@@ -673,7 +675,8 @@ public class ArkeaDirectBankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2023-04-28T00:00"), hasShares(100.00), //
+                        hasDate("2023-04-28T00:00"), hasExDate(null), //
+                        hasShares(100.00), //
                         hasSource("Dividende02.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 140.00), hasGrossValue("EUR", 140.00), //
@@ -707,7 +710,8 @@ public class ArkeaDirectBankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2024-12-10T00:00"), hasShares(211.00), //
+                        hasDate("2024-12-10T00:00"), hasExDate(null), //
+                        hasShares(211.00), //
                         hasSource("Dividende03.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 44.31), hasGrossValue("EUR", 44.31), //

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
@@ -23,6 +23,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.skippedItem;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
@@ -1706,11 +1707,11 @@ public class ConsorsbankPDFExtractorTest
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
-        assertThat(countBuySell(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
         assertThat(countAccountTransactions(results), is(0L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, "EUR");
 
@@ -1720,8 +1721,8 @@ public class ConsorsbankPDFExtractorTest
                         hasName("X(IE)-MSCI WORLD 1D"), //
                         hasCurrencyCode("EUR"))));
 
-        // check buy sell transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         purchase( //
                                         hasDate("2024-06-03T09:30:09"), hasShares(4.09855), //

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dekabank/DekaBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dekabank/DekaBankPDFExtractorTest.java
@@ -5,6 +5,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.fee;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasExDate;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasIsin;
@@ -16,9 +17,11 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.inboundDelivery;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.outboundDelivery;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.skippedItem;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
@@ -5606,87 +5609,25 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check delivery inbound (Einlieferung) transaction
-        var deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        inboundDelivery( //
+                                        hasDate("2021-05-28T00:00"), hasShares(1.315), //
+                                        hasSource("Quartalsbericht01.txt"), //
+                                        hasNote("Fusion"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(deliveryTransaction.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
-
-        assertThat(deliveryTransaction.getDateTime(), is(LocalDateTime.parse("2021-05-28T00:00")));
-        assertThat(deliveryTransaction.getShares(), is(Values.Share.factorize(1.315)));
-        assertThat(deliveryTransaction.getSource(), is("Quartalsbericht01.txt"));
-        assertThat(deliveryTransaction.getNote(), is("Fusion"));
-
-        assertThat(deliveryTransaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check delivery outbound (Auslieferung) transaction
-        deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(1)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(deliveryTransaction.getType(), is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-
-        assertThat(deliveryTransaction.getDateTime(), is(LocalDateTime.parse("2021-05-28T00:00")));
-        assertThat(deliveryTransaction.getShares(), is(Values.Share.factorize(2.140)));
-        assertThat(deliveryTransaction.getSource(), is("Quartalsbericht01.txt"));
-        assertThat(deliveryTransaction.getNote(), is("Fusion"));
-
-        assertThat(deliveryTransaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 1st cancellation transaction
-        var cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((PortfolioTransaction) cancellation.getSubject()).getType(),
-                        is(PortfolioTransaction.Type.DELIVERY_INBOUND));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2021-05-28T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(1.315)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("Quartalsbericht01.txt"));
-        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Fusion"));
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 2nd cancellation transaction
-        cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((PortfolioTransaction) cancellation.getSubject()).getType(),
-                        is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2021-05-28T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(2.140)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("Quartalsbericht01.txt"));
-        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Fusion"));
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        outboundDelivery( //
+                                        hasDate("2021-05-28T00:00"), hasShares(2.140), //
+                                        hasSource("Quartalsbericht01.txt"), //
+                                        hasNote("Fusion"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -5704,11 +5645,11 @@ public class DekaBankPDFExtractorTest
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(3L));
-        assertThat(countBuySell(results), is(10L));
+        assertThat(countBuySell(results), is(9L));
         assertThat(countAccountTransactions(results), is(2L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(2L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(1L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(15));
         new AssertImportActions().check(results, "EUR");
 
@@ -5779,56 +5720,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2022-05-20T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht02.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
+
         // check 1st security buy sell transaction
         entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2022-05-20T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht02.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 1st cancellation transaction
-        var cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2022-05-20T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht02.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 1st security buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -5849,7 +5752,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 2nd security buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(4).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -5870,7 +5773,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 2nd security buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(4).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -5891,7 +5794,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 2nd security buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -5912,7 +5815,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 3rd security buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(7).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -5933,7 +5836,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 3rd security buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(8).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(7).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -5954,7 +5857,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 3rd security buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(9).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(8).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -5974,23 +5877,22 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2022-05-20T00:00"), hasExDate("2022-05-20T00:00"), //
+                                        hasShares(15.396 + 0.255 + 0.268), //
+                                        hasSource("Quartalsbericht02.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
+
         // check 1st dividends transaction
-        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(1)
+                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2022-05-20T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(16.190 - 0.271 + 0.000 + 0.000)));
-        assertThat(transaction.getSource(), is("Quartalsbericht02.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 2nd dividends transaction
+        // check 1nd dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(1)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
@@ -6005,31 +5907,6 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(33.43))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        var cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2022-05-20T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(),
-                        is(Values.Share.factorize(15.396 + 0.255 + 0.268)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht02.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
     }
 
     @Test
@@ -7081,11 +6958,11 @@ public class DekaBankPDFExtractorTest
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(9L));
-        assertThat(countBuySell(results), is(10L));
+        assertThat(countBuySell(results), is(4L));
         assertThat(countAccountTransactions(results), is(11L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(12L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(6L));
+        assertThat(countSkippedItems(results), is(6L));
         assertThat(results.size(), is(30));
         new AssertImportActions().check(results, "EUR");
 
@@ -7162,68 +7039,38 @@ public class DekaBankPDFExtractorTest
         assertThat(security9.getName(), is("Deka-BR 100"));
         assertThat(security9.getCurrencyCode(), is("EUR"));
 
-        // check 1st buy sell transaction
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2012-07-02T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht06.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2012-12-28T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht06.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2012-10-01T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht06.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
+
+        // check 1th buy sell transaction
         var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2012-07-02T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht06.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 2nd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2012-12-28T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht06.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 3rd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht06.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 4th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -7243,48 +7090,28 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 5th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(4).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2012-10-01T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht06.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2012-10-01T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht06.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht06.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 6th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht06.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 7th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
+        // check 2th buy sell transaction
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -7304,28 +7131,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 7th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(7).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2012-12-28T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht06.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2012-12-28T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht06.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 9th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(8).findFirst()
+        // check 3th buy sell transaction
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -7345,8 +7162,8 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 10th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(9).findFirst()
+        // check 4th buy sell transaction
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -7382,54 +7199,22 @@ public class DekaBankPDFExtractorTest
         assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 1st dividends transaction
-        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(1)
+        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(7)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2012-07-02T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(12.778)));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2012-08-20T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(13.772)));
         assertThat(transaction.getSource(), is("Quartalsbericht06.txt"));
         assertNull(transaction.getNote());
 
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(15.29))));
+        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(15.29))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 2nd dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(2)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2012-12-28T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(50.169)));
-        assertThat(transaction.getSource(), is("Quartalsbericht06.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 3rd dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(3)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(5.454)));
-        assertThat(transaction.getSource(), is("Quartalsbericht06.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 4th dividends transaction
+        // check 2st dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(4)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
@@ -7445,69 +7230,71 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 5th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(5)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2012-07-02T00:00"), hasExDate("2012-07-02T00:00"), //
+                                        hasShares(12.778), //
+                                        hasSource("Quartalsbericht06.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2012-12-28T00:00"), hasExDate("2012-12-28T00:00"), //
+                                        hasShares(50.169), //
+                                        hasSource("Quartalsbericht06.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(10.694)));
-        assertThat(transaction.getSource(), is("Quartalsbericht06.txt"));
-        assertNull(transaction.getNote());
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2012-10-01T00:00"), hasExDate("2012-10-01T00:00"), //
+                                        hasShares(5.454), //
+                                        hasSource("Quartalsbericht06.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2012-10-01T00:00"), hasExDate("2012-10-01T00:00"), //
+                                        hasShares(10.694), //
+                                        hasSource("Quartalsbericht06.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        // check 6th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(6)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2012-10-01T00:00"), hasExDate("2012-10-01T00:00"), //
+                                        hasShares(6.332), //
+                                        hasSource("Quartalsbericht06.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(6.332)));
-        assertThat(transaction.getSource(), is("Quartalsbericht06.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 7th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(7)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2012-08-20T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(13.772)));
-        assertThat(transaction.getSource(), is("Quartalsbericht06.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(15.29))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(15.29))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 8th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(8)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2012-12-28T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(28.237)));
-        assertThat(transaction.getSource(), is("Quartalsbericht06.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2012-12-28T00:00"), hasExDate("2012-12-28T00:00"), //
+                                        hasShares(28.237), //
+                                        hasSource("Quartalsbericht06.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 9th dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(9)
@@ -7525,187 +7312,13 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 1st cancellation transaction
-        var cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2012-07-02T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht06.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 2nd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2012-12-28T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht06.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 3rd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht06.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 4th cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(3).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht06.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 5th cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(4).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht06.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 6th cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(5).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2012-12-28T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht06.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check transaction
-        var iter = results.stream().filter(TransactionItem.class::isInstance).skip(10).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(11L));
-
-        var item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2012-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(10.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht06.txt"));
-        assertThat(transaction.getNote(), is("Depotpreis 2012"));
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2012-12-31T00:00"), //
+                        hasSource("Quartalsbericht06.txt"), //
+                        hasNote("Depotpreis 2012"), //
+                        hasAmount("EUR", 10.00), hasGrossValue("EUR", 10.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -8224,11 +7837,11 @@ public class DekaBankPDFExtractorTest
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(10L));
-        assertThat(countBuySell(results), is(38L));
+        assertThat(countBuySell(results), is(34L));
         assertThat(countAccountTransactions(results), is(16L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(9L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(5L));
+        assertThat(countSkippedItems(results), is(4L));
         assertThat(results.size(), is(64));
         new AssertImportActions().check(results, "EUR");
 
@@ -8709,28 +8322,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 20th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(19).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2005-12-30T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht09.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2005-12-30T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht09.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 21th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(20).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(19).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -8751,7 +8354,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 22th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(21).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(20).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -8772,7 +8375,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 23th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(22).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(21).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -8793,7 +8396,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 24th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(23).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(22).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -8814,7 +8417,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 25th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(24).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(23).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -8835,7 +8438,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 26th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(25).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(24).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -8855,7 +8458,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 27th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(26).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(25).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -8876,7 +8479,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 28th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(27).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(26).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -8896,28 +8499,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 29th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(28).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2005-12-30T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht09.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2005-12-30T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht09.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 30th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(29).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(27).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -8937,7 +8530,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 31th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(30).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(28).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
@@ -8958,7 +8551,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 32th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(31).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(29).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -8979,7 +8572,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 33th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(32).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(30).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -8998,28 +8591,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 34th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(33).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2005-09-09T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0.00)));
-        assertThat(entry.getSource(), is("Quartalsbericht09.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2005-09-09T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht09.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 35th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(34).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(31).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -9038,28 +8621,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 36th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(35).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2005-09-14T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht09.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2005-09-14T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht09.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 37th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(36).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(32).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -9080,7 +8653,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 38th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(37).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(33).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
@@ -9098,118 +8671,6 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 1st cancellation transaction
-        var cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2005-12-30T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht09.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 2nd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2005-12-30T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht09.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 3rd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2005-09-09T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht09.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 4th cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(3).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2005-09-14T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht09.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 1st dividends transaction
@@ -9278,23 +8739,6 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 5th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(4)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2005-12-30T00:00")));
-        // assertThat(transaction.getShares(),
-        // is(Values.Share.factorize(0.913)));
-        assertThat(transaction.getSource(), is("Quartalsbericht09.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 6th dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(5)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
@@ -9310,7 +8754,7 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 7th dividends transaction
+        // check 6th dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(6)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
@@ -9323,22 +8767,6 @@ public class DekaBankPDFExtractorTest
 
         assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.08))));
         assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.08))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 8th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(7)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2005-12-30T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(45.986)));
-        assertThat(transaction.getSource(), is("Quartalsbericht09.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
@@ -9374,220 +8802,56 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 11th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(10)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2005-12-30T00:00"), hasExDate("2005-12-30T00:00"), //
+                                        hasShares(0.913), //
+                                        hasSource("Quartalsbericht09.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2005-12-30T00:00"), hasExDate("2005-12-30T00:00"), //
+                                        hasShares(31.348 + 0.002 + 5.854 + 8.782), //
+                                        hasSource("Quartalsbericht09.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2005-08-22T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(26.194)));
-        assertThat(transaction.getSource(), is("Quartalsbericht09.txt"));
-        assertNull(transaction.getNote());
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2005-09-09T00:00"), hasExDate("2005-09-09T00:00"), //
+                                        hasShares(26.194), //
+                                        hasSource("Quartalsbericht09.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(1.05))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(1.05))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2005-09-14T00:00"), hasExDate("2005-09-14T00:00"), //
+                                        hasShares(26.194 + 0.025), //
+                                        hasSource("Quartalsbericht09.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        // check 12th dividends transaction (Storno)
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(11)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2005-08-22T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(26.194)));
-        assertThat(transaction.getSource(), is("Quartalsbericht09.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(1.05))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(1.05))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 13th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(12)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2005-09-09T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(26.194)));
-        assertThat(transaction.getSource(), is("Quartalsbericht09.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 14th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(13)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2005-08-22T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(26.194)));
-        assertThat(transaction.getSource(), is("Quartalsbericht09.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(1.05))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(1.05))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 15th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(14)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2005-09-14T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(26.194 + 0.025)));
-        assertThat(transaction.getSource(), is("Quartalsbericht09.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        var cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2005-12-30T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(0.913)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht09.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2005-12-30T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(),
-                        is(Values.Share.factorize(31.348 + 0.002 + 5.854 + 8.782)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht09.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation (Storno) transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionOrderCancellationUnsupported));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2005-08-22T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(26.194)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht09.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(1.05))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(1.05))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(3).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2005-09-09T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(26.194)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht09.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(4).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2005-09-14T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(26.194 + 0.025)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht09.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check transaction
-        var iter = results.stream().filter(TransactionItem.class::isInstance).skip(15).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(16L));
-
-        var item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2005-12-16T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(10.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht09.txt"));
-        assertThat(transaction.getNote(), is("Depotpreis 2005"));
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2005-12-16T00:00"), hasShares(0), //
+                        hasSource("Quartalsbericht09.txt"), hasNote("Depotpreis 2005"), //
+                        hasAmount("EUR", 10.00), hasGrossValue("EUR", 10.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -9605,11 +8869,11 @@ public class DekaBankPDFExtractorTest
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(9L));
-        assertThat(countBuySell(results), is(30L));
+        assertThat(countBuySell(results), is(28L));
         assertThat(countAccountTransactions(results), is(11L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(4L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(2L));
+        assertThat(countSkippedItems(results), is(2L));
         assertThat(results.size(), is(50));
         new AssertImportActions().check(results, "EUR");
 
@@ -10165,28 +9429,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 24th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(23).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2006-12-29T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht10.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2006-12-29T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht10.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 25th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(24).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(23).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -10207,7 +9461,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 26th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(25).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(24).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -10227,28 +9481,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 27th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(26).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2006-12-29T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht10.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2006-12-29T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht10.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 28th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(27).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(25).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -10269,7 +9513,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 29th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(28).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(26).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -10290,7 +9534,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 30th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(29).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(27).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -10307,62 +9551,6 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 1st cancellation transaction
-        var cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2006-12-29T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht10.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 2nd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2006-12-29T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht10.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 1st dividends transaction
@@ -10430,21 +9618,16 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 5th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(4)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2006-12-29T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(0.913 + 0.005 + 15.323)));
-        assertThat(transaction.getSource(), is("Quartalsbericht10.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2006-12-29T00:00"), hasExDate("2006-12-29T00:00"), //
+                                        hasShares(0.913 + 0.005 + 15.323), //
+                                        hasSource("Quartalsbericht10.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 6th dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(5)
@@ -10462,21 +9645,16 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 7th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(6)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2006-12-29T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(45.986 + 8.699)));
-        assertThat(transaction.getSource(), is("Quartalsbericht10.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2006-12-29T00:00"), hasExDate("2006-12-29T00:00"), //
+                                        hasShares(45.986 + 8.699), //
+                                        hasSource("Quartalsbericht10.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 8th dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(7)
@@ -10510,78 +9688,19 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check cancellation transaction
-        var cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2006-12-15T00:00"), hasShares(0), //
+                        hasSource("Quartalsbericht10.txt"), hasNote("Depotpreis 2006"), //
+                        hasAmount("EUR", 10.00), hasGrossValue("EUR", 10.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2006-12-29T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(),
-                        is(Values.Share.factorize(0.913 + 0.005 + 15.323)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht10.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2006-12-29T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(45.986 + 8.699)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht10.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check transaction
-        var iter = results.stream().filter(TransactionItem.class::isInstance).skip(9).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(11L));
-
-        var item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2006-12-15T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(10.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht10.txt"));
-        assertThat(transaction.getNote(), is("Depotpreis 2006"));
-
-        item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2006-12-15T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(5.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht10.txt"));
-        assertThat(transaction.getNote(), is("Vertragsgebühr 2006"));
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2006-12-15T00:00"), hasShares(0), //
+                        hasSource("Quartalsbericht10.txt"), hasNote("Vertragsgebühr 2006"), //
+                        hasAmount("EUR", 5.00), hasGrossValue("EUR", 5.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -10599,11 +9718,11 @@ public class DekaBankPDFExtractorTest
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(10L));
-        assertThat(countBuySell(results), is(34L));
+        assertThat(countBuySell(results), is(32L));
         assertThat(countAccountTransactions(results), is(10L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(4L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(2L));
+        assertThat(countSkippedItems(results), is(2L));
         assertThat(results.size(), is(54));
         new AssertImportActions().check(results, "EUR");
 
@@ -11212,28 +10331,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 26th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(25).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2008-10-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht11.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2008-10-01T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht11.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 27th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(26).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(25).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -11254,7 +10363,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 28th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(27).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(26).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -11275,7 +10384,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 29th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(28).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(27).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -11295,7 +10404,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 30th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(29).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(28).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -11316,7 +10425,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 31th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(30).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(29).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
@@ -11337,7 +10446,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 32th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(31).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(30).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -11357,28 +10466,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 33th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(32).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2008-06-30T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht11.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2008-06-30T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht11.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 34th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(33).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(31).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
@@ -11396,62 +10495,6 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 1st cancellation transaction
-        var cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2008-10-01T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht11.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 2nd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2008-06-30T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht11.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 1st dividends transaction
@@ -11486,21 +10529,16 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 3rd dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(2)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2008-10-01T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(15.216)));
-        assertThat(transaction.getSource(), is("Quartalsbericht11.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2008-10-01T00:00"), hasExDate("2008-10-01T00:00"), //
+                                        hasShares(15.216), //
+                                        hasSource("Quartalsbericht11.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 4th dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(3)
@@ -11566,94 +10604,30 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 8th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(7)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2008-06-30T00:00"), hasExDate("2008-06-30T00:00"), //
+                                        hasShares(0.000 + 48.399 - 0.000), //
+                                        hasSource("Quartalsbericht11.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2008-12-12T00:00"), hasShares(0), //
+                        hasSource("Quartalsbericht11.txt"), hasNote("Depotpreis 2008"), //
+                        hasAmount("EUR", 10.00), hasGrossValue("EUR", 10.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2008-06-30T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(0.000 + 48.399 - 0.000)));
-        assertThat(transaction.getSource(), is("Quartalsbericht11.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        var cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2008-10-01T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(15.216)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht11.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2008-06-30T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(),
-                        is(Values.Share.factorize(0.000 + 48.399 - 0.000)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht11.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check transaction
-        var iter = results.stream().filter(TransactionItem.class::isInstance).skip(8).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(10L));
-
-        var item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2008-12-12T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(10.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht11.txt"));
-        assertThat(transaction.getNote(), is("Depotpreis 2008"));
-
-        item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2008-12-12T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(10.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht11.txt"));
-        assertThat(transaction.getNote(), is("Vertragsgebühr 2008"));
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2008-12-12T00:00"), hasShares(0), //
+                        hasSource("Quartalsbericht11.txt"), hasNote("Vertragsgebühr 2008"), //
+                        hasAmount("EUR", 10.00), hasGrossValue("EUR", 10.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -11671,11 +10645,11 @@ public class DekaBankPDFExtractorTest
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(9L));
-        assertThat(countBuySell(results), is(17L));
+        assertThat(countBuySell(results), is(14L));
         assertThat(countAccountTransactions(results), is(14L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(6L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(3L));
+        assertThat(countSkippedItems(results), is(3L));
         assertThat(results.size(), is(40));
         new AssertImportActions().check(results, "EUR");
 
@@ -11857,28 +10831,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 6th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2009-07-02T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht12.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2009-07-02T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht12.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 7th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -11898,7 +10862,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 8th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(7).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -11919,7 +10883,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 9th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(8).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(7).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -11940,7 +10904,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 10th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(9).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(8).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -11961,7 +10925,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 11th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(10).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(9).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -11981,28 +10945,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 12th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(11).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2009-10-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht12.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2009-10-01T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht12.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 13th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(12).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(10).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -12023,7 +10977,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 14th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(13).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(11).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -12043,7 +10997,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 15th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(14).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(12).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -12064,7 +11018,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 16th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(15).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(13).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -12083,109 +11037,15 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 17th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(16).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2009-12-30T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht12.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 1st cancellation transaction
-        var cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2009-07-02T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht12.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 2nd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2009-10-01T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht12.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 3rd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2009-12-30T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht12.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2009-12-30T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht12.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check delivery inbound (Einlieferung) transaction
         var deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
@@ -12219,21 +11079,16 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 2nd dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(2)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2009-07-02T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(15.795)));
-        assertThat(transaction.getSource(), is("Quartalsbericht12.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2009-07-02T00:00"), hasExDate("2009-07-02T00:00"), //
+                                        hasShares(15.795), //
+                                        hasSource("Quartalsbericht12.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 3rd dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(3)
@@ -12267,21 +11122,16 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 5th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(5)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2009-10-01T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(15.216)));
-        assertThat(transaction.getSource(), is("Quartalsbericht12.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2009-10-01T00:00"), hasExDate("2009-10-01T00:00"), //
+                                        hasShares(15.216), //
+                                        hasSource("Quartalsbericht12.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 6th dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(6)
@@ -12315,111 +11165,26 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check cancellation transaction
-        var cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2009-12-31T00:00"), hasShares(0), //
+                        hasSource("Quartalsbericht12.txt"), hasNote("Depotpreis 2009"), //
+                        hasAmount("EUR", 10.00), hasGrossValue("EUR", 10.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2009-12-31T00:00"), hasShares(0), //
+                        hasSource("Quartalsbericht12.txt"), hasNote("Abschluss-/ Vertriebskosten 2009"), //
+                        hasAmount("EUR", 21.06), hasGrossValue("EUR", 21.06), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2009-07-02T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(15.795)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht12.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2009-10-01T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(15.216)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht12.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2009-12-30T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(36.045)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht12.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check transaction
-        var iter = results.stream().filter(TransactionItem.class::isInstance).skip(11).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(14L));
-
-        var item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2009-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(10.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht12.txt"));
-        assertThat(transaction.getNote(), is("Depotpreis 2009"));
-
-        item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2009-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(21.06))));
-        assertThat(transaction.getSource(), is("Quartalsbericht12.txt"));
-        assertThat(transaction.getNote(), is("Abschluss-/ Vertriebskosten 2009"));
-
-        item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2009-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(10.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht12.txt"));
-        assertThat(transaction.getNote(), is("Vertragspreis 2009"));
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2009-12-31T00:00"), hasShares(0), //
+                        hasSource("Quartalsbericht12.txt"), hasNote("Vertragspreis 2009"), //
+                        hasAmount("EUR", 10.00), hasGrossValue("EUR", 10.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -12437,11 +11202,11 @@ public class DekaBankPDFExtractorTest
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(9L));
-        assertThat(countBuySell(results), is(15L));
-        assertThat(countAccountTransactions(results), is(17L));
+        assertThat(countBuySell(results), is(10L));
+        assertThat(countAccountTransactions(results), is(14L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(13L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(5L));
+        assertThat(countSkippedItems(results), is(8L));
         assertThat(results.size(), is(41));
         new AssertImportActions().check(results, "EUR");
 
@@ -12559,28 +11324,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 3rd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2010-07-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht13.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2010-07-01T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht13.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 4th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -12601,7 +11356,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 5th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(4).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -12622,7 +11377,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 6th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(4).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -12642,28 +11397,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 7th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2010-10-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht13.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2010-10-01T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht13.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 8th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(7).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -12683,28 +11428,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 9th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(8).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2010-10-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht13.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2010-10-01T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht13.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 10th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(9).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -12724,28 +11459,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 11th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(10).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2010-10-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht13.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2010-10-01T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht13.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 12th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(11).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(7).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -12765,28 +11490,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 13th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(12).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2010-12-30T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht13.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2010-12-30T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht13.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 14th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(13).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(8).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -12806,7 +11521,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 15th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(14).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(9).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -12824,146 +11539,6 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 1st cancellation transaction
-        var cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2010-07-01T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht13.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 2nd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2010-10-01T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht13.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 3rd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2010-10-01T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht13.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 4th cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(3).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2010-10-01T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht13.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 5th cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(4).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2010-12-30T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht13.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check delivery inbound (Einlieferung) transaction
@@ -12998,21 +11573,16 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 2nd dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(2)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-07-01T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(15.795)));
-        assertThat(transaction.getSource(), is("Quartalsbericht13.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2010-07-01T00:00"), hasExDate("2010-07-01T00:00"), //
+                                        hasShares(15.795), //
+                                        hasSource("Quartalsbericht13.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 3rd dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(3)
@@ -13030,37 +11600,27 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 4th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(4)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2010-10-01T00:00"), hasExDate("2010-10-01T00:00"), //
+                                        hasShares(15.216), //
+                                        hasSource("Quartalsbericht13.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-10-01T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(15.216)));
-        assertThat(transaction.getSource(), is("Quartalsbericht13.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 5th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(5)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-10-01T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(5.864)));
-        assertThat(transaction.getSource(), is("Quartalsbericht13.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2010-10-01T00:00"), hasExDate("2010-10-01T00:00"), //
+                                        hasShares(5.864), //
+                                        hasSource("Quartalsbericht13.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 6th dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(6)
@@ -13078,21 +11638,16 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 7th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(7)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-10-01T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(32.371)));
-        assertThat(transaction.getSource(), is("Quartalsbericht13.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2010-10-01T00:00"), hasExDate("2010-10-01T00:00"), //
+                                        hasShares(32.371), //
+                                        hasSource("Quartalsbericht13.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 8th dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(8)
@@ -13110,21 +11665,16 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 9th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(9)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-12-30T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(36.045)));
-        assertThat(transaction.getSource(), is("Quartalsbericht13.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2010-12-30T00:00"), hasExDate("2010-12-30T00:00"), //
+                                        hasShares(36.045), //
+                                        hasSource("Quartalsbericht13.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 10th dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(10)
@@ -13142,262 +11692,56 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check cancellation transaction
-        var cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        fee( //
+                                        hasDate("2010-12-31T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht13.txt"), //
+                                        hasNote("Vertragspreis (zu Lasten Vertrag) 2010"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        fee( //
+                                        hasDate("2010-12-31T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht13.txt"), //
+                                        hasNote("Weitere Preise (zu Lasten Girokonto) 2010"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2010-07-01T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(15.795)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht13.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        fee( //
+                                        hasDate("2010-12-31T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht13.txt"), //
+                                        hasNote("Weitere Preise (zu Lasten Vertrag) 2010"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2010-12-31T00:00"), hasShares(0), //
+                        hasSource("Quartalsbericht13.txt"), hasNote("Depotpreis 2010"), //
+                        hasAmount("EUR", 10.00), hasGrossValue("EUR", 10.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2010-12-31T00:00"), hasShares(0), //
+                        hasSource("Quartalsbericht13.txt"), hasNote("Abschluss-/ Vertriebskosten 2010"), //
+                        hasAmount("EUR", 10.77), hasGrossValue("EUR", 10.77), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2010-10-01T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(15.216)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht13.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2010-10-01T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(5.864)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht13.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(3).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2010-10-01T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(32.371)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht13.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(4).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2010-12-30T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(36.045)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht13.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(5).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.FEES));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2010-12-31T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(0)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht13.txt"));
-        assertThat(((Transaction) cancellation1.getSubject()).getNote(), is("Vertragspreis (zu Lasten Vertrag) 2010"));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(6).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.FEES));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2010-12-31T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(0)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht13.txt"));
-        assertThat(((Transaction) cancellation1.getSubject()).getNote(),
-                        is("Weitere Preise (zu Lasten Girokonto) 2010"));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(7).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.FEES));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2010-12-31T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(0)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht13.txt"));
-        assertThat(((Transaction) cancellation1.getSubject()).getNote(), is("Weitere Preise (zu Lasten Vertrag) 2010"));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check transaction
-        var iter = results.stream().filter(TransactionItem.class::isInstance).skip(11).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(17L));
-
-        var item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(10.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht13.txt"));
-        assertThat(transaction.getNote(), is("Depotpreis 2010"));
-
-        item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(10.77))));
-        assertThat(transaction.getSource(), is("Quartalsbericht13.txt"));
-        assertThat(transaction.getNote(), is("Abschluss-/ Vertriebskosten 2010"));
-
-        item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(10.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht13.txt"));
-        assertThat(transaction.getNote(), is("Vertragspreis (zu Lasten Girokonto) 2010"));
-
-        item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht13.txt"));
-        assertThat(transaction.getNote(), is("Vertragspreis (zu Lasten Vertrag) 2010"));
-
-        item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht13.txt"));
-        assertThat(transaction.getNote(), is("Weitere Preise (zu Lasten Girokonto) 2010"));
-
-        item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht13.txt"));
-        assertThat(transaction.getNote(), is("Weitere Preise (zu Lasten Vertrag) 2010"));
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2010-12-31T00:00"), hasShares(0), //
+                        hasSource("Quartalsbericht13.txt"), hasNote("Vertragspreis (zu Lasten Girokonto) 2010"), //
+                        hasAmount("EUR", 10.00), hasGrossValue("EUR", 10.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -13415,11 +11759,11 @@ public class DekaBankPDFExtractorTest
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(9L));
-        assertThat(countBuySell(results), is(11L));
+        assertThat(countBuySell(results), is(7L));
         assertThat(countAccountTransactions(results), is(12L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(8L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(4L));
+        assertThat(countSkippedItems(results), is(4L));
         assertThat(results.size(), is(32));
         new AssertImportActions().check(results, "EUR");
 
@@ -13517,28 +11861,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 2nd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2011-07-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht14.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2011-07-01T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht14.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 3rd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -13557,48 +11891,28 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 4th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2011-10-04T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht14.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2011-10-04T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht14.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 5th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(4).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2011-10-04T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht14.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2011-10-04T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht14.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 6th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -13619,7 +11933,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 7th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -13639,7 +11953,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 8th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(7).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(4).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -13659,28 +11973,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 9th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(8).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2011-12-30T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht14.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2011-12-30T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht14.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 10th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(9).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -13700,7 +12004,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 11th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(10).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -13718,118 +12022,6 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 1st cancellation transaction
-        var cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2011-07-01T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht14.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 2nd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2011-10-04T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht14.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 3rd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2011-10-04T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht14.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 4th cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(3).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2011-12-30T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht14.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check delivery inbound (Einlieferung) transaction
@@ -13864,21 +12056,16 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 2nd dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(2)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2011-07-01T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(15.795)));
-        assertThat(transaction.getSource(), is("Quartalsbericht14.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2011-07-01T00:00"), hasExDate("2011-07-01T00:00"), //
+                                        hasShares(15.795), //
+                                        hasSource("Quartalsbericht14.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 3rd dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(3)
@@ -13896,37 +12083,27 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 4th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(4)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2011-10-04T00:00"), hasExDate("2011-10-04T00:00"), //
+                                        hasShares(15.216), //
+                                        hasSource("Quartalsbericht14.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2011-10-04T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(15.216)));
-        assertThat(transaction.getSource(), is("Quartalsbericht14.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 5th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(5)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2011-10-04T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(5.864)));
-        assertThat(transaction.getSource(), is("Quartalsbericht14.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2011-10-04T00:00"), hasExDate("2011-10-04T00:00"), //
+                                        hasShares(5.864), //
+                                        hasSource("Quartalsbericht14.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 6th dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(6)
@@ -13976,21 +12153,16 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 9th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(9)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2011-12-30T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(36.045)));
-        assertThat(transaction.getSource(), is("Quartalsbericht14.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2011-12-30T00:00"), hasExDate("2011-12-30T00:00"), //
+                                        hasShares(36.045), //
+                                        hasSource("Quartalsbericht14.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 10th dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(10)
@@ -14008,115 +12180,12 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check cancellation transaction
-        var cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2011-07-01T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(15.795)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht14.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2011-10-04T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(15.216)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht14.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2011-10-04T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(5.864)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht14.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(3).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2011-12-30T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(36.045)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht14.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check transaction
-        var iter = results.stream().filter(TransactionItem.class::isInstance).skip(11).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(12L));
-
-        var item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2011-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(10.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht14.txt"));
-        assertThat(transaction.getNote(), is("Depotpreis 2011"));
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2011-12-31T00:00"), hasShares(0), //
+                        hasSource("Quartalsbericht14.txt"), hasNote("Depotpreis 2011"), //
+                        hasAmount("EUR", 10.00), hasGrossValue("EUR", 10.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -14134,11 +12203,11 @@ public class DekaBankPDFExtractorTest
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(9L));
-        assertThat(countBuySell(results), is(12L));
+        assertThat(countBuySell(results), is(7L));
         assertThat(countAccountTransactions(results), is(10L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(10L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(5L));
+        assertThat(countSkippedItems(results), is(5L));
         assertThat(results.size(), is(31));
         new AssertImportActions().check(results, "EUR");
 
@@ -14236,28 +12305,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 2nd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2012-07-02T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht15.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2012-07-02T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht15.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 3rd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -14277,48 +12336,28 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 4th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2012-10-01T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht15.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht15.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 5th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(4).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht15.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2012-10-01T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht15.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 6th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -14338,28 +12377,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 7th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht15.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2012-10-01T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht15.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 8th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(7).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
@@ -14379,28 +12408,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 9th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(8).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2012-12-28T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht15.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2012-12-28T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht15.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 10th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(9).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(4).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -14421,7 +12440,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 11th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(10).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -14442,7 +12461,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 12th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(11).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -14462,146 +12481,6 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 1st cancellation transaction
-        var cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2012-07-02T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht15.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 2nd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht15.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 3rd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht15.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 4th cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(3).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht15.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 5th cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(4).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2012-12-28T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht15.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
         // check delivery inbound (Einlieferung) transaction
         var deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
@@ -14618,24 +12497,19 @@ public class DekaBankPDFExtractorTest
         assertThat(deliveryTransaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 1st dividends transaction
-        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(1)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2012-07-02T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(15.795)));
-        assertThat(transaction.getSource(), is("Quartalsbericht15.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2012-07-02T00:00"), hasExDate("2012-07-02T00:00"), //
+                                        hasShares(15.795), //
+                                        hasSource("Quartalsbericht15.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 2nd dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(2)
+        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(2)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
@@ -14650,37 +12524,27 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 3rd dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(3)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2012-10-01T00:00"), hasExDate("2012-10-01T00:00"), //
+                                        hasShares(15.216), //
+                                        hasSource("Quartalsbericht15.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(15.216)));
-        assertThat(transaction.getSource(), is("Quartalsbericht15.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 4th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(4)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(5.864)));
-        assertThat(transaction.getSource(), is("Quartalsbericht15.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2012-10-01T00:00"), hasExDate("2012-10-01T00:00"), //
+                                        hasShares(5.864), //
+                                        hasSource("Quartalsbericht15.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 5th dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(5)
@@ -14698,37 +12562,27 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 6th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(6)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2012-10-01T00:00"), hasExDate("2012-10-01T00:00"), //
+                                        hasShares(32.445), //
+                                        hasSource("Quartalsbericht15.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(32.445)));
-        assertThat(transaction.getSource(), is("Quartalsbericht15.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 7th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(7)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2012-12-28T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(36.045)));
-        assertThat(transaction.getSource(), is("Quartalsbericht15.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check failure message
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2012-12-28T00:00"), hasExDate("2012-12-28T00:00"), //
+                                        hasShares(36.045), //
+                                        hasSource("Quartalsbericht15.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 8th dividends transaction
         transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(8)
@@ -14746,139 +12600,12 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check cancellation transaction
-        var cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2012-07-02T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(15.795)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht15.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(15.216)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht15.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(5.864)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht15.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(3).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2012-10-01T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(32.445)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht15.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(4).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2012-12-28T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(36.045)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht15.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check transaction
-        var iter = results.stream().filter(TransactionItem.class::isInstance).skip(9).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(10L));
-
-        var item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2012-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(10.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht15.txt"));
-        assertThat(transaction.getNote(), is("Depotpreis 2012"));
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2012-12-31T00:00"), hasShares(0), //
+                        hasSource("Quartalsbericht15.txt"), hasNote("Depotpreis 2012"), //
+                        hasAmount("EUR", 10.00), hasGrossValue("EUR", 10.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -14896,11 +12623,11 @@ public class DekaBankPDFExtractorTest
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(7L));
-        assertThat(countBuySell(results), is(17L));
-        assertThat(countAccountTransactions(results), is(18L));
+        assertThat(countBuySell(results), is(10L));
+        assertThat(countAccountTransactions(results), is(11L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(14L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(14L));
         assertThat(results.size(), is(42));
         new AssertImportActions().check(results, "EUR");
 
@@ -14961,28 +12688,18 @@ public class DekaBankPDFExtractorTest
         assertThat(security7.getName(), is("Deka-BR 100"));
         assertThat(security7.getCurrencyCode(), is("EUR"));
 
-        // check 1st buy sell transaction
-        var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht16.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2017-12-29T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht16.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 2nd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
+        var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -15002,28 +12719,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 3rd buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht16.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2017-12-29T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht16.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 4th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(1).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -15043,28 +12750,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 5th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(4).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht16.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2017-12-29T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht16.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 6th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(2).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -15084,28 +12781,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 7th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht16.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2017-12-29T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht16.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 8th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(7).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(3).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -15124,28 +12811,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 9th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(8).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht16.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2017-12-29T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht16.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 10th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(9).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(4).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -15165,28 +12842,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 11th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(10).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht16.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2017-12-29T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht16.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 12th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(11).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(5).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -15207,7 +12874,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 13th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(12).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(6).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -15227,7 +12894,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 14th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(13).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(7).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -15247,28 +12914,18 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 15th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(14).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(0)));
-        assertThat(entry.getSource(), is("Quartalsbericht16.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2017-12-29T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht16.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 16th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(15).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(8).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -15289,7 +12946,7 @@ public class DekaBankPDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 17th buy sell transaction
-        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(16).findFirst()
+        entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).skip(9).findFirst()
                         .orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
@@ -15309,202 +12966,6 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 1st cancellation transaction
-        var cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht16.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 2nd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht16.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 3rd cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht16.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 4th cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(3).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht16.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 5th cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(4).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht16.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 6th cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(5).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht16.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 7th cancellation transaction
-        cancellation = (BuySellEntryItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(BuySellEntryItem.class::isInstance) //
-                        .skip(6).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getType(),
-                        is(PortfolioTransaction.Type.BUY));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getAccountTransaction().getType(),
-                        is(AccountTransaction.Type.BUY));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getDateTime(),
-                        is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getShares(),
-                        is(Values.Share.factorize(0)));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getSource(), is("Quartalsbericht16.txt"));
-        assertNull(((BuySellEntry) cancellation.getSubject()).getNote());
-
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((BuySellEntry) cancellation.getSubject()).getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
         // check delivery inbound (Einlieferung) transaction
         var deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
@@ -15521,24 +12982,19 @@ public class DekaBankPDFExtractorTest
         assertThat(deliveryTransaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 1st dividends transaction
-        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(1)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(16.642 - 0.091)));
-        assertThat(transaction.getSource(), is("Quartalsbericht16.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2018-01-26T00:00"), hasExDate("2017-12-29T00:00"), //
+                                        hasShares(0.00), //
+                                        hasSource("Quartalsbericht16.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 2nd dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(2)
+        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(1)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
@@ -15553,24 +13009,19 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 3rd dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(3)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(39.231 - 0.239)));
-        assertThat(transaction.getSource(), is("Quartalsbericht16.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2018-01-26T00:00"), hasExDate("2017-12-29T00:00"), //
+                                        hasShares(0.00), //
+                                        hasSource("Quartalsbericht16.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 4th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(4)
+        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(2)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
@@ -15585,24 +13036,19 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 5th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(5)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(15.615 - 0.101)));
-        assertThat(transaction.getSource(), is("Quartalsbericht16.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2018-01-26T00:00"), hasExDate("2017-12-29T00:00"), //
+                                        hasShares(0.00), //
+                                        hasSource("Quartalsbericht16.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 6th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(6)
+        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(3)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
@@ -15617,24 +13063,19 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 7th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(7)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(6.018 - 0.039)));
-        assertThat(transaction.getSource(), is("Quartalsbericht16.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2018-01-26T00:00"), hasExDate("2017-12-29T00:00"), //
+                                        hasShares(0.00), //
+                                        hasSource("Quartalsbericht16.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 8th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(8)
+        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(4)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
@@ -15649,24 +13090,19 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 9th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(9)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(6.833 - 0.052)));
-        assertThat(transaction.getSource(), is("Quartalsbericht16.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2018-01-26T00:00"), hasExDate("2017-12-29T00:00"), //
+                                        hasShares(0.00), //
+                                        hasSource("Quartalsbericht16.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 10th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(10)
+        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(5)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
@@ -15681,24 +13117,19 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 11th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(11)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(34.621 - 0.236)));
-        assertThat(transaction.getSource(), is("Quartalsbericht16.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2018-01-26T00:00"), hasExDate("2017-12-29T00:00"), //
+                                        hasShares(0.00), //
+                                        hasSource("Quartalsbericht16.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 12th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(12)
+        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(6)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
@@ -15714,13 +13145,13 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 13th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(13)
+        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(7)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
 
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(37.758 - 0.220 - 0.009)));
+        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-01-12T00:00")));
+        assertThat(transaction.getShares(), is(Values.Share.factorize(0.00)));
         assertThat(transaction.getSource(), is("Quartalsbericht16.txt"));
         assertNull(transaction.getNote());
 
@@ -15730,7 +13161,7 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
         // check 14th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(14)
+        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(8)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
@@ -15745,204 +13176,12 @@ public class DekaBankPDFExtractorTest
         assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 15th dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(15)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(295.513 - 25.428 - 2.024 - 0.582)));
-        assertThat(transaction.getSource(), is("Quartalsbericht16.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        var cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(16.642 - 0.091)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht16.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(39.231 - 0.239)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht16.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(15.615 - 0.101)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht16.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(3).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(6.0180 - 0.039)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht16.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(4).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(6.833 - 0.052)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht16.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(5).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(), is(Values.Share.factorize(34.621 - 0.236)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht16.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation1 = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(6).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation1.getSubject()).getType(), is(AccountTransaction.Type.DIVIDENDS));
-        assertThat(cancellation1.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation1.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2017-12-29T00:00")));
-        assertThat(((Transaction) cancellation1.getSubject()).getShares(),
-                        is(Values.Share.factorize(295.513 - 25.428 - 2.024 - 0.582)));
-        assertThat(((Transaction) cancellation1.getSubject()).getSource(), is("Quartalsbericht16.txt"));
-        assertNull(((Transaction) cancellation1.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation1.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation1.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check transaction
-        var iter = results.stream().filter(TransactionItem.class::isInstance).skip(17).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(18L));
-
-        var item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2018-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(12.50))));
-        assertThat(transaction.getSource(), is("Quartalsbericht16.txt"));
-        assertThat(transaction.getNote(), is("Depotpreis 2018"));
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2018-12-31T00:00"), hasShares(0), //
+                        hasSource("Quartalsbericht16.txt"), hasNote("Depotpreis 2018"), //
+                        hasAmount("EUR", 12.50), hasGrossValue("EUR", 12.50), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -16392,10 +13631,10 @@ public class DekaBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(7L));
         assertThat(countBuySell(results), is(12L));
-        assertThat(countAccountTransactions(results), is(15L));
+        assertThat(countAccountTransactions(results), is(14L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(8L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(7L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(34));
         new AssertImportActions().check(results, "EUR");
 
@@ -16707,121 +13946,9 @@ public class DekaBankPDFExtractorTest
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 1st delivery outbound (Auslieferung) transaction
+        // check 1st delivery inbound (Einlieferung) transaction
         var deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(deliveryTransaction.getType(), is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-
-        assertThat(deliveryTransaction.getDateTime(), is(LocalDateTime.parse("2020-03-18T00:00")));
-        assertThat(deliveryTransaction.getShares(), is(Values.Share.factorize(16)));
-        assertThat(deliveryTransaction.getSource(), is("Quartalsbericht18.txt"));
-        assertNull(deliveryTransaction.getNote());
-
-        assertThat(deliveryTransaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 2nd delivery outbound (Auslieferung) transaction
-        deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(1)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(deliveryTransaction.getType(), is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-
-        assertThat(deliveryTransaction.getDateTime(), is(LocalDateTime.parse("2020-03-18T00:00")));
-        assertThat(deliveryTransaction.getShares(), is(Values.Share.factorize(40)));
-        assertThat(deliveryTransaction.getSource(), is("Quartalsbericht18.txt"));
-        assertNull(deliveryTransaction.getNote());
-
-        assertThat(deliveryTransaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 3rd delivery outbound (Auslieferung) transaction
-        deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(2)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(deliveryTransaction.getType(), is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-
-        assertThat(deliveryTransaction.getDateTime(), is(LocalDateTime.parse("2020-03-18T00:00")));
-        assertThat(deliveryTransaction.getShares(), is(Values.Share.factorize(15)));
-        assertThat(deliveryTransaction.getSource(), is("Quartalsbericht18.txt"));
-        assertNull(deliveryTransaction.getNote());
-
-        assertThat(deliveryTransaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 4th delivery outbound (Auslieferung) transaction
-        deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(3)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(deliveryTransaction.getType(), is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-
-        assertThat(deliveryTransaction.getDateTime(), is(LocalDateTime.parse("2020-03-18T00:00")));
-        assertThat(deliveryTransaction.getShares(), is(Values.Share.factorize(6)));
-        assertThat(deliveryTransaction.getSource(), is("Quartalsbericht18.txt"));
-        assertNull(deliveryTransaction.getNote());
-
-        assertThat(deliveryTransaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 5th delivery outbound (Auslieferung) transaction
-        deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(4)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(deliveryTransaction.getType(), is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-
-        assertThat(deliveryTransaction.getDateTime(), is(LocalDateTime.parse("2020-03-18T00:00")));
-        assertThat(deliveryTransaction.getShares(), is(Values.Share.factorize(6)));
-        assertThat(deliveryTransaction.getSource(), is("Quartalsbericht18.txt"));
-        assertNull(deliveryTransaction.getNote());
-
-        assertThat(deliveryTransaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 6th delivery outbound (Auslieferung) transaction
-        deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(5)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(deliveryTransaction.getType(), is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-
-        assertThat(deliveryTransaction.getDateTime(), is(LocalDateTime.parse("2020-03-18T00:00")));
-        assertThat(deliveryTransaction.getShares(), is(Values.Share.factorize(34)));
-        assertThat(deliveryTransaction.getSource(), is("Quartalsbericht18.txt"));
-        assertNull(deliveryTransaction.getNote());
-
-        assertThat(deliveryTransaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 7th delivery outbound (Auslieferung) transaction
-        deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(6)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(deliveryTransaction.getType(), is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-
-        assertThat(deliveryTransaction.getDateTime(), is(LocalDateTime.parse("2020-03-18T00:00")));
-        assertThat(deliveryTransaction.getShares(), is(Values.Share.factorize(37)));
-        assertThat(deliveryTransaction.getSource(), is("Quartalsbericht18.txt"));
-        assertNull(deliveryTransaction.getNote());
-
-        assertThat(deliveryTransaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 8th delivery inbound (Einlieferung) transaction
-        deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(7)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+                        .skip(7).findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
         assertThat(deliveryTransaction.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
@@ -16835,7 +13962,7 @@ public class DekaBankPDFExtractorTest
         assertThat(deliveryTransaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 9th delivery outbound (Auslieferung) transaction
+        // check 1st delivery outbound (Auslieferung) transaction
         deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(8)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
@@ -16851,7 +13978,7 @@ public class DekaBankPDFExtractorTest
         assertThat(deliveryTransaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 10th delivery outbound (Auslieferung) transaction
+        // check 2nd delivery outbound (Auslieferung) transaction
         deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(9)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
@@ -16867,7 +13994,7 @@ public class DekaBankPDFExtractorTest
         assertThat(deliveryTransaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 11th delivery outbound (Auslieferung) transaction
+        // check 3rd delivery outbound (Auslieferung) transaction
         deliveryTransaction = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(10)
                         .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
 
@@ -16883,260 +14010,22 @@ public class DekaBankPDFExtractorTest
         assertThat(deliveryTransaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(deliveryTransaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
 
-        // check 1st dividends transaction
-        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(11)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        fee( //
+                                        hasDate("2020-12-31T00:00"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht18.txt"), //
+                                        hasNote("Depotpreis 2020"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-02-21T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(0.000 + 0.388 + 40.000 - 0.761)));
-        assertThat(transaction.getSource(), is("Quartalsbericht18.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(56.27))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(56.27))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 2nd dividends transaction
-        transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(12)
-                        .findFirst().orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-02-21T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(0.000 + 0.901 + 37.000 - 0.018)));
-        assertThat(transaction.getSource(), is("Quartalsbericht18.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(2.65))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(2.65))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        var cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((PortfolioTransaction) cancellation.getSubject()).getType(),
-                        is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2020-03-18T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(16)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("Quartalsbericht18.txt"));
-        assertNull(((Transaction) cancellation.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((PortfolioTransaction) cancellation.getSubject()).getType(),
-                        is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2020-03-18T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(40)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("Quartalsbericht18.txt"));
-        assertNull(((Transaction) cancellation.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((PortfolioTransaction) cancellation.getSubject()).getType(),
-                        is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2020-03-18T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(15)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("Quartalsbericht18.txt"));
-        assertNull(((Transaction) cancellation.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(3).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((PortfolioTransaction) cancellation.getSubject()).getType(),
-                        is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2020-03-18T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(6)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("Quartalsbericht18.txt"));
-        assertNull(((Transaction) cancellation.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(4).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((PortfolioTransaction) cancellation.getSubject()).getType(),
-                        is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2020-03-18T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(6)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("Quartalsbericht18.txt"));
-        assertNull(((Transaction) cancellation.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(5).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((PortfolioTransaction) cancellation.getSubject()).getType(),
-                        is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2020-03-18T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(34)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("Quartalsbericht18.txt"));
-        assertNull(((Transaction) cancellation.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(6).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((PortfolioTransaction) cancellation.getSubject()).getType(),
-                        is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2020-03-18T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(37)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("Quartalsbericht18.txt"));
-        assertNull(((Transaction) cancellation.getSubject()).getNote());
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check cancellation transaction
-        cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(7).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation.getSubject()).getType(), is(AccountTransaction.Type.FEES));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2020-12-31T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(0)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("Quartalsbericht18.txt"));
-        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Depotpreis 2020"));
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check transaction
-        var iter = results.stream().filter(TransactionItem.class::isInstance).skip(13).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(15L));
-
-        var item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getSource(), is("Quartalsbericht18.txt"));
-        assertThat(transaction.getNote(), is("Depotpreis 2020"));
-
-        item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-11-24T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(48.74))));
-        assertThat(transaction.getSource(), is("Quartalsbericht18.txt"));
-        assertThat(transaction.getNote(), is("Entgelt Auflösung"));
+        // check fee transaction
+        assertThat(results, hasItem(fee( //
+                        hasDate("2020-11-24T00:00"), hasShares(0.00), //
+                        hasSource("Quartalsbericht18.txt"), hasNote("Entgelt Auflösung"), //
+                        hasAmount("EUR", 48.74), hasGrossValue("EUR", 48.74), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -19882,7 +16771,8 @@ public class DekaBankPDFExtractorTest
 
         // check 1st dividende transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-05-22"), hasShares(8.083 - 0.180), //
+                        hasDate("2020-05-22"), hasExDate("2020-05-22"), //
+                        hasShares(8.083 - 0.180), //
                         hasSource("Quartalsbericht23.txt"), hasNote(null), //
                         hasAmount("EUR", 16.10), hasGrossValue("EUR", 16.10), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
@@ -20005,10 +16895,10 @@ public class DekaBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(3L));
         assertThat(countBuySell(results), is(90L));
-        assertThat(countAccountTransactions(results), is(5L));
+        assertThat(countAccountTransactions(results), is(4L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(2L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(1L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(98));
         new AssertImportActions().check(results, "EUR");
 
@@ -20053,7 +16943,8 @@ public class DekaBankPDFExtractorTest
 
         // check 1st dividende transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-05-22"), hasShares(0.00 + 4.128 - 0.180), //
+                        hasDate("2020-05-22"), hasExDate("2020-05-22"), //
+                        hasShares(0.00 + 4.128 - 0.180), //
                         hasSource("Quartalsbericht24.txt"), hasNote(null), //
                         hasAmount("EUR", 16.10), hasGrossValue("EUR", 16.10), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
@@ -20081,7 +16972,8 @@ public class DekaBankPDFExtractorTest
 
         // check 2nd dividende transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-11-13"), hasShares(9.359 + 5.036 - 5.036 - 0.122), //
+                        hasDate("2020-11-13"), hasExDate("2020-11-13"), //
+                        hasShares(9.359 + 5.036 - 5.036 - 0.122), //
                         hasSource("Quartalsbericht24.txt"), hasNote(null), //
                         hasAmount("EUR", 18.47), hasGrossValue("EUR", 18.47), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
@@ -20100,7 +16992,7 @@ public class DekaBankPDFExtractorTest
                         hasAmount("EUR", 805.00), hasGrossValue("EUR", 805.00), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
-        // check cancellation transaction
+        // check failure message
         assertThat(results, hasItem(withFailureMessage(Messages.MsgErrorTransactionOrderCancellationUnsupported, //
                         sale( //
                                         hasDate("2020-12-01"), hasShares(5.036), //
@@ -20696,18 +17588,13 @@ public class DekaBankPDFExtractorTest
                         hasAmount("EUR", 276.42), hasGrossValue("EUR", 276.42), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
-        // check fee transaction
-        assertThat(results, hasItem(fee( //
-                        hasDate("2020-12-31"), hasShares(0), //
-                        hasSource("Quartalsbericht24.txt"), hasNote("Depotpreis 2020"), //
-                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
-
-        // check cancellation transaction
-        assertThat(results, hasItem(withFailureMessage(Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         fee( //
-                                        hasDate("2020-12-31"), hasShares(0), //
-                                        hasSource("Quartalsbericht24.txt"), hasNote("Depotpreis 2020"), //
+                                        hasDate("2020-12-31"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht24.txt"), //
+                                        hasNote("Depotpreis 2020"), //
                                         hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
                                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
@@ -20777,11 +17664,11 @@ public class DekaBankPDFExtractorTest
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(2L));
-        assertThat(countBuySell(results), is(15L));
+        assertThat(countBuySell(results), is(14L));
         assertThat(countAccountTransactions(results), is(4L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(2L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(1L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(21));
         new AssertImportActions().check(results, "EUR");
 
@@ -20796,12 +17683,15 @@ public class DekaBankPDFExtractorTest
                         hasName("Deka-ImmobilienEuropa"), //
                         hasCurrencyCode("EUR"))));
 
-        // check 1st buy sell transaction
-        assertThat(results, hasItem(purchase( //
-                        hasDate("2020-06-16"), hasShares(0), //
-                        hasSource("Quartalsbericht26.txt"), hasNote(null), //
-                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        purchase( //
+                                        hasDate("2020-06-16"), hasShares(0.00), //
+                                        hasSource("Quartalsbericht26.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // check 2st buy sell transaction
         assertThat(results, hasItem(purchase( //
@@ -20901,25 +17791,29 @@ public class DekaBankPDFExtractorTest
                         hasAmount("EUR", 333.00), hasGrossValue("EUR", 333.00), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
-        // check 1st dividende transaction
+        // check dividend transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-06-16"), hasSource("Quartalsbericht26.txt"), hasAmount("EUR", 0.00),
-                        hasGrossValue("EUR", 0.00), hasShares(271.125))));
+                        hasDate("2020-06-18"), hasExDate("2020-06-17"), //
+                        hasShares(0.00), //
+                        hasSource("Quartalsbericht26.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 108.45), hasGrossValue("EUR", 108.45), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
-        // check 2st dividende transaction
+        // check dividend transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-06-17"), hasSource("Quartalsbericht26.txt"), hasAmount("EUR", 108.45),
-                        hasGrossValue("EUR", 108.45), hasShares(271.125))));
-
-        // check 3st dividende transaction
-        assertThat(results, hasItem(dividend( //
-                        hasDate("2020-01-10"), hasSource("Quartalsbericht26.txt"), hasAmount("EUR", 33.38),
-                        hasGrossValue("EUR", 33.38), hasShares(26.702))));
+                        hasDate("2020-01-10"), hasExDate("2020-01-10"), //
+                        hasShares(26.702), //
+                        hasSource("Quartalsbericht26.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 33.38), hasGrossValue("EUR", 33.38), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
         // check fee transaction
         assertThat(results, hasItem(fee( //
-                        hasDate("2020-12-31"), //
-                        hasSource("Quartalsbericht26.txt"), //
-                        hasAmount("EUR", 12.18))));
+                        hasDate("2020-12-31"), hasShares(0), //
+                        hasSource("Quartalsbericht26.txt"), hasNote("Depotpreis 2020"), //
+                        hasAmount("EUR", 12.18), hasGrossValue("EUR", 12.18), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/Direkt1822BankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/direkt1822bank/Direkt1822BankPDFExtractorTest.java
@@ -22,6 +22,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.outboundDeli
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.skippedItem;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxRefund;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
@@ -970,15 +971,15 @@ public class Direkt1822BankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(5L));
+        assertThat(countAccountTransactions(results), is(4L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(5));
         new AssertImportActions().check(results, "EUR");
 
-        // check unsupported transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         fee( //
                                         hasDate("2025-02-28T00:00"), hasShares(0.00), //

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dkb/DkbPDFExtractorTest.java
@@ -24,9 +24,9 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.skippedItem;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxRefund;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
@@ -2857,10 +2857,10 @@ public class DkbPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, "EUR");
 
@@ -2870,8 +2870,8 @@ public class DkbPDFExtractorTest
                         hasName("WERTGRUND WOHNSELECT D INHABER-ANTEILE"), //
                         hasCurrencyCode("EUR"))));
 
-        // check taxes transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         taxes( //
                                         hasDate("2024-01-15T00:00"), hasShares(9.6469), //

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
@@ -6,9 +6,9 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.fee;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasExDate;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFeed;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFeedProperty;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasExDate;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasForexGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
@@ -27,6 +27,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.skippedItem;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxRefund;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
@@ -1075,10 +1076,10 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(5L));
+        assertThat(countAccountTransactions(results), is(4L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(5));
         new AssertImportActions().check(results, "EUR");
 
@@ -1099,16 +1100,15 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(results, hasItem(fee(hasDate("2013-03-28"), hasAmount("EUR", 10.00), //
                         hasSource("biwAGKontoauszug03.txt"), hasNote("flatex trader 2.0 Basis"))));
 
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2013-03-31"), hasAmount("EUR", 0.00), //
-                        hasSource("biwAGKontoauszug03.txt"), hasNote("Zinsabschluss 01.01.2013 - 31.03.2013"))));
-
-        // assert transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
-                        interest(hasDate("2013-03-31"), hasAmount("EUR", 0.00), //
-                                        hasSource("biwAGKontoauszug03.txt"),
-                                        hasNote("Zinsabschluss 01.01.2013 - 31.03.2013")))));
+                        interest( //
+                                        hasDate("2013-03-31"), hasShares(0.00), //
+                                        hasSource("biwAGKontoauszug03.txt"), //
+                                        hasNote("Zinsabschluss 01.01.2013 - 31.03.2013"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -2913,60 +2913,26 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(2L));
+        assertThat(countAccountTransactions(results), is(1L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, "EUR");
 
-        // check transaction
-        var iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(2L));
-
-        var item = iter.next();
-
         // assert transaction
-        var transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-01-29T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(1100.00))));
-        assertThat(transaction.getSource(), is("FinTechKontoauszug01.txt"));
-        assertThat(transaction.getNote(), is("Überweisung"));
+        assertThat(results, hasItem(deposit(hasDate("2016-01-29T00:00"), hasAmount("EUR", 1100.00), //
+                        hasSource("FinTechKontoauszug01.txt"), hasNote("Überweisung"))));
 
-        item = iter.next();
-
-        // assert transaction is cancellation
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-03-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getSource(), is("FinTechKontoauszug01.txt"));
-        assertThat(transaction.getNote(), is("Zinsabschluss 01.01.2016 - 31.03.2016"));
-
-        // check cancellation (Amount = 0,00) transaction
-        var cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation.getSubject()).getType(), is(AccountTransaction.Type.INTEREST));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2016-03-31T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(0)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("FinTechKontoauszug01.txt"));
-        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Zinsabschluss 01.01.2016 - 31.03.2016"));
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        interest( //
+                                        hasDate("2016-03-31T00:00"), hasShares(0.00), //
+                                        hasSource("FinTechKontoauszug01.txt"), //
+                                        hasNote("Zinsabschluss 01.01.2016 - 31.03.2016"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -2981,30 +2947,26 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(2L));
+        assertThat(countAccountTransactions(results), is(1L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, "EUR");
 
-        // check transaction
-
         // assert transaction
-        assertThat(results, hasItem(removal( //
-                        hasDate("2016-01-26"), //
-                        hasSource("FinTechKontoauszug02.txt"), //
-                        hasNote("Überweisung"), //
-                        hasAmount("EUR", 15000))));
+        assertThat(results, hasItem(removal(hasDate("2016-01-26"), hasAmount("EUR", 15000.00), //
+                        hasSource("FinTechKontoauszug02.txt"), hasNote("Überweisung"))));
 
-        // assert transaction is cancellation
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         interest( //
-                                        hasDate("2016-03-31"), //
+                                        hasDate("2016-03-31"), hasShares(0.00), //
                                         hasSource("FinTechKontoauszug02.txt"), //
                                         hasNote("Zinsabschluss 01.01.2016 - 31.03.2016"), //
-                                        hasAmount("EUR", 0)))));
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -3019,94 +2981,36 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(3L));
+        assertThat(countAccountTransactions(results), is(1L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(2L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(2L));
         assertThat(results.size(), is(3));
         new AssertImportActions().check(results, "EUR");
 
-        // check transaction
-        var iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(3L));
-
-        var item = iter.next();
-
-        // assert transaction is cancellation
-        var transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-09-30T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getSource(), is("FinTechKontoauszug03.txt"));
-        assertThat(transaction.getNote(), is("Zinsabschluss 01.07.2016 - 30.09.2016"));
-
-        // check cancellation (Amount = 0,00) transaction
-        var cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation.getSubject()).getType(), is(AccountTransaction.Type.INTEREST));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2016-09-30T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(0)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("FinTechKontoauszug03.txt"));
-        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Zinsabschluss 01.07.2016 - 30.09.2016"));
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        item = iter.next();
-
-        // assert transaction is cancellation
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getSource(), is("FinTechKontoauszug03.txt"));
-        assertThat(transaction.getNote(), is("Zinsabschluss 01.10.2016 - 31.12.2016"));
-
-        // check cancellation (Amount = 0,00) transaction
-        cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation.getSubject()).getType(), is(AccountTransaction.Type.INTEREST));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2016-12-31T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(0)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("FinTechKontoauszug03.txt"));
-        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Zinsabschluss 01.10.2016 - 31.12.2016"));
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        item = iter.next();
-
         // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.TAX_REFUND));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(4.94))));
-        assertThat(transaction.getSource(), is("FinTechKontoauszug03.txt"));
-        assertThat(transaction.getNote(), is("Steuertopfoptimierung 2016"));
+        assertThat(results, hasItem(taxRefund(hasDate("2016-12-31T00:00"), hasAmount("EUR", 4.94), //
+                        hasSource("FinTechKontoauszug03.txt"), hasNote("Steuertopfoptimierung 2016"))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        interest( //
+                                        hasDate("2016-09-30T00:00"), hasShares(0.00), //
+                                        hasSource("FinTechKontoauszug03.txt"), //
+                                        hasNote("Zinsabschluss 01.07.2016 - 30.09.2016"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        interest( //
+                                        hasDate("2016-09-30T00:00"), hasShares(0.00), //
+                                        hasSource("FinTechKontoauszug03.txt"), //
+                                        hasNote("Zinsabschluss 01.07.2016 - 30.09.2016"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -3121,70 +3025,30 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(3L));
+        assertThat(countAccountTransactions(results), is(2L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(3));
         new AssertImportActions().check(results, "EUR");
 
-        // check transaction
-        var iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(3L));
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2010-10-01T00:00"), hasAmount("EUR", 2000.00), //
+                        hasSource("FinTechKontoauszug04.txt"), hasNote("EINZAHLUNG 4 FLATEX / 0/16765097"))));
 
-        var item = iter.next();
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        interest( //
+                                        hasDate("2010-09-30T00:00"), hasShares(0.00), //
+                                        hasSource("FinTechKontoauszug04.txt"), //
+                                        hasNote("Zinsabschluss 01.07.2010 - 30.09.2010"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // assert transaction
-        var transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-10-01T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(2000.00))));
-        assertThat(transaction.getSource(), is("FinTechKontoauszug04.txt"));
-        assertThat(transaction.getNote(), is("EINZAHLUNG 4 FLATEX / 0/16765097"));
-
-        item = iter.next();
-
-        // assert transaction is cancellation
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-09-30T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getSource(), is("FinTechKontoauszug04.txt"));
-        assertThat(transaction.getNote(), is("Zinsabschluss 01.07.2010 - 30.09.2010"));
-
-        // check cancellation (Amount = 0,00) transaction
-        var cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation.getSubject()).getType(), is(AccountTransaction.Type.INTEREST));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2010-09-30T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(0)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("FinTechKontoauszug04.txt"));
-        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Zinsabschluss 01.07.2010 - 30.09.2010"));
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        item = iter.next();
-
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2010-12-31T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.20))));
-        assertThat(transaction.getSource(), is("FinTechKontoauszug04.txt"));
-        assertThat(transaction.getNote(), is("Zinsabschluss 01.10.2010 - 31.12.2010"));
+        assertThat(results, hasItem(interestCharge(hasDate("2010-12-31T00:00"), hasAmount("EUR", 0.20), //
+                        hasSource("FinTechKontoauszug04.txt"), hasNote("Zinsabschluss 01.10.2010 - 31.12.2010"))));
     }
 
     @Test
@@ -3656,45 +3520,28 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, "EUR");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("IE00B4L5Y983"));
-        assertThat(security.getWkn(), is("A0RPWH"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("ISHS CR WD USD-AC"));
-        assertThat(security.getCurrencyCode(), is("EUR"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00B4L5Y983"), hasWkn("A0RPWH"), hasTicker(null), //
+                        hasName("ISHS CR WD USD-AC"), //
+                        hasCurrencyCode("EUR"))));
 
-        // check cancellation (Amount = 0,00) transaction
-        var cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation.getSubject()).getType(), is(AccountTransaction.Type.TAXES));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2020-01-11T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(1.741300)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("FlatExVorabpauschale02.txt"));
-        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Transaktion-Nr.: 1222222222"));
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        taxes( //
+                                        hasDate("2020-01-11T00:00"), hasShares(1.741300), //
+                                        hasSource("FlatExVorabpauschale02.txt"), //
+                                        hasNote("Transaktion-Nr.: 1222222222"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -7175,158 +7022,58 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(7L));
+        assertThat(countAccountTransactions(results), is(4L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(3L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(3L));
         assertThat(results.size(), is(7));
         new AssertImportActions().check(results, "EUR");
 
-        // check transaction
-        var iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(7L));
-
-        var item = iter.next();
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2021-07-08T00:00"), hasAmount("EUR", 200.00), //
+                        hasSource("FlatExDegiroKontoauszug01.txt"), hasNote("Überweisung"))));
 
         // assert transaction
-        var transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-07-08T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(200.00))));
-        assertThat(transaction.getSource(), is("FlatExDegiroKontoauszug01.txt"));
-        assertThat(transaction.getNote(), is("Überweisung"));
-
-        item = iter.next();
+        assertThat(results, hasItem(deposit(hasDate("2021-08-10T00:00"), hasAmount("EUR", 200.00), //
+                        hasSource("FlatExDegiroKontoauszug01.txt"), hasNote("Überweisung"))));
 
         // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-08-10T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(200.00))));
-        assertThat(transaction.getSource(), is("FlatExDegiroKontoauszug01.txt"));
-        assertThat(transaction.getNote(), is("Überweisung"));
+        assertThat(results, hasItem(deposit(hasDate("2021-09-08T00:00"), hasAmount("EUR", 200.00), //
+                        hasSource("FlatExDegiroKontoauszug01.txt"), hasNote("Überweisung"))));
 
-        item = iter.next();
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        fee( //
+                                        hasDate("2021-07-19T00:00"), hasShares(0.00), //
+                                        hasSource("FlatExDegiroKontoauszug01.txt"), //
+                                        hasNote("Depotgebühren 01.04.2021 - 30.04.2021"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DEPOSIT));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-09-08T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(200.00))));
-        assertThat(transaction.getSource(), is("FlatExDegiroKontoauszug01.txt"));
-        assertThat(transaction.getNote(), is("Überweisung"));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        fee( //
+                                        hasDate("2021-07-19T00:00"), hasShares(0.00), //
+                                        hasSource("FlatExDegiroKontoauszug01.txt"), //
+                                        hasNote("Depotgebühren 01.05.2021 - 31.05.2021"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        item = iter.next();
-
-        // assert transaction is cancellation
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-07-19T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getSource(), is("FlatExDegiroKontoauszug01.txt"));
-        assertThat(transaction.getNote(), is("Depotgebühren 01.04.2021 - 30.04.2021"));
-
-        // check cancellation (Amount = 0,00) transaction
-        var cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation.getSubject()).getType(), is(AccountTransaction.Type.FEES));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2021-07-19T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(0)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("FlatExDegiroKontoauszug01.txt"));
-        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Depotgebühren 01.04.2021 - 30.04.2021"));
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        item = iter.next();
-
-        // assert transaction is cancellation
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-07-19T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getSource(), is("FlatExDegiroKontoauszug01.txt"));
-        assertThat(transaction.getNote(), is("Depotgebühren 01.05.2021 - 31.05.2021"));
-
-        // check cancellation (Amount = 0,00) transaction
-        cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation.getSubject()).getType(), is(AccountTransaction.Type.FEES));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2021-07-19T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(0)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("FlatExDegiroKontoauszug01.txt"));
-        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Depotgebühren 01.05.2021 - 31.05.2021"));
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        item = iter.next();
-
-        // assert transaction is cancellation
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-07-19T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getSource(), is("FlatExDegiroKontoauszug01.txt"));
-        assertThat(transaction.getNote(), is("Depotgebühren 01.06.2021 - 30.06.2021"));
-
-        // check cancellation (Amount = 0,00) transaction
-        cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(2).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation.getSubject()).getType(), is(AccountTransaction.Type.FEES));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2021-07-19T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(0)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("FlatExDegiroKontoauszug01.txt"));
-        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Depotgebühren 01.06.2021 - 30.06.2021"));
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        item = iter.next();
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        fee( //
+                                        hasDate("2021-07-19T00:00"), hasShares(0.00), //
+                                        hasSource("FlatExDegiroKontoauszug01.txt"), //
+                                        hasNote("Depotgebühren 01.06.2021 - 30.06.2021"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // assert transaction
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST_CHARGE));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-06-30T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(2.73))));
-        assertThat(transaction.getSource(), is("FlatExDegiroKontoauszug01.txt"));
-        assertThat(transaction.getNote(), is("Zinsabschluss 01.04.2021 - 30.06.2021"));
+        assertThat(results, hasItem(interestCharge(hasDate("2021-06-30T00:00"), hasAmount("EUR", 2.73), //
+                        hasSource("FlatExDegiroKontoauszug01.txt"), hasNote("Zinsabschluss 01.04.2021 - 30.06.2021"))));
     }
 
     @Test
@@ -7722,24 +7469,30 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(2L));
+        assertThat(countAccountTransactions(results), is(1L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, "EUR");
 
-        // assert cancellation transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         interest( //
-                                        hasDate("2024-01-02"), hasAmount("EUR", 0.00), //
-                                        hasSource("FlatExDegiroKontoauszug06.txt"),
-                                        hasNote("Zinsabschluss 01.10.2023 - 31.12.2023")))));
+                                        hasDate("2024-01-02"), hasShares(0.00), //
+                                        hasSource("FlatExDegiroKontoauszug06.txt"), //
+                                        hasNote("Zinsabschluss 01.10.2023 - 31.12.2023"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        // assert transaction
-        assertThat(results, hasItem(taxes(hasDate("2024-01-15"), hasAmount("EUR", 22.98), //
-                        hasSource("FlatExDegiroKontoauszug06.txt"), hasNote("Steuerkorrektur aufgrund FSA-Thematik"))));
+        // check taxes transaction
+        assertThat(results, hasItem(taxes( //
+                        hasDate("2024-01-15T00:00"), hasShares(0.00), //
+                        hasSource("FlatExDegiroKontoauszug06.txt"), //
+                        hasNote("Steuerkorrektur aufgrund FSA-Thematik"), //
+                        hasAmount("EUR", 22.98), hasGrossValue("EUR", 22.98), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -7811,20 +7564,22 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(4L));
+        assertThat(countAccountTransactions(results), is(3L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(4));
         new AssertImportActions().check(results, "EUR");
 
-        // assert cancellation transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         interest( //
-                                        hasDate("2025-09-30"), hasAmount("EUR", 0.00), //
+                                        hasDate("2025-09-30"), hasShares(0.00), //
                                         hasSource("FlatExDegiroKontoauszug09.txt"), //
-                                        hasNote("Zinsabschluss 01.07.2025 - 30.09.2025")))));
+                                        hasNote("Zinsabschluss 01.07.2025 - 30.09.2025"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
         // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2025-10-03"), hasAmount("EUR", 150.00), //
@@ -8794,10 +8549,10 @@ public class FinTechGroupBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, "EUR");
 
@@ -8807,8 +8562,8 @@ public class FinTechGroupBankPDFExtractorTest
                         hasName("AM S&P XXXXXXX"), //
                         hasCurrencyCode("EUR"))));
 
-        // check taxes transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         taxes( //
                                         hasDate("2024-01-29T00:00"), hasShares(265.851), //

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/ingdiba/INGDiBaPDFExtractorTest.java
@@ -25,6 +25,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.skippedItem;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
@@ -2170,10 +2171,10 @@ public class INGDiBaPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, "EUR");
 
@@ -2183,8 +2184,8 @@ public class INGDiBaPDFExtractorTest
                         hasName("SPDR MSCI USA Sm.C.Val.W.UETF Registered Shares o.N."), //
                         hasCurrencyCode("EUR"))));
 
-        // check taxes transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         taxes( //
                                         hasDate("2024-01-02T00:00"), hasShares(60.00), //

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/modenaestonia/ModenaEstoniaPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/modenaestonia/ModenaEstoniaPDFExtractorTest.java
@@ -3,11 +3,15 @@ package name.abuchen.portfolio.datatransfer.pdf.modenaestonia;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interest;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interestCharge;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.skippedItem;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
@@ -109,10 +113,10 @@ public class ModenaEstoniaPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(2L));
+        assertThat(countAccountTransactions(results), is(1L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, "EUR");
 
@@ -120,13 +124,14 @@ public class ModenaEstoniaPDFExtractorTest
         assertThat(results, hasItem(interest(hasDate("2025-05-01T08:00:10"), hasAmount("EUR", 0.61), //
                         hasSource("Kontoauszug03.txt"), hasNote("Vault accrued revenue"))));
 
-        // assert transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         interestCharge( //
-                                        hasDate("2025-05-12T07:30:56"), //
+                                        hasDate("2025-05-12T07:30:56"), hasShares(0.00), //
                                         hasSource("Kontoauszug03.txt"), //
                                         hasNote("Debt claims buyback"), //
-                                        hasAmount("EUR", 0.00)))));
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/oldenburgischelandesbankag/OldenburgischeLandesbankAGPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/oldenburgischelandesbankag/OldenburgischeLandesbankAGPDFExtractorTest.java
@@ -21,6 +21,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.inboundDeliv
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.skippedItem;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
@@ -781,10 +782,10 @@ public class OldenburgischeLandesbankAGPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, "EUR");
 
@@ -794,8 +795,8 @@ public class OldenburgischeLandesbankAGPDFExtractorTest
                         hasName("AIS-AM.WORLD SRI PAB Act.Nom. UCITS ETF DR (C)o.N."), //
                         hasCurrencyCode("EUR"))));
 
-        // check taxes transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         taxes( //
                                         hasDate("2024-01-02T00:00"), hasShares(255.212216), //

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/RaiffeisenbankgruppePDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/RaiffeisenbankgruppePDFExtractorTest.java
@@ -22,9 +22,11 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.inboundDelivery;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interest;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interestCharge;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.outboundDelivery;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.skippedItem;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
@@ -60,7 +62,6 @@ import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
-import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
@@ -2656,7 +2657,7 @@ public class RaiffeisenbankgruppePDFExtractorTest
     }
 
     @Test
-    public void testEinbuchung01()
+    public void testUmtausch01()
     {
         var extractor = new RaiffeisenBankgruppePDFExtractor(new Client());
 
@@ -2667,10 +2668,10 @@ public class RaiffeisenbankgruppePDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(2L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(2L));
+        assertThat(countAccountTransactions(results), is(1L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(2L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(1L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(4));
         new AssertImportActions().check(results, "EUR");
 
@@ -2690,89 +2691,26 @@ public class RaiffeisenbankgruppePDFExtractorTest
         assertNull(security2.getTickerSymbol());
         assertThat(security2.getName(), is("AIS-MSCI Eu.SC ESG CL.NZ AMCTB Act.Nom. U.ETF EUR Dis. oN"));
         assertThat(security2.getCurrencyCode(), is("EUR"));
+  
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        outboundDelivery( //
+                                        hasDate("2023-03-10T00:00"), hasShares(433.00), //
+                                        hasSource("Umtausch01.txt"), //
+                                        hasNote("Abrechnungsnummer: 46711492"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 
-        // check delivery outbound (Auslieferung) transaction
-        var entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-
-        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2023-03-10T00:00")));
-        assertThat(entry.getShares(), is(Values.Share.factorize(433)));
-        assertThat(entry.getSource(), is("Umtausch01.txt"));
-        assertThat(entry.getNote(), is("Abrechnungsnummer: 46711492"));
-
-        assertThat(entry.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check delivery inbound (Einlieferung) transaction
-        entry = (PortfolioTransaction) results.stream().filter(TransactionItem.class::isInstance).skip(1).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getType(), is(PortfolioTransaction.Type.DELIVERY_INBOUND));
-
-        assertThat(entry.getDateTime(), is(LocalDateTime.parse("2023-03-10T00:00")));
-        assertThat(entry.getShares(), is(Values.Share.factorize(433)));
-        assertThat(entry.getSource(), is("Umtausch01.txt"));
-        assertThat(entry.getNote(), is("Abrechnungsnummer: 45664992 | Verhältnis: 1 : 1"));
-
-        assertThat(entry.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getUnitSum(Unit.Type.TAX), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 1st cancellation (Amount 0,00) transaction
-        var cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((PortfolioTransaction) cancellation.getSubject()).getType(),
-                        is(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2023-03-10T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(433)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("Umtausch01.txt"));
-        assertThat(((Transaction) cancellation.getSubject()).getNote(), is("Abrechnungsnummer: 46711492"));
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        // check 2nd cancellation (Amount 0,00) transaction
-        cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .skip(1).findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((PortfolioTransaction) cancellation.getSubject()).getType(),
-                        is(PortfolioTransaction.Type.DELIVERY_INBOUND));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2023-03-10T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(433)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("Umtausch01.txt"));
-        assertThat(((Transaction) cancellation.getSubject()).getNote(),
-                        is("Abrechnungsnummer: 45664992 | Verhältnis: 1 : 1"));
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check unsupported transaction
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionSplitUnsupported, //
+                        inboundDelivery( //
+                                        hasDate("2023-03-10T00:00"), hasShares(433.00), //
+                                        hasSource("Umtausch01.txt"), //
+                                        hasNote("Abrechnungsnummer: 45664992 | Verhältnis: 1 : 1"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -2840,7 +2778,7 @@ public class RaiffeisenbankgruppePDFExtractorTest
         assertThat(results, hasItem(withFailureMessage( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         inboundDelivery( //
-                                        hasDate("2022-07-08"), hasShares(200), //
+                                        hasDate("2022-07-08"), hasShares(200.00), //
                                         hasSource("FreierErhalt02.txt"), //
                                         hasNote(null), //
                                         hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
@@ -2866,7 +2804,7 @@ public class RaiffeisenbankgruppePDFExtractorTest
         assertThat(results.size(), is(1));
         new AssertImportActions().check(results, "CHF");
 
-        // check interest transaction
+        // check fee transaction
         assertThat(results, hasItem(fee( //
                         hasDate("2024-09-30T00:00"), //
                         hasSource("Gebuehrenbelastung01.txt"), //

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/SBrokerPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/SBrokerPDFExtractorTest.java
@@ -26,6 +26,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.skippedItem;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxRefund;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
@@ -2470,10 +2471,10 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, "EUR");
 
@@ -2483,8 +2484,8 @@ public class SBrokerPDFExtractorTest
                         hasName("UBS(L)FS-MSCI WLD SOC.RSP.UETF NAMENS-ANTEILE (USD) A-DIS O.N"), //
                         hasCurrencyCode("EUR"))));
 
-        // check taxes transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         taxes( //
                                         hasDate("2024-01-02T00:00"), hasShares(8.781), //
@@ -2506,10 +2507,10 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, "EUR");
 
@@ -2519,8 +2520,8 @@ public class SBrokerPDFExtractorTest
                         hasName("ISHARES MDAX UCITS ETF DE"), //
                         hasCurrencyCode("EUR"))));
 
-        // check taxes transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         taxes( //
                                         hasDate("2024-01-02T00:00"), hasShares(12.2335), //
@@ -2650,10 +2651,10 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(20L));
+        assertThat(countAccountTransactions(results), is(19L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(20));
         new AssertImportActions().check(results, "EUR");
 
@@ -2733,17 +2734,15 @@ public class SBrokerPDFExtractorTest
         assertThat(results, hasItem(fee(hasDate("2023-03-31"), hasAmount("EUR", 5.40), //
                         hasSource("GiroKontoauszug01.txt"), hasNote("Entgelte vom 01.03.2023 bis 31.03.2023"))));
 
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2023-03-31"), hasAmount("EUR", 0.00), //
-                        hasSource("GiroKontoauszug01.txt"),
-                        hasNote("Abrechnungszeitraum vom 01.01.2023 bis 31.03.2023"))));
-
-        // assert transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
-                        interest(hasDate("2023-03-31"), hasAmount("EUR", 0.00), //
-                                        hasSource("GiroKontoauszug01.txt"),
-                                        hasNote("Abrechnungszeitraum vom 01.01.2023 bis 31.03.2023")))));
+                        interest( //
+                                        hasDate("2023-03-31"), hasShares(0.00), //
+                                        hasSource("GiroKontoauszug01.txt"), //
+                                        hasNote("Abrechnungszeitraum vom 01.01.2023 bis 31.03.2023"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -2943,17 +2942,17 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(8L));
+        assertThat(countAccountTransactions(results), is(7L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(8));
         new AssertImportActions().check(results, "EUR");
 
         // check transaction
         // get transactions
         var iter = results.stream().filter(TransactionItem.class::isInstance).iterator();
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(8L));
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(7L));
 
         var item = iter.next();
 
@@ -3025,39 +3024,15 @@ public class SBrokerPDFExtractorTest
         assertThat(transaction.getSource(), is("GiroKontoauszug03.txt"));
         assertThat(transaction.getNote(), is("Entgelte vom 01.09.2020 bis 30.09.2020"));
 
-        item = iter.next();
-
-        // assert transaction is cancellation
-        transaction = (AccountTransaction) item.getSubject();
-        assertThat(transaction.getType(), is(AccountTransaction.Type.INTEREST));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-09-30T00:00")));
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getSource(), is("GiroKontoauszug03.txt"));
-        assertThat(transaction.getNote(), is("Abrechnungszeitraum vom 01.07.2020 bis 30.09.2020"));
-
-        // check cancellation (Amount = 0,00) transaction
-        var cancellation = (TransactionItem) results.stream() //
-                        .filter(i -> i.isFailure()) //
-                        .filter(TransactionItem.class::isInstance) //
-                        .findFirst().orElseThrow(IllegalArgumentException::new);
-
-        assertThat(((AccountTransaction) cancellation.getSubject()).getType(), is(AccountTransaction.Type.INTEREST));
-        assertThat(cancellation.getFailureMessage(), is(Messages.MsgErrorTransactionTypeNotSupportedOrRequired));
-
-        assertThat(((Transaction) cancellation.getSubject()).getDateTime(),
-                        is(LocalDateTime.parse("2020-09-30T00:00")));
-        assertThat(((Transaction) cancellation.getSubject()).getShares(), is(Values.Share.factorize(0)));
-        assertThat(((Transaction) cancellation.getSubject()).getSource(), is("GiroKontoauszug03.txt"));
-        assertThat(transaction.getNote(), is("Abrechnungszeitraum vom 01.07.2020 bis 30.09.2020"));
-
-        assertThat(((Transaction) cancellation.getSubject()).getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(((Transaction) cancellation.getSubject()).getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        interest( //
+                                        hasDate("2020-09-30T00:00"), hasShares(0.00), //
+                                        hasSource("GiroKontoauszug03.txt"), //
+                                        hasNote("Abrechnungszeitraum vom 01.07.2020 bis 30.09.2020"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -3342,10 +3317,10 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(5L));
+        assertThat(countAccountTransactions(results), is(4L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(5));
         new AssertImportActions().check(results, "EUR");
 
@@ -3365,17 +3340,15 @@ public class SBrokerPDFExtractorTest
         assertThat(results, hasItem(fee(hasDate("2018-12-28"), hasAmount("EUR", 4.40), //
                         hasSource("GiroKontoauszug08.txt"), hasNote("Entgelte vom 01.12.2018 bis 28.12.2018"))));
 
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2018-12-31"), hasAmount("EUR", 0.00), //
-                        hasSource("GiroKontoauszug08.txt"),
-                        hasNote("Abrechnungszeitraum vom 01.10.2018 bis 31.12.2018"))));
-
-        // assert transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
-                        interest(hasDate("2018-12-31"), hasAmount("EUR", 0.00), //
-                                        hasSource("GiroKontoauszug08.txt"),
-                                        hasNote("Abrechnungszeitraum vom 01.10.2018 bis 31.12.2018")))));
+                        interest( //
+                                        hasDate("2018-12-31"), hasShares(0.00), //
+                                        hasSource("GiroKontoauszug08.txt"), //
+                                        hasNote("Abrechnungszeitraum vom 01.10.2018 bis 31.12.2018"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -3390,14 +3363,14 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(3L));
+        assertThat(countAccountTransactions(results), is(2L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(3));
         new AssertImportActions().check(results, "EUR");
 
-        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(3L));
+        assertThat(results.stream().filter(TransactionItem.class::isInstance).count(), is(2L));
 
         // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2019-12-27"), hasAmount("EUR", 1111.11), //
@@ -3407,17 +3380,15 @@ public class SBrokerPDFExtractorTest
         assertThat(results, hasItem(fee(hasDate("2019-12-30"), hasAmount("EUR", 6.20), //
                         hasSource("GiroKontoauszug09.txt"), hasNote("Entgelte vom 30.11.2019 bis 30.12.2019"))));
 
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2019-12-31"), hasAmount("EUR", 0.00), //
-                        hasSource("GiroKontoauszug09.txt"),
-                        hasNote("Abrechnungszeitraum vom 01.10.2019 bis 31.12.2019"))));
-
-        // assert transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
-                        interest(hasDate("2019-12-31"), hasAmount("EUR", 0.00), //
-                                        hasSource("GiroKontoauszug09.txt"),
-                                        hasNote("Abrechnungszeitraum vom 01.10.2019 bis 31.12.2019")))));
+                        interest( //
+                                        hasDate("2019-12-31"), hasShares(0.00), //
+                                        hasSource("GiroKontoauszug09.txt"), //
+                                        hasNote("Abrechnungszeitraum vom 01.10.2019 bis 31.12.2019"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -3432,10 +3403,10 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(7L));
+        assertThat(countAccountTransactions(results), is(6L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(7));
         new AssertImportActions().check(results, "EUR");
 
@@ -3463,17 +3434,15 @@ public class SBrokerPDFExtractorTest
         assertThat(results, hasItem(fee(hasDate("2014-06-30"), hasAmount("EUR", 4.05), //
                         hasSource("GiroKontoauszug10.txt"), hasNote("Entgelte vom 31.05.2014 bis 30.06.2014"))));
 
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2014-06-30"), hasAmount("EUR", 0.00), //
-                        hasSource("GiroKontoauszug10.txt"),
-                        hasNote("Abrechnungszeitraum vom 01.04.2014 bis 30.06.2014"))));
-
-        // assert transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
-                        interest(hasDate("2014-06-30"), hasAmount("EUR", 0.00), //
-                                        hasSource("GiroKontoauszug10.txt"),
-                                        hasNote("Abrechnungszeitraum vom 01.04.2014 bis 30.06.2014")))));
+                        interest( //
+                                        hasDate("2014-06-30"), hasShares(0.00), //
+                                        hasSource("GiroKontoauszug10.txt"), //
+                                        hasNote("Abrechnungszeitraum vom 01.04.2014 bis 30.06.2014"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -3488,10 +3457,10 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(3L));
+        assertThat(countAccountTransactions(results), is(2L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(3));
         new AssertImportActions().check(results, "EUR");
 
@@ -3503,17 +3472,15 @@ public class SBrokerPDFExtractorTest
         assertThat(results, hasItem(fee(hasDate("2015-06-30"), hasAmount("EUR", 3.55), //
                         hasSource("GiroKontoauszug11.txt"), hasNote("Entgelte vom 30.05.2015 bis 30.06.2015"))));
 
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2015-06-30"), hasAmount("EUR", 0.00), //
-                        hasSource("GiroKontoauszug11.txt"),
-                        hasNote("Abrechnungszeitraum vom 01.04.2015 bis 30.06.2015"))));
-
-        // assert transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
-                        interest(hasDate("2015-06-30"), hasAmount("EUR", 0.00), //
-                                        hasSource("GiroKontoauszug11.txt"),
-                                        hasNote("Abrechnungszeitraum vom 01.04.2015 bis 30.06.2015")))));
+                        interest( //
+                                        hasDate("2015-06-30"), hasShares(0.00), //
+                                        hasSource("GiroKontoauszug11.txt"), //
+                                        hasNote("Abrechnungszeitraum vom 01.04.2015 bis 30.06.2015"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -3664,10 +3631,10 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(9L));
+        assertThat(countAccountTransactions(results), is(8L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(9));
         new AssertImportActions().check(results, "EUR");
 
@@ -3703,17 +3670,15 @@ public class SBrokerPDFExtractorTest
         assertThat(results, hasItem(fee(hasDate("2019-03-29"), hasAmount("EUR", 5.00), //
                         hasSource("GiroKontoauszug15.txt"), hasNote("Entgelte vom 01.03.2019 bis 29.03.2019"))));
 
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2019-03-31"), hasAmount("EUR", 0.00), //
-                        hasSource("GiroKontoauszug15.txt"),
-                        hasNote("Abrechnungszeitraum vom 01.01.2019 bis 31.03.2019"))));
-
-        // assert transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
-                        interest(hasDate("2019-03-31"), hasAmount("EUR", 0.00), //
-                                        hasSource("GiroKontoauszug15.txt"),
-                                        hasNote("Abrechnungszeitraum vom 01.01.2019 bis 31.03.2019")))));
+                        interest( //
+                                        hasDate("2019-03-31"), hasShares(0.00), //
+                                        hasSource("GiroKontoauszug15.txt"), //
+                                        hasNote("Abrechnungszeitraum vom 01.01.2019 bis 31.03.2019"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -3808,10 +3773,10 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(9L));
+        assertThat(countAccountTransactions(results), is(8L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(9));
         new AssertImportActions().check(results, "EUR");
 
@@ -3847,17 +3812,15 @@ public class SBrokerPDFExtractorTest
         assertThat(results, hasItem(fee(hasDate("2022-12-30"), hasAmount("EUR", 4.60), //
                         hasSource("GiroKontoauszug17.txt"), hasNote("Entgelte vom 01.12.2022 bis 30.12.2022"))));
 
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2022-12-31"), hasAmount("EUR", 0.00), //
-                        hasSource("GiroKontoauszug17.txt"),
-                        hasNote("Abrechnungszeitraum vom 01.10.2022 bis 31.12.2022"))));
-
-        // assert transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
-                        interest(hasDate("2022-12-31"), hasAmount("EUR", 0.00), //
-                                        hasSource("GiroKontoauszug17.txt"),
-                                        hasNote("Abrechnungszeitraum vom 01.10.2022 bis 31.12.2022")))));
+                        interest( //
+                                        hasDate("2022-12-31"), hasShares(0.00), //
+                                        hasSource("GiroKontoauszug17.txt"), //
+                                        hasNote("Abrechnungszeitraum vom 01.10.2022 bis 31.12.2022"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -4102,10 +4065,10 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(3L));
+        assertThat(countAccountTransactions(results), is(2L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(3));
         new AssertImportActions().check(results, "EUR");
 
@@ -4117,17 +4080,15 @@ public class SBrokerPDFExtractorTest
         assertThat(results, hasItem(fee(hasDate("2012-12-28"), hasAmount("EUR", 4.30 - 1.80), //
                         hasSource("GiroKontoauszug24.txt"), hasNote("Entgelte vom 01.12.2012 bis 28.12.2012"))));
 
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2012-12-31"), hasAmount("EUR", 0.00), //
-                        hasSource("GiroKontoauszug24.txt"),
-                        hasNote("Abrechnungszeitraum vom 01.10.2012 bis 31.12.2012"))));
-
-        // assert transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
-                        interest(hasDate("2012-12-31"), hasAmount("EUR", 0.00), //
-                                        hasSource("GiroKontoauszug24.txt"),
-                                        hasNote("Abrechnungszeitraum vom 01.10.2012 bis 31.12.2012")))));
+                        interest( //
+                                        hasDate("2012-12-31"), hasShares(0.00), //
+                                        hasSource("GiroKontoauszug24.txt"), //
+                                        hasNote("Abrechnungszeitraum vom 01.10.2012 bis 31.12.2012"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -4142,10 +4103,10 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(10L));
+        assertThat(countAccountTransactions(results), is(9L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(10));
         new AssertImportActions().check(results, "EUR");
 
@@ -4185,17 +4146,15 @@ public class SBrokerPDFExtractorTest
         assertThat(results, hasItem(fee(hasDate("2011-06-30"), hasAmount("EUR", 4.05), //
                         hasSource("GiroKontoauszug25.txt"), hasNote("Entgelte vom 01.06.2011 bis 30.06.2011"))));
 
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2011-06-30"), hasAmount("EUR", 0.00), //
-                        hasSource("GiroKontoauszug25.txt"),
-                        hasNote("Abrechnungszeitraum vom 01.04.2011 bis 30.06.2011"))));
-
-        // assert transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
-                        interest(hasDate("2011-06-30"), hasAmount("EUR", 0.00), //
-                                        hasSource("GiroKontoauszug25.txt"),
-                                        hasNote("Abrechnungszeitraum vom 01.04.2011 bis 30.06.2011")))));
+                        interest( //
+                                        hasDate("2011-06-30"), hasShares(0.00), //
+                                        hasSource("GiroKontoauszug25.txt"), //
+                                        hasNote("Abrechnungszeitraum vom 01.04.2011 bis 30.06.2011"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -4687,10 +4646,10 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(4L));
+        assertThat(countAccountTransactions(results), is(3L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(4));
         new AssertImportActions().check(results, "EUR");
 
@@ -4707,17 +4666,15 @@ public class SBrokerPDFExtractorTest
         assertThat(results, hasItem(fee(hasDate("2019-03-29"), hasAmount("EUR", 8.50), //
                         hasSource("GiroKontoauszug34.txt"), hasNote("Entgelte vom 01.03.2019 bis 29.03.2019"))));
 
-        // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2019-03-31"), hasAmount("EUR", 0.00), //
-                        hasSource("GiroKontoauszug34.txt"),
-                        hasNote("Abrechnungszeitraum vom 01.01.2019 bis 31.03.2019"))));
-
-        // assert transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
-                        interest(hasDate("2019-03-31"), hasAmount("EUR", 0.00), //
-                                        hasSource("GiroKontoauszug34.txt"),
-                                        hasNote("Abrechnungszeitraum vom 01.01.2019 bis 31.03.2019")))));
+                        interest( //
+                                        hasDate("2019-03-31"), hasShares(0.00), //
+                                        hasSource("GiroKontoauszug34.txt"), //
+                                        hasNote("Abrechnungszeitraum vom 01.01.2019 bis 31.03.2019"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -5112,10 +5069,10 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(15L));
+        assertThat(countAccountTransactions(results), is(14L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(15));
         new AssertImportActions().check(results, "EUR");
 
@@ -5175,12 +5132,15 @@ public class SBrokerPDFExtractorTest
         assertThat(results, hasItem(fee(hasDate("2019-12-30"), hasAmount("EUR", 6.20), //
                         hasSource("GiroKontoauszug39.txt"), hasNote("Entgelte vom 30.11.2019 bis 30.12.2019"))));
 
-        // assert transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
-                        interest(hasDate("2019-12-31"), hasAmount("EUR", 0.00), //
-                                        hasSource("GiroKontoauszug39.txt"),
-                                        hasNote("Abrechnungszeitraum vom 01.10.2019 bis 31.12.2019")))));
+                        interest( //
+                                        hasDate("2019-12-31"), hasShares(0.00), //
+                                        hasSource("GiroKontoauszug39.txt"), //
+                                        hasNote("Abrechnungszeitraum vom 01.10.2019 bis 31.12.2019"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -5195,10 +5155,10 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(31L));
+        assertThat(countAccountTransactions(results), is(30L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(31));
         new AssertImportActions().check(results, "EUR");
 
@@ -5318,12 +5278,15 @@ public class SBrokerPDFExtractorTest
         assertThat(results, hasItem(fee(hasDate("2020-06-30"), hasAmount("EUR", 8.50), //
                         hasSource("GiroKontoauszug40.txt"), hasNote("Entgelte vom 30.05.2020 bis 30.06.2020"))));
 
-        // assert transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
-                        interest(hasDate("2020-06-30"), hasAmount("EUR", 0.00), //
-                                        hasSource("GiroKontoauszug40.txt"),
-                                        hasNote("Abrechnungszeitraum vom 01.04.2020 bis 30.06.2020")))));
+                        interest( //
+                                        hasDate("2020-06-30"), hasShares(0.00), //
+                                        hasSource("GiroKontoauszug40.txt"), //
+                                        hasNote("Abrechnungszeitraum vom 01.04.2020 bis 30.06.2020"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test
@@ -5367,10 +5330,10 @@ public class SBrokerPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(44L));
+        assertThat(countAccountTransactions(results), is(43L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(44));
         new AssertImportActions().check(results, "EUR");
 
@@ -5534,12 +5497,15 @@ public class SBrokerPDFExtractorTest
         assertThat(results, hasItem(fee(hasDate("2016-06-30"), hasAmount("EUR", 8.50), //
                         hasSource("GiroKontoauszug42.txt"), hasNote("Entgelte vom 01.06.2016 bis 30.06.2016"))));
 
-        // assert transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
-                        interest(hasDate("2016-06-30"), hasAmount("EUR", 0.00), //
-                                        hasSource("GiroKontoauszug42.txt"),
-                                        hasNote("Abrechnungszeitraum vom 01.04.2016 bis 30.06.2016")))));
+                        interest( //
+                                        hasDate("2016-06-30"), hasShares(0.00), //
+                                        hasSource("GiroKontoauszug42.txt"), //
+                                        hasNote("Abrechnungszeitraum vom 01.04.2016 bis 30.06.2016"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/tradegateag/TradegateAGPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/tradegateag/TradegateAGPDFExtractorTest.java
@@ -20,9 +20,9 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.skippedItem;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxRefund;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
@@ -509,10 +509,10 @@ public class TradegateAGPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(2));
         new AssertImportActions().check(results, "EUR");
 
@@ -522,8 +522,8 @@ public class TradegateAGPDFExtractorTest
                         hasName("PFI ETFs-EO Sh.Mat.UC.ETF Registered Shares EUR Acc.o.N."), //
                         hasCurrencyCode("EUR"))));
 
-        // check taxes transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         taxes( //
                                         hasDate("2025-01-02T00:00"), hasShares(220.00), //

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/WirBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/WirBankPDFExtractorTest.java
@@ -22,8 +22,8 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interest;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.skippedItem;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxRefund;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
@@ -1282,15 +1282,15 @@ public class WirBankPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
         assertThat(countAccountTransfers(results), is(0L));
-        assertThat(countItemsWithFailureMessage(results), is(1L));
-        assertThat(countSkippedItems(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
         assertThat(results.size(), is(1));
         new AssertImportActions().check(results, "CHF");
 
-        // check fee transaction
-        assertThat(results, hasItem(withFailureMessage( //
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
                         Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
                         fee( //
                                         hasDate("2023-07-31T00:00"), hasShares(0.00), //

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TextUtilTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/util/TextUtilTest.java
@@ -174,6 +174,25 @@ public class TextUtilTest
     }
 
     @Test
+    public void testTrim()
+    {
+        assertThat(TextUtil.trim(" "), is(""));
+        assertThat(TextUtil.trim("  hello  "), is("hello"));
+        assertThat(TextUtil.trim("\thello\t"), is("hello"));
+
+        // U+00A0 non-breaking space: trimmed leading and trailing
+        var nbsp = String.valueOf((char) 0x00A0);
+        assertThat(TextUtil.trim(nbsp + "hello"), is("hello"));
+        assertThat(TextUtil.trim("hello" + nbsp), is("hello"));
+        assertThat(TextUtil.trim(nbsp + "hello" + nbsp), is("hello"));
+
+        // U+FEFF zero-width non-breaking space (BOM): trimmed leading and trailing
+        var bom = String.valueOf('﻿');
+        assertThat(TextUtil.trim(bom + "hello"), is("hello"));
+        assertThat(TextUtil.trim("hello" + bom), is("hello"));
+    }
+
+    @Test
     public void testTrimStringInArray()
     {
         String toTrimString = " Portfolio , Performance ,   is  , a, great tool! ";
@@ -181,7 +200,6 @@ public class TextUtilTest
 
         String[] trimParts = TextUtil.trim(toTrimString.split(","));
 
-        assertThat(TextUtil.trim(" "), is(""));
         assertThat(trimParts, is(trimPartsAnswer));
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -23,7 +23,7 @@ AccountMenuTroubleshootBalanceDiscrepancy = Solucionar discrepancia de saldo
 
 AttributeSettings = Configuraci\u00F3n
 
-AttributeSettings_LimitPrice_ColorSettings = Ajustes de color\u202F
+AttributeSettings_LimitPrice_ColorSettings = Ajustes de color
 
 AttributeSettings_LimitPrice_ColorSettings_LimitExceededNegatively = Color si se excede el l\u00EDmite \u201Fpor debajo de\u201D
 
@@ -31,7 +31,7 @@ AttributeSettings_LimitPrice_ColorSettings_LimitExceededPositively = Color si se
 
 AttributeSettings_LimitPrice_ColorSettings_SwapColors = Intercambiar colores
 
-AttributeSettings_LimitPrice_ColumnSettings = Ajustes adicionales\u202F
+AttributeSettings_LimitPrice_ColumnSettings = Ajustes adicionales
 
 AttributeSettings_LimitPrice_ColumnSettings_ShowAbsoluteDiff = Mostrar la diferencia total
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ABNAMROGroupPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ABNAMROGroupPDFExtractor.java
@@ -94,11 +94,7 @@ public class ABNAMROGroupPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -123,11 +119,7 @@ public class ABNAMROGroupPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -156,11 +148,7 @@ public class ABNAMROGroupPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -177,21 +165,21 @@ public class ABNAMROGroupPDFExtractor extends AbstractPDFExtractor
                             if (v.containsKey("taxDate1") && v.containsKey("tax1")
                                             && t.getDateTime().equals(asDate(v.get("taxDate1"))))
                             {
-                                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax1")));
+                                Money tax = Money.of(v.get("currency"), asAmount(v.get("tax1")));
                                 t.addUnit(new Unit(Unit.Type.TAX, tax));
                             }
 
                             if (v.containsKey("taxDate2") && v.containsKey("tax2")
                                             && t.getDateTime().equals(asDate(v.get("taxDate2"))))
                             {
-                                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax2")));
+                                Money tax = Money.of(v.get("currency"), asAmount(v.get("tax2")));
                                 t.addUnit(new Unit(Unit.Type.TAX, tax));
                             }
 
                             if (v.containsKey("taxDate3") && v.containsKey("tax3")
                                             && t.getDateTime().equals(asDate(v.get("taxDate3"))))
                             {
-                                Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax3")));
+                                Money tax = Money.of(v.get("currency"), asAmount(v.get("tax3")));
                                 t.addUnit(new Unit(Unit.Type.TAX, tax));
                             }
                         })

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AJBellSecuritiesLimitedPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AJBellSecuritiesLimitedPDFExtractor.java
@@ -54,11 +54,7 @@ public class AJBellSecuritiesLimitedPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "sold" change from BUY to SELL
                         .section("type").optional() //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -249,7 +249,7 @@ public abstract class AbstractPDFExtractor implements Extractor
     {
         try
         {
-            var tickerSymbol = values.get("tickerSymbol").trim(); //$NON-NLS-1$
+            var tickerSymbol = trim(values.get("tickerSymbol")); //$NON-NLS-1$
 
             for (SecuritySearchProvider provider : lookupCryptoProvider())
             {
@@ -276,23 +276,23 @@ public abstract class AbstractPDFExtractor implements Extractor
     {
         var isin = values.get("isin"); //$NON-NLS-1$
         if (isin != null)
-            isin = isin.trim();
+            isin = trim(isin);
 
         var tickerSymbol = values.get("tickerSymbol"); //$NON-NLS-1$
         if (tickerSymbol != null)
-            tickerSymbol = tickerSymbol.trim();
+            tickerSymbol = trim(tickerSymbol);
 
         var wkn = values.get("wkn"); //$NON-NLS-1$
         if (wkn != null)
-            wkn = wkn.trim();
+            wkn = trim(wkn);
 
         var name = values.get("name"); //$NON-NLS-1$
         if (name != null)
-            name = name.trim();
+            name = trim(name);
 
         var nameRowTwo = values.get("nameContinued"); //$NON-NLS-1$
         if (nameRowTwo != null)
-            name = name + " " + nameRowTwo.trim(); //$NON-NLS-1$
+            name = name + " " + trim(nameRowTwo); //$NON-NLS-1$
 
         var security = securityCache.lookup(isin, tickerSymbol, wkn, name, factory);
 
@@ -325,15 +325,15 @@ public abstract class AbstractPDFExtractor implements Extractor
         if (currency == null)
             return client.getBaseCurrency();
 
-        var unit = CurrencyUnit.getInstance(currency.trim());
+        var unit = CurrencyUnit.getInstance(trim(currency));
         if (unit != null)
             return unit.getCurrencyCode();
 
-        unit = CurrencyUnit.getInstanceBySymbol(currency.trim());
+        unit = CurrencyUnit.getInstanceBySymbol(trim(currency));
         if (unit != null)
             return unit.getCurrencyCode();
 
-        unit = CurrencyUnit.getInstanceByDisplayName(currency.trim());
+        unit = CurrencyUnit.getInstanceByDisplayName(trim(currency));
         if (unit != null)
             return unit.getCurrencyCode();
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AdvanziaBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AdvanziaBankPDFExtractor.java
@@ -46,11 +46,7 @@ public class AdvanziaBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock_Format01);
         interestBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -70,11 +66,7 @@ public class AdvanziaBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock_Format02);
         interestBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -94,11 +86,7 @@ public class AdvanziaBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock_Format01);
         depositBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -118,11 +106,7 @@ public class AdvanziaBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock_Format02);
         depositBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -142,11 +126,7 @@ public class AdvanziaBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock_Format01);
         removalBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -166,11 +146,7 @@ public class AdvanziaBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock_Format02);
         removalBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "amount") //
                         .documentContext("currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AkfBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AkfBankPDFExtractor.java
@@ -48,11 +48,7 @@ public class AkfBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount") //
                         .documentContext("currency") //
@@ -84,11 +80,7 @@ public class AkfBankPDFExtractor extends AbstractPDFExtractor
         removalBlock.setMaxSize(2);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "note", "amount", "type") //
                         .documentContext("currency") //
@@ -117,11 +109,7 @@ public class AkfBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         // @formatter:off
                         // 02 30.11.2012 / 30.11.2012 Kontoabschluß 2,71
@@ -150,7 +138,7 @@ public class AkfBankPDFExtractor extends AbstractPDFExtractor
                         .match("^[\\d]{2} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} \\/ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Kontoabschlu. \\-(?<tax>[\\.,\\d]+)$") //
                         .match("^Abgeltungssteuer.*$") //
                         .assign((t, v) -> {
-                            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            Money tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
@@ -166,7 +154,7 @@ public class AkfBankPDFExtractor extends AbstractPDFExtractor
                         .match("^[\\d]{2} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) \\/ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Kontoabschlu. \\-(?<tax>[\\.,\\d]+)$") //
                         .match("^Solidarit.tszuschlag.*$") //
                         .assign((t, v) -> {
-                            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            Money tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
@@ -182,7 +170,7 @@ public class AkfBankPDFExtractor extends AbstractPDFExtractor
                         .match("^[\\d]{2} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) \\/ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Kontoabschlu. \\-(?<tax>[\\.,\\d]+)$") //
                         .match("^Kirchensteuer.*$") //
                         .assign((t, v) -> {
-                            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            Money tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AlpacCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AlpacCapitalPDFExtractor.java
@@ -61,11 +61,7 @@ public class AlpacCapitalPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "sell" change from BUY to SELL
                         .section("type").optional() //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ApoBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ApoBankPDFExtractor.java
@@ -43,11 +43,7 @@ public class ApoBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // Is type --> "Verkauf" change from BUY to SELL
@@ -146,11 +142,7 @@ public class ApoBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Wertpapierbezeichnung iShs VII-$ Trsy Bd 3-7yr U.ETF Registered Shs EUR DIS.Hgd

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ArkeaDirectBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ArkeaDirectBankPDFExtractor.java
@@ -108,11 +108,7 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Vente" change from BUY to SELL
                         .section("type").optional() //
@@ -183,17 +179,13 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
 
         var pdfTransaction = new Transaction<BuySellEntry>();
 
-        var firstRelevantLine = new Block("^RESULTAT D'OST.*$");
+        var firstRelevantLine = new Block("^RESULTAT D.OST.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // Nous vous informons que  nous avons procédé à la souscription de 1 titre(s) VEOLIA ENVIRON. (FR0000124141).
@@ -201,14 +193,14 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("name", "isin", "currency") //
                         .match("^.*titre\\(s\\) (?<name>.*) \\((?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\).*$") //
-                        .match("^montant net.* \\- [\\,\\d\\s]+ (?<currency>[\\w]{3})$") //
+                        .match("^montant net.* \\- [\\d\\s]+,[\\d]{2} (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                         // @formatter:off
                         // Nous vous informons que  nous avons procédé à la souscription de 1 titre(s) VEOLIA ENVIRON. (FR0000124141).
                         // @formatter:on
                         .section("shares") //
-                        .match("^.*la souscription de (?<shares>[\\,\\d]+) titre\\(s\\).*.*$") //
+                        .match("^.*la souscription de (?<shares>[\\,\\d]+) titre\\(s\\).*$") //
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                         // @formatter:off
@@ -222,7 +214,7 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
                         // montant net de  : - 22,70 EUR
                         // @formatter:on
                         .section("amount", "currency") //
-                        .match("^montant net.* \\- (?<amount>[\\,\\d\\s]+) (?<currency>[\\w]{3})$") //
+                        .match("^montant net.* \\- (?<amount>[\\d\\s]+,[\\d]{2}) (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> {
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -233,24 +225,22 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
 
     private void addDepositTransaction()
     {
-        var type = new DocumentType("LIQUIDITES sur PEA",
+        final var type = new DocumentType("LIQUIDITES sur PEA", //
                         documentContext -> documentContext //
-                        // @formatter:off
-                        // Nouveau Solde au 31/12/2020 5 315,65
-                        // @formatter:on
-                        .section("year") //
-                        .match("^Nouveau Solde au 31/12/(?<year>[\\d]{4}) .*$") //
-                        .assign((ctx, v) -> {
-                            ctx.put("year", v.get("year"));
-                        })
-                        // @formatter:off
-                        // Date Libellé Débit € Crédit €
-                        // @formatter:on
-                        .section("currency") //
-                                        .match("^Date Libell. D.bit (?<currency>\\p{Sc}) Cr.dit \\1$") //
-                        .assign((ctx, v) -> {
-                            ctx.put("currency", v.get("currency"));
-                        }));
+                                        // @formatter:off
+                                        // Nouveau Solde au 31/12/2020 5 315,65
+                                        // @formatter:on
+                                        .section("year") //
+                                        .match("^Nouveau Solde au 31\\/12\\/(?<year>[\\d]{4}).*$") //
+                                        .assign((ctx, v) -> ctx.put("year", v.get("year")))
+
+                                        // @formatter:off
+                                        // Date Libellé Débit € Crédit €
+                                        // @formatter:on
+                                        .section("currency") //
+                                        .match("^Date Libell. D.bit (?<currency>\\p{Sc}) Cr.dit.*$") //
+                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency")))));
+
         this.addDocumentTyp(type);
 
 
@@ -258,26 +248,20 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
         // 02/03 VERSEMENT 3 000,00
         // 10/03 REGULARISATION 331,98
         // @formatter:on
-        var depositBlock = new Block("^(?<day>[\\d]{2})\\/(?<month>[\\d]{2}) " //
-                        + "(VERSEMENT|REGULARISATION) " //
-                        + "(?<amount>[\\.,\\d\\\s]+)");
+        var depositBlock = new Block("^(?<day>[\\d]{2})\\/(?<month>[\\d]{2}) (VERSEMENT|REGULARISATION) [\\d\\s]+,[\\d]{2}$");
         type.addBlock(depositBlock);
 
         depositBlock.set(new Transaction<AccountTransaction>() //
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
+
                         .section("amount", "day", "month", "note") //
                         .documentContext("year", "currency") //
-                        .match("^(?<day>[\\d]{2})\\/(?<month>[\\d]{2}) " //
-                                        + "(?<note>VERSEMENT|REGULARISATION) " //
-                                        + "(?<amount>[\\.,\\d\\\s]+)")
+                        .match("^(?<day>[\\d]{2})\\/(?<month>[\\d]{2}) (?<note>VERSEMENT|REGULARISATION) (?<amount>[\\d\\s]+,[\\d]{2})$")
                         .assign((t, v) -> {
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
-                            t.setAmount(asAmount(v.get("amount")));
                             t.setDateTime(asDate(v.get("day") + "." + v.get("month") + "." + v.get("year")));
+                            t.setCurrencyCode(v.get("currency"));
+                            t.setAmount(asAmount(v.get("amount")));
                             t.setNote(v.get("note"));
                         })
 
@@ -286,7 +270,7 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("AVIS D.ENCAISSEMENT COUPON");
+        final var type = new DocumentType("AVIS D.ENCAISSEMENT COUPON");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -297,11 +281,7 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -311,7 +291,7 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("name", "isin", "currency") //
                                                         .match("^.* (ACTION|OPCVM) (?<name>.*) \\((?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\).*$") //
-                                                        .match("^Montant unitaire [\\,\\d\\s]+ (?<currency>\\p{Sc})$") //
+                                                        .match("^Montant unitaire [\\d\\s]+,[\\d]{2} (?<currency>\\p{Sc})$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
                                         //   n       OPCVM  AMUND.MSCI WORLD D (LU2655993207)
@@ -320,7 +300,7 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("name", "isin", "currency") //
                                                         .match("^.* (ACTION|OPCVM) (?<name>.*) \\((?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\).*$") //
-                                                        .match("^Montant unitaire [\\,\\d\\s]+ (?<currency>[\\w]{3})$") //
+                                                        .match("^Montant unitaire [\\d\\s]+,[\\d]{2} (?<currency>[A-Z]{3})$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
                                         //   n       ACTION  ENGIE (FR0010208488))
@@ -329,7 +309,7 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("name", "isin", "currency") //
                                                         .match("^.* (ACTION|OPCVM) (?<name>.*) \\((?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\).*$") //
-                                                        .match("^Montant Net [\\,\\d\\s]+ (?<currency>\\p{Sc}).*$") //
+                                                        .match("^Montant Net [\\d\\s]+,[\\d]{2} (?<currency>\\p{Sc}).*$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
 
                         // @formatter:off
@@ -352,7 +332,7 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
                         // Montant Net 140,00 € 140,00 €
                         // @formatter:on
                         .section("amount", "currency") //
-                        .match("^Montant Net (?<amount>[\\,\\d\\s]+) (?<currency>\\p{Sc}).*$") //
+                        .match("^Montant Net (?<amount>[\\d\\s]+,[\\d]{2}) (?<currency>\\p{Sc}).*$") //
                         .assign((t, v) -> {
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -366,7 +346,7 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
 
     private void addTaxesTreatmentTransaction()
     {
-        var type = new DocumentType("AVIS RECAPITULATIF DE LA TAXE SUR LES");
+        final var type = new DocumentType("AVIS RECAPITULATIF DE LA TAXE SUR LES");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -377,11 +357,7 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // ¾ ORANGE (FR0000133308)
@@ -389,7 +365,7 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("name", "isin", "currency") //
                         .match("^. (?<name>.*) \\((?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\)$") //
-                        .match("^Montant global soumis à la TTF : [\\,\\d\\s]+ (?<currency>\\p{Sc})$") //
+                        .match("^Montant global soumis à la TTF : [\\d\\s]+,[\\d]{2} (?<currency>\\p{Sc})$") //
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                         // @formatter:off
@@ -412,9 +388,9 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
                         // 1,47
                         // @formatter:on
                         .section("currency", "amount") //
-                        .match("^Montant global soumis à la TTF : [\\,\\d\\s]+ (?<currency>\\p{Sc})$") //
-                        .find("Taux de TTF : [\\,\\d\\s]+ %")
-                        .match("(Montant de la TTF:[\\s]*|^)(?<amount>[\\,\\d\\s]+)$") //
+                        .match("^Montant global soumis à la TTF : [\\d\\s]+,[\\d]{2} (?<currency>\\p{Sc})$") //
+                        .find("Taux de TTF : [\\d\\s]+,[\\d]{2} %")
+                        .match("(Montant de la TTF:[\\s]*|^)(?<amount>[\\d\\s]+,[\\d]{2})$") //
                         .assign((t, v) -> {
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -438,14 +414,14 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
                         // Prélèvement fiscal 0,00 €
                         // @formatter:on
                         .section("tax", "currency").optional() //
-                        .match("^Pr.l.vement fiscal (?<tax>[\\,\\d\\s]+) (?<currency>\\p{Sc})$") //
+                        .match("^Pr.l.vement fiscal (?<tax>[\\d\\s]+,[\\d]{2}) (?<currency>\\p{Sc})$") //
                         .assign((t, v) -> processTaxEntries(t, v, type))
 
                         // @formatter:off
                         // Prélèvements sociaux 0,00 €
                         // @formatter:on
                         .section("tax", "currency").optional() //
-                        .match("^Pr.l.vements sociaux (?<tax>[\\,\\d\\s]+) (?<currency>\\p{Sc})$") //
+                        .match("^Pr.l.vements sociaux (?<tax>[\\d\\s]+,[\\d]{2}) (?<currency>\\p{Sc})$") //
                         .assign((t, v) -> processTaxEntries(t, v, type));
     }
 
@@ -458,7 +434,7 @@ public class ArkeaDirectBankPDFExtractor extends AbstractPDFExtractor
                         // Droits entrée/sortie 116,31 €
                         // @formatter:on
                         .section("fee", "currency").optional() //
-                        .match("^(Courtage et Commission|Droits entr.e\\/sortie) (?<fee>[\\,\\d\\s]+) (?<currency>\\p{Sc})$") //
+                        .match("^(Courtage et Commission|Droits entr.e\\/sortie) (?<fee>[\\d\\s]+,[\\d]{2}) (?<currency>\\p{Sc})$") //
                         .assign((t, v) -> processFeeEntries(t, v, type));
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AudiBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AudiBankPDFExtractor.java
@@ -26,7 +26,6 @@ public class AudiBankPDFExtractor extends AbstractPDFExtractor
         return "Audi Bank";
     }
 
-
     private void addAccountStatementTransaction()
     {
         final var type = new DocumentType("Kontoauszug / Saldenmitteilung", //
@@ -48,11 +47,7 @@ public class AudiBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -73,11 +68,7 @@ public class AudiBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -100,11 +91,7 @@ public class AudiBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -119,7 +106,7 @@ public class AudiBankPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Abgeltungsteuer [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} \\-(?<tax>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
@@ -129,7 +116,7 @@ public class AudiBankPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Solidarit.tszuschlag [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} \\-(?<tax>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
@@ -139,7 +126,7 @@ public class AudiBankPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Kirchensteuer [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} \\-(?<tax>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AustrianAnadiBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AustrianAnadiBankPDFExtractor.java
@@ -60,11 +60,7 @@ public class AustrianAnadiBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock_Format01);
         depositBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "amount") //
                         .documentContext("currency", "year") //
@@ -93,11 +89,7 @@ public class AustrianAnadiBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock_Format02);
         depositBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount") //
                         .documentContext("currency", "year") //
@@ -125,11 +117,7 @@ public class AustrianAnadiBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "amount") //
                         .documentContext("currency", "year") //
@@ -155,11 +143,7 @@ public class AustrianAnadiBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock_Format01);
         interestBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "note", "amount") //
                         .documentContext("currency", "year") //
@@ -176,7 +160,7 @@ public class AustrianAnadiBankPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^(?i)KESt[\\s]{1,}(?<tax>[\\.,\\d]+)\\-$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
 
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
                         })
@@ -195,11 +179,7 @@ public class AustrianAnadiBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock_Format02);
         interestBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "note", "amount") //
                         .documentContext("currency", "year") //
@@ -217,7 +197,7 @@ public class AustrianAnadiBankPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^(?i)KESt[\\s]{1,}(?<tax>[\\.,\\d]+)\\-$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
 
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AvivaPLCPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AvivaPLCPDFExtractor.java
@@ -54,11 +54,7 @@ public class AvivaPLCPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "SOLD" change from BUY to SELL
                         .section("type").optional() //
@@ -82,7 +78,7 @@ public class AvivaPLCPDFExtractor extends AbstractPDFExtractor
                                                         .match("^SEDOL: (?<wkn>[A-Z0-9]{7})$") //
                                                         .match("^Citicode: (?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?)\\..*$") //
                                                         .assign((t, v) -> {
-                                                            v.put("currency", GBP);
+                                                            v.put("currency", asCurrencyCode(GBP));
 
                                                             t.setSecurity(getOrCreateSecurity(v));
                                                         }),
@@ -93,7 +89,7 @@ public class AvivaPLCPDFExtractor extends AbstractPDFExtractor
                                                         .attributes("name") //
                                                         .match("^Investment Name: (?<name>.*)$") //
                                                         .assign((t, v) -> {
-                                                            v.put("currency", GBP);
+                                                            v.put("currency", asCurrencyCode(GBP));
 
                                                             t.setSecurity(getOrCreateSecurity(v));
                                                         }))
@@ -121,7 +117,7 @@ public class AvivaPLCPDFExtractor extends AbstractPDFExtractor
                                                         .attributes("amount") //
                                                         .match("^Total Consideration \\p{Sc}(?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
-                                                            t.setCurrencyCode(GBP);
+                                                            t.setCurrencyCode(asCurrencyCode(GBP));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }),
                                         // @formatter:off
@@ -132,7 +128,7 @@ public class AvivaPLCPDFExtractor extends AbstractPDFExtractor
                                                         .attributes("amount") //
                                                         .match("^Consideration([:])? \\p{Sc}(?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
-                                                            t.setCurrencyCode(GBP);
+                                                            t.setCurrencyCode(asCurrencyCode(GBP));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }))
                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BSDEXPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BSDEXPDFExtractor.java
@@ -55,11 +55,7 @@ public class BSDEXPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .oneOf( //
                                         // @formatter:off
@@ -71,8 +67,8 @@ public class BSDEXPDFExtractor extends AbstractPDFExtractor
                                                         .match("^([a-f0-9\\-]+) Kauf (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<shares>[\\.,\\d]+) (?<tickerSymbol>[A-Z0-9]{1,5}(?:[\\-\\/][A-Z0-9]{1,5})?) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+) (?<feeCurrency>[\\w]{3})$") //
                                                         .match("^([a-f0-9\\-]+)? ?(?<time>[\\d]{2}\\:[\\d]{2}\\:[\\d]{2})") //
                                                         .assign((t, v) -> {
-                                                            var fee = Money.of(v.get("feeCurrency"), asAmount(v.get("fee")));
-                                                            var amount = Money.of(v.get("currency"), asAmount(v.get("amount")));
+                                                            var fee = Money.of(asCurrencyCode(v.get("feeCurrency")), asAmount(v.get("fee")));
+                                                            var amount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
 
                                                             t.setSecurity(getOrCreateCryptoCurrency(v));
 
@@ -88,8 +84,8 @@ public class BSDEXPDFExtractor extends AbstractPDFExtractor
                                                         .attributes("date", "time", "shares", "tickerSymbol", "amount", "currency", "fee", "feeCurrency") //
                                                         .match("^([a-f0-9\\-]+) Kauf (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}\\:[\\d]{2}\\:[\\d]{2}) (?<shares>[\\.,\\d]+) (?<tickerSymbol>[A-Z0-9]{1,5}(?:[\\-\\/][A-Z0-9]{1,5})?) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}) (?<fee>[\\.,\\d]+) (?<feeCurrency>[\\w]{3})$") //
                                                         .assign((t, v) -> {
-                                                            var fee = Money.of(v.get("feeCurrency"), asAmount(v.get("fee")));
-                                                            var amount = Money.of(v.get("currency"), asAmount(v.get("amount")));
+                                                            var fee = Money.of(asCurrencyCode(v.get("feeCurrency")), asAmount(v.get("fee")));
+                                                            var amount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
 
                                                             t.setSecurity(getOrCreateCryptoCurrency(v));
 
@@ -118,11 +114,7 @@ public class BSDEXPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.SELL);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.SELL))
 
                         .oneOf( //
                                         // @formatter:off
@@ -134,8 +126,8 @@ public class BSDEXPDFExtractor extends AbstractPDFExtractor
                                                         .match("^([a-f0-9\\-]+) Verkauf (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}) (?<shares>[\\.,\\d]+) (?<tickerSymbol>[A-Z0-9]{1,5}(?:[\\-\\/][A-Z0-9]{1,5})?) (?<fee>[\\.,\\d]+) (?<feeCurrency>[\\w]{3})$") //
                                                         .match("^([a-f0-9\\-\\s]+)?(?<time>[\\d]{2}\\:[\\d]{2}\\:[\\d]{2}).*") //
                                                         .assign((t, v) -> {
-                                                            var fee = Money.of(v.get("feeCurrency"), asAmount(v.get("fee")));
-                                                            var amount = Money.of(v.get("currency"), asAmount(v.get("amount")));
+                                                            var fee = Money.of(asCurrencyCode(v.get("feeCurrency")), asAmount(v.get("fee")));
+                                                            var amount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
 
                                                             t.setSecurity(getOrCreateCryptoCurrency(v));
 
@@ -151,8 +143,8 @@ public class BSDEXPDFExtractor extends AbstractPDFExtractor
                                                         .attributes("date", "time", "amount", "currency", "shares", "tickerSymbol", "fee", "feeCurrency") //
                                                         .match("^([a-f0-9\\-]+) Verkauf (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}\\:[\\d]{2}\\:[\\d]{2}) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3}) (?<shares>[\\.,\\d]+) (?<tickerSymbol>[A-Z0-9]{1,5}(?:[\\-\\/][A-Z0-9]{1,5})?) (?<fee>[\\.,\\d]+) (?<feeCurrency>[\\w]{3})$") //
                                                         .assign((t, v) -> {
-                                                            var fee = Money.of(v.get("feeCurrency"), asAmount(v.get("fee")));
-                                                            var amount = Money.of(v.get("currency"), asAmount(v.get("amount")));
+                                                            var fee = Money.of(asCurrencyCode(v.get("feeCurrency")), asAmount(v.get("fee")));
+                                                            var amount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
 
                                                             t.setSecurity(getOrCreateCryptoCurrency(v));
 
@@ -170,7 +162,7 @@ public class BSDEXPDFExtractor extends AbstractPDFExtractor
 
     private void addDepositAndRemovalTransaction()
     {
-        var type = new DocumentType("Transaktionshistorie");
+        final var type = new DocumentType("Transaktionshistorie");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -182,11 +174,7 @@ public class BSDEXPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         // @formatter:off
                         // f5f27cba-6e3a-4120-8d96-c6be8859ce6f Einzahlung 14.06.2024 25.5 EUR IBAN-A IBAN-B

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
@@ -70,11 +70,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -369,11 +365,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // Nominale Kennung: BTC Kurs
@@ -448,11 +440,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // If we have a positive amount and a gross reinvestment,
@@ -661,11 +649,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Nominale ISIN: IE00BWBXM385 WKN: A14QBZ
@@ -762,10 +746,12 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<note>(Zahlungszeitraum|Payment Period): .*)$") //
                         .assign((t, v) -> t.setNote(concatenate(t.getNote(), v.get("note"), " | ")))
 
-                        .wrap(t -> t.getCurrencyCode() != null && t.getAmount() == 0
-                                        ? new SkippedItem(new TransactionItem(t),
-                                                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired)
-                                        : new TransactionItem(t));
+                        .wrap(t -> {
+                            if (t.getCurrencyCode() != null && t.getAmount() == 0)
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                            return new TransactionItem(t);
+                        });
     }
 
     private void addTaxAdjustmentTransaction()
@@ -781,11 +767,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         // Is type --> "Nachbelastung" change from TAX_REFUND to TAXES
                         .section("type").optional() //
@@ -878,11 +860,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("note", "date", "amount") //
                         .documentContext("currency") //
@@ -904,11 +882,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositEnglishBlock);
         depositEnglishBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("note", "date", "amount") //
                         .documentContext("currency") //
@@ -931,11 +905,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("note", "date", "amount") //
                         .documentContext("currency") //
@@ -958,11 +928,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
         feesBlock.setMaxSize(3);
         feesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .oneOf( //
                                         // @formatter:off
@@ -1006,11 +972,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
         feesBlock.setMaxSize(3);
         feesEnglishBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("note1", "date", "amount", "note2") //
                         .documentContext("currency") //
@@ -1030,11 +992,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
         interestBlock.setMaxSize(1);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .oneOf( //
                                         // @formatter:off
@@ -1086,11 +1044,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // Leistungen Beträge (EUR)
@@ -1150,11 +1104,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .oneOf( //
                                         // @formatter:off
@@ -1245,11 +1195,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         // @formatter:off
                         // Is type --> "Einbuchung" change from DELIVERY_INBOUND to DELIVERY_OUTBOUND
@@ -1351,11 +1297,7 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_OUTBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_OUTBOUND))
 
                         .oneOf( //
                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BancoBilbaoVizcayaArgentariaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BancoBilbaoVizcayaArgentariaPDFExtractor.java
@@ -51,11 +51,7 @@ public class BancoBilbaoVizcayaArgentariaPDFExtractor extends AbstractPDFExtract
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "VENTA" change from BUY to SELL
                         .section("type").optional() //
@@ -151,11 +147,7 @@ public class BancoBilbaoVizcayaArgentariaPDFExtractor extends AbstractPDFExtract
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
-        pdfTransaction.subject(() -> {
-            var portfolioTransaction = new BuySellEntry();
-            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-            return portfolioTransaction;
-        })
+        pdfTransaction.subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "REEMBOLSO" change from BUY to SELL
                         .section("type").optional() //
@@ -222,11 +214,7 @@ public class BancoBilbaoVizcayaArgentariaPDFExtractor extends AbstractPDFExtract
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
-        pdfTransaction.subject(() -> {
-            var accountTransaction = new AccountTransaction();
-            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-            return accountTransaction;
-        })
+        pdfTransaction.subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // CODIGO CUENTA VALOR VALOR (US8299331004) TIPO INTERÉS FECHA VENCIMIENTO CAMBIO DIVISA
@@ -323,11 +311,7 @@ public class BancoBilbaoVizcayaArgentariaPDFExtractor extends AbstractPDFExtract
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // ACC.AMAZON -USD- T 967,26 USD 1,1678 828,28 Mínimo 20,88

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Bank11PDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Bank11PDFExtractor.java
@@ -51,11 +51,7 @@ public class Bank11PDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount") //
                         .documentContext("currency", "year") //
@@ -81,11 +77,7 @@ public class Bank11PDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "note", "amount") //
                         .documentContext("currency", "year") //
@@ -112,11 +104,7 @@ public class Bank11PDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "amount") //
                         .documentContext("currency", "year") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractor.java
@@ -57,11 +57,7 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -153,11 +149,7 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Namen-Aktien nom CHF 100.00 Ex Datum: 02.05.2016

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BarclaysBankIrelandPLCPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BarclaysBankIrelandPLCPDFExtractor.java
@@ -52,11 +52,7 @@ public class BarclaysBankIrelandPLCPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount", "type") //
                         .documentContext("currency") //
@@ -84,11 +80,7 @@ public class BarclaysBankIrelandPLCPDFExtractor extends AbstractPDFExtractor
         interestBlock.setMaxSize(4);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         // @formatter:off
                         // 31.12.2023 31.12.2023 Habenzinsen 4,80
@@ -112,7 +104,7 @@ public class BarclaysBankIrelandPLCPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Abgeltungsteuer \\-(?<tax>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            Money tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
 
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
@@ -125,7 +117,7 @@ public class BarclaysBankIrelandPLCPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Solidarit.tszuschlag \\-(?<tax>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            Money tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
 
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BasellandschaftlicheKantonalbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BasellandschaftlicheKantonalbankPDFExtractor.java
@@ -50,11 +50,7 @@ public class BasellandschaftlicheKantonalbankPDFExtractor extends AbstractPDFExt
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BawagAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BawagAGPDFExtractor.java
@@ -52,11 +52,7 @@ public class BawagAGPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount", "type") //
                         .documentContext("currency") //
@@ -84,11 +80,7 @@ public class BawagAGPDFExtractor extends AbstractPDFExtractor
         interestBlock.setMaxSize(4);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         // @formatter:off
                         // 31.12.2023 31.12.2023 Habenzinsen 4,80
@@ -112,7 +104,7 @@ public class BawagAGPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Abgeltungsteuer \\-(?<tax>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            Money tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
 
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
@@ -125,7 +117,7 @@ public class BawagAGPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Solidarit.tszuschlag \\-(?<tax>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            Money tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
 
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BigbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BigbankPDFExtractor.java
@@ -47,11 +47,7 @@ public class BigbankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -73,11 +69,7 @@ public class BigbankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -97,11 +89,7 @@ public class BigbankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "amount") //
                         .documentContext("currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BisonPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BisonPDFExtractor.java
@@ -52,11 +52,7 @@ public class BisonPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -94,7 +90,7 @@ public class BisonPDFExtractor extends AbstractPDFExtractor
 
     private void addDeliveryInboundTransaction()
     {
-        var type = new DocumentType("Info-Report");
+        final var type = new DocumentType("Info-Report");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<PortfolioTransaction>();
@@ -105,11 +101,7 @@ public class BisonPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         // @formatter:off
                         // Gutschein BTC 0,00130130
@@ -137,7 +129,7 @@ public class BisonPDFExtractor extends AbstractPDFExtractor
 
     private void addDepositRemovalTransaction()
     {
-        var type = new DocumentType("Info-Report");
+        final var type = new DocumentType("Info-Report");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -148,11 +140,7 @@ public class BisonPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         // Is type --> "Auszahlung" change from BUY to SELL
                         .section("type").optional() //
@@ -195,11 +183,7 @@ public class BisonPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Name LYX ETF EUR CASH

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
@@ -9,7 +9,6 @@ import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
-import name.abuchen.portfolio.money.CurrencyUnit;
 
 /**
  * @implNote Bondora Capital does not have a specific bank identifier.
@@ -32,23 +31,19 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
 
     private void addAccountStatementTransaction()
     {
-        final DocumentType type = new DocumentType("(?m)^(Zusammenfassung|Summary)$");
+        final var type = new DocumentType("(?m)^(Zusammenfassung|Summary)$");
         this.addDocumentTyp(type);
 
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
+        var pdfTransaction = new Transaction<AccountTransaction>();
 
-        Block firstRelevantLine = new Block("^([\\d]{1,2}.[\\d]{1,2}.[\\d]{4}|[\\d]{4}.[\\d]{1,2}.[\\d]{1,2}) (?!Automatische .berweisung).*$");
+        var firstRelevantLine = new Block("^([\\d]{1,2}.[\\d]{1,2}.[\\d]{4}|[\\d]{4}.[\\d]{1,2}.[\\d]{1,2}) (?!Automatische .berweisung).*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.setMaxSize(1);
         firstRelevantLine.set(pdfTransaction);
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("type").optional()
                         .match("^([\\d]{1,2}.[\\d]{1,2}.[\\d]{4}|[\\d]{4}.[\\d]{1,2}.[\\d]{1,2}) " //
@@ -102,10 +97,10 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date")));
 
-                                                            String language = "de";
-                                                            String country = "DE";
+                                                            var language = "de";
+                                                            var country = "DE";
 
-                                                            int apostrophe = v.get("amount").indexOf("\'");
+                                                            var apostrophe = v.get("amount").indexOf("\'");
                                                             if (apostrophe >= 0)
                                                             {
                                                                 language = "de";
@@ -113,7 +108,7 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                                             }
 
                                                             t.setAmount(asAmount(v.get("amount"), language, country));
-                                                            t.setCurrencyCode(CurrencyUnit.EUR);
+                                                            t.setCurrencyCode(asCurrencyCode("EUR"));
                                                             t.setNote(trim(v.get("note")));
                                                         }),
                                         // @formatter:off
@@ -143,11 +138,11 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date"), Locale.UK));
 
-                                                            String language = "de";
-                                                            String country = "DE";
+                                                            var language = "de";
+                                                            var country = "DE";
 
-                                                            int lastDot = v.get("amount").lastIndexOf(".");
-                                                            int lastComma = v.get("amount").lastIndexOf(",");
+                                                            var lastDot = v.get("amount").lastIndexOf(".");
+                                                            var lastComma = v.get("amount").lastIndexOf(",");
 
                                                             if (Math.max(lastDot, lastComma) == lastDot)
                                                             {
@@ -162,7 +157,7 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                                             }
 
                                                             t.setAmount(asAmount(v.get("amount"), language, country));
-                                                            t.setCurrencyCode(CurrencyUnit.EUR);
+                                                            t.setCurrencyCode(asCurrencyCode("EUR"));
                                                             t.setNote(trim(v.get("note")));
                                                         }),
                                         // @formatter:off
@@ -187,7 +182,7 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setAmount(asAmount(v.get("amount"), "de", "DE"));
-                                                            t.setCurrencyCode(CurrencyUnit.EUR);
+                                                            t.setCurrencyCode(asCurrencyCode("EUR"));
                                                             t.setNote(trim(v.get("note")));
                                                         }))
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BourseDirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BourseDirectPDFExtractor.java
@@ -92,11 +92,7 @@ public class BourseDirectPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "VENTE" change from BUY to SELL
                         .section("type").optional() //
@@ -154,7 +150,7 @@ public class BourseDirectPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^.*[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}[\\s]{1,}(ACHAT|VENTE).*[\\s]{2,}(?<amount>[\\d\\s]+,[\\d]{2})$") //
                         .assign((t, v) -> {
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setCurrencyCode(v.get("currency"));
                             t.setAmount(asAmount(v.get("amount")));
 
                             var taxAmountTransactionHelper = type.getCurrentContext().getType(TaxAmountTransactionHelper.class).orElseGet(TaxAmountTransactionHelper::new);
@@ -215,11 +211,7 @@ public class BourseDirectPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         //   06/08/2025  COUPONS  NL0010273215  ASML HOLDING  4,08
@@ -251,7 +243,7 @@ public class BourseDirectPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^.*[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}[\\s]{1,}COUPONS.*[\\s]{2,}(?<amount>[\\d\\s]+,[\\d]{2})$") //
                         .assign((t, v) -> {
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setCurrencyCode(v.get("currency"));
                             t.setAmount(asAmount(v.get("amount")));
                         })
 
@@ -264,8 +256,8 @@ public class BourseDirectPDFExtractor extends AbstractPDFExtractor
                         .match("^.*[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}[\\s]{1,}COUPONS.*[\\s]{2,}(?<amount>[\\d\\s]+,[\\d]{2})$") //
                         .match("^.*PX UN.BRUT :[\\s]{1,}\\+[\\d\\s]+,[\\d]+[\\s]{1,}BRUT :[\\s]{1,}\\+(?<gross>[\\d\\s]+,[\\d]{2})$") //
                         .assign((t, v) -> {
-                            var amount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
-                            var gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
+                            var amount = Money.of(v.get("currency"), asAmount(v.get("amount")));
+                            var gross = Money.of(v.get("currency"), asAmount(v.get("gross")));
 
                             // @formatter:off
                             // we assume that the difference between gross and amount is tax
@@ -298,11 +290,7 @@ public class BourseDirectPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         // @formatter:off
                         //  24/02/2021  VIREMENT ESPECES  VIRT M. ET/OU MME  2 400,00
@@ -312,7 +300,7 @@ public class BourseDirectPDFExtractor extends AbstractPDFExtractor
                         .match("^.*(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4})[\\s]{1,}VIREMENT ESPECES.*[\\s]{2,}(?<amount>[\\d\\s]+,[\\d]{2})$") //
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setCurrencyCode(v.get("currency"));
                             t.setAmount(asAmount(v.get("amount")));
                         })
 
@@ -322,11 +310,7 @@ public class BourseDirectPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feesBlock);
         feesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         //  06/07/2021  DROITS DE GARDE  DDG ETG 2T21  0,81
@@ -336,7 +320,7 @@ public class BourseDirectPDFExtractor extends AbstractPDFExtractor
                         .match("^.*(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4})[\\s]{1,}DROITS DE GARDE(?<note>.*)[\\s]{2,}(?<amount>[\\d\\s]+,[\\d]{2})$") //
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setCurrencyCode(v.get("currency"));
                             t.setAmount(asAmount(v.get("amount")));
                             t.setNote(trim(v.get("note")));
                         })

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BoursoBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BoursoBankPDFExtractor.java
@@ -38,7 +38,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("(ACHAT|SOUSCRIPTION|VENTE|REPRISE)");
+        final var type = new DocumentType("(ACHAT|SOUSCRIPTION|VENTE|REPRISE)");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -49,11 +49,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "VENTE" change from BUY to SELL
                         // Is type --> "REPRISE" change from BUY to SELL
@@ -223,7 +219,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("COUPONS");
+        final var type = new DocumentType("COUPONS");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -234,11 +230,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // 15/02/2024 248 ISHS DEV MK PRO US (IE00B1FZS350) 40,33 12,09 28,24 28,24

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BundesschatzPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BundesschatzPDFExtractor.java
@@ -38,7 +38,7 @@ public class BundesschatzPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         .section("currency") //
                                         .match("^W.hrung: (?<currency>[A-Z]{3}) Erstellt am:.*$") //
-                                        .assign((ctx, v) -> ctx.put("currency", v.get("currency"))));
+                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency")))));
         this.addDocumentTyp(type);
 
         // @formatter:off
@@ -48,11 +48,7 @@ public class BundesschatzPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "amount", "note") //
                         .documentContext("currency") //
@@ -73,11 +69,7 @@ public class BundesschatzPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "amount", "note") //
                         .documentContext("currency") //
@@ -102,7 +94,7 @@ public class BundesschatzPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         .section("currency") //
                                         .match("^W.hrung: (?<currency>[A-Z]{3}) Erstellt am:.*$") //
-                                        .assign((ctx, v) -> ctx.put("currency", v.get("currency"))));
+                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency")))));
         this.addDocumentTyp(type);
 
         // @formatter:off
@@ -121,11 +113,7 @@ public class BundesschatzPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("note1", "note2", "date", "tax", "amount") //
                         .documentContext("currency") //
@@ -145,7 +133,7 @@ public class BundesschatzPDFExtractor extends AbstractPDFExtractor
                             t.setAmount(asAmount(v.get("amount")));
                             t.setNote(v.get("note2") + " - " + v.get("date") + " (" + trim(v.get("note1")) + ")");
 
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
                         })
 
@@ -158,11 +146,7 @@ public class BundesschatzPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "note", "amount") //
                         .documentContext("currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/C24BankGmbHPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/C24BankGmbHPDFExtractor.java
@@ -69,11 +69,7 @@ public class C24BankGmbHPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "type", "amount", "currency") //
                         .documentContext("year") //
@@ -104,11 +100,7 @@ public class C24BankGmbHPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "note", "type", "amount", "currency") //
                         .documentContext("year") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CetesDirectoPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CetesDirectoPDFExtractor.java
@@ -114,11 +114,7 @@ public class CetesDirectoPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // Is type --> "AMORTIZACION" change from BUY to SELL
@@ -212,11 +208,7 @@ public class CetesDirectoPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // 06/01/22 06/01/22 SVD148097667COMPSI BONDDIA PF2 3 1.57377100 0 0.00 4.72 0.00 1.48

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
@@ -94,7 +94,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("(Wertpapierkauf" //
+        final var type = new DocumentType("(Wertpapierkauf" //
                         + "|Wertpapierverkauf" //
                         + "|Verkauf .* B.rsenplatz" //
                         + "|Wertpapierumtausch)");
@@ -112,11 +112,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Wertpapierverkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -490,7 +486,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
     private void addSellWithNegativeAmountTransaction()
     {
-        var type = new DocumentType("Wertpapierverkauf");
+        final var type = new DocumentType("Wertpapierverkauf");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -501,11 +497,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .oneOf( //
                                         // @formatter:off
@@ -698,7 +690,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("(Dividendengutschrift" //
+        final var type = new DocumentType("(Dividendengutschrift" //
                         + "|Ertragsgutschrift" //
                         + "|Zinsgutschrift" //
                         + "|Ertragsthesaurierung)");
@@ -715,11 +707,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -810,7 +798,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> {
                                                             v.put("wkn", stripBlanks(v.get("wkn")));
                                                             v.put("isin", stripBlanks(v.get("isin")));
-                                                            v.put("currency", stripBlanks(v.get("currency")));
+                                                            v.put("currency", asCurrencyCode(stripBlanks(v.get("currency"))));
                                                             v.put("name", trim(replaceMultipleBlanks(v.get("name"))));
                                                             v.put("nameContinued", trim(replaceMultipleBlanks(v.get("nameContinued"))));
 
@@ -1004,7 +992,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
     private void addTaxesTreatmentTransaction()
     {
-        var type = new DocumentType("Steuerliche Behandlung: " //
+        final var type = new DocumentType("Steuerliche Behandlung: " //
                         + "(Wertpapierkauf" //
                         + "|Verkauf" //
                         + "|Wertpapierverkauf" //
@@ -1025,11 +1013,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         .oneOf( //
                                         // @formatter:off
@@ -1043,7 +1027,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                                                         + "(G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n|L[\\s]*a[\\s]*s[\\s]*t[\\s]*e[\\s]*n)" //
                                                                         + "[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?:[A-Z][\\s]*){3}[\\s]{1,}[\\.,\\d\\s]+[\\s]{1,}(?<currency>(?:[A-Z][\\s]*){3})[\\-\\s]{1,}[\\.,\\d\\s]+.*$") //
                                                         .assign((t, v) -> {
-                                                            v.put("currency", stripBlanks(v.get("currency")));
+                                                            v.put("currency", asCurrencyCode(stripBlanks(v.get("currency"))));
                                                             v.put("name", trim(replaceMultipleBlanks(v.get("name"))));
 
                                                             t.setSecurity(getOrCreateSecurity(v));
@@ -1065,7 +1049,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                                                         + "(G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n|L[\\s]*a[\\s]*s[\\s]*t[\\s]*e[\\s]*n)" //
                                                                         + "[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?<currency>(?:[A-Z][\\s]*){3})[\\-\\s]{1,}[\\.,\\d\\s]+.*$") //
                                                         .assign((t, v) -> {
-                                                            v.put("currency", stripBlanks(v.get("currency")));
+                                                            v.put("currency", asCurrencyCode(stripBlanks(v.get("currency"))));
                                                             v.put("name", trim(replaceMultipleBlanks(v.get("name"))));
 
                                                             t.setSecurity(getOrCreateSecurity(v));
@@ -1081,7 +1065,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                                                         + "(G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n|L[\\s]*a[\\s]*s[\\s]*t[\\s]*e[\\s]*n)" //
                                                                         + "[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?:[A-Z][\\s]*){3}[\\-\\s]{1,}[\\.,\\d\\s]+.*$") //
                                                         .assign((t, v) -> {
-                                                            v.put("currency", stripBlanks(v.get("currency")));
+                                                            v.put("currency", asCurrencyCode(stripBlanks(v.get("currency"))));
                                                             v.put("name", trim(replaceMultipleBlanks(v.get("name"))));
 
                                                             t.setSecurity(getOrCreateSecurity(v));
@@ -1456,7 +1440,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
     private void addDepositoryFeeTransaction()
     {
-        var type = new DocumentType("Verwahrentgelt", "Finanzreport");
+        final var type = new DocumentType("Verwahrentgelt", "Finanzreport");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -1467,11 +1451,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // Abrechnung Verwahrentgelt Xetra Gold, WKN A0S9GB 06.01.2020
@@ -1529,7 +1509,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
 
     private void addFinancialReport()
     {
-        var type = new DocumentType("Finanzreport", (context, lines) -> {
+        final var type = new DocumentType("Finanzreport", (context, lines) -> {
             var pCurrency = Pattern.compile("^Kontow.hrung (?<currency>[A-Z]{3})$");
             var pForeignCurrencyAccount = Pattern.compile("^W.hrungsanlagekonto \\((?<foreignCurrency>[A-Z]{3})\\) .*$");
             var pAccountingBillDate = Pattern.compile("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) Kontoabschluss .*$");
@@ -1609,11 +1589,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
         removalBlock.setMaxSize(3);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("note1", "note2", "amount", "date") //
                         .match("(^|^A)[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} " //
@@ -1685,11 +1661,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
         depositBlock.setMaxSize(3);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("note1", "note2", "amount", "date") //
                         .match("(^|^A)[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} " //
@@ -1763,11 +1735,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feesBlock);
         feesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("date", "amount", "note") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} " //
@@ -1797,11 +1765,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
         type.addBlock(accountingBillFeeBlock);
         accountingBillFeeBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("note", "amount", "currency") //
                         .match("^(?<note>Versandpauschale) " //
@@ -1834,11 +1798,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "type", "amount") //
                         .documentContext("currency") //
@@ -1894,11 +1854,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
         type.addBlock(taxesBlock);
         taxesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .section("date", "type", "amount") //
                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) " //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommSecPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommSecPDFExtractor.java
@@ -52,11 +52,7 @@ public class CommSecPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "SOLD" change from BUY to SELL
                         .section("type").optional() //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CommerzbankPDFExtractor.java
@@ -102,11 +102,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Wertpapierkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -214,11 +210,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // p e r 2 7 . 0 3 . 2 0 2 0 Samsung E l e c t r o n i c s Co. L t d . 881823
@@ -355,11 +347,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         .oneOf( //
                                         // @formatter:off
@@ -391,7 +379,7 @@ public class CommerzbankPDFExtractor extends AbstractPDFExtractor
                                                         .match("^[\\s]*Z[\\s]*u[\\s]*I[\\s]*h[\\s]*r[\\s]*e[\\s]*n[\\s]*(?:G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n|L[\\s]*a[\\s]*s[\\s]*t[\\s]*e[\\s]*n)[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:?[\\s]*?(?<currency>[A-Z\\s]{3,}).*$") //
                                                         .assign((t, v) -> {
                                                             v.put("name", trim(replaceMultipleBlanks(v.get("name"))));
-                                                            v.put("currency", stripBlanks(v.get("currency")));
+                                                            v.put("currency", asCurrencyCode(stripBlanks(v.get("currency"))));
 
                                                             t.setSecurity(getOrCreateSecurity(v));
                                                         }))

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComputersharePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComputersharePDFExtractor.java
@@ -11,7 +11,6 @@ import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
-import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Values;
 
 /**
@@ -26,6 +25,7 @@ import name.abuchen.portfolio.money.Values;
 public class ComputersharePDFExtractor extends AbstractPDFExtractor
 {
 
+    private static final String USD = "USD";
     private static final String TICKERSYMBOL = "tickerSymbol";
     private static final String WKN = "wkn";
 
@@ -110,18 +110,14 @@ public class ComputersharePDFExtractor extends AbstractPDFExtractor
         // create source
         final Transaction<BuySellEntry> purchaseTransaction = new Transaction<>();
         purchaseBlocks.set(purchaseTransaction);
-        purchaseTransaction.subject(() -> {
-            BuySellEntry entry = new BuySellEntry();
-            entry.setType(PortfolioTransaction.Type.BUY);
-            return entry;
-        });
+        purchaseTransaction.subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY));
         purchaseTransaction.oneOf(
 
                         section -> section.attributes("date", "amount", "shares", "fee") //
                                         .documentContext(TICKERSYMBOL, WKN) //
                                         .match("^(?<date>[\\d]{2} [\\w]{3} [\\d]{4}) Purchase (?<amount>[\\.,\\d]+) (?<fee>[\\.,\\d]+) (?<netAmount>[\\.,\\d]+) (?<grantDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvGrant>[\\.,\\d]+) (?<purchaseDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvPurchase>[\\.,\\d]+) (?<sharePrice>[\\.,\\d]+) (?<shares>[\\.,\\d]+) (?<totalShares>[\\.,\\d]+).*") //
                                         .assign((t, v) -> {
-                                            v.put("currency", CurrencyUnit.USD);
+                                            v.put("currency", asCurrencyCode(USD));
                                             t.setDate(asDate(v.get("date")));
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));
@@ -134,7 +130,7 @@ public class ComputersharePDFExtractor extends AbstractPDFExtractor
                                         .documentContext(TICKERSYMBOL, WKN) //
                                         .match("^(?<date>[\\d]{2} [\\w]{3} [\\d]{4}) Purchase (?<amount>[\\.,\\d]+) (?<netAmount>[\\.,\\d]+) (?<grantDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvGrant>[\\.,\\d]+) (?<purchaseDate>[\\d]{2} [\\w]{3} [\\d]{4}) (?<fmvPurchase>[\\.,\\d]+) (?<sharePrice>[\\.,\\d]+) (?<shares>[\\.,\\d]+) (?<totalShares>[\\.,\\d]+).*") //
                                         .assign((t, v) -> {
-                                            v.put("currency", CurrencyUnit.USD);
+                                            v.put("currency", asCurrencyCode(USD));
                                             t.setDate(asDate(v.get("date")));
                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                             t.setAmount(asAmount(v.get("amount")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -18,7 +18,6 @@ import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
-import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 
@@ -84,11 +83,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "VERKAUF" change from BUY to SELL
                         .section("type").optional() //
@@ -370,13 +365,11 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                             t.setNote(concatenate(t.getNote(), v.get("note2"), " "));
                         })
 
-                        .wrap((t, ctx) -> {
-                            var item = new BuySellEntryItem(t);
-
+                        .wrap(t -> {
                             if (t.getPortfolioTransaction().getCurrencyCode() != null && t.getPortfolioTransaction().getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new BuySellEntryItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            return item;
+                            return new BuySellEntryItem(t);
                         });
 
         addTaxesSectionsTransaction(pdfTransaction, type);
@@ -405,11 +398,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Storno wegen geänderten steuerrelevanten Daten. Neuabrechnung folgt.
@@ -705,11 +694,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.SELL);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.SELL))
 
                         // @formatter:off
                         // Wertpapierbezeichnung WKN ISIN
@@ -769,11 +754,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Wertpapierbezeichnung WKN ISIN
@@ -809,13 +790,11 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                             t.setAmount(asAmount(v.get("amount")));
                         })
 
-                        .wrap((t, ctx) -> {
-                            var item = new TransactionItem(t);
+                        .wrap(t -> {
+                            if (t.getCurrencyCode() != null && t.getAmount() == 0)
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            if (t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
-
-                            return item;
+                            return new TransactionItem(t);
                         });
     }
 
@@ -832,15 +811,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-
-                            // Set currency
-                            accountTransaction.setCurrencyCode(CurrencyUnit.EUR);
-
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         // @formatter:off
                         // Den Steuerausgleich buchen wir mit Wertstellung 10.07.2017
@@ -870,15 +841,14 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                 t.setType(AccountTransaction.Type.TAXES);
 
                             t.setAmount(asAmount(v.get("amount")));
+                            t.setCurrencyCode(asCurrencyCode("EUR"));
                         })
 
-                        .wrap((t, ctx) -> {
-                            var item = new TransactionItem(t);
+                        .wrap(t -> {
+                            if (t.getCurrencyCode() != null && t.getAmount() == 0)
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            if (t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
-
-                            return item;
+                            return new TransactionItem(t);
                         });
     }
 
@@ -944,11 +914,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("note", "date", "amount") //
                         .documentContext("year", "currency") //
@@ -985,11 +951,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("note", "date", "amount") //
                         .documentContext("year", "currency") //
@@ -1019,11 +981,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock_Format01);
         interestBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "amount", "type") //
                         .documentContext("year", "currency") //
@@ -1061,11 +1019,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock_Format02);
         interestBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("amount", "type") //
                         .documentContext("currency", "date") //
@@ -1110,11 +1064,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         // @formatter:off
                         // Is type --> "AUSGANG" change from DELIVERY_INBOUND to DELIVERY_OUTBOUND
@@ -1261,12 +1211,12 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }
@@ -1285,12 +1235,12 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }
@@ -1338,12 +1288,12 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }
@@ -1362,12 +1312,12 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }
@@ -1414,12 +1364,12 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }
@@ -1454,12 +1404,12 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CreditMutuelAllianceFederalePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CreditMutuelAllianceFederalePDFExtractor.java
@@ -40,11 +40,7 @@ public class CreditMutuelAllianceFederalePDFExtractor extends AbstractPDFExtract
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // Montant brut (frais inclus) : 3 000,00 €

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CreditSuisseAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CreditSuisseAGPDFExtractor.java
@@ -55,11 +55,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -185,11 +181,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -274,11 +266,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES_REFUND))
 
                         .oneOf( //
                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CrowdestorPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CrowdestorPDFExtractor.java
@@ -48,11 +48,7 @@ public class CrowdestorPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         // 14.07.2022 CRF-6-4911 Deposit +50.00 50.00
                         // 16.07.2022 CRF-6-4911 Profit +0.03 50.03
@@ -62,7 +58,7 @@ public class CrowdestorPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setCurrencyCode(v.get("currency"));
 
                             // Switch transactions if ...
                             switch (v.get("type"))

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -57,11 +57,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -301,11 +297,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -586,11 +578,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            PortfolioTransaction portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         // @formatter:off
                         // Is type --> "Lasten Ihres Depots" change from DELIVERY_INBOUND to DELIVERY_OUTBOUND
@@ -752,11 +740,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         // @formatter:off
                         // Gattungsbezeichnung ISIN
@@ -867,11 +851,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Gattungsbezeichnung ISIN
@@ -930,11 +910,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .oneOf( //
                                         // @formatter:off
@@ -1146,11 +1122,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock_Format01);
         depositBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("note", "date", "amount") //
                         .documentContext("currency") //
@@ -1171,11 +1143,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock_Format02);
         depositBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount", "currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<note>SEPA\\-.berweisung) .* (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
@@ -1195,11 +1163,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock_Format03);
         depositBlock_Format03.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount") //
                         .documentContext("year", "currency") //
@@ -1221,11 +1185,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock_Format01);
         removalBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("note", "date", "amount") //
                         .documentContext("currency") //
@@ -1246,11 +1206,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock_Format02);
         removalBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "note", "amount", "currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<note>SEPA\\-.berweisung) .* -(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
@@ -1270,11 +1226,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock_Format03);
         removalBlock_Format03.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("note", "date", "amount") //
                         .documentContext("year", "currency") //
@@ -1295,11 +1247,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feesBlock_Format01);
         feesBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("note", "date", "amount") //
                         .documentContext("currency") //
@@ -1320,11 +1268,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feesBlock_Format02);
         feesBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("note", "date", "amount") //
                         .documentContext("currency") //
@@ -1347,11 +1291,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         feeBlock_Format03.setMaxSize(2);
         feeBlock_Format03.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("amount", "date", "note") //
                         .documentContext("currency", "year") //
@@ -1376,11 +1316,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestChargeBlock);
         interestChargeBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST_CHARGE);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST_CHARGE))
 
                         .section("note", "date", "amount", "currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<note>Sollzinsen) -(?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
@@ -1404,11 +1340,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
         type.addBlock(BuySellBlock);
         BuySellBlock.set(new Transaction<BuySellEntry>()
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .section("amount", "date", "isin", "shares", "type") //
                         .documentContext("currency", "year") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DADATBankenhausPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DADATBankenhausPDFExtractor.java
@@ -47,7 +47,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("(Abrechnungsauskunft|Kauf Depot)");
+        final var type = new DocumentType("(Abrechnungsauskunft|Kauf Depot)");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -58,11 +58,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .oneOf( //
                                         // @formatter:off
@@ -160,7 +156,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("Gesch.ftsart: Ertrag");
+        final var type = new DocumentType("Gesch.ftsart: Ertrag");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -171,11 +167,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Titel: US09247X1019 B L A C K R O C K I NC.
@@ -280,11 +272,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -386,11 +374,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -514,11 +498,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         .oneOf( //
                                         // @formatter:off
@@ -620,11 +600,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         // @formatter:off
                         // 15.10 KESt-Verlustausgleich            Depot    7806000200/20211014-41350584 18.10 159,57
@@ -693,11 +669,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -771,11 +743,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -859,11 +827,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -952,10 +916,7 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransferEntry = new AccountTransferEntry();
-                            return accountTransferEntry;
-                        })
+                        .subject(AccountTransferEntry::new)
 
                         // @formatter:off
                         // 07.01 UMBUCHUNG   INTERNET AM 2025-01-03 03.01 20.000,00

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankGruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankGruppePDFExtractor.java
@@ -83,11 +83,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -187,11 +183,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -316,11 +308,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Nominale Wertpapierbezeichnung ISIN (WKN)
@@ -367,9 +355,9 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                         .match("^.*(?<note>Abrechnungsnr\\. [\\d]+).*$") //
                         .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
-                        .wrap((t, ctx) -> {
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
                             return new TransactionItem(t);
                         });
@@ -529,11 +517,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
         // 01.03.2022 Anlage 4,24 25,5849 0,166
         // @formatter:on
         Transaction<BuySellEntry> pdfTransaction1 = new Transaction<>();
-        pdfTransaction1.subject(() -> {
-            BuySellEntry entry = new BuySellEntry();
-            entry.setType(PortfolioTransaction.Type.BUY);
-            return entry;
-        });
+        pdfTransaction1.subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY));
 
         Block firstRelevantLine1 = new Block("^[\\s\\d]{2,3}\\.[\\d]{2}\\.[\\d]{4} (Kauf|Wiederanlage|Verkauf|Anlage) .*$");
         type.addBlock(firstRelevantLine1);
@@ -683,11 +667,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
         // 1 0.12.2020 Wiederanlage 362,80 0,00 53,91 6,730
         // @formatter:on
         Transaction<AccountTransaction> pdfTransaction2 = new Transaction<>();
-        pdfTransaction2.subject(() -> {
-            AccountTransaction transaction = new AccountTransaction();
-            transaction.setType(AccountTransaction.Type.DIVIDENDS);
-            return transaction;
-        });
+        pdfTransaction2.subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS));
 
         Block firstRelevantLine2 = new Block("^(Gesamtaussch.ttung|Aussch.ttung) \\*[\\d]+ [\\.,\\d]+$", "^Bestand .*$");
         type.addBlock(firstRelevantLine2);
@@ -735,11 +715,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
         // Anlage 2,09 0,00 241,88 0,009
         // @formatter:on
         Transaction<PortfolioTransaction> pdfTransaction3 = new Transaction<>();
-        pdfTransaction3.subject(() -> {
-            PortfolioTransaction transaction = new PortfolioTransaction();
-            transaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-            return transaction;
-        });
+        pdfTransaction3.subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
         Block firstRelevantLine3 = new Block("^[\\s\\d]{2,3}\\.[\\d]{2}\\.[\\d]{4} Ausgleichsbuchung Steuer.* .*$");
         type.addBlock(firstRelevantLine3);
@@ -789,11 +765,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
         // Anlage 458,99 0,00 37,77 12,152
         // @formatter:on
         Transaction<PortfolioTransaction> pdfTransaction4 = new Transaction<>();
-        pdfTransaction4.subject(() -> {
-            PortfolioTransaction transaction = new PortfolioTransaction();
-            transaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-            return transaction;
-        });
+        pdfTransaction4.subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND));
 
         Block firstRelevantLine4 = new Block("^[\\s\\d]{2,3}\\.[\\d]{2}\\.[\\d]{4} Umtausch .*$");
         type.addBlock(firstRelevantLine4);
@@ -866,11 +838,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
         // Postbox
         // @formatter:on
         Transaction<AccountTransaction> pdfTransaction5 = new Transaction<>();
-        pdfTransaction5.subject(() -> {
-            AccountTransaction transaction = new AccountTransaction();
-            transaction.setType(AccountTransaction.Type.FEES);
-            return transaction;
-        });
+        pdfTransaction5.subject(() -> new AccountTransaction(AccountTransaction.Type.FEES));
 
         Block firstRelevantLine5 = new Block("^Depotgeb.hr .*$", "^Bestand .*$");
         type.addBlock(firstRelevantLine5);
@@ -900,11 +868,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
         // inklusive Solidaritätszuschlag
         // @formatter:on
         Transaction<AccountTransaction> pdfTransaction6 = new Transaction<>();
-        pdfTransaction6.subject(() -> {
-            AccountTransaction transaction = new AccountTransaction();
-            transaction.setType(AccountTransaction.Type.TAX_REFUND);
-            return transaction;
-        });
+        pdfTransaction6.subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND));
 
         Block firstRelevantLine6 = new Block("^Erstattung Kapitalertragsteuer .*$", "^Bestand .*$");
         type.addBlock(firstRelevantLine6);
@@ -933,11 +897,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
         // Erstattung Kirchensteuer 1,27
         // @formatter:on
         Transaction<AccountTransaction> pdfTransaction7 = new Transaction<>();
-        pdfTransaction7.subject(() -> {
-            AccountTransaction transaction = new AccountTransaction();
-            transaction.setType(AccountTransaction.Type.TAX_REFUND);
-            return transaction;
-        });
+        pdfTransaction7.subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND));
 
         Block firstRelevantLine7 = new Block("^Erstattung Kirchensteuer .*$", "^Bestand .*$");
         type.addBlock(firstRelevantLine7);
@@ -973,11 +933,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         // @formatter:off
                         // Ausmachender Betrag 29,57 EUR
@@ -1044,12 +1000,12 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }
@@ -1079,12 +1035,12 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }
@@ -1113,12 +1069,12 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DebitumInvestmentsPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DebitumInvestmentsPDFExtractor.java
@@ -56,11 +56,7 @@ public class DebitumInvestmentsPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("type", "amount") //
                         .documentContext("date") //
@@ -97,11 +93,7 @@ public class DebitumInvestmentsPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         // @formatter:off
                         // Other balance increases during reporting period: 0.0

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
@@ -59,11 +59,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         Block block = new Block("^Dividend note .*$");
         type.addBlock(block);
         Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>()
-            .subject(() -> {
-                AccountTransaction entry = new AccountTransaction();
-                entry.setType(AccountTransaction.Type.DIVIDENDS);
-                return entry;
-            });
+            .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS));
 
         pdfTransaction
                 // @formatter:off
@@ -329,11 +325,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockDeposit);
         blockDeposit.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction t = new AccountTransaction();
-                            t.setType(AccountTransaction.Type.DEPOSIT);
-                            return t;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "time", "note", "currency", "amount")
                         .match("^(?<date>[\\d]{2}\\-[\\d]{2}\\-[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}) "
@@ -386,11 +378,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockRemoval);
         blockRemoval.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction t = new AccountTransaction();
-                            t.setType(AccountTransaction.Type.REMOVAL);
-                            return t;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "time", "note", "currency", "amount")
                         .match("(?<date>[\\d]{2}\\-[\\d]{2}\\-[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}) "
@@ -492,11 +480,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockDividends);
         blockDividends.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction t = new AccountTransaction();
-                            t.setType(AccountTransaction.Type.DIVIDENDS);
-                            return t;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .optionalOneOf(
                                         // @formatter:off
@@ -804,11 +788,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockDividendTax);
         blockDividendTax.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction t = new AccountTransaction();
-                            t.setType(AccountTransaction.Type.TAX_REFUND);
-                            return t;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         // @formatter:off
                         // 16-12-2021 18:26 22-10-2021 VANGUARD TOTAL INTERNA US9219097683 Dividendbelasting USD -10,45 USD -22,78
@@ -932,11 +912,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockInterest);
         blockInterest.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction t = new AccountTransaction();
-                            t.setType(AccountTransaction.Type.INTEREST);
-                            return t;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "time", "note", "currency", "type", "amount")
                         .match("^(?<date>[\\d]{2}\\-[\\d]{2}\\-[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}) "
@@ -988,11 +964,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockDepositFee);
         blockDepositFee.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction t = new AccountTransaction();
-                            t.setType(AccountTransaction.Type.FEES);
-                            return t;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("date", "time", "note", "currency", "amount")
                         .match("^(?<date>[\\d]{2}\\-[\\d]{2}\\-[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}) "
@@ -1065,11 +1037,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockTrademodalities);
         blockTrademodalities.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction t = new AccountTransaction();
-                            t.setType(AccountTransaction.Type.FEES_REFUND);
-                            return t;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES_REFUND))
 
                         .oneOf(
                                 section -> section
@@ -1243,11 +1211,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockFeeStrike);
         blockFeeStrike.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction t = new AccountTransaction();
-                            t.setType(AccountTransaction.Type.FEES);
-                            return t;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("date", "time", "name", "isin", "note", "currency", "amount")
                         .match("^(?<date>[\\d]{2}\\-[\\d]{2}\\-[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}) "
@@ -1294,11 +1258,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockFeeReturn);
         blockFeeReturn.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction t = new AccountTransaction();
-                            t.setType(AccountTransaction.Type.FEES_REFUND);
-                            return t;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES_REFUND))
 
                         .section("date", "time", "note", "currency", "amount")
                         .match("^(?<date>[\\d]{2}\\-[\\d]{2}\\-[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}) "
@@ -1348,11 +1308,7 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
 
         blockBuy.set(new Transaction<BuySellEntry>()
 
-                        .subject(() -> {
-                            BuySellEntry entry = new BuySellEntry();
-                            entry.setType(PortfolioTransaction.Type.BUY);
-                            return entry;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .oneOf(
                             // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DekaBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DekaBankPDFExtractor.java
@@ -19,8 +19,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import name.abuchen.portfolio.Messages;
-import name.abuchen.portfolio.datatransfer.DocumentContext;
-import name.abuchen.portfolio.datatransfer.ExtrExchangeRate;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
@@ -28,7 +26,6 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
-import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 
@@ -60,17 +57,13 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        DocumentType type = new DocumentType("(LASTSCHRIFTEINZUG|VERKAUF|KAUF|KAUF AUS ERTRAG)");
+        final var type = new DocumentType("(LASTSCHRIFTEINZUG|VERKAUF|KAUF|KAUF AUS ERTRAG)");
         this.addDocumentTyp(type);
 
-        Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
-        pdfTransaction.subject(() -> {
-            BuySellEntry entry = new BuySellEntry();
-            entry.setType(PortfolioTransaction.Type.BUY);
-            return entry;
-        });
+        var pdfTransaction = new Transaction<BuySellEntry>();
+        pdfTransaction.subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY));
 
-        Block firstRelevantLine = new Block("^(LASTSCHRIFTEINZUG|VERKAUF|KAUF|KAUF AUS ERTRAG) .*$");
+        var firstRelevantLine = new Block("^(LASTSCHRIFTEINZUG|VERKAUF|KAUF|KAUF AUS ERTRAG) .*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -159,17 +152,13 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
 
     private void addSwapBuyTransaction()
     {
-        DocumentType type = new DocumentType("TAUSCH\\/KAUF");
+        final var type = new DocumentType("TAUSCH\\/KAUF");
         this.addDocumentTyp(type);
 
-        Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
-        pdfTransaction.subject(() -> {
-            BuySellEntry entry = new BuySellEntry();
-            entry.setType(PortfolioTransaction.Type.BUY);
-            return entry;
-        });
+        var pdfTransaction = new Transaction<BuySellEntry>();
+        pdfTransaction.subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY));
 
-        Block firstRelevantLine = new Block("^TAUSCH\\/KAUF.*$", "^Bestand neu:.*$");
+        var firstRelevantLine = new Block("^TAUSCH\\/KAUF.*$", "^Bestand neu:.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -244,11 +233,11 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> {
                     v.put("baseCurrency", asCurrencyCode(v.get("currency")));
 
-                    ExtrExchangeRate rate = asExchangeRate(v);
+                    var rate = asExchangeRate(v);
                     type.getCurrentContext().putType(rate);
 
-                    Money gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
-                    Money fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
+                    var gross = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("gross")));
+                    var fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
 
                     checkAndSetGrossUnit(gross, fxGross, t, type.getCurrentContext());
                 })
@@ -267,17 +256,13 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
 
     private void addSwapSellTransaction()
     {
-        DocumentType type = new DocumentType("TAUSCH\\/VERKAUF");
+        final var type = new DocumentType("TAUSCH\\/VERKAUF");
         this.addDocumentTyp(type);
 
-        Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
-        pdfTransaction.subject(() -> {
-            BuySellEntry entry = new BuySellEntry();
-            entry.setType(PortfolioTransaction.Type.SELL);
-            return entry;
-        });
+        var pdfTransaction = new Transaction<BuySellEntry>();
+        pdfTransaction.subject(() -> new BuySellEntry(PortfolioTransaction.Type.SELL));
 
-        Block firstRelevantLine = new Block("^TAUSCH\\/VERKAUF.*$", "^Bestand neu:.*$");
+        var firstRelevantLine = new Block("^TAUSCH\\/VERKAUF.*$", "^Bestand neu:.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -355,17 +340,13 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
 
     private void addReinvestTransaction()
     {
-        DocumentType type = new DocumentType("(ERTRAGSAUSSCH.TTUNG \\/ KAUF AUS ERTRAG|ERTRAGSABRECHNUNG|ERTRAGSAUSSCH.TTUNG)");
+        final var type = new DocumentType("(ERTRAGSAUSSCH.TTUNG \\/ KAUF AUS ERTRAG|ERTRAGSABRECHNUNG|ERTRAGSAUSSCH.TTUNG)");
         this.addDocumentTyp(type);
 
-        Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
-        pdfTransaction.subject(() -> {
-            BuySellEntry entry = new BuySellEntry();
-            entry.setType(PortfolioTransaction.Type.BUY);
-            return entry;
-        });
+        var pdfTransaction = new Transaction<BuySellEntry>();
+        pdfTransaction.subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY));
 
-        Block firstRelevantLine = new Block("^(ERTRAGSAUSSCH.TTUNG \\/ KAUF AUS ERTRAG|ERTRAGSABRECHNUNG|ERTRAGSAUSSCH.TTUNG)$");
+        var firstRelevantLine = new Block("^(ERTRAGSAUSSCH.TTUNG \\/ KAUF AUS ERTRAG|ERTRAGSABRECHNUNG|ERTRAGSAUSSCH.TTUNG)$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -443,16 +424,12 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        DocumentType type = new DocumentType("(ERTRAGSAUSSCH.TTUNG|ERTRAGSABRECHNUNG)");
+        final var type = new DocumentType("(ERTRAGSAUSSCH.TTUNG|ERTRAGSABRECHNUNG)");
         this.addDocumentTyp(type);
 
-        Block block = new Block("^(ERTRAGSAUSSCH.TTUNG|ERTRAGSABRECHNUNG).*$");
+        var block = new Block("^(ERTRAGSAUSSCH.TTUNG|ERTRAGSABRECHNUNG).*$");
         type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
-            AccountTransaction entry = new AccountTransaction();
-            entry.setType(AccountTransaction.Type.DIVIDENDS);
-            return entry;
-        });
+        var pdfTransaction = new Transaction<AccountTransaction>().subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS));
 
         pdfTransaction
                 .oneOf(
@@ -525,7 +502,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                 .section("currency", "tax").optional()
                 .match("^\\-.*Verrechnete Steuern (?<currency>[\\w]{3}) (?<tax>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
-                    Money tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                    var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
                     t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
                 })
 
@@ -561,17 +538,13 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
 
     private void addDeliveryInOutBoundTransaction()
     {
-        DocumentType type = new DocumentType("AUSLIEFERUNG");
+        final var type = new DocumentType("AUSLIEFERUNG");
         this.addDocumentTyp(type);
 
-        Transaction<PortfolioTransaction> pdfTransaction = new Transaction<>();
-        pdfTransaction.subject(() -> {
-            PortfolioTransaction entry = new PortfolioTransaction();
-            entry.setType(PortfolioTransaction.Type.DELIVERY_OUTBOUND);
-            return entry;
-        });
+        var pdfTransaction = new Transaction<PortfolioTransaction>();
+        pdfTransaction.subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_OUTBOUND));
 
-        Block firstRelevantLine = new Block("^AUSLIEFERUNG.*$");
+        var firstRelevantLine = new Block("^AUSLIEFERUNG.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -587,7 +560,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                     t.setSecurity(getOrCreateSecurity(v));
 
                     v.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
-                    t.setCurrencyCode(CurrencyUnit.EUR);
+                    t.setCurrencyCode(asCurrencyCode("EUR"));
                     t.setAmount(0L);
                 })
 
@@ -612,12 +585,20 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                 .match("^.* (?<note>Auftragsnummer: .*)$")
                 .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
-                .wrap(TransactionItem::new);
+                .wrap((t, ctx) -> {
+                    if (ctx.getFailureReason() != null)
+                        return new TransactionItem(t);
+
+                    if (t.getCurrencyCode() != null && t.getAmount() == 0)
+                        return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                    return new TransactionItem(t);
+                });
     }
 
     public void addDepotStatementTransaction()
     {
-        final DocumentType type = new DocumentType("(Quartalsbericht|Umsatz\\-Jahres.bersicht)", (context, lines) -> {
+        final var type = new DocumentType("(Quartalsbericht|Umsatz\\-Jahres.bersicht)", (context, lines) -> {
 
             Pattern pSecurity = Pattern.compile("^(?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])( [\\d]+)? ([\\s]+)?[\\d]{2}( \\-)?( .*: )?(?<name>.*) ([\\s]+)?[\\.,\\d]+( [\\.,\\d]+ [\\w]{3})? ([\\-|\\+])?[\\.,\\d]+$");
             Pattern pISIN = Pattern.compile("^((?<name>.*)\\/ )?ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]).*$");
@@ -827,7 +808,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
         });
         this.addDocumentTyp(type);
 
-        Block buySellBlock = new Block("^(Lastschrifteinzug"
+        var buySellBlock = new Block("^(Lastschrifteinzug"
                         + "|Storno Lastschrifteinzug"
                         + "|Verkauf( \\/ Tausch)?(?! aus Ertrag)"
                         + "|Zulagenr.ckforderung"
@@ -844,13 +825,11 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                         + ")"
                         + " .*$");
         type.addBlock(buySellBlock);
-        buySellBlock.set(new Transaction<BuySellEntry>().subject(() -> {
-            BuySellEntry entry = new BuySellEntry();
-            entry.setType(PortfolioTransaction.Type.BUY);
-            return entry;
-        })
+        buySellBlock.set(new Transaction<BuySellEntry>()
 
-            .oneOf(
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
+
+                        .oneOf(
                             // @formatter:off
                             // Lastschrifteinzug 250,00 198,660000 +1,258 01.04.2021 01.04.2021
                             // Lastschrifteinzug 1.000,00 59,320000 + 16,858 28.06.2005 28.06.2005
@@ -888,7 +867,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                                     + "[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} "
                                                     + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
                                     .assign((t, v) -> {
-                                        DocumentContext context = type.getCurrentContext();
+                                        var context = type.getCurrentContext();
 
                                         // Is type --> "-" change from BUY to SELL
                                         if ("-".equals(trim(v.get("type"))))
@@ -897,8 +876,8 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         if ("Storno Lastschrifteinzug".equals(v.get("type")))
                                             v.markAsFailure(Messages.MsgErrorTransactionOrderCancellationUnsupported);
 
-                                        SecurityListHelper securityListHelper = context.getType(SecurityListHelper.class).orElseGet(SecurityListHelper::new);
-                                        Optional<SecurityItem> securityItem = securityListHelper.findItemByLineNoStart(v.getStartLineNumber());
+                                        var securityListHelper = context.getType(SecurityListHelper.class).orElseGet(SecurityListHelper::new);
+                                        var securityItem = securityListHelper.findItemByLineNoStart(v.getStartLineNumber());
 
                                         if (securityItem.isPresent())
                                         {
@@ -907,7 +886,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         }
                                         else
                                         {
-                                            Optional<SecurityItem> securityItemByName = securityListHelper.findItemByName(trim(v.get("name")));
+                                            var securityItemByName = securityListHelper.findItemByName(trim(v.get("name")));
                                             if (securityItemByName.isPresent())
                                             {
                                                 v.put("name", securityItemByName.get().name);
@@ -919,7 +898,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         t.setDate(asDate(v.get("date")));
                                         t.setShares(asShares(v.get("shares")));
                                         t.setAmount(asAmount(v.get("amount")));
-                                        t.setCurrencyCode(CurrencyUnit.EUR);
+                                        t.setCurrencyCode(asCurrencyCode("EUR"));
 
                                         // @formatter:off
                                         // Deka indicates only up to 3 digits after the decimal point.
@@ -934,10 +913,10 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                             if (trim(v.get("note")).startsWith("Verkauf"))
                                                 t.setType(PortfolioTransaction.Type.SELL);
 
-                                            BigDecimal amountPerShare = BigDecimal.valueOf(asAmount(v.get("amountPerShare")));
-                                            BigDecimal amount = BigDecimal.valueOf(asAmount(v.get("amount")));
+                                            var amountPerShare = BigDecimal.valueOf(asAmount(v.get("amountPerShare")));
+                                            var amount = BigDecimal.valueOf(asAmount(v.get("amount")));
 
-                                            BigDecimal shares = amount.divide(amountPerShare, Values.Share.precision(), RoundingMode.HALF_UP);
+                                            var shares = amount.divide(amountPerShare, Values.Share.precision(), RoundingMode.HALF_UP);
                                             t.setShares(shares.movePointRight(Values.Share.precision()).longValue());
                                         }
 
@@ -996,7 +975,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                                     + "[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} "
                                                     + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
                                     .assign((t, v) -> {
-                                        DocumentContext context = type.getCurrentContext();
+                                        var context = type.getCurrentContext();
 
                                         // Is type --> "-" change from BUY to SELL
                                         if ("-".equals(trim(v.get("type"))))
@@ -1005,8 +984,8 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         if ("Storno Lastschrifteinzug".equals(v.get("note")))
                                             v.markAsFailure(Messages.MsgErrorTransactionOrderCancellationUnsupported);
 
-                                        SecurityListHelper securityListHelper = context.getType(SecurityListHelper.class).orElseGet(SecurityListHelper::new);
-                                        Optional<SecurityItem> securityItem = securityListHelper.findItemByLineNoStart(v.getStartLineNumber());
+                                        var securityListHelper = context.getType(SecurityListHelper.class).orElseGet(SecurityListHelper::new);
+                                        var securityItem = securityListHelper.findItemByLineNoStart(v.getStartLineNumber());
 
                                         if (securityItem.isPresent())
                                         {
@@ -1015,7 +994,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         }
                                         else
                                         {
-                                            Optional<SecurityItem> securityItemByName = securityListHelper.findItemByName(trim(v.get("name")));
+                                            var securityItemByName = securityListHelper.findItemByName(trim(v.get("name")));
                                             if (securityItemByName.isPresent())
                                             {
                                                 v.put("name", securityItemByName.get().name);
@@ -1027,7 +1006,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         t.setDate(asDate(v.get("date")));
                                         t.setShares(asShares(v.get("shares")));
                                         t.setAmount(asAmount(v.get("amount")));
-                                        t.setCurrencyCode(CurrencyUnit.EUR);
+                                        t.setCurrencyCode(asCurrencyCode("EUR"));
 
                                         // @formatter:off
                                         // Deka indicates only up to 3 digits after the decimal point.
@@ -1042,10 +1021,10 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                             if (trim(v.get("note")).startsWith("Verkauf"))
                                                 t.setType(PortfolioTransaction.Type.SELL);
 
-                                            BigDecimal amountPerShare = BigDecimal.valueOf(asAmount(v.get("amountPerShare")));
-                                            BigDecimal amount = BigDecimal.valueOf(asAmount(v.get("amount")));
+                                            var amountPerShare = BigDecimal.valueOf(asAmount(v.get("amountPerShare")));
+                                            var amount = BigDecimal.valueOf(asAmount(v.get("amount")));
 
-                                            BigDecimal shares = amount.divide(amountPerShare, Values.Share.precision(), RoundingMode.HALF_UP);
+                                            var shares = amount.divide(amountPerShare, Values.Share.precision(), RoundingMode.HALF_UP);
                                             t.setShares(shares.movePointRight(Values.Share.precision()).longValue());
                                         }
 
@@ -1068,14 +1047,27 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                     )
 
             .wrap((t, ctx) -> {
-                if (t.getPortfolioTransaction().getCurrencyCode() != null && t.getPortfolioTransaction().getAmount() == 0)
-                    ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                var item = new BuySellEntryItem(t);
 
-                return new BuySellEntryItem(t);
+                if (ctx.getFailureReason() != null)
+                    return item;
+
+                if (t.getPortfolioTransaction().getCurrencyCode() != null && t.getPortfolioTransaction().getAmount() == 0)
+                {
+                    if (t.getPortfolioTransaction().getShares() != 0)
+                    {
+                        item.setFailureMessage(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                        return item;
+                    }
+                    return new SkippedItem(item, Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                }
+
+                return item;
             }));
 
-        Block deliveryInOutbondblock = new Block("^(Einbuchung"
-                        + "|Ausbuchung|Auslieferung"
+        var deliveryInOutbondblock = new Block("^(Einbuchung"
+                        + "|Ausbuchung"
+                        + "|Auslieferung"
                         + "|Zulagenzahlung"
                         + "|Zulagenr.ckzahlung"
                         + "|Korrekturbuchung"
@@ -1084,12 +1076,11 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                         + "|Kauf (aus )?(Zulagenzahlung|Steuererstattung))"
                         + " .*$");
         type.addBlock(deliveryInOutbondblock);
-        deliveryInOutbondblock.set(new Transaction<PortfolioTransaction>().subject(() -> {
-            PortfolioTransaction transaction = new PortfolioTransaction();
-            transaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-            return transaction;
-        })
-                .oneOf(
+        deliveryInOutbondblock.set(new Transaction<PortfolioTransaction>()
+                        
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
+
+                        .oneOf(
                             // @formatter:off
                             // Kauf aus Steuererstattung 12,29 47,355000 +0,260 19.08.2020 19.08.2020
                             // Kauf Zulagenzahlung 354,00 32,950000  +10,744 17.11.2009 17.11.2009
@@ -1110,14 +1101,14 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                                     + "[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} "
                                                     + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
                                     .assign((t, v) -> {
-                                        DocumentContext context = type.getCurrentContext();
+                                        var context = type.getCurrentContext();
 
                                         // Is type --> "-" change from BUY to SELL
                                         if ("-".equals(trim(v.get("type"))))
                                             t.setType(PortfolioTransaction.Type.SELL);
 
-                                        SecurityListHelper securityListHelper = context.getType(SecurityListHelper.class).orElseGet(SecurityListHelper::new);
-                                        Optional<SecurityItem> securityItem = securityListHelper.findItemByLineNoStart(v.getStartLineNumber());
+                                        var securityListHelper = context.getType(SecurityListHelper.class).orElseGet(SecurityListHelper::new);
+                                        var securityItem = securityListHelper.findItemByLineNoStart(v.getStartLineNumber());
 
                                         if (securityItem.isPresent())
                                         {
@@ -1126,7 +1117,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         }
                                         else
                                         {
-                                            Optional<SecurityItem> securityItemByName = securityListHelper.findItemByName(trim(v.get("name")));
+                                            var securityItemByName = securityListHelper.findItemByName(trim(v.get("name")));
                                             if (securityItemByName.isPresent())
                                             {
                                                 v.put("name", securityItemByName.get().name);
@@ -1138,7 +1129,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         t.setDateTime(asDate(v.get("date")));
                                         t.setShares(asShares(v.get("shares")));
                                         t.setAmount(asAmount(v.get("amount")));
-                                        t.setCurrencyCode(CurrencyUnit.EUR);
+                                        t.setCurrencyCode(asCurrencyCode("EUR"));
                                         t.setNote(trim(replaceMultipleBlanks(v.get("note"))));
                                     })
                             ,
@@ -1168,14 +1159,14 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                                     + "[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} "
                                                     + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
                                     .assign((t, v) -> {
-                                        DocumentContext context = type.getCurrentContext();
+                                        var context = type.getCurrentContext();
 
                                         // Is type --> "-" change from DELIVERY_INBOUND to DELIVERY_OUTBOUND
                                         if ("-".equals(trim(v.get("type"))))
                                             t.setType(PortfolioTransaction.Type.DELIVERY_OUTBOUND);
 
-                                        SecurityListHelper securityListHelper = context.getType(SecurityListHelper.class).orElseGet(SecurityListHelper::new);
-                                        Optional<SecurityItem> securityItem = securityListHelper.findItemByLineNoStart(v.getStartLineNumber());
+                                        var securityListHelper = context.getType(SecurityListHelper.class).orElseGet(SecurityListHelper::new);
+                                        var securityItem = securityListHelper.findItemByLineNoStart(v.getStartLineNumber());
 
                                         if (securityItem.isPresent())
                                         {
@@ -1184,7 +1175,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         }
                                         else
                                         {
-                                            Optional<SecurityItem> securityItemByName = securityListHelper.findItemByName(trim(v.get("name")));
+                                            var securityItemByName = securityListHelper.findItemByName(trim(v.get("name")));
                                             if (securityItemByName.isPresent())
                                             {
                                                 v.put("name", securityItemByName.get().name);
@@ -1196,7 +1187,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         t.setDateTime(asDate(v.get("date")));
                                         t.setShares(asShares(v.get("shares")));
                                         t.setAmount(asAmount(v.get("amount")));
-                                        t.setCurrencyCode(CurrencyUnit.EUR);
+                                        t.setCurrencyCode(asCurrencyCode("EUR"));
                                         t.setNote(trim(replaceMultipleBlanks(v.get("note"))));
                                     })
                             ,
@@ -1213,14 +1204,14 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                                     + "[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} "
                                                     + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
                                     .assign((t, v) -> {
-                                        DocumentContext context = type.getCurrentContext();
+                                        var context = type.getCurrentContext();
 
                                         // Is type --> "-" change from DELIVERY_INBOUND to DELIVERY_OUTBOUND
                                         if ("-".equals(v.get("type")))
                                             t.setType(PortfolioTransaction.Type.DELIVERY_OUTBOUND);
 
-                                        SecurityListHelper securityListHelper = context.getType(SecurityListHelper.class).orElseGet(SecurityListHelper::new);
-                                        Optional<SecurityItem> securityItem = securityListHelper.findItemByLineNoStart(v.getStartLineNumber());
+                                        var securityListHelper = context.getType(SecurityListHelper.class).orElseGet(SecurityListHelper::new);
+                                        var securityItem = securityListHelper.findItemByLineNoStart(v.getStartLineNumber());
 
                                         if (securityItem.isPresent())
                                         {
@@ -1229,7 +1220,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         }
                                         else
                                         {
-                                            Optional<SecurityItem> securityItemByName = securityListHelper.findItemByName(trim(v.get("name")));
+                                            var securityItemByName = securityListHelper.findItemByName(trim(v.get("name")));
                                             if (securityItemByName.isPresent())
                                             {
                                                 v.put("name", securityItemByName.get().name);
@@ -1241,7 +1232,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         t.setDateTime(asDate(v.get("date")));
                                         t.setShares(asShares(v.get("shares")));
                                         t.setAmount(0L);
-                                        t.setCurrencyCode(CurrencyUnit.EUR);
+                                        t.setCurrencyCode(asCurrencyCode("EUR"));
                                     })
                     )
 
@@ -1254,13 +1245,25 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                 .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
                 .wrap((t, ctx) -> {
-                    if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                        ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                    var item = new TransactionItem(t);
 
-                    return new TransactionItem(t);
+                    if (ctx.getFailureReason() != null)
+                        return item;
+
+                    if (t.getCurrencyCode() != null && t.getAmount() == 0)
+                    {
+                        if (t.getShares() != 0)
+                        {
+                            item.setFailureMessage(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                            return item;
+                        }
+                        return new SkippedItem(item, Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                    }
+
+                    return item;
                 }));
 
-        Block dividendeBlock = new Block("^(Verkauf aus Ertrag"
+        var dividendeBlock = new Block("^(Verkauf aus Ertrag"
                         + "|Aussch.ttung \\/ Kauf aus Ertrag"
                         + "|Abrechnungsbetrag Ausschüttung"
                         + "|Abrechnungsbetrag Thesaurierung"
@@ -1268,13 +1271,11 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                         + "|Kauf aus Ertrag"
                         + "|Thesaurierung \\/ Kauf aus Ertrag) .*$");
         type.addBlock(dividendeBlock);
-        dividendeBlock.set(new Transaction<AccountTransaction>().subject(() -> {
-            AccountTransaction entry = new AccountTransaction();
-            entry.setType(AccountTransaction.Type.DIVIDENDS);
-            return entry;
-        })
+        dividendeBlock.set(new Transaction<AccountTransaction>()
+                        
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
-            .oneOf(
+                        .oneOf(
                             // @formatter:off
                             // Verkauf aus Ertrag 33,43 177,600000 +0,000 20.05.2022 20.05.2022
                             // Ausschüttung / Kauf aus Ertrag 1,46 179,310000 +0,008 15.02.2019 15.02.2019
@@ -1283,7 +1284,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                             // Ertragsausschüttung-Storno 1,05 41,970000 - 0,025 07.09.2005 22.08.2005
                             // @formatter:on
                             section -> section
-                                    .attributes("type", "amount", "shares", "date")
+                                    .attributes("type", "amount", "shares", "date", "exDate")
                                     .match("^(?<type>(Verkauf aus Ertrag"
                                                     + "|Aussch.ttung \\/ Kauf aus Ertrag"
                                                     + "|Abrechnungsbetrag Ausschüttung"
@@ -1294,25 +1295,25 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                                     + "(?<amount>[\\.,\\d]+) "
                                                     + "[\\.,\\d]+"
                                                     + "([\\+\\-\\s]+)?(?<shares>[\\.,\\d]+) "
-                                                    + "[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} "
-                                                    + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
+                                                    + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) "
+                                                    + "(?<exDate>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
                                     .assign((t, v) -> {
-                                        DocumentContext context = type.getCurrentContext();
+                                        var context = type.getCurrentContext();
 
                                         if ("Ertragsausschüttung-Storno".equals(v.get("type")))
                                             v.markAsFailure(Messages.MsgErrorTransactionOrderCancellationUnsupported);
 
-                                        SecurityListHelper securityListHelper = context.getType(SecurityListHelper.class).orElseGet(SecurityListHelper::new);
-                                        SharesListHelper sharesListHelper = context.getType(SharesListHelper.class).orElseGet(SharesListHelper::new);
+                                        var securityListHelper = context.getType(SecurityListHelper.class).orElseGet(SecurityListHelper::new);
+                                        var sharesListHelper = context.getType(SharesListHelper.class).orElseGet(SharesListHelper::new);
 
-                                        Optional<SecurityItem> securityItem = securityListHelper.findItemByLineNoStart(v.getStartLineNumber());
+                                        var securityItem = securityListHelper.findItemByLineNoStart(v.getStartLineNumber());
 
                                         if (securityItem.isPresent())
                                         {
                                             v.put("name", securityItem.get().name);
                                             v.put("isin", securityItem.get().isin);
 
-                                            Optional<ShareItem> shareItem = sharesListHelper.findItem(v.get("isin"), //
+                                            var shareItem = sharesListHelper.findItem(v.get("isin"), //
                                                             securityItem.get().lineNoEnd, //
                                                             LocalDate.parse(v.get("date"), DATEFORMAT), //
                                                             asShares(v.get("shares")));
@@ -1322,13 +1323,13 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         }
                                         else
                                         {
-                                            Optional<SecurityItem> securityItemByName = securityListHelper.findItemByName(trim(v.get("name")));
+                                            var securityItemByName = securityListHelper.findItemByName(trim(v.get("name")));
                                             if (securityItemByName.isPresent())
                                             {
                                                 v.put("name", securityItemByName.get().name);
                                                 v.put("isin", securityItemByName.get().isin);
 
-                                                Optional<ShareItem> shareItem = sharesListHelper.findItem(v.get("isin"), //
+                                                var shareItem = sharesListHelper.findItem(v.get("isin"), //
                                                                 securityItemByName.get().lineNoEnd, //
                                                                 LocalDate.parse(v.get("date"), DATEFORMAT), //
                                                                 asShares(v.get("shares")));
@@ -1340,8 +1341,9 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
 
                                         t.setSecurity(getOrCreateSecurity(v));
                                         t.setDateTime(asDate(v.get("date")));
+                                        t.setExDate(asDate(v.get("exDate")));
                                         t.setAmount(asAmount(v.get("amount")));
-                                        t.setCurrencyCode(CurrencyUnit.EUR);
+                                        t.setCurrencyCode(asCurrencyCode("EUR"));
                                     })
                             ,
                             // @formatter:off
@@ -1350,7 +1352,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                             // Thesaurierung / Kauf aus Ertrag Deka-BR 100 0,00 72,270000 +0,000 12.01.2018 29.12.2017
                             // @formatter:on
                             section -> section
-                                    .attributes("name", "amount", "shares", "date")
+                                    .attributes("name", "amount", "shares", "date", "exDate")
                                     .match("^(?<type>(Verkauf aus Ertrag"
                                                     + "|Aussch.ttung \\/ Kauf aus Ertrag"
                                                     + "|Abrechnungsbetrag Ausschüttung"
@@ -1362,25 +1364,25 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                                     + "(?<amount>[\\.,\\d]+) "
                                                     + "[\\.,\\d]+"
                                                     + "([\\+\\-\\s]+)?(?<shares>[\\.,\\d]+) "
-                                                    + "[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} "
-                                                    + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
+                                                    + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) "
+                                                    + "(?<exDate>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$")
                                     .assign((t, v) -> {
-                                        DocumentContext context = type.getCurrentContext();
+                                        var context = type.getCurrentContext();
 
                                         if ("Ertragsausschüttung-Storno".equals(v.get("type")))
                                             v.markAsFailure(Messages.MsgErrorTransactionOrderCancellationUnsupported);
 
-                                        SecurityListHelper securityListHelper = context.getType(SecurityListHelper.class).orElseGet(SecurityListHelper::new);
-                                        SharesListHelper sharesListHelper = context.getType(SharesListHelper.class).orElseGet(SharesListHelper::new);
+                                        var securityListHelper = context.getType(SecurityListHelper.class).orElseGet(SecurityListHelper::new);
+                                        var sharesListHelper = context.getType(SharesListHelper.class).orElseGet(SharesListHelper::new);
 
-                                        Optional<SecurityItem> securityItem = securityListHelper.findItemByLineNoStart(v.getStartLineNumber());
+                                        var securityItem = securityListHelper.findItemByLineNoStart(v.getStartLineNumber());
 
                                         if (securityItem.isPresent())
                                         {
                                             v.put("name", securityItem.get().name);
                                             v.put("isin", securityItem.get().isin);
 
-                                            Optional<ShareItem> shareItem = sharesListHelper.findItem(v.get("isin"), //
+                                            var shareItem = sharesListHelper.findItem(v.get("isin"), //
                                                             securityItem.get().lineNoEnd, //
                                                             LocalDate.parse(v.get("date"), DATEFORMAT), //
                                                             asShares(v.get("shares")));
@@ -1391,13 +1393,13 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         else
                                         {
 
-                                            Optional<SecurityItem> securityItemByName = securityListHelper.findItemByName(trim(v.get("name")));
+                                            var securityItemByName = securityListHelper.findItemByName(trim(v.get("name")));
                                             if (securityItemByName.isPresent())
                                             {
                                                 v.put("name", securityItemByName.get().name);
                                                 v.put("isin", securityItemByName.get().isin);
 
-                                                Optional<ShareItem> shareItem = sharesListHelper.findItem(v.get("isin"), //
+                                                var shareItem = sharesListHelper.findItem(v.get("isin"), //
                                                                 securityItemByName.get().lineNoEnd, //
                                                                 LocalDate.parse(v.get("date"), DATEFORMAT), //
                                                                 asShares(v.get("shares")));
@@ -1409,19 +1411,32 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
 
                                         t.setSecurity(getOrCreateSecurity(v));
                                         t.setDateTime(asDate(v.get("date")));
+                                        t.setExDate(asDate(v.get("exDate")));
                                         t.setAmount(asAmount(v.get("amount")));
-                                        t.setCurrencyCode(CurrencyUnit.EUR);
+                                        t.setCurrencyCode(asCurrencyCode("EUR"));
                                     })
                     )
 
                 .wrap((t, ctx) -> {
-                    if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                        ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                    var item = new TransactionItem(t);
 
-                    return new TransactionItem(t);
+                    if (ctx.getFailureReason() != null)
+                        return item;
+
+                    if (t.getCurrencyCode() != null && t.getAmount() == 0)
+                    {
+                        if (t.getShares() != 0)
+                        {
+                            item.setFailureMessage(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                            return item;
+                        }
+                        return new SkippedItem(item, Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                    }
+
+                    return item;
                 }));
 
-        Block feesBlock = new Block("^.*(Vertragsgeb.hr in [\\d]{4}"
+        var feesBlock = new Block("^.*(Vertragsgeb.hr in [\\d]{4}"
                         + "|.* (inkl|incl)\\.( [\\d]+%)? (Mehrwertsteuer \\(MwSt\\)|MwSt|MWSt)"
                         + "|Entgelt Aufl.sung "
                         + "|Vertragspreis(?!.*gesamt) "
@@ -1429,13 +1444,11 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                         + "|Abschluss\\- und Vertriebskosten(?!.*gesamt) "
                         + ").*$");
         type.addBlock(feesBlock);
-        feesBlock.set(new Transaction<AccountTransaction>().subject(() -> {
-            AccountTransaction entry = new AccountTransaction();
-            entry.setType(AccountTransaction.Type.FEES);
-            return entry;
-        })
+        feesBlock.set(new Transaction<AccountTransaction>()
+                        
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
-                .oneOf(
+                        .oneOf(
                                 // @formatter:off
                                 // Vertragspreis (zu Lasten Girokonto) -10,00
                                 // Vertragspreis (zu Lasten Vertrag)  0,00
@@ -1457,7 +1470,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
 
                                             t.setDateTime(asDate(context.get("documentDate")));
                                             t.setAmount(asAmount(v.get("amount")));
-                                            t.setCurrencyCode(CurrencyUnit.EUR);
+                                            t.setCurrencyCode(asCurrencyCode("EUR"));
                                             t.setNote(trim(v.get("note")));
 
                                             // Formatting some notes
@@ -1483,7 +1496,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                         .assign((t, v) -> {
                                             t.setDateTime(asDate(v.get("date")));
                                             t.setAmount(asAmount(v.get("amount")));
-                                            t.setCurrencyCode(CurrencyUnit.EUR);
+                                            t.setCurrencyCode(asCurrencyCode("EUR"));
                                             t.setNote(trim(v.get("note")));
 
                                             // Formatting some note
@@ -1506,7 +1519,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                                 t.setDateTime(asDate(context.get("documentDate")));
 
                                             t.setAmount(asAmount(v.get("amount")));
-                                            t.setCurrencyCode(CurrencyUnit.EUR);
+                                            t.setCurrencyCode(asCurrencyCode("EUR"));
                                             t.setNote(v.get("note") + " " + t.getDateTime().getYear());
                                         })
                                 ,
@@ -1526,7 +1539,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                                                 t.setDateTime(asDate(context.get("documentDate")));
 
                                             t.setAmount(asAmount(v.get("amount")));
-                                            t.setCurrencyCode(CurrencyUnit.EUR);
+                                            t.setCurrencyCode(asCurrencyCode("EUR"));
                                             t.setNote(v.get("note") + " " + t.getDateTime().getYear());
                                         })
                                 ,
@@ -1584,65 +1597,74 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                         )
 
                 .wrap((t, ctx) -> {
+                    var item = new TransactionItem(t);
+
+                    if (ctx.getFailureReason() != null)
+                        return item;
+
                     if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                        ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
-                    return new TransactionItem(t);
+                    {
+                        if (t.getShares() != 0)
+                        {
+                            item.setFailureMessage(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                            return item;
+                        }
+                        return new SkippedItem(item, Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                    }
+
+                    return item;
                 }));
     }
 
     private void addTaxReturnBlock(DocumentType type)
     {
-        Block block = new Block("^(ERTRAGSAUSSCH.TTUNG|ERTRAGSABRECHNUNG)$");
+        var block = new Block("^(ERTRAGSAUSSCH.TTUNG|ERTRAGSABRECHNUNG)$");
         type.addBlock(block);
-        block.set(new Transaction<AccountTransaction>().subject(() -> {
-            AccountTransaction t = new AccountTransaction();
-            t.setType(AccountTransaction.Type.TAX_REFUND);
-            return t;
-        })
+        block.set(new Transaction<AccountTransaction>()
+                        
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
-            .oneOf(
-                            // @formatter:off
-                            // Ausschüttung (pro Anteil EUR 0,2292000): EUR 0,14
-                            // Bezeichnung: iShares J.P. Morgan USD EM Bond EUR Hedged UCITS ETF (Dist)
-                            // ISIN: IE00B9M6RS56 Unterdepot: 00 Auftragsnummer: 9302 2538
-                            // @formatter:on
-                            section -> section
-                                    .attributes("currency", "name", "isin")
-                                    .match("^Aussch.ttung .* (?<currency>[\\w]{3}) [\\.,\\d]+$")
-                                    .match("^Bezeichnung: (?<name>.*)$")
-                                    .match("^ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]).*$")
-                                    .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
-                            ,
-                            // @formatter:off
-                            // Fondsbezeichnung: AriDeka CF
-                            // ISIN: DE0008474511 Unterkonto: 00 Auftragsnummer: 9387 9103
-                            // +Verrechnete Steuern EUR 1,43 EUR 29,15 EUR 33,420000 Anteilumsatz: 0,872
-                            // @formatter:on
-                            section -> section
-                                    .attributes("name", "isin", "currency")
-                                    .match("^Fondsbezeichnung: (?<name>.*)$")
-                                    .match("^ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]).*$")
-                                    .match("^.*(?<currency>[\\w]{3}) [\\.,\\d]+ Anteilumsatz: [\\.,\\d]+$")
-                                    .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
-                    )
+                        .oneOf(
+                                // @formatter:off
+                                // Ausschüttung (pro Anteil EUR 0,2292000): EUR 0,14
+                                // Bezeichnung: iShares J.P. Morgan USD EM Bond EUR Hedged UCITS ETF (Dist)
+                                // ISIN: IE00B9M6RS56 Unterdepot: 00 Auftragsnummer: 9302 2538
+                                // @formatter:on
+                                section -> section
+                                        .attributes("currency", "name", "isin")
+                                        .match("^Aussch.ttung .* (?<currency>[\\w]{3}) [\\.,\\d]+$")
+                                        .match("^Bezeichnung: (?<name>.*)$")
+                                        .match("^ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]).*$")
+                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+                                ,
+                                // @formatter:off
+                                // Fondsbezeichnung: AriDeka CF
+                                // ISIN: DE0008474511 Unterkonto: 00 Auftragsnummer: 9387 9103
+                                // +Verrechnete Steuern EUR 1,43 EUR 29,15 EUR 33,420000 Anteilumsatz: 0,872
+                                // @formatter:on
+                                section -> section
+                                        .attributes("name", "isin", "currency")
+                                        .match("^Fondsbezeichnung: (?<name>.*)$")
+                                        .match("^ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]).*$")
+                                        .match("^.*(?<currency>[\\w]{3}) [\\.,\\d]+ Anteilumsatz: [\\.,\\d]+$")
+                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
 
-            .oneOf(
-                            // @formatter:off
-                            // Anteilbestand am Ertragstermin: 0,619
-                            // @formatter:on
-                            section -> section
-                                    .attributes("shares")
-                                    .match("^Anteilbestand am Ertragstermin: (?<shares>[\\.,\\d]+)$")
-                                    .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
-                            ,
-                            // @formatter:off
-                            //  Ausschüttung EUR 27,72 Preis Bestand alt: 29,811
-                            // @formatter:on
-                            section -> section
-                                    .attributes("shares")
-                                    .match("^.* Bestand alt: (?<shares>[\\.,\\d]+)$")
-                                    .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
-                    )
+                        .oneOf(
+                                // @formatter:off
+                                // Anteilbestand am Ertragstermin: 0,619
+                                // @formatter:on
+                                section -> section
+                                        .attributes("shares")
+                                        .match("^Anteilbestand am Ertragstermin: (?<shares>[\\.,\\d]+)$")
+                                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+                                ,
+                                // @formatter:off
+                                //  Ausschüttung EUR 27,72 Preis Bestand alt: 29,811
+                                // @formatter:on
+                                section -> section
+                                        .attributes("shares")
+                                        .match("^.* Bestand alt: (?<shares>[\\.,\\d]+)$")
+                                        .assign((t, v) -> t.setShares(asShares(v.get("shares")))))
 
             // @formatter:off
             // Verwahrart: GiroSammel Abrechnungstag: 31.03.2022
@@ -1702,20 +1724,20 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                 .match("^Ausgabeaufschlag: (?<percentageFee>[\\.,\\d]+)%$")
                 .match("^.*(Einzugsbetrag|Auszahlungsbetrag|Abrechnungsbetrag) [\\w]{3} [\\.,\\d]+ [\\w]{3} [\\.,\\d]+ (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+).*$")
                 .assign((t, v) -> {
-                    BigDecimal percentageFee = asBigDecimal(v.get("percentageFee"));
-                    BigDecimal amount = asBigDecimal(v.get("amount"));
+                    var percentageFee = asBigDecimal(v.get("percentageFee"));
+                    var amount = asBigDecimal(v.get("amount"));
 
                     if (percentageFee.compareTo(BigDecimal.ZERO) != 0)
                     {
                         // @formatter:off
                         // fxFee = (amount / (1 + percentageFee / 100)) * (percentageFee / 100)
                         // @formatter:on
-                        BigDecimal fxFee = amount
+                        var fxFee = amount
                                         .divide(percentageFee.divide(BigDecimal.valueOf(100))
                                                         .add(BigDecimal.ONE), Values.MC)
                                         .multiply(percentageFee, Values.MC);
 
-                        Money fee = Money.of(asCurrencyCode(v.get("currency")),
+                        var fee = Money.of(asCurrencyCode(v.get("currency")),
                                         fxFee.setScale(0, Values.MC.getRoundingMode()).longValue());
 
                         checkAndSetFee(fee, t, type.getCurrentContext());
@@ -1734,9 +1756,9 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
             if (items.isEmpty())
                 return Optional.empty();
 
-            for (int i = items.size() - 1; i >= 0; i--) // NOSONAR
+            for (var i = items.size() - 1; i >= 0; i--) // NOSONAR
             {
-                SecurityItem item = items.get(i);
+                var item = items.get(i);
 
                 if ((item.lineNoStart > lineNo) || (item.lineNoEnd < lineNo))
                     continue;
@@ -1753,9 +1775,9 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
             if (items.isEmpty())
                 return Optional.empty();
 
-            for (int i = items.size() - 1; i >= 0; i--) // NOSONAR
+            for (var i = items.size() - 1; i >= 0; i--) // NOSONAR
             {
-                SecurityItem item = items.get(i);
+                var item = items.get(i);
 
                 // We cannot take "equals" because the security names continue
                 // on the next line as well. Therefore we take "contains".
@@ -1793,18 +1815,15 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
             if (items.isEmpty())
                 return Optional.empty();
 
-            for (int i = items.size() - 1; i >= 0; i--) // NOSONAR
+            for (var i = items.size() - 1; i >= 0; i--) // NOSONAR
             {
-                ShareItem item = items.get(i);
+                var item = items.get(i);
 
                 if (!item.isin.equals(isin))
                     continue;
 
-                if (securitylineNoEnd != 0)
-                {
-                    if (item.lineNo >= securitylineNoEnd)
-                        continue;
-                }
+                if ((securitylineNoEnd != 0) && (item.lineNo >= securitylineNoEnd))
+                    continue;
 
                 if (!item.date.equals(date))
                     continue;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DeutscheBankPDFExtractor.java
@@ -47,7 +47,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("Abrechnung: (Kauf|Verkauf|Zeichnung) von Wertpapieren");
+        final var type = new DocumentType("Abrechnung: (Kauf|Verkauf|Zeichnung) von Wertpapieren");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -58,11 +58,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -253,7 +249,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
 
     private void addBuyTransactionFundsSavingsPlan()
     {
-        var type = new DocumentType("(db AnsparPlan|Verm.gensSparplan)");
+        final var type = new DocumentType("(db AnsparPlan|Verm.gensSparplan)");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -265,11 +261,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .oneOf( //
                         // @formatter:off
@@ -338,7 +330,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("(Dividendengutschrift|Ertragsgutschrift|Kupongutschrift)");
+        final var type = new DocumentType("(Dividendengutschrift|Ertragsgutschrift|Kupongutschrift)");
         this.addDocumentTyp(type);
 
         var firstRelevantLine = new Block("^(Dividendengutschrift|Ertragsgutschrift|Kupongutschrift)$");
@@ -349,11 +341,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -495,11 +483,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Stück WKN ISIN
@@ -565,10 +549,12 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
                                                         })
                         )
 
-                        .wrap(t -> t.getCurrencyCode() == null || t.getAmount() == 0
-                                        ? new SkippedItem(new TransactionItem(t),
-                                                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired)
-                                        : new TransactionItem(t));
+                        .wrap(t -> {
+                            if (t.getCurrencyCode() == null || t.getAmount() == 0)
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                            return new TransactionItem(t);
+                        });
     }
 
     private void addAccountStatementTransaction()
@@ -600,11 +586,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
         depositRemovalBlock.setMaxSize(2);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .oneOf( //
                                         // @formatter:off
@@ -794,11 +776,7 @@ public class DeutscheBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockFees);
         blockFees.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("date", "amount", "note").optional() //
                         .documentContext("currency", "year") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DirectaSimPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DirectaSimPDFExtractor.java
@@ -61,11 +61,7 @@ public class DirectaSimPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // Tipo di Operazione: Vendita     Mercato di esecuzione: Borsa - XETRA

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Direkt1822BankPDFExtractor.java
@@ -52,7 +52,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("Wertpapier Abrechnung (Kauf|Verkauf|(Ausgabe|R.cknahme) Investmentfonds)");
+        final var type = new DocumentType("Wertpapier Abrechnung (Kauf|Verkauf|(Ausgabe|R.cknahme) Investmentfonds)");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -66,11 +66,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -185,7 +181,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("(Gutschrift von .*" //
+        final var type = new DocumentType("(Gutschrift von .*" //
                         + "|Aussch.ttung Investmentfonds" //
                         + "|Aussch.ttung aus Genussschein" //
                         + "|Dividendengutschrift)");
@@ -199,11 +195,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Stück 920 ISHSIV-FA.AN.HI.YI.CO.BD U.ETF IE00BYM31M36 (A2AFCX)
@@ -273,7 +265,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
     private void addAdvanceTaxTransaction()
     {
-        var type = new DocumentType("Vorabpauschale Investmentfonds");
+        final var type = new DocumentType("Vorabpauschale Investmentfonds");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -284,11 +276,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Stück 16,0871 AIS AMUNDI DJ SWITZTIT30 LU2611732632 (ETF198)
@@ -345,11 +333,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         // @formatter:off
                         // Steuerliche Ausgleichrechnung
@@ -396,11 +380,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount", "currency") //
                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<note>Gutschrift .berw\\.) .* \\+(?<amount>[\\.,\\d]+)(?<currency>\\p{Sc})$")
@@ -426,11 +406,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "note", "amount", "currency") //
                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<note>(Echtzeit.berweisung" //
@@ -453,11 +429,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feeBlock);
         feeBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("note", "date", "amount") //
                         .match("^Entgelte vom (?<note>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} bis [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) [\\.,\\d]+\\-$") //
@@ -469,13 +441,11 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
                             t.setNote(v.get("note"));
                         })
 
-                        .wrap((t, ctx) -> {
-                            var item = new TransactionItem(t);
-
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            return item;
+                            return new TransactionItem(t);
                         }));
     }
 
@@ -492,11 +462,7 @@ public class Direkt1822BankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_OUTBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_OUTBOUND))
 
                         // @formatter:off
                         // Nominale Wertpapierbezeichnung ISIN (WKN)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DkbPDFExtractor.java
@@ -117,11 +117,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -338,11 +334,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -492,11 +484,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.TRANSFER_OUT);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.TRANSFER_OUT))
 
                         // @formatter:off
                         // Nominale Wertpapierbezeichnung ISIN (WKN)
@@ -556,11 +544,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Nominale Wertpapierbezeichnung ISIN (WKN)
@@ -640,9 +624,9 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                         .match("^.*(?<note>Abrechnungsnr\\. [\\d]+).*$") //
                         .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
-                        .wrap((t, ctx) -> {
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
                             return new TransactionItem(t);
                         });
@@ -680,11 +664,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .oneOf( //
                                         // @formatter:off
@@ -776,11 +756,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestChargeBlock);
         interestChargeBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("note", "amount", "type").optional() //
                         .documentContext("date", "currency") //
@@ -803,7 +779,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^Kapitalertrags(s)?teuer[\\s]{1,}(?<tax>[\\.,\\d]+)\\-$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             if (t.getType() == AccountTransaction.Type.INTEREST)
@@ -816,7 +792,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^Solidarit.tszuschlag[\\s]{1,}(?<tax>[\\.,\\d]+)\\-$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             if (t.getType() == AccountTransaction.Type.INTEREST)
@@ -829,7 +805,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^Kirchensteuer[\\s]{1,}(?<tax>[\\.,\\d]+)\\-$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             if (t.getType() == AccountTransaction.Type.INTEREST)
@@ -848,11 +824,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestChargeCreditBlock);
         interestChargeCreditBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST_CHARGE);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST_CHARGE))
 
                         .section("note", "amount", "type") //
                         .documentContext("date", "currency") //
@@ -881,11 +853,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("month1", "day", "month2", "note", "amount") //
                         .documentContext("nr", "year", "currency") //
@@ -943,11 +911,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("month1", "day", "month2", "note", "amount") //
                         .documentContext("nr", "year", "currency") //
@@ -982,11 +946,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         type.addBlock(taxReturnBlock);
         taxReturnBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .section("month1", "day", "month2", "note", "amount") //
                         .documentContext("nr", "year", "currency") //
@@ -1011,11 +971,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feesBlock);
         feesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("month1", "day", "month2", "note1", "amount", "note2") //
                         .documentContext("nr", "year", "currency") //
@@ -1083,11 +1039,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         depositRemovalBlock_Format01.setMaxSize(2);
         depositRemovalBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("type", "amount", "date", "note").optional() //
                         .documentContext("currency") //
@@ -1173,11 +1125,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         depositRemovalBlock_Format02.setMaxSize(1);
         depositRemovalBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "type", "amount").optional() //
                         .documentContext("currency") //
@@ -1282,11 +1230,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         depositRemovalBlock_Format03.setMaxSize(2);
         depositRemovalBlock_Format03.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "type", "amount").optional() //
                         .documentContext("currency") //
@@ -1364,11 +1308,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         feesBlock.setMaxSize(3);
         feesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES_REFUND))
 
                         .section("type", "amount", "date", "note1", "note2").optional() //
                         .documentContext("currency") //
@@ -1427,11 +1367,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestChargeBlock);
         interestChargeBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("note", "amount", "type").optional() //
                         .documentContext("currency", "date") //
@@ -1454,7 +1390,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^Kapitalertrags(s)?teuer[\\s]{1,}(?<tax>[\\.,\\d]+)\\-$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             if (t.getType() == AccountTransaction.Type.INTEREST)
@@ -1467,7 +1403,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^Solidarit.tszuschlag[\\s]{1,}(?<tax>[\\.,\\d]+)\\-$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             if (t.getType() == AccountTransaction.Type.INTEREST)
@@ -1480,7 +1416,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^Kirchensteuer[\\s]{1,}(?<tax>[\\.,\\d]+)\\-$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             if (t.getType() == AccountTransaction.Type.INTEREST)
@@ -1503,11 +1439,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestStorno);
         interestStorno.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("amount", "date", "note").optional() //
                         .documentContext("currency") //
@@ -1561,11 +1493,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .oneOf( //
                                         section -> section //
@@ -1631,11 +1559,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "note", "amount") //
                         .documentContext("currency") //
@@ -1655,11 +1579,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         type.addBlock(taxesBlock);
         taxesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         .section("date", "note", "amount") //
                         .documentContext("currency") //
@@ -1679,11 +1599,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .oneOf( //
 
@@ -1738,11 +1654,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feeBlock);
         feeBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("date", "note", "amount") //
                         .documentContext("currency") //
@@ -1768,11 +1680,7 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         // @formatter:off
                         // Ausmachender Betrag 56,57 EUR
@@ -1846,12 +1754,12 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }
@@ -1882,12 +1790,12 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }
@@ -1917,12 +1825,12 @@ public class DkbPDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DreiBankenEDVPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DreiBankenEDVPDFExtractor.java
@@ -45,11 +45,7 @@ public class DreiBankenEDVPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -113,11 +109,7 @@ public class DreiBankenEDVPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // IE00B0M63284 iShs Euro.Property Yield U.ETF Stk .               4,00

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ETradePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ETradePDFExtractor.java
@@ -31,7 +31,7 @@ public class ETradePDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("Purchase Summary");
+        final var type = new DocumentType("Purchase Summary");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -42,11 +42,7 @@ public class ETradePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // Company Name (Symbol) NXP SEMICONDUCTORS, Beginning Balance 0.0000

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EasyBankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EasyBankAGPDFExtractor.java
@@ -56,11 +56,7 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         // Is type --> "Tilgung" change from BUY to SELL
@@ -290,11 +286,7 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Geschäftsart: Ertrag - STORNO
@@ -491,13 +483,11 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
 
                         .conclude(ExtractorUtils.fixGrossValueA())
 
-                        .wrap((t, ctx) -> {
-                            var item = new TransactionItem(t);
-
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            return item;
+                            return new TransactionItem(t);
                         });
 
         addTaxesSectionsTransaction(pdfTransaction, type);
@@ -522,11 +512,7 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .oneOf( //
                                         // @formatter:off
@@ -859,11 +845,7 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         // @formatter:off
                         // 28.06 Mustermann 28.06 2.000,00
@@ -888,11 +870,7 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feeBlock);
         feeBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // 30.09 Abschluss 30.09 4,50-
@@ -927,11 +905,7 @@ public class EasyBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_OUTBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_OUTBOUND))
 
                         // Is type --> "Zugang" change from DELIVERY_OUTBOUND to DELIVERY_INBOUND
                         .section("type").optional() //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EbasePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EbasePDFExtractor.java
@@ -46,7 +46,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("Dividendengutschrift");
+        final var type = new DocumentType("Dividendengutschrift");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -57,11 +57,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Nominale Wertpapierbezeichnung ISIN (WKN)
@@ -132,7 +128,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
 
     private void addDepotStatement_BuySellTransaction()
     {
-        var type = new DocumentType("(Umsatzabrechnung|Depotauszug)\\-Nr\\.");
+        final var type = new DocumentType("(Umsatzabrechnung|Depotauszug)\\-Nr\\.");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -153,11 +149,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -483,7 +475,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
 
     private void addDepotStatement_DividendeTransaction()
     {
-        var type = new DocumentType("(Umsatzabrechnung|Depotauszug)\\-Nr\\.");
+        final var type = new DocumentType("(Umsatzabrechnung|Depotauszug)\\-Nr\\.");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -498,11 +490,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Fondsertrag (Ausschüttung) mit Bestandsdatum 11.12.2019 in Depotposition 1234567890.31
@@ -677,7 +665,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
         // Vorabpauschale zum Stichtag 31.12.2020 aus Depotposition xxx.25
         // @formatter:on
 
-        var type = new DocumentType("(Umsatzabrechnung|Depotauszug)\\-Nr\\.");
+        final var type = new DocumentType("(Umsatzabrechnung|Depotauszug)\\-Nr\\.");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -688,11 +676,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Vorabpauschale zum Stichtag 31.12.2019 aus Depotposition XXXXXXXXXX.05
@@ -757,7 +741,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
 
     private void addDepotStatement_DeliveryInOutBoundTransaction()
     {
-        var type = new DocumentType("(Umsatzabrechnung|Depotauszug)\\-Nr\\.");
+        final var type = new DocumentType("(Umsatzabrechnung|Depotauszug)\\-Nr\\.");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<PortfolioTransaction>();
@@ -768,11 +752,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_OUTBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_OUTBOUND))
 
                         // @formatter:off
                         // Is type --> "Eingang" change from DELIVERY_OUTBOUND to DELIVERY_INBOUND
@@ -850,7 +830,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
 
     private void addDepotStatement_FeesWithSecurityTransaction()
     {
-        var type = new DocumentType("(Umsatzabrechnung|Depotauszug)\\-Nr\\.");
+        final var type = new DocumentType("(Umsatzabrechnung|Depotauszug)\\-Nr\\.");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -861,11 +841,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // Entgelt Verkauf mit Kursdatum 20.12.2017 aus Depotposition 11111111111.01
@@ -955,7 +931,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
 
     private void addDepotStatement_FeesWithDeliveryInOutBoundTransaction()
     {
-        var type = new DocumentType("(Umsatzabrechnung|Depotauszug)\\-Nr\\.");
+        final var type = new DocumentType("(Umsatzabrechnung|Depotauszug)\\-Nr\\.");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -966,11 +942,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .oneOf( //
                                         // @formatter:off
@@ -1066,7 +1038,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
 
     private void addAccountStatementTransaction()
     {
-        var type = new DocumentType("Kontoauszug\\-Nr\\. [\\d]+");
+        final var type = new DocumentType("Kontoauszug\\-Nr\\. [\\d]+");
         this.addDocumentTyp(type);
 
         // @formatter:off
@@ -1077,11 +1049,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note1", "note2", "amount", "currency") //
                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) " //
@@ -1107,11 +1075,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "note1", "note2", "amount", "currency") //
                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) " //
@@ -1135,11 +1099,7 @@ public class EbasePDFExtractor extends AbstractPDFExtractor
         type.addBlock(feeBlock);
         feeBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("date", "note1", "note2", "amount", "currency") //
                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) " //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
@@ -69,11 +69,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -341,11 +337,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -512,11 +504,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // ERSTE R ST DIV EUR R01 T ISIN AT0000A1QA79
@@ -573,11 +561,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -776,11 +760,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -900,11 +880,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Abcdefghijkl: 12.12.2012 Wien, 28.04.2013
@@ -944,11 +920,7 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         // @formatter:off
                         // Wertpapier: DWS TOP 50 WELT KESt II EUR 0,02-

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EstateGuruPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EstateGuruPDFExtractor.java
@@ -56,11 +56,7 @@ public class EstateGuruPDFExtractor extends AbstractPDFExtractor
         depositBlock.setMaxSize(1);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "currency", "amount") //
                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}), [\\d]{2}:[\\d]{2} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}, [\\d]{2}:[\\d]{2} .*" //
@@ -94,11 +90,7 @@ public class EstateGuruPDFExtractor extends AbstractPDFExtractor
         removalBlock.setMaxSize(1);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
 
                         .section("date", "currency", "amount") //
@@ -138,11 +130,7 @@ public class EstateGuruPDFExtractor extends AbstractPDFExtractor
         interestBlock.setMaxSize(1);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "note", "currency", "amount") //
                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}), [\\d]{2}:[\\d]{2} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}, [\\d]{2}:[\\d]{2} " //
@@ -185,11 +173,7 @@ public class EstateGuruPDFExtractor extends AbstractPDFExtractor
         feesBlock.setMaxSize(1);
         feesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("date", "note", "currency", "amount") //
                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}), [\\d]{2}:[\\d]{2} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}, [\\d]{2}:[\\d]{2} " //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FILFondbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FILFondbankPDFExtractor.java
@@ -48,11 +48,7 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -269,11 +265,7 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.SELL);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.SELL))
 
                         // We have a sell transaction, we set a flag.
                         .section("type").optional() //
@@ -379,11 +371,7 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .oneOf( //
                                         // @formatter:off
@@ -503,11 +491,7 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Fondsname iShs S&P SmallCap 600 UCITS ET Datum der Ausschüttung 25.07.2018

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FidelityInternationalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FidelityInternationalPDFExtractor.java
@@ -9,7 +9,6 @@ import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
-import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Values;
 
 /**
@@ -25,6 +24,8 @@ import name.abuchen.portfolio.money.Values;
 @SuppressWarnings("nls")
 public class FidelityInternationalPDFExtractor extends AbstractPDFExtractor
 {
+    private static final String USD = "USD";
+
     public FidelityInternationalPDFExtractor(Client client)
     {
         super(client);
@@ -55,11 +56,7 @@ public class FidelityInternationalPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "SOLD" change from BUY to SELL
                         .section("type").optional() //
@@ -168,11 +165,7 @@ public class FidelityInternationalPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "SOLD" change from BUY to SELL
                         .section("type").optional() //
@@ -198,7 +191,7 @@ public class FidelityInternationalPDFExtractor extends AbstractPDFExtractor
                                                         .find("Symbol:.*") //
                                                         .match("^(?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?).*$") //
                                                         .assign((t, v) -> {
-                                                            v.put("currency", CurrencyUnit.USD);
+                                                            v.put("currency", asCurrencyCode(USD));
                                                             t.setSecurity(getOrCreateSecurity(v));
                                                         }),
                                         // @formatter:off
@@ -215,7 +208,7 @@ public class FidelityInternationalPDFExtractor extends AbstractPDFExtractor
                                                         .find("Symbol:.*") //
                                                         .match("^(?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?).*$") //
                                                         .assign((t, v) -> {
-                                                            v.put("currency", CurrencyUnit.USD);
+                                                            v.put("currency", asCurrencyCode(USD));
                                                             t.setSecurity(getOrCreateSecurity(v));
                                                         }),
                                         // @formatter:off
@@ -231,7 +224,7 @@ public class FidelityInternationalPDFExtractor extends AbstractPDFExtractor
                                                         .find("Symbol:.*") //
                                                         .match("^(?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?).*$") //
                                                         .assign((t, v) -> {
-                                                            v.put("currency", CurrencyUnit.USD);
+                                                            v.put("currency", asCurrencyCode(USD));
                                                             t.setSecurity(getOrCreateSecurity(v));
                                                         }))
 
@@ -259,7 +252,7 @@ public class FidelityInternationalPDFExtractor extends AbstractPDFExtractor
                         .find("You (Bought|Sold) .*") //
                         .match("^.* Settlement Amount([\\s]{1,})(?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            t.setCurrencyCode(asCurrencyCode("USD"));
+                            t.setCurrencyCode(asCurrencyCode(USD));
                             t.setAmount(asAmount(v.get("amount")));
                         })
 
@@ -294,7 +287,7 @@ public class FidelityInternationalPDFExtractor extends AbstractPDFExtractor
                         .find("You (Bought|Sold) .*") //
                         .match("^.* Activity .*([\\s]{1,})(?<fee>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(USD));
 
                             processFeeEntries(t, v, type);
                         })

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -78,11 +78,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -455,11 +451,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -584,11 +576,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -860,11 +848,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.SELL);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.SELL))
 
                         // @formatter:off
                         // WKN     ISIN          Wertpapierbezeichnung           Anzahl
@@ -941,11 +925,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Storno Ertragsmitteilung - ausschüttender/teilthesaurierender Fonds
@@ -1250,11 +1230,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         .oneOf( //
                                         // @formatter:off
@@ -1431,11 +1407,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // WKN     ISIN          Wertpapierbezeichnung           Anzahl
@@ -1522,11 +1494,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // WKN     ISIN          Wertpapierbezeichnung           Anzahl
@@ -1618,11 +1586,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // WKN     ISIN          Wertpapierbezeichnung           Anzahl
@@ -1710,11 +1674,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // WKN     ISIN          Wertpapierbezeichnung           Anzahl
@@ -1789,11 +1749,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         depositRemovalblock_Format01.setMaxSize(2);
         depositRemovalblock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .oneOf( //
                                         // @formatter:off
@@ -1884,11 +1840,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         depositRemovalblock_Format02.setMaxSize(2);
         depositRemovalblock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount", "type") //
                         .documentContext("year", "currency") //
@@ -1935,11 +1887,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feeblock);
         feeblock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .oneOf( //
                                         // @formatter:off
@@ -2020,13 +1968,11 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                                             t.setCurrencyCode(v.get("currency"));
                                                             t.setNote(concatenate(v.get("note"), v.get("isin"), " "));
                                                         }))
-                        .wrap((t, ctx) -> {
-                            var item = new TransactionItem(t);
-
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            return item;
+                            return new TransactionItem(t);
                         }));
 
         var interestBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\s]{1,}[\\d]{2}\\.[\\d]{2}\\.[\\s]{1,}" //
@@ -2036,11 +1982,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST_CHARGE);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST_CHARGE))
 
                         .oneOf( //
                                         // @formatter:off
@@ -2088,13 +2030,11 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                                             t.setNote(trim(v.get("note")));
                                                         }))
 
-                        .wrap((t, ctx) -> {
-                            var item = new TransactionItem(t);
-
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            return item;
+                            return new TransactionItem(t);
                         }));
 
         // @formatter:off
@@ -2104,11 +2044,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestCancellationBlock);
         interestCancellationBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST_CHARGE);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST_CHARGE))
 
                         .section("date", "note", "amount", "type") //
                         .documentContext("year", "currency") //
@@ -2137,11 +2073,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(taxesBlock);
         taxesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .oneOf( //
                                         // @formatter:off
@@ -2209,11 +2141,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.SELL);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.SELL))
 
                         .oneOf( //
                                         // @formatter:off
@@ -2369,11 +2297,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         // @formatter:off
                         // Is type --> "wertlos" change from DELIVERY_INBOUND to DELIVERY_OUTBOUND
@@ -2522,11 +2446,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // ISHS MSCI EM USD-AC                 IE00BKM4GZ66/A111X9
@@ -2580,9 +2500,9 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                                         .match("^[\\s]*(?<note2>[\\d]+).*$") //
                                                         .assign((t, v) -> t.setNote(trim(v.get("note1")) + " " + v.get("note2"))))
 
-                        .wrap((t, ctx) -> {
-                            if (t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                        .wrap(t -> {
+                            if (t.getCurrencyCode() != null && t.getAmount() == 0)
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
                             return new TransactionItem(t);
                         });
@@ -2608,11 +2528,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // Wir belasten den Betrag Ihrem Konto 1009999999 per Valuta 23.03.2023.
@@ -2658,11 +2574,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .oneOf( //
                                         // @formatter:off
@@ -2893,11 +2805,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .oneOf( //
                                         // @formatter:off
@@ -3056,11 +2964,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -3198,11 +3102,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -3545,11 +3445,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -3685,11 +3581,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         .oneOf( //
                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FindependentAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FindependentAGPDFExtractor.java
@@ -51,11 +51,7 @@ public class FindependentAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -139,11 +135,7 @@ public class FindependentAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // ETF-Name UBS SXI Real Estate Funds ETF
@@ -203,11 +195,7 @@ public class FindependentAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         // @formatter:off
                         // Is type --> "Depotgebühren" or "Verwaltungsgebühren" change from DEPOSIT to FEES

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FirstradeSecuritiesIncPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FirstradeSecuritiesIncPDFExtractor.java
@@ -50,11 +50,7 @@ public class FirstradeSecuritiesIncPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "SOLD" change from BUY to SELL
                         .section("type").optional() //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FordMoneyPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FordMoneyPDFExtractor.java
@@ -46,11 +46,7 @@ public class FordMoneyPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date","note", "type", "amount") //
                         .documentContext("currency") //
@@ -74,11 +70,7 @@ public class FordMoneyPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         // @formatter:off
                         // Zinsen vom 30.09.2024 bis 31.10.2024 Steuern vom 30.09.2024 bis 31.10.2024

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FreiburgerKantonalbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FreiburgerKantonalbankPDFExtractor.java
@@ -50,11 +50,7 @@ public class FreiburgerKantonalbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // Wir haben für Sie am 07.02.2023 gezeichnet.

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/GenoBrokerPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/GenoBrokerPDFExtractor.java
@@ -12,7 +12,6 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
-import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 
 @SuppressWarnings("nls")
@@ -37,7 +36,7 @@ public class GenoBrokerPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("Wertpapier Abrechnung (Kauf|Verkauf)");
+        final var type = new DocumentType("Wertpapier Abrechnung (Kauf|Verkauf)");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -48,11 +47,7 @@ public class GenoBrokerPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -174,7 +169,7 @@ public class GenoBrokerPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("(Dividendengutschrift|Aussch.ttung Investmentfonds)");
+        final var type = new DocumentType("(Dividendengutschrift|Aussch.ttung Investmentfonds)");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -185,11 +180,7 @@ public class GenoBrokerPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -323,11 +314,7 @@ public class GenoBrokerPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         // @formatter:off
                         // Is type --> "Ausbuchung" change from DELIVERY_INBOUND to DELIVERY_OUTBOUND
@@ -355,7 +342,7 @@ public class GenoBrokerPDFExtractor extends AbstractPDFExtractor
 
                             // No amount available
                             v.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
-                            t.setCurrencyCode(CurrencyUnit.EUR);
+                            t.setCurrencyCode(asCurrencyCode("EUR"));
                             t.setAmount(0);
                         })
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/GinmonPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/GinmonPDFExtractor.java
@@ -42,11 +42,7 @@ public class GinmonPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // Rechnungsbetrag 0.04 €

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/GladbacherBankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/GladbacherBankAGPDFExtractor.java
@@ -46,11 +46,7 @@ public class GladbacherBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -137,11 +133,7 @@ public class GladbacherBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Stück 52 AMETEK INC. US0311001004 (908668)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HargreavesLansdownPlcExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HargreavesLansdownPlcExtractor.java
@@ -55,11 +55,7 @@ public class HargreavesLansdownPlcExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "SOLD" change from BUY to SELL
                         .section("type").optional()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HelloBankPDFExtractor.java
@@ -47,11 +47,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -144,11 +140,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Titel: NO0003054108  M a r i n e  H a r v est ASA
@@ -221,11 +213,7 @@ public class HelloBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            PortfolioTransaction  portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         // @formatter:off
                         // Titel: DK0060534915  N o v o - N o r d i s k AS

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HypothekarbankLenzburgAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/HypothekarbankLenzburgAGPDFExtractor.java
@@ -49,7 +49,7 @@ public class HypothekarbankLenzburgAGPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("(Wir haben am .* f.r Sie (gekauft|verkauft)|Titelr.ckzahlung)");
+        final var type = new DocumentType("(Wir haben am .* f.r Sie (gekauft|verkauft)|Titelr.ckzahlung)");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -60,11 +60,7 @@ public class HypothekarbankLenzburgAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         // Is type --> "Rücknahme" change from BUY to SELL
@@ -276,7 +272,7 @@ public class HypothekarbankLenzburgAGPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendTransaction()
     {
-        var type = new DocumentType("(Ertragsaussch.ttung|Dividendenzahlung)");
+        final var type = new DocumentType("(Ertragsaussch.ttung|Dividendenzahlung)");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -287,11 +283,7 @@ public class HypothekarbankLenzburgAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/INGDiBaPDFExtractor.java
@@ -100,11 +100,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -370,11 +366,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Sie erhalten eine neue Abrechnung.
@@ -561,11 +553,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // ISIN (WKN) IE00BKPT2S34 (A2P1KU)
@@ -612,13 +600,11 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                         })
 
-                        .wrap((t, ctx) -> {
-                            var item = new TransactionItem(t);
-
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            return item;
+                            return new TransactionItem(t);
                         });
     }
 
@@ -697,11 +683,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "note", "amount") //
                         .documentContext("currency") //
@@ -746,11 +728,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount") //
                         .documentContext("currency") //
@@ -774,11 +752,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .oneOf( //
                                         // @formatter:off
@@ -791,7 +765,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                                                         .documentContextOptionally("taxDate1", "taxDate2", "taxDate3", "tax1", "tax2", "tax3")
                                                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (Zinsertrag|Zinsgutschrift) (?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
-                                                            var amount = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("amount")));
+                                                            var amount = Money.of(v.get("currency"), asAmount(v.get("amount")));
 
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setMonetaryAmount(amount);
@@ -799,7 +773,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                                                             if (v.containsKey("taxDate1") && v.containsKey("tax1")
                                                                             && t.getDateTime().equals(asDate(v.get("taxDate1"))))
                                                             {
-                                                                var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax1")));
+                                                                var tax = Money.of(v.get("currency"), asAmount(v.get("tax1")));
                                                                 t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
                                                                 t.addUnit(new Unit(Unit.Type.TAX, tax));
                                                             }
@@ -807,7 +781,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                                                             if (v.containsKey("taxDate2") && v.containsKey("tax2")
                                                                             && t.getDateTime().equals(asDate(v.get("taxDate2"))))
                                                             {
-                                                                var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax2")));
+                                                                var tax = Money.of(v.get("currency"), asAmount(v.get("tax2")));
                                                                 t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
                                                                 t.addUnit(new Unit(Unit.Type.TAX, tax));
                                                             }
@@ -815,7 +789,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                                                             if (v.containsKey("taxDate3") && v.containsKey("tax3")
                                                                             && t.getDateTime().equals(asDate(v.get("taxDate3"))))
                                                             {
-                                                                var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax3")));
+                                                                var tax = Money.of(v.get("currency"), asAmount(v.get("tax3")));
                                                                 t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
                                                                 t.addUnit(new Unit(Unit.Type.TAX, tax));
                                                             }
@@ -830,11 +804,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feesBlock);
         feesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -865,11 +835,7 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         // @formatter:off
                         // Is type --> "Ausgang" change from DELIVERY_INBOUND to DELIVERY_OUTBOUND
@@ -986,12 +952,12 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }
@@ -1021,12 +987,12 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }
@@ -1056,12 +1022,12 @@ public class INGDiBaPDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JTDirektbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/JTDirektbankPDFExtractor.java
@@ -55,11 +55,7 @@ public class JTDirektbankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount", "type") //
                         .documentContext("currency", "year") //
@@ -99,11 +95,7 @@ public class JTDirektbankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "amount") //
                         .documentContext("currency", "year") //
@@ -124,11 +116,7 @@ public class JTDirektbankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestCancellation);
         interestCancellation.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST_CHARGE);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST_CHARGE))
 
                         .section("date", "amount") //
                         .documentContext("currency", "year") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KBCGroupNVPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KBCGroupNVPDFExtractor.java
@@ -36,7 +36,7 @@ public class KBCGroupNVPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("Uw (Aankoop|Verkoop)");
+        final var type = new DocumentType("Uw (Aankoop|Verkoop)");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -47,11 +47,7 @@ public class KBCGroupNVPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkoop" change from BUY to SELL
                         .section("type").optional() //
@@ -259,7 +255,7 @@ public class KBCGroupNVPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("Uw Uitbetaling dividenden");
+        final var type = new DocumentType("Uw Uitbetaling dividenden");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -270,11 +266,7 @@ public class KBCGroupNVPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -400,11 +392,7 @@ public class KBCGroupNVPDFExtractor extends AbstractPDFExtractor
         depositBlock.setMaxSize(1);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount", "currency") //
                         .match("^(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) " //
@@ -429,11 +417,7 @@ public class KBCGroupNVPDFExtractor extends AbstractPDFExtractor
         removalBlock.setMaxSize(1);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "note", "amount", "currency") //
                         .match("^(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) " //
@@ -457,11 +441,7 @@ public class KBCGroupNVPDFExtractor extends AbstractPDFExtractor
         feesBlock.setMaxSize(1);
         feesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("date", "note", "amount", "currency") //
                         .match("^(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) " //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KFintechPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KFintechPDFExtractor.java
@@ -77,11 +77,7 @@ public class KFintechPDFExtractor extends AbstractPDFExtractor
         purchase.setMaxSize(10);
         purchase.set(new Transaction<BuySellEntry>()
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .section("date", "amount", "units") //
                         .optional() //
@@ -96,7 +92,7 @@ public class KFintechPDFExtractor extends AbstractPDFExtractor
                             t.setSecurity(getOrCreateSecurity(v));
 
                             t.setDate(LocalDate.parse(v.get("date"), DATE_FORMAT).atStartOfDay());
-                            t.setCurrencyCode(INR);
+                            t.setCurrencyCode(asCurrencyCode(INR));
                             t.setAmount(asAmount(v.get("amount")));
                             t.setShares(asShares(v.get("units")));
                         })
@@ -134,11 +130,7 @@ public class KFintechPDFExtractor extends AbstractPDFExtractor
         creation.setMaxSize(10);
         creation.set(new Transaction<BuySellEntry>()
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .section("date", "units", "note") //
                         .optional() //
@@ -152,7 +144,7 @@ public class KFintechPDFExtractor extends AbstractPDFExtractor
                             t.setSecurity(getOrCreateSecurity(v));
 
                             t.setDate(LocalDate.parse(v.get("date"), DATE_FORMAT).atStartOfDay());
-                            t.setCurrencyCode(INR);
+                            t.setCurrencyCode(asCurrencyCode(INR));
                             t.setAmount(Values.Amount.factorize(1));
                             t.setShares(asShares(v.get("units")));
 
@@ -169,11 +161,7 @@ public class KFintechPDFExtractor extends AbstractPDFExtractor
         sale.setMaxSize(10);
         sale.set(new Transaction<BuySellEntry>()
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.SELL);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.SELL))
 
                         .section("date", "amount", "units", "note") //
                         .optional() //
@@ -188,7 +176,7 @@ public class KFintechPDFExtractor extends AbstractPDFExtractor
                             t.setSecurity(getOrCreateSecurity(v));
 
                             t.setDate(LocalDate.parse(v.get("date"), DATE_FORMAT).atStartOfDay());
-                            t.setCurrencyCode(INR);
+                            t.setCurrencyCode(asCurrencyCode(INR));
                             t.setAmount(asAmount(v.get("amount")));
                             t.setShares(asShares(v.get("units")));
 
@@ -205,11 +193,7 @@ public class KFintechPDFExtractor extends AbstractPDFExtractor
         switchOut.setMaxSize(10);
         switchOut.set(new Transaction<BuySellEntry>()
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.SELL);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.SELL))
 
                         .section("date", "amount", "units", "note") //
                         .optional() //
@@ -224,7 +208,7 @@ public class KFintechPDFExtractor extends AbstractPDFExtractor
                             t.setSecurity(getOrCreateSecurity(v));
 
                             t.setDate(LocalDate.parse(v.get("date"), DATE_FORMAT).atStartOfDay());
-                            t.setCurrencyCode(INR);
+                            t.setCurrencyCode(asCurrencyCode(INR));
                             t.setAmount(asAmount(v.get("amount")));
                             t.setShares(asShares(v.get("units")));
 
@@ -257,11 +241,7 @@ public class KFintechPDFExtractor extends AbstractPDFExtractor
         switchIn.setMaxSize(10);
         switchIn.set(new Transaction<BuySellEntry>()
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .section("date", "amount", "units", "note") //
                         .optional() //
@@ -276,7 +256,7 @@ public class KFintechPDFExtractor extends AbstractPDFExtractor
                             t.setSecurity(getOrCreateSecurity(v));
 
                             t.setDate(LocalDate.parse(v.get("date"), DATE_FORMAT).atStartOfDay());
-                            t.setCurrencyCode(INR);
+                            t.setCurrencyCode(asCurrencyCode(INR));
                             t.setAmount(asAmount(v.get("amount")));
                             t.setShares(asShares(v.get("units")));
 
@@ -313,11 +293,7 @@ public class KFintechPDFExtractor extends AbstractPDFExtractor
         dividend.setMaxSize(10);
         dividend.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction t = new AccountTransaction();
-                            t.setType(AccountTransaction.Type.DIVIDENDS);
-                            return t;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .section("date", "amount") //
                         .optional() //
@@ -330,7 +306,7 @@ public class KFintechPDFExtractor extends AbstractPDFExtractor
                             t.setSecurity(getOrCreateSecurity(v));
 
                             t.setDateTime(LocalDate.parse(v.get("date"), DATE_FORMAT).atStartOfDay());
-                            t.setCurrencyCode(INR);
+                            t.setCurrencyCode(asCurrencyCode(INR));
                             t.setAmount(asAmount(v.get("amount")));
                         })
 
@@ -387,7 +363,7 @@ public class KFintechPDFExtractor extends AbstractPDFExtractor
 
         // add the default currency
 
-        values.put("currency", INR);
+        values.put("currency", asCurrencyCode(INR));
 
         return super.getOrCreateSecurity(values);
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
@@ -59,11 +59,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         // Is type --> "Vente" change from BUY to SELL
@@ -234,11 +230,7 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LGTBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LGTBankPDFExtractor.java
@@ -47,11 +47,7 @@ public class LGTBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -169,11 +165,7 @@ public class LGTBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // 551 Veolia Environnement SA

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LibertyVorsorgeAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LibertyVorsorgeAGPDFExtractor.java
@@ -60,11 +60,7 @@ public class LibertyVorsorgeAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "verkauft" change from BUY to SELL
                         .section("type").optional() //
@@ -121,7 +117,7 @@ public class LibertyVorsorgeAGPDFExtractor extends AbstractPDFExtractor
                                                             v.put("name", trim(replaceMultipleBlanks(replaceSingleBlank(v.get("name")))));
                                                             v.put("wkn", stripBlanks(v.get("wkn")));
                                                             v.put("isin", stripBlanks(v.get("isin")));
-                                                            v.put("currency", stripBlanks(v.get("currency")));
+                                                            v.put("currency", asCurrencyCode(stripBlanks(v.get("currency"))));
 
                                                             t.setSecurity(getOrCreateSecurity(v));
                                                         }))
@@ -195,8 +191,8 @@ public class LibertyVorsorgeAGPDFExtractor extends AbstractPDFExtractor
                                                         .match("^T[\\s]*o[\\s]*t[\\s]*a[\\s]*l[\\s]*K[\\s]*u[\\s]*r[\\s]*s[\\s]*w[\\s]*e[\\s]*r[\\s]*t[\\s]*(?<currency>[A-Z\\s]{3,}) (?<fxGross>[\\.,\\d]+)$") //
                                                         .match("^C[\\s]*h[\\s]*a[\s]*n[\\s]*g[\\s]*e[\\s]*(?<baseCurrency>[A-Z\\s]{3,})[\\s]*\\/[\\s]*(?<termCurrency>[A-Z\\s]{3,}) (?<exchangeRate>[\\.,\\d]+) [A-Z\\s]{3,} [\\.,\\d]+$") //
                                                         .assign((t, v) -> {
-                                                            v.put("termCurrency", stripBlanks(v.get("termCurrency")));
-                                                            v.put("baseCurrency", stripBlanks(v.get("baseCurrency")));
+                                                            v.put("termCurrency", asCurrencyCode(stripBlanks(v.get("termCurrency"))));
+                                                            v.put("baseCurrency", asCurrencyCode(stripBlanks(v.get("baseCurrency"))));
 
                                                             var rate = asExchangeRate(v);
                                                             type.getCurrentContext().putType(rate);
@@ -242,11 +238,7 @@ public class LibertyVorsorgeAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -272,7 +264,7 @@ public class LibertyVorsorgeAGPDFExtractor extends AbstractPDFExtractor
                                                             v.put("nameContinued", trim(replaceMultipleBlanks(v.get("nameContinued"))));
                                                             v.put("wkn", stripBlanks(v.get("wkn")));
                                                             v.put("isin", stripBlanks(v.get("isin")));
-                                                            v.put("currency", stripBlanks(v.get("currency")));
+                                                            v.put("currency", asCurrencyCode(stripBlanks(v.get("currency"))));
 
                                                             t.setSecurity(getOrCreateSecurity(v));
                                                         }))
@@ -326,7 +318,7 @@ public class LibertyVorsorgeAGPDFExtractor extends AbstractPDFExtractor
                         .section("currency", "tax").optional() //
                         .match("^[\\d]+%[\\s]*V[\\s]*e[\\s]*r[\\s]*r[\\s]*e[\\s]*c[\\s]*h[\\s]*n[\\s]*u[\\s]*n[\\s]*g[\\s]*s[\\s]*s[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*(?<currency>[A-Z\\s]{3,}) \\-(?<tax>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            v.put("currency", stripBlanks(v.get("currency")));
+                            v.put("currency", asCurrencyCode(stripBlanks(v.get("currency"))));
 
                             processTaxEntries(t, v, type);
                         })
@@ -337,7 +329,7 @@ public class LibertyVorsorgeAGPDFExtractor extends AbstractPDFExtractor
                         .section("currency", "tax").optional() //
                         .match("^S[\\s]*t[\\s]*e[\\s]*m[\\s]*p[\\s]*e[\\s]*l[\\s]*(?<currency>[A-Z\\s]{3,}) \\-(?<tax>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            v.put("currency", stripBlanks(v.get("currency")));
+                            v.put("currency", asCurrencyCode(stripBlanks(v.get("currency"))));
 
                             processTaxEntries(t, v, type);
                         });
@@ -353,7 +345,7 @@ public class LibertyVorsorgeAGPDFExtractor extends AbstractPDFExtractor
                         .section("currency", "fee").optional() //
                         .match("^A[\\s]*n[\\s]*d[\\s]*e[\\s]*r[\\s]*e[\\s]*S[\\s]*p[\\s]*e[\\s]*s[\\s]*e[\\s]*n[\\s]*(?<currency>[A-Z\\s]{3,}) \\-(?<fee>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            v.put("currency", stripBlanks(v.get("currency")));
+                            v.put("currency", asCurrencyCode(stripBlanks(v.get("currency"))));
                             v.put("fee", stripBlanks(v.get("fee")));
 
                             processFeeEntries(t, v, type);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LiechtensteinischeLandesbankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LiechtensteinischeLandesbankAGPDFExtractor.java
@@ -58,11 +58,7 @@ public class LiechtensteinischeLandesbankAGPDFExtractor extends AbstractPDFExtra
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -158,11 +154,7 @@ public class LiechtensteinischeLandesbankAGPDFExtractor extends AbstractPDFExtra
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -273,11 +265,7 @@ public class LiechtensteinischeLandesbankAGPDFExtractor extends AbstractPDFExtra
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "amount", "note") //
                         .documentContext("currency", "year") //
@@ -301,11 +289,7 @@ public class LiechtensteinischeLandesbankAGPDFExtractor extends AbstractPDFExtra
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "note1", "note2", "amount") //
                         .documentContext("currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LimeTradingCorpPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/LimeTradingCorpPDFExtractor.java
@@ -13,7 +13,6 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
-import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 
@@ -34,6 +33,8 @@ import name.abuchen.portfolio.money.Values;
 @SuppressWarnings("nls")
 public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
 {
+    private static final String USD = "USD";
+
     public LimeTradingCorpPDFExtractor(Client client)
     {
         super(client);
@@ -79,11 +80,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockBuySell);
         blockBuySell.set(new Transaction<BuySellEntry>()
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .section("month", "day", "name", "wkn", "type", "shares", "amount", "nameContinued") //
                         .documentContext("year") //
@@ -95,7 +92,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                 t.setType(PortfolioTransaction.Type.SELL);
 
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(USD));
 
                             t.setDate(asDate(v.get("date")));
                             t.setShares(asShares(v.get("shares")));
@@ -130,11 +127,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockDividende);
         blockDividende.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         section -> section //
@@ -144,7 +137,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                                         .match("^[\\w]{3} [\\d]{2} .* [\\w]{9} (NRA Withhold|Foreign Withholding) \\((?<tax>[\\.,\\d]+)\\)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                                                            v.put("currency", CurrencyUnit.USD);
+                                                            v.put("currency", asCurrencyCode(USD));
 
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
@@ -152,7 +145,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                                             t.setSecurity(getOrCreateSecurity(v));
 
-                                                            Money tax = Money.of(CurrencyUnit.USD,
+                                                            Money tax = Money.of(USD,
                                                                             asAmount(v.get("tax")));
                                                             checkAndSetTax(tax, t, type.getCurrentContext());
                                                         }),
@@ -163,7 +156,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                                         .match("^[\\w]{3} [\\d]{2} .* [\\w]{9} (NRA Withhold|Foreign Withholding) \\((?<tax>[\\.,\\d]+)\\)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                                                            v.put("currency", CurrencyUnit.USD);
+                                                            v.put("currency", asCurrencyCode(USD));
 
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
@@ -171,7 +164,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                                                             t.setSecurity(getOrCreateSecurity(v));
 
-                                                            Money tax = Money.of(CurrencyUnit.USD,
+                                                            Money tax = Money.of(USD,
                                                                             asAmount(v.get("tax")));
 
                                                             checkAndSetTax(tax, t, type.getCurrentContext());
@@ -182,7 +175,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                                         .match("^(?<month>.*) (?<day>[\\d]{1,2}) (?<name>.*) (?<shares>[\\.,\\d]+) (?<wkn>(?!Qualified).{9}) (Qualified )?Dividend (?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                                                            v.put("currency", CurrencyUnit.USD);
+                                                            v.put("currency", asCurrencyCode(USD));
 
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
@@ -198,11 +191,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
         blockWithholdTaxForDividende.setMaxSize(2);
         blockWithholdTaxForDividende.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .oneOf( //
                                         section -> section //
@@ -212,7 +201,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                                                         .match("^(?<name>.*)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                                                            v.put("currency", CurrencyUnit.USD);
+                                                            v.put("currency", asCurrencyCode(USD));
 
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setShares(0L);
@@ -237,11 +226,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockDeliveryInBound);
         blockDeliveryInBound.set(new Transaction<PortfolioTransaction>()
 
-                        .subject(() -> {
-                            PortfolioTransaction portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         .section("month", "day", "name", "wkn", "shares", "nameContinued") //
                         .documentContext("year") //
@@ -249,7 +234,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                         .match("(?<nameContinued>.*)") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setShares(asShares(v.get("shares")));
@@ -271,18 +256,14 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockFees);
         blockFees.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("month", "day", "name", "wkn", "amount") //
                         .documentContext("year") //
                         .match("^(?<month>[\\w]{3}) (?<day>[\\d]{1,2}) Ca Fee_spinoff.* (?<name>.*) (?<wkn>.*) Journal \\((?<amount>[\\.,\\d]+)\\)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -308,11 +289,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockCashAllocation);
         blockCashAllocation.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .section("month", "day", "name", "wkn", "amount") //
                         .documentContext("year") //
@@ -320,7 +297,7 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<name>.*)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setShares(0L);
@@ -341,18 +318,14 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockDeposit);
         blockDeposit.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("month", "day", "amount") //
                         .documentContext("year") //
                         .match("^(?<month>[\\w]{3}) (?<day>[\\d]{1,2}) Wire .* (?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -371,18 +344,14 @@ public class LimeTradingCorpPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockInterest);
         blockInterest.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("month", "day", "amount") //
                         .documentContext("year") //
                         .match("^(?<month>[\\w]{3}) (?<day>[\\d]{1,2}) .* Credit Interest (?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MLPBankingAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MLPBankingAGPDFExtractor.java
@@ -52,11 +52,7 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -164,11 +160,7 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // If we have a positive amount and a gross
@@ -273,11 +265,7 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalblock);
         depositRemovalblock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("day", "month", "note", "amount", "type") //
                         .documentContext("year", "currency") //
@@ -304,11 +292,7 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feeblock);
         feeblock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES_REFUND))
 
                         .oneOf( //
                                         section -> section //
@@ -475,11 +459,7 @@ public class MLPBankingAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         // @formatter:off
                         // Ausmachender Betrag 0,79 EUR

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MeDirectBankPlcPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MeDirectBankPlcPDFExtractor.java
@@ -44,11 +44,7 @@ public class MeDirectBankPlcPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkoop" change from BUY to SELL
                         .section("type").optional() //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MerkurPrivatBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/MerkurPrivatBankPDFExtractor.java
@@ -39,7 +39,7 @@ public class MerkurPrivatBankPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("Wertpapier Abrechnung (Kauf|Verkauf)");
+        final var type = new DocumentType("Wertpapier Abrechnung (Kauf|Verkauf)");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -50,11 +50,7 @@ public class MerkurPrivatBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // Is type --> "Verkauf" change from BUY to SELL
@@ -121,7 +117,7 @@ public class MerkurPrivatBankPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("(Ertragsgutschrift nach" //
+        final var type = new DocumentType("(Ertragsgutschrift nach" //
                         + "|Aussch.ttung Investmentfonds" //
                         + "|Dividendengutschrift)");
         this.addDocumentTyp(type);
@@ -134,11 +130,7 @@ public class MerkurPrivatBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Stück 55 DEUTSCHE TELEKOM AG DE0005557508 (555750)
@@ -238,11 +230,7 @@ public class MerkurPrivatBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount", "type") //
                         .documentContext("currency", "year") //
@@ -285,11 +273,7 @@ public class MerkurPrivatBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         .section("name", "isin", "wkn", "nameContinued", "currency") //
                         .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)") //
@@ -318,9 +302,9 @@ public class MerkurPrivatBankPDFExtractor extends AbstractPDFExtractor
                         .match("^.*(?<note>Abrechnungsnr\\. [\\d]+).*$") //
                         .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
-                        .wrap((t, ctx) -> {
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
                             return new TransactionItem(t);
                         });

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ModenaEstoniaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ModenaEstoniaPDFExtractor.java
@@ -45,11 +45,7 @@ public class ModenaEstoniaPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -103,9 +99,9 @@ public class ModenaEstoniaPDFExtractor extends AbstractPDFExtractor
                             t.setNote(trim(v.get("note")));
                         })
 
-                        .wrap((t, ctx) -> {
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
                             return new TransactionItem(t);
                         });

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/N26BankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/N26BankAGPDFExtractor.java
@@ -40,11 +40,7 @@ public class N26BankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         // @formatter:off
                         // Max Mustermann 19.06.2024 +5.000,00€
@@ -90,11 +86,7 @@ public class N26BankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .oneOf( //
                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NIBCBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NIBCBankPDFExtractor.java
@@ -40,11 +40,7 @@ public class NIBCBankPDFExtractor extends AbstractPDFExtractor
         this.addDocumentTyp(type);
 
         Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
-        pdfTransaction.subject(() -> {
-            BuySellEntry entry = new BuySellEntry();
-            entry.setType(PortfolioTransaction.Type.BUY);
-            return entry;
-        });
+        pdfTransaction.subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY));
 
         Block firstRelevantLine = new Block("^Wertpapier Abrechnung (Kauf|Verkauf).*$");
         type.addBlock(firstRelevantLine);
@@ -129,11 +125,7 @@ public class NIBCBankPDFExtractor extends AbstractPDFExtractor
 
         Block block = new Block("^(Dividendengutschrift|Aussch.ttung Investmentfonds|Ertragsgutschrift .*)$");
         type.addBlock(block);
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> {
-            AccountTransaction entry = new AccountTransaction();
-            entry.setType(AccountTransaction.Type.DIVIDENDS);
-            return entry;
-        });
+        Transaction<AccountTransaction> pdfTransaction = new Transaction<AccountTransaction>().subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS));
 
         pdfTransaction
                 // Stück 100 VANGUARD FTSE ALL-WORLD U.ETF IE00B3RBWM25 (A1JX52)
@@ -207,11 +199,7 @@ public class NIBCBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 
-                .subject(() -> {
-                    AccountTransaction t = new AccountTransaction();
-                    t.setType(AccountTransaction.Type.TAX_REFUND);
-                    return t;
-                })
+                .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                 // Ausmachender Betrag 29,57 EUR
                 // Den Gegenwert buchen wir mit Valuta 13.08.2019 zu Gunsten des Kontos 5052258000

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NeonSwitzerlandAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NeonSwitzerlandAGPDFExtractor.java
@@ -66,11 +66,7 @@ public class NeonSwitzerlandAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Sell" change from BUY to SELL
                         .section("type").optional() //
@@ -146,11 +142,7 @@ public class NeonSwitzerlandAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         // @formatter:off
                         // 18.11.2025 Deposit 18.11.2025  1'000.00  1'000.00
@@ -189,11 +181,7 @@ public class NeonSwitzerlandAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // 03.12.2025 Management fee 0.45% 31.12.2025  0.47 -0.47

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NordaxBankABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NordaxBankABPDFExtractor.java
@@ -47,11 +47,7 @@ public class NordaxBankABPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .oneOf(
                                         //
@@ -92,10 +88,7 @@ public class NordaxBankABPDFExtractor extends AbstractPDFExtractor
         type.addBlock(transferBlock);
         transferBlock.set(new Transaction<AccountTransferEntry>()
 
-                        .subject(() -> {
-                            var accountTransferEntry = new AccountTransferEntry();
-                            return accountTransferEntry;
-                        })
+                        .subject(AccountTransferEntry::new)
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -117,11 +110,7 @@ public class NordaxBankABPDFExtractor extends AbstractPDFExtractor
         depositRemovalBlock.setMaxSize(3);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "type", "amount") //
                         .documentContext("currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NorddeutscheLandesbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/NorddeutscheLandesbankPDFExtractor.java
@@ -41,11 +41,7 @@ public class NorddeutscheLandesbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OldenburgischeLandesbankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OldenburgischeLandesbankAGPDFExtractor.java
@@ -37,7 +37,7 @@ public class OldenburgischeLandesbankAGPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("WERTPAPIERABRECHNUNG");
+        final var type = new DocumentType("WERTPAPIERABRECHNUNG");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -48,11 +48,7 @@ public class OldenburgischeLandesbankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -157,7 +153,7 @@ public class OldenburgischeLandesbankAGPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("(ERTRAGSAUSSCH.TTUNG|Stornierung Dividendengutschrift)");
+        final var type = new DocumentType("(ERTRAGSAUSSCH.TTUNG|Stornierung Dividendengutschrift)");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -168,11 +164,7 @@ public class OldenburgischeLandesbankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Stornierung Dividendengutschrift – VanEck Sust.World EQ.UC.ETF Aandelen oop naam o.N.
@@ -242,7 +234,7 @@ public class OldenburgischeLandesbankAGPDFExtractor extends AbstractPDFExtractor
 
     private void addAdvanceTaxTransaction()
     {
-        var type = new DocumentType("VORABPAUSCHALE");
+        final var type = new DocumentType("VORABPAUSCHALE");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -253,11 +245,7 @@ public class OldenburgischeLandesbankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // DE000A0H0785 (A0H078) iS.EO G.B.C.1.5-10.5y.U.ETF DE Inhaber-Anteile 26,634225
@@ -305,9 +293,9 @@ public class OldenburgischeLandesbankAGPDFExtractor extends AbstractPDFExtractor
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                         })
 
-                        .wrap((t, ctx) -> {
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
                             return new TransactionItem(t);
                         });
@@ -341,11 +329,7 @@ public class OldenburgischeLandesbankAGPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .oneOf( //
                                         // @formatter:off
@@ -418,11 +402,7 @@ public class OldenburgischeLandesbankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         // @formatter:off
                         // Steuerpflichtige Fondsfusion

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OnvistaPDFExtractor.java
@@ -68,11 +68,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -349,11 +345,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // If we have a reinvest we pick the second
@@ -535,11 +527,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Is type --> "Ertragsthesaurierung" change from DIVIDENDS to TAXES
@@ -934,11 +922,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Gattungsbezeichnung ISIN
@@ -1011,12 +995,10 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setNote(v.get("note1") + " " + v.get("note2")))
 
                         .wrap(t -> {
-                            var item = new TransactionItem(t);
-
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                return new SkippedItem(item, Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            return item;
+                            return new TransactionItem(t);
                         });
     }
 
@@ -1033,11 +1015,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         // @formatter:off
                         // Is type --> "Wertlose Ausbuchung" change from DELIVERY_INBOUND to DELIVERY_OUTBOUND
@@ -1108,11 +1086,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // Gattungsbezeichnung ISIN
@@ -1225,11 +1199,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         // @formatter:off
                         // 04.04. 04.04. REF: 000045862247 200,00+
@@ -1391,11 +1361,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -1567,11 +1533,7 @@ public class OnvistaPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .oneOf( //
                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OpenBankSAPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OpenBankSAPDFExtractor.java
@@ -40,11 +40,7 @@ public class OpenBankSAPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OrangeBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/OrangeBankPDFExtractor.java
@@ -45,11 +45,7 @@ public class OrangeBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -70,10 +66,7 @@ public class OrangeBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(transferBlock);
         transferBlock.set(new Transaction<AccountTransferEntry>()
 
-                        .subject(() -> {
-                            var accountTransferEntry = new AccountTransferEntry();
-                            return accountTransferEntry;
-                        })
+                        .subject(AccountTransferEntry::new)
 
                         .section("date", "amount") //
                         .documentContext("currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PictetCieGruppeSAPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PictetCieGruppeSAPDFExtractor.java
@@ -46,11 +46,7 @@ public class PictetCieGruppeSAPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Sale" change from BUY to SELL
                         .section("type") //
@@ -159,11 +155,7 @@ public class PictetCieGruppeSAPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // UBS(LUX)-MSCI WOR.SOC.RES.A USD-INC 2'420 GeneralTrade date 01.08.2022

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostbankPDFExtractor.java
@@ -60,7 +60,7 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("(Wertpapier )?Abrechnung(:)? "//
+        final var type = new DocumentType("(Wertpapier )?Abrechnung(:)? "//
                         + "(Kauf" //
                         + "|Kauf von Wertpapieren" //
                         + "|Verkauf" //
@@ -77,11 +77,7 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -259,7 +255,7 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("(Dividendengutschrift" //
+        final var type = new DocumentType("(Dividendengutschrift" //
                         + "|Aussch.ttung Investmentfonds" //
                         + "|Gutschrift von Investmentertr.gen" //
                         + "|Ertragsgutschrift" //
@@ -275,11 +271,7 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Storno einer Ertragsgutschrift
@@ -519,7 +511,7 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
 
     private void addAdvanceTaxTransaction()
     {
-        var type = new DocumentType("Vorabpauschale");
+        final var type = new DocumentType("Vorabpauschale");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -530,11 +522,7 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Stück WKN ISIN
@@ -601,9 +589,12 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
                                                         })
                         )
 
-                        .wrap(t -> t.getCurrencyCode() == null || t.getAmount() == 0
-                                        ? new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired)
-                                        : new TransactionItem(t));
+                        .wrap(t -> {
+                            if (t.getCurrencyCode() == null || t.getAmount() == 0)
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                            return new TransactionItem(t);
+                        });
     }
 
     private void addDepotStatementTransaction()
@@ -636,11 +627,7 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var t = new AccountTransaction();
-                            t.setType(AccountTransaction.Type.DEPOSIT);
-                            return t;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount").optional() //
                         .documentContext("currency", "year") //
@@ -675,11 +662,7 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var t = new AccountTransaction();
-                            t.setType(AccountTransaction.Type.REMOVAL);
-                            return t;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "note", "amount").optional() //
                         .documentContext("currency", "year") //
@@ -758,12 +741,12 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }
@@ -800,12 +783,12 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }
@@ -842,12 +825,12 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
                             if (type.getCurrentContext().getBoolean(IS_JOINT_ACCOUNT))
                             {
                                 // Account 1
-                                v.put("currency", v.get("currency1"));
+                                v.put("currency", asCurrencyCode(v.get("currency1")));
                                 v.put("tax", v.get("tax1"));
                                 processTaxEntries(t, v, type);
 
                                 // Account 2
-                                v.put("currency", v.get("currency2"));
+                                v.put("currency", asCurrencyCode(v.get("currency2")));
                                 v.put("tax", v.get("tax2"));
                                 processTaxEntries(t, v, type);
                             }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostfinancePDFExtractor.java
@@ -72,11 +72,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         // Is type --> "Rücknahme" change from BUY to SELL
@@ -292,11 +288,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // Bitcoin BTC 0.006124 USD 97 376.126639
@@ -373,11 +365,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -496,11 +484,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         // Is type --> "Belastung" change from DEPOSIT to REMOVAL
                         .section("type").optional() //
@@ -550,11 +534,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // Jahresgebühr Unsere Referenz: 161333839
@@ -594,11 +574,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .oneOf( //
                                         // @formatter:off
@@ -685,11 +661,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .oneOf( //
                                         section -> section //
@@ -745,11 +717,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // Gebührenausweis 01.01.2015 - 31.12.2015
@@ -801,11 +769,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Verrechnungssteuer 35.00% 40.83
@@ -850,11 +814,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .optionalOneOf( //
                                         section -> section //
@@ -991,11 +951,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("note", "amount", "date").optional() //
                         .documentContext("currency") //
@@ -1095,11 +1051,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
         type.addBlock(feesBlock);
         feesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("note", "amount", "date").optional() //
                         .documentContext("currency") //
@@ -1166,11 +1118,7 @@ public class PostfinancePDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("note", "date", "amount").optional() //
                         .documentContext("currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/QuestradeGroupPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/QuestradeGroupPDFExtractor.java
@@ -65,11 +65,7 @@ public class QuestradeGroupPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // 04-10-2025 04-11-2025 Buy .VEQT VANGUARD ALL-EQUITY ETF  PORTFOLIO
@@ -158,11 +154,7 @@ public class QuestradeGroupPDFExtractor extends AbstractPDFExtractor
         firstRelevantLine.set(pdfTransaction);
 
         pdfTransaction //
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // 01-07-2025 01-07-2025    .VEQT UNIT DIST      ON      29 SHS REC 12/30/24 PAY - - - - 20.69 - - - -
@@ -236,11 +228,7 @@ public class QuestradeGroupPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "amount") //
                         .documentContext("currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/QuirinBankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/QuirinBankAGPDFExtractor.java
@@ -44,7 +44,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction_Format01()
     {
-        var type = new DocumentType("Wertpapierabrechnung");
+        final var type = new DocumentType("Wertpapierabrechnung");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -55,11 +55,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -121,7 +117,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction_Format02()
     {
-        var type = new DocumentType("Abrechnungskonditionen");
+        final var type = new DocumentType("Abrechnungskonditionen");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -135,11 +131,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -274,7 +266,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction_Format01()
     {
-        var type = new DocumentType("F.r aus Ihrem Depot f.llig gewordene Ertr.gnisse", "Vorabpauschale");
+        final var type = new DocumentType("F.r aus Ihrem Depot f.llig gewordene Ertr.gnisse", "Vorabpauschale");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -285,11 +277,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -385,7 +373,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction_Format02()
     {
-        var type = new DocumentType("(Dividendenabrechnung" //
+        final var type = new DocumentType("(Dividendenabrechnung" //
                         + "|Ertrag aus Investments)");
         this.addDocumentTyp(type);
 
@@ -398,11 +386,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -516,7 +500,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
 
     private void addAdvanceTaxTransaction()
     {
-        var type = new DocumentType("Vorabpauschale");
+        final var type = new DocumentType("Vorabpauschale");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -527,11 +511,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         .oneOf( //
                                         // @formatter:off
@@ -594,7 +574,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
 
     private void addDepotStatementTransaction()
     {
-        var type = new DocumentType("Kontoauszug");
+        final var type = new DocumentType("Kontoauszug");
         this.addDocumentTyp(type);
 
         // @formatter:off
@@ -613,11 +593,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
         depositBlock.setMaxSize(5);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("note1", "note2", "date", "amount", "currency") //
                         .match("^(?<note1>(Konto.bertrag [\\d]+" //
@@ -644,11 +620,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
         removalBlock.setMaxSize(5);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .oneOf( //
                                         // @formatter:off
@@ -698,11 +670,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
         taxesBlock.setMaxSize(3);
         taxesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         .section("note1", "note2", "date", "amount", "currency").optional() //
                         .match("^(?<note1>Steuerbuchung Abgeltungsteuer),[\\s]{1,}.*: (?<note2>.*) " //
@@ -732,11 +700,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
         taxRefundBlock01.setMaxSize(5);
         taxRefundBlock01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .section("note1", "note2", "date", "amount", "currency") //
                         .match("^(?<note1>Steueroptimierung) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} " //
@@ -761,11 +725,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
         taxRefundBlock02.setMaxSize(3);
         taxRefundBlock02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .section("note1", "note2", "date", "amount", "currency").optional() //
                         .match("^(?<note1>Steuerbuchung Abgeltungsteuer),[\\s]{1,}.*: (?<note2>.*) " //
@@ -795,11 +755,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
         taxesBlock01.setMaxSize(5);
         taxesBlock01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         .section("note1", "note2", "date", "amount", "currency") //
                         .match("^(?<note1>Steueroptimierung) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} " //
@@ -824,11 +780,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
         feesBlock01.setMaxSize(5);
         feesBlock01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("note1", "date", "amount", "currency", "note2") //
                         .match("^(?<note1>Verm.gensverwaltungshonorar).* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (\\- )?" //
@@ -853,11 +805,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
         feesBlock02.setMaxSize(5);
         feesBlock02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("note1", "note2", "date", "amount", "currency", "note3") //
                         .match("^(?<note1>Flatrate),[\\s]{1,}.*: (?<note2>.*) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (\\- )?" //
@@ -881,11 +829,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feesBlock03);
         feesBlock03.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("note1", "note2", "date", "amount", "currency", "note3", "note4") //
                         .match("^(?<note1>Volumen Fee),[\\s]{1,}.*: (?<note2>.*) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (\\- )?" //
@@ -912,11 +856,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
         feeBlock04.setMaxSize(5);
         feeBlock04.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES_REFUND))
 
                         .section("note1", "note2", "date", "amount", "currency", "note3", "note4") //
                         .match("^[\\d]+ (?<note1>Bestandsprovision), "
@@ -943,11 +883,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feesBlock05);
         feesBlock05.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("note1", "note2", "date", "amount", "currency", "note3") //
                         .match("^(?<note1>Honorar),[\\s]{1,}.*: (?<note2>.*) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (\\- )?" //
@@ -973,11 +909,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
         feeRefundBlock.setMaxSize(5);
         feeRefundBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES_REFUND))
 
                         .section("note1", "note2", "date", "amount", "currency", "note3") //
                         .match("^R.ckverg.tung (?<note1>Bestand.*), .*: (?<note2>.*) " //
@@ -1001,11 +933,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("note1", "note2", "date", "amount", "currency") //
                         .match("^(?<note1>Haben\\-Zinsen Kontoabschluss), " //
@@ -1032,11 +960,7 @@ public class QuirinBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Verrechnungstopf Sonstige  0,00 EUR Steuerbetrag  0,05 EUR

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
@@ -69,11 +69,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         // Is type --> "Rücknahme Fonds" change from BUY to SELL
@@ -276,11 +272,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -546,11 +538,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // Belastung Valuta 30.09.2024 CHF 100.04
@@ -586,13 +574,11 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                         .match("^F.r den Zeitraum vom (?<note>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} .* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$") //
                         .assign((t, v) -> t.setNote(concatenate(t.getNote(), v.get("note"), " | ")))
 
-                        .wrap((t, ctx) -> {
-                            var item = new TransactionItem(t);
-
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            return item;
+                            return new TransactionItem(t);
                         });
     }
 
@@ -609,11 +595,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         // Is type --> "Einbuchung" change from DELIVERY_OUTBOUND to DELIVERY_INBOUND
                         .section("type").optional() //
@@ -675,12 +657,13 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                         })
 
                         .wrap((t, ctx) -> {
-                            var item = new TransactionItem(t);
+                            if (ctx.getFailureReason() != null)
+                                return new TransactionItem(t);
 
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            return item;
+                            return new TransactionItem(t);
                         });
     }
 
@@ -697,11 +680,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         // @formatter:off
                         // Titel: IE00BKX55T58 Vang.FTSE Develop.World U.ETF
@@ -800,11 +779,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         // @formatter:off
                         // 01.12. 01.12. BASISLASTSCHRIFT PN:931                                             42,13 S
@@ -920,11 +895,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .optionalOneOf(
                                         // @formatter:off
@@ -973,7 +944,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. Kapitalertrags(s)?teuer .* (?<tax>[\\.,\\d]+) S$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             if (t.getType() == AccountTransaction.Type.INTEREST)
@@ -989,7 +960,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. Solid\\.\\-Zuschlag .* (?<tax>[\\.,\\d]+) S$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             if (t.getType() == AccountTransaction.Type.INTEREST)
@@ -1005,7 +976,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. Kirchensteuer .* (?<tax>[\\.,\\d]+) S$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             if (t.getType() == AccountTransaction.Type.INTEREST)
@@ -1024,11 +995,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
         type.addBlock(feesBlock);
         feesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // 30.12. 31.12. Abschluss PN:905                                                      1,95 S
@@ -1121,11 +1088,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount") //
                         .documentContext("currency", "year") //
@@ -1147,11 +1110,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var t = new AccountTransaction();
-                            t.setType(AccountTransaction.Type.INTEREST);
-                            return t;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "amount") //
                         .documentContext("currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaisinBankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaisinBankAGPDFExtractor.java
@@ -48,11 +48,7 @@ public class RaisinBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -141,11 +137,7 @@ public class RaisinBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // VANG.FTSE DEV.EU.UETF EOD IE00B945VV12
@@ -231,11 +223,7 @@ public class RaisinBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Wertpapierbezeichnung Vanguard FTSE N.America U.ETF Registered Shares USD Dis.oN
@@ -279,9 +267,9 @@ public class RaisinBankAGPDFExtractor extends AbstractPDFExtractor
                         .match("^.*(?<note>Dokument ID: .*)$") //
                         .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
-                        .wrap((t, ctx) -> {
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
                             return new TransactionItem(t);
                         });

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RenaultBankDirektPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RenaultBankDirektPDFExtractor.java
@@ -102,11 +102,7 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock_Format01);
         depositRemovalBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount", "type") //
                         .documentContext("currency", "year") //
@@ -134,11 +130,7 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock_Format02);
         depositRemovalBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "amount", "type") //
                         .documentContext("currency", "year") //
@@ -165,11 +157,7 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock_Format03);
         depositRemovalBlock_Format03.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("type", "amount", "date") //
                         .documentContext("currency") //
@@ -196,11 +184,7 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock_Format01);
         interestBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "note", "amount", "type") //
                         .documentContext("currency", "year") //
@@ -250,11 +234,7 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock_Format02);
         interestBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         // @formatter:off
                         // 05.08. 31.07. Storno Abschluss                                                      3,59 S
@@ -333,11 +313,7 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock_Format03);
         interestBlock_Format03.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("note", "amount", "date") //
                         .documentContext("currency") //
@@ -363,11 +339,7 @@ public class RenaultBankDirektPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock_Format04);
         interestBlock_Format04.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("type", "amount", "date") //
                         .documentContext("currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RevolutLtdPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RevolutLtdPDFExtractor.java
@@ -45,11 +45,7 @@ public class RevolutLtdPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Sell" change from BUY to SELL
                         .section("type").optional() //
@@ -124,11 +120,7 @@ public class RevolutLtdPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockDeposit);
         blockDeposit.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "currency", "amount") //
                         .match("^(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) [\\d]{2}\\/[\\d]{2}\\/[\\d]{4} (?<currency>[\\w]{3}) .* Cash Disbursement \\- Wallet \\([\\w]{3}\\) (?<amount>[\\.,\\d]+)$") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
@@ -71,11 +71,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional()
@@ -270,7 +266,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendTransaction()
     {
-        var type = new DocumentType("(Dividendengutschrift|" //
+        final var type = new DocumentType("(Dividendengutschrift|" //
                         + "Aussch.ttung|" //
                         + "Kapitalr.ckzahlung)");
         this.addDocumentTyp(type);
@@ -286,11 +282,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Storno unserer Erträgnisgutschrift Nr. 81565205 vom 15.06.2016.
@@ -611,7 +603,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
 
     private void addAdvanceTaxTransaction()
     {
-        var type = new DocumentType("Vorabpauschale");
+        final var type = new DocumentType("Vorabpauschale");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -622,11 +614,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Stück 155 ISHSIV-AUTOMATION&ROBOT.U.ETF IE00BYZK4552 (A2ANH0)
@@ -687,9 +675,9 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<note>Abrechnungsnr\\. .*)$") //
                         .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
-                        .wrap((t, ctx) -> {
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
                             return new TransactionItem(t);
                         });
@@ -727,11 +715,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // Kauf 145,00 172520/34.00 282,3348 1,0000 0,5269 02.07.2021 06.07.2021 0,00 0,00
@@ -791,11 +775,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock_Format01);
         depositRemovalBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("type", "amount", "date", "note").optional() //
                         .documentContext("currency") //
@@ -921,11 +901,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock_Format02);
         depositRemovalBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "type", "amount") //
                         .documentContext("currency") //
@@ -993,9 +969,9 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                             t.setNote(v.get("note"));
                         })
 
-                        .wrap((t, ctx) -> {
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
                             return new TransactionItem(t);
                         }));
@@ -1005,11 +981,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock_Format03);
         depositRemovalBlock_Format03.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -1203,11 +1175,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock_Format04);
         depositRemovalBlock_Format04.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount", "type") //
                         .documentContext("currency") //
@@ -1312,11 +1280,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock_Format05);
         depositRemovalBlock_Format05.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount", "type") //
                         .documentContext("currency") //
@@ -1393,11 +1357,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feesBlock);
         feesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES_REFUND))
 
                         .oneOf( //
                                         // @formatter:off
@@ -1462,9 +1422,9 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                                                             t.setNote(trim(v.get("note")));
                                                         }))
 
-                        .wrap((t, ctx) -> {
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
                             return new TransactionItem(t);
                         }));
@@ -1473,11 +1433,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .oneOf( //
                                         // @formatter:off
@@ -1529,9 +1485,9 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                                                             t.setNote(trim(v.get("note")));
                                                         }))
 
-                        .wrap((t, ctx) -> {
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
                             return new TransactionItem(t);
                         }));
@@ -1541,11 +1497,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         type.addBlock(taxReturnBlock_Format01);
         taxReturnBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .section("type", "amount", "date", "note").optional() //
                         .documentContext("currency") //
@@ -1588,11 +1540,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .oneOf( //
                                         // @formatter:off
@@ -1664,11 +1612,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feesBlock);
         feesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES_REFUND))
 
                         // @formatter:off
                         // 23.01.21 25.01.21 EVERDRIVE.ME, KRAKOW USD 181,00 1,2192 148,46 -
@@ -1712,11 +1656,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .oneOf( //
                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SantanderConsumerBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SantanderConsumerBankPDFExtractor.java
@@ -43,7 +43,7 @@ public class SantanderConsumerBankPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("Wertpapier Abrechnung Kauf");
+        final var type = new DocumentType("Wertpapier Abrechnung Kauf");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -54,11 +54,7 @@ public class SantanderConsumerBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // Stück 2 3M CO. US88579Y1010 (851745)
@@ -117,7 +113,7 @@ public class SantanderConsumerBankPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("(Dividendengutschrift|Aussch.ttung Investmentfonds)");
+        final var type = new DocumentType("(Dividendengutschrift|Aussch.ttung Investmentfonds)");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -128,11 +124,7 @@ public class SantanderConsumerBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Nominale Wertpapierbezeichnung ISIN (WKN)
@@ -250,11 +242,7 @@ public class SantanderConsumerBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "amount", "note") //
                         .documentContext("currency") //
@@ -270,7 +258,7 @@ public class SantanderConsumerBankPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (\\-)?(?<tax>[\\.,\\d]+) [\\.,\\d]+ Kapitalertrags(s)?teuer.*$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
 
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
@@ -280,7 +268,7 @@ public class SantanderConsumerBankPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (\\-)?(?<tax>[\\.,\\d]+) [\\.,\\d]+ Solidarit.tszuschlag.*$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
 
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
@@ -290,7 +278,7 @@ public class SantanderConsumerBankPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (\\-)?(?<tax>[\\.,\\d]+) [\\.,\\d]+ Kirchensteuer.*$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
 
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
@@ -305,11 +293,7 @@ public class SantanderConsumerBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock_Format01);
         depositBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "amount", "note") //
                         .documentContext("currency") //
@@ -336,11 +320,7 @@ public class SantanderConsumerBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock_Format02);
         depositBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("note", "date", "amount") //
                         .documentContext("currency") //
@@ -362,11 +342,7 @@ public class SantanderConsumerBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "amount", "note") //
                         .documentContext("currency") //
@@ -409,11 +385,7 @@ public class SantanderConsumerBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "amount", "note") //
                         .documentContext("year", "currency") //
@@ -434,11 +406,7 @@ public class SantanderConsumerBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "amount", "note") //
                         .documentContext("year", "currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SaxoBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SaxoBankPDFExtractor.java
@@ -64,11 +64,7 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -357,11 +353,7 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -463,11 +455,7 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         // @formatter:off
                         // Interest 43681798738 01-Mai-2025 3,32 USD 1,000000 3,32
@@ -496,7 +484,7 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
 
     private void addDepositTransaction()
     {
-        var type = new DocumentType("Cash Transfer Detail Report");
+        final var type = new DocumentType("Cash Transfer Detail Report");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -507,11 +495,7 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .oneOf( //
                                         // @formatter:off
@@ -582,11 +566,7 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "amount") //
                         .documentContext("currency") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SberbankEuropeAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SberbankEuropeAGPDFExtractor.java
@@ -54,11 +54,7 @@ public class SberbankEuropeAGPDFExtractor extends AbstractPDFExtractor
 
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction transaction = new AccountTransaction();
-                            transaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return transaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount", "type") //
                         .documentContext("currency", "year") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
@@ -57,11 +57,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         // Is type --> "Sell" change from BUY to SELL
@@ -298,11 +294,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -456,11 +448,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         // @formatter:off
                         // Gesamt 13,69 EUR
@@ -508,11 +496,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount", "currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) " //
@@ -537,11 +521,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "note", "amount", "currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) " //
@@ -566,11 +546,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
         type.addBlock(taxesBlock);
         taxesBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         .section("date", "note", "type", "amount", "currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) " //
@@ -598,11 +574,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "type", "amount", "currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*" //
@@ -629,11 +601,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
         type.addBlock(skippedBlock);
         skippedBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "amount", "currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) Vorabpauschale " //
@@ -644,13 +612,11 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
                             t.setAmount(asAmount(v.get("amount")));
                         })
 
-                        .wrap((t, ctx) -> {
-                            var item = new TransactionItem(t);
-
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                return new SkippedItem(item, Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            return item;
+                            return new TransactionItem(t);
                         }));
     }
 
@@ -667,11 +633,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         // @formatter:off
                         // Der Betrag wurde am 10.01.2026 auf Ihrem Verrechnungskonto gebucht.
@@ -712,11 +674,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // für iShs3-M.Wld SC CTBEnh.ESG UETF (IE000T9EOCL3)
@@ -791,13 +749,11 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
                                                         })
                         )
 
-                        .wrap((t, ctx) -> {
-                            var item = new TransactionItem(t);
-
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                return new SkippedItem(item, Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            return item;
+                            return new TransactionItem(t);
                         });
     }
 
@@ -811,11 +767,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         // @formatter:off
                         // Erstattete Steuern 366,75 EUR

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SchelhammerCapitalBankAG.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SchelhammerCapitalBankAG.java
@@ -31,7 +31,7 @@ public class SchelhammerCapitalBankAG extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("Gesch.ftsart: (Kauf|Verkauf|Ausgabe Fonds aus Dauerauftrag)");
+        final var type = new DocumentType("Gesch.ftsart: (Kauf|Verkauf|Ausgabe Fonds aus Dauerauftrag)");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -42,11 +42,7 @@ public class SchelhammerCapitalBankAG extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -119,7 +115,7 @@ public class SchelhammerCapitalBankAG extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("Geschäftsart: Ertrag");
+        final var type = new DocumentType("Geschäftsart: Ertrag");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -130,11 +126,7 @@ public class SchelhammerCapitalBankAG extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScorePriorityIncPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScorePriorityIncPDFExtractor.java
@@ -16,7 +16,6 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
-import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 
@@ -34,6 +33,8 @@ import name.abuchen.portfolio.money.Values;
 @SuppressWarnings("nls")
 public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
 {
+    private static final String USD = "USD";
+
     public ScorePriorityIncPDFExtractor(Client client)
     {
         super(client);
@@ -75,11 +76,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockBuySell);
         blockBuySell.set(new Transaction<BuySellEntry>()
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .section("month", "day", "name", "wkn", "type", "shares", "amount", "nameContinued") //
                         .documentContext("year") //
@@ -92,7 +89,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
 
                             Map<String, String> context = type.getCurrentContext();
                             v.put("date", v.get("day") + " " + v.get("month") + " " + context.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(USD));
 
                             t.setDate(asDate(v.get("date")));
                             t.setShares(asShares(v.get("shares")));
@@ -122,11 +119,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockDividende);
         blockDividende.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         section -> section //
@@ -136,7 +129,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
                                                         .match("^[\\w]{3} [\\d]{2} .* [\\w]{9} (NRA Withhold|Foreign Withholding) \\((?<tax>[\\.,\\d]+)\\)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                                                            v.put("currency", CurrencyUnit.USD);
+                                                            v.put("currency", asCurrencyCode(USD));
 
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
@@ -154,7 +147,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
                                                         .match("^(?<month>.*) (?<day>[\\d]{2}) (?<name>.*) (?<shares>[\\.,\\d]+) (?<wkn>(?!Qualified).{9}) (Qualified )?Dividend (?<amount>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
                                                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                                                            v.put("currency", CurrencyUnit.USD);
+                                                            v.put("currency", asCurrencyCode(USD));
 
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
@@ -178,11 +171,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockDeliveryInBound);
         blockDeliveryInBound.set(new Transaction<PortfolioTransaction>()
 
-                        .subject(() -> {
-                            PortfolioTransaction portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         .section("month", "day", "name", "wkn", "shares", "nameContinued") //
                         .documentContext("year") //
@@ -190,7 +179,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
                         .match("(?<nameContinued>.*)") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setShares(asShares(v.get("shares")));
@@ -212,18 +201,14 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockFees);
         blockFees.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("month", "day", "name", "wkn", "amount") //
                         .documentContext("year") //
                         .match("^(?<month>[\\w]{3}) (?<day>[\\d]{2}) Ca Fee_spinoff.* (?<name>.*) (?<wkn>.*) Journal \\((?<amount>[\\.,\\d]+)\\)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(USD));
 
                             // if CUSIP length != 9
                             if (trim(v.get("wkn")).length() != 9)
@@ -249,11 +234,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockCashAllocation);
         blockCashAllocation.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .section("month", "day", "name", "wkn", "amount") //
                         .documentContext("year") //
@@ -261,7 +242,7 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<name>.*)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setShares(0L);
@@ -282,18 +263,14 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockDeposit);
         blockDeposit.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("month", "day", "amount") //
                         .documentContext("year") //
                         .match("^(?<month>[\\w]{3}) (?<day>[\\d]{2}) Incoming Wire .* (?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -312,18 +289,14 @@ public class ScorePriorityIncPDFExtractor extends AbstractPDFExtractor
         type.addBlock(blockInterest);
         blockInterest.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("month", "day", "amount") //
                         .documentContext("year") //
                         .match("^(?<month>[\\w]{3}) (?<day>[\\d]{2}) .* Credit Interest (?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             v.put("date", v.get("day") + " " + v.get("month") + " " + v.get("year"));
-                            v.put("currency", CurrencyUnit.USD);
+                            v.put("currency", asCurrencyCode(USD));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SelfWealthPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SelfWealthPDFExtractor.java
@@ -51,11 +51,7 @@ public class SelfWealthPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Sell" change from BUY to SELL
                         .section("type").optional() //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SimpelPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SimpelPDFExtractor.java
@@ -13,7 +13,6 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
-import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Values;
 
 /**
@@ -29,6 +28,7 @@ import name.abuchen.portfolio.money.Values;
 @SuppressWarnings("nls")
 public class SimpelPDFExtractor extends AbstractPDFExtractor
 {
+    private static final String EUR = "EUR";
 
     public SimpelPDFExtractor(Client client)
     {
@@ -59,11 +59,7 @@ public class SimpelPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -133,11 +129,7 @@ public class SimpelPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Fondsname: Standortfonds Deutschland Datum des
@@ -148,7 +140,7 @@ public class SimpelPDFExtractor extends AbstractPDFExtractor
                         .match("^Fondsname: (?<name>.*) Datum .*$") //
                         .match("^WKN \\/ ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) .*$") //
                         .assign((t, v) -> {
-                            v.put("currency", CurrencyUnit.EUR);
+                            v.put("currency", asCurrencyCode(EUR));
 
                             t.setSecurity(getOrCreateSecurity(v));
                         })
@@ -184,7 +176,7 @@ public class SimpelPDFExtractor extends AbstractPDFExtractor
                         .match("^Zur (Wiederveranlagung|Wiederanlage/Auszahlung) zur Verf.gung stehend: (?<amount>[\\.'\\d]+)$") //
                         .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(CurrencyUnit.EUR);
+                            t.setCurrencyCode(asCurrencyCode("EUR"));
                         })
 
                         // @formatter:off
@@ -216,7 +208,7 @@ public class SimpelPDFExtractor extends AbstractPDFExtractor
                         .section("tax").optional() //
                         .match("^Kapitalertragssteuer \\(KESt\\) gesamt: (?<tax>[\\.'\\d]+)$") //
                         .assign((t, v) -> {
-                            v.put("currency", CurrencyUnit.EUR);
+                            v.put("currency", asCurrencyCode(EUR));
 
                             processTaxEntries(t, v, type);
                         });

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SolarisbankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SolarisbankAGPDFExtractor.java
@@ -43,11 +43,7 @@ public class SolarisbankAGPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount", "currency") //
                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*(SEPA\\-.berweisung|.berweisung|Kartenvorgang)(?<note>.*) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
@@ -70,11 +66,7 @@ public class SolarisbankAGPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "note", "amount", "currency") //
                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*(Kartenzahlung|.berweisung|SEPA\\-Lastschrift|SEPA\\-.berweisung)(?<note>.*) \\-(?<amount>[\\.,\\d]+) (?<currency>\\w{3})$") //
@@ -102,11 +94,7 @@ public class SolarisbankAGPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("note", "date", "type", "amount", "currency") //
                         .match("^(?<note>.*) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})(?<type>[\\-\\s]+)(?<amount>[\\.,\\d]+)(?<currency>\\p{Sc})$") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/StakeshopPtyLtdPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/StakeshopPtyLtdPDFExtractor.java
@@ -52,11 +52,7 @@ public class StakeshopPtyLtdPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "sell" change from BUY to SELL
                         .section("type").optional() //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SunrisePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SunrisePDFExtractor.java
@@ -5,6 +5,7 @@ import static name.abuchen.portfolio.util.TextUtil.trim;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
+import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -13,7 +14,6 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
-import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 
@@ -29,6 +29,8 @@ import name.abuchen.portfolio.money.Values;
 @SuppressWarnings("nls")
 public class SunrisePDFExtractor extends AbstractPDFExtractor
 {
+    private static final String EUR = "EUR";
+
     public SunrisePDFExtractor(Client client)
     {
         super(client);
@@ -59,11 +61,7 @@ public class SunrisePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // Kauf Standortfonds Österreich 10.00 € 140.59 € 0.071
@@ -123,11 +121,7 @@ public class SunrisePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Fondsname: Standortfonds Österreich
@@ -137,7 +131,7 @@ public class SunrisePDFExtractor extends AbstractPDFExtractor
                         .match("^Fondsname: (?<name>.*)$") //
                         .match("^WKN\\/ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) Datum des.*$") //
                         .assign((t, v) -> {
-                            v.put("currency", CurrencyUnit.EUR);
+                            v.put("currency", asCurrencyCode(EUR));
 
                             t.setSecurity(getOrCreateSecurity(v));
                         })
@@ -173,7 +167,7 @@ public class SunrisePDFExtractor extends AbstractPDFExtractor
                         .match("^.*Zur Auszahlung kommender Betrag: (?<amount>[\\.'\\d]+)$") //
                         .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(CurrencyUnit.EUR);
+                            t.setCurrencyCode(asCurrencyCode("EUR"));
 
                             // @formatter:off
                             // If the dividend amount correspond to the tax amount to be paid,
@@ -215,11 +209,7 @@ public class SunrisePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Fondsname: Standortfonds Österreich
@@ -229,7 +219,7 @@ public class SunrisePDFExtractor extends AbstractPDFExtractor
                         .match("^Fondsname: (?<name>.*)$") //
                         .match("^WKN\\/ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) Datum des.*$") //
                         .assign((t, v) -> {
-                            v.put("currency", CurrencyUnit.EUR);
+                            v.put("currency", asCurrencyCode(EUR));
 
                             t.setSecurity(getOrCreateSecurity(v));
                         })
@@ -270,8 +260,8 @@ public class SunrisePDFExtractor extends AbstractPDFExtractor
                         .match("^Kapitalertragsteuer \\(KESt\\) gesamt: (?<tax>[\\.'\\d]+)$") //
                         .match("^.*Zur Auszahlung kommender Betrag: (?<amount>[\\.'\\d]+)$") //
                         .assign((t, v) -> {
-                            Money tax = Money.of(CurrencyUnit.EUR, asAmount(v.get("tax")));
-                            Money amount = Money.of(CurrencyUnit.EUR, asAmount(v.get("amount")));
+                            Money tax = Money.of(EUR, asAmount(v.get("tax")));
+                            Money amount = Money.of(EUR, asAmount(v.get("amount")));
 
                             if (amount.isZero())
                             {
@@ -280,17 +270,15 @@ public class SunrisePDFExtractor extends AbstractPDFExtractor
                             else
                             {
                                 t.setAmount(0L);
-                                t.setCurrencyCode(CurrencyUnit.EUR);
+                                t.setCurrencyCode(asCurrencyCode("EUR"));
                             }
                         })
 
-                        .wrap((t, ctx) -> {
-                            TransactionItem item = new TransactionItem(t);
-
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                return null;
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            return item;
+                            return new TransactionItem(t);
                         });
     }
 
@@ -313,7 +301,7 @@ public class SunrisePDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> {
                             if (!type.getCurrentContext().getBoolean("noTax"))
                             {
-                                v.put("currency", CurrencyUnit.EUR);
+                                v.put("currency", asCurrencyCode(EUR));
                                 processTaxEntries(t, v, type);
                             }
                         });

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SuresseDirektBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SuresseDirektBankPDFExtractor.java
@@ -49,11 +49,7 @@ public class SuresseDirektBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "type", "amount", "currency", "note") //
                         .documentContext("year") //
@@ -78,11 +74,7 @@ public class SuresseDirektBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         // @formatter:off
                         // Periode von: 01-01-2023 bis 31-01-2023 Referenz: C3A31IN111111

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SutorBankGmbHPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SutorBankGmbHPDFExtractor.java
@@ -27,6 +27,8 @@ import name.abuchen.portfolio.money.Money;
 @SuppressWarnings("nls")
 public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 {
+    private static final String EUR = "EUR";
+
     public SutorBankGmbHPDFExtractor(Client client)
     {
         super(client);
@@ -52,7 +54,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("((Transaktionsart:|Wertpapier Abrechnung) (Kauf|Verkauf)|F.lligkeit\\/Verfall)", "ABRECHNUNG KRYPTOHANDEL");
+        final var type = new DocumentType("((Transaktionsart:|Wertpapier Abrechnung) (Kauf|Verkauf)|F.lligkeit\\/Verfall)", "ABRECHNUNG KRYPTOHANDEL");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -63,11 +65,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // If type is "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -233,7 +231,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellCryptoTransaction()
     {
-        var type = new DocumentType("ABRECHNUNG KRYPTOHANDEL");
+        final var type = new DocumentType("ABRECHNUNG KRYPTOHANDEL");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -244,11 +242,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // If type is "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -320,7 +314,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("Dividende");
+        final var type = new DocumentType("Dividende");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -331,11 +325,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Produktbezeichnung - Kellogg Co.:
@@ -391,7 +381,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
     private void addAdvanceTaxTransaction()
     {
-        var type = new DocumentType("Abrechnung Vorabpauschale");
+        final var type = new DocumentType("Abrechnung Vorabpauschale");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -402,11 +392,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Name iShares MSCI World (Acc)
@@ -448,7 +434,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
     private void addAccountStatementTransaction()
     {
-        var type = new DocumentType("(Sutor fairriester 2\\.0|Ums.tze) .*");
+        final var type = new DocumentType("(Sutor fairriester 2\\.0|Ums.tze) .*");
         this.addDocumentTyp(type);
 
         var buySellBlock = new Transaction<BuySellEntry>();
@@ -459,11 +445,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
         buySellBlock //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -497,7 +479,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date"), v.get("time")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             v.markAsFailure(Messages.MsgErrorTransactionOrderCancellationUnsupported);
@@ -529,7 +511,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date"), v.get("time")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             var tax1 = Money.of(t.getPortfolioTransaction().getCurrencyCode(), asAmount(v.get("tax1")));
@@ -562,7 +544,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date"), v.get("time")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }),
                                         // @formatter:off
@@ -589,7 +571,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date"), v.get("time")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }),
                                         // @formatter:off
@@ -621,7 +603,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date"), v.get("time")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }),
                                         // @formatter:off
@@ -646,7 +628,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }),
                                         // @formatter:off
@@ -669,7 +651,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }),
                                         // @formatter:off
@@ -691,7 +673,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }),
                                         // @formatter:off
@@ -712,7 +694,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }),
                                         // @formatter:off
@@ -734,7 +716,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note"));
@@ -757,7 +739,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDate(asDate(v.get("date")));
                                                             t.setShares(asShares(v.get("shares")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note"));
@@ -773,11 +755,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
         dividendsBlock //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -803,7 +781,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setShares(0L);
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             var tax1 = Money.of(t.getCurrencyCode(), asAmount(v.get("tax1")));
@@ -832,7 +810,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setDateTime(asDate(v.get("date")));
                                                             t.setShares(0L);
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                         }))
 
@@ -851,11 +829,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
         depositRemovalBlock //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .oneOf( //
                                         // @formatter:off
@@ -873,7 +847,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
                                                             t.setDateTime(asDate(v.get("date")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note"));
@@ -891,7 +865,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note"));
@@ -915,7 +889,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
                                                             t.setDateTime(asDate(v.get("date")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note"));
@@ -931,11 +905,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
         taxesBlock //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // 20.01.2024 20.01.2024 Steuerbuchung KapSt2023Vorabpauschale AIS-Amundi I.S.Stoxx - -0,26
@@ -951,7 +921,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> {
                             t.setDateTime(asDate(v.get("date")));
 
-                            t.setCurrencyCode("EUR");
+                            t.setCurrencyCode(asCurrencyCode(EUR));
                             t.setAmount(asAmount(v.get("amount")));
 
                             t.setNote(v.get("note"));
@@ -976,11 +946,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
         feesBlock //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .oneOf( //
                                         section -> section //
@@ -998,7 +964,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note"));
@@ -1020,7 +986,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note"));
@@ -1035,7 +1001,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note"));
@@ -1060,7 +1026,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
                                                             t.setDateTime(asDate(v.get("date")));
 
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
                                                             t.setAmount(asAmount(v.get("amount")));
 
                                                             t.setNote(v.get("note1") + " " + v.get("note2") + " vom " + v.get("stornoDate"));
@@ -1076,11 +1042,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
         deliveryOutbound //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_OUTBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_OUTBOUND))
 
                         .oneOf( //
                                         section -> section //
@@ -1099,7 +1061,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
                                                             t.setSecurity(getOrCreateSecurity(v));
 
                                                             t.setAmount(0L);
-                                                            t.setCurrencyCode("EUR");
+                                                            t.setCurrencyCode(asCurrencyCode(EUR));
 
                                                             t.setNote(v.get("note"));
 
@@ -1124,11 +1086,7 @@ public class SutorBankGmbHPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_OUTBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_OUTBOUND))
 
                         // @formatter:off
                         // Produktbezeichnung - OXFORD SQUARE CAP. DL-,01

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SwissquotePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SwissquotePDFExtractor.java
@@ -62,11 +62,7 @@ public class SwissquotePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -253,11 +249,7 @@ public class SwissquotePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // @formatter:off
                         // Anzahl Währung Rate
@@ -326,11 +318,7 @@ public class SwissquotePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -480,11 +468,7 @@ public class SwissquotePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         // @formatter:off
                         // Is type --> "Belastung" change from DEPOSIT to REMOVAL
@@ -565,11 +549,7 @@ public class SwissquotePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         // @formatter:off
                         // 30.12.2022 1.36 0.00 1.36 0.00 1.36
@@ -620,11 +600,7 @@ public class SwissquotePDFExtractor extends AbstractPDFExtractor
         type.addBlock(feeBlock);
         feeBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("note", "amount", "date") //
                         .documentRange("baseCurrency") //
@@ -653,11 +629,7 @@ public class SwissquotePDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST_CHARGE);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST_CHARGE))
 
                         .section("note", "amount", "date") //
                         .documentRange("baseCurrency") //
@@ -694,11 +666,7 @@ public class SwissquotePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_OUTBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_OUTBOUND))
 
                         // @formatter:off
                         // Bezeichnung Anzahl Kontraktwährung Preis

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SydbankASPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SydbankASPDFExtractor.java
@@ -41,7 +41,7 @@ public class SydbankASPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("Du har den .* \\(UTC: .*\\) (k.bt|solgt):");
+        final var type = new DocumentType("Du har den .* \\(UTC: .*\\) (k.bt|solgt):");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -52,11 +52,7 @@ public class SydbankASPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "solgt" change from BUY to SELL
                         .section("type").optional() //
@@ -125,7 +121,7 @@ public class SydbankASPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("Udbytte\\-meddelelse");
+        final var type = new DocumentType("Udbytte\\-meddelelse");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -136,11 +132,7 @@ public class SydbankASPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // 10.02.2025 6010520 Sparinvest Korte Obligationer KL A

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java
@@ -96,11 +96,7 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -186,11 +182,7 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Wertpapier Vang.FTSE Develop.World U.ETF - Registered Shares USD Dis.oN
@@ -285,11 +277,7 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         .oneOf( //
                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TigerBrokersPteLtdPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TigerBrokersPteLtdPDFExtractor.java
@@ -148,11 +148,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
 
         buyBlock_Format01 //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .section("tickerSymbol", "date", "time", "shares", "gross", "fee1", "fee2", "fee3") //
                         .find("Settlement Fee: \\-[\\.,\\d]+") //
@@ -211,11 +207,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
 
         buyBlock_Format02 //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .section("tickerSymbol", "date", "time", "shares", "gross", "fee1", "fee2", "fee3").optional() //
                         .match("^(?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?) " //
@@ -273,11 +265,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
 
         buyBlock_Format03 //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .section("tickerSymbol", "shares", "gross", "fee1", "fee2", "date", "fee3", "time").optional() //
                         .match("^(?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?) [A-Z]+ " //
@@ -332,11 +320,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
 
         buyBlock_Format04 //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -447,11 +431,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
 
         buyBlock_Format05 //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
                         .section("fee1", "date", "name", "shares", "gross", "fee2", "time", "tickerSymbol", "fee3") //
                         .find("Settlement Fee:[\\s]*") //
                         .match("^\\-(?<fee1>[\\.,\\d]+) (?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2})$") //
@@ -506,11 +486,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
 
         dividendBlock //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .section("date", "tickerSymbol", "amountPerShare", "note", "amount") //
                         .match("^(?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}) " //
@@ -584,11 +560,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
 
         dividendBlock_late24 //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .optionalOneOf(
                                         // Pattern 1: three-line instrument
@@ -735,11 +707,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
 
         taxRefundBlock //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .section("date", "amount", "currency") //
                         .match("^(?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}) " //
@@ -764,11 +732,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
 
         depositBlock //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "note", "amount") //
                         .match("^(?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}) Deposit " //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -86,11 +86,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -839,11 +835,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // Korrektur des Belegs 8ac7-2fd8 vom 17.01.2025
@@ -1005,11 +997,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -1274,11 +1262,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .optionalOneOf(
                                         // @formatter:off
@@ -1704,13 +1688,11 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
                         .conclude(ExtractorUtils.fixGrossValueA())
 
-                        .wrap((t, ctx) -> {
-                            var item = new TransactionItem(t);
-
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            return item;
+                            return new TransactionItem(t);
                         });
 
         addTaxesSectionsTransaction(pdfTransaction, type);
@@ -1731,11 +1713,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         .oneOf( //
                                      // @formatter:off
@@ -1830,11 +1808,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .oneOf( //
                                         // @formatter:off
@@ -1930,11 +1904,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         depositBlock.setMaxSize(1);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -1958,11 +1928,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         removalBlock.setMaxSize(1);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -1983,11 +1949,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         taxRefundBlock.setMaxSize(1);
         taxRefundBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -2008,11 +1970,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         interestBlock.setMaxSize(1);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -2114,11 +2072,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         depositRemovalBlock_Format01.setMaxSize(1);
         depositRemovalBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -2230,11 +2184,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         depositRemovalBlock_Format02.setMaxSize(4);
         depositRemovalBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -2740,11 +2690,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         depositRemovalBlock_Format03.setMaxSize(5);
         depositRemovalBlock_Format03.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -3137,11 +3083,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         feesBlock_Format01.setMaxSize(2);
         feesBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .optionalOneOf( //
                                         section -> section //
@@ -3170,11 +3112,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         feesBlock_Format02.setMaxSize(1);
         feesBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .optionalOneOf( //
                                         section -> section //
@@ -3203,11 +3141,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         interestBlock_Format01.setMaxSize(1);
         interestBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .optionalOneOf( //
                                         section -> section //
@@ -3232,11 +3166,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         interestBlock_Format02.setMaxSize(5);
         interestBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -3337,11 +3267,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         interestBlock_Format03.setMaxSize(5);
         interestBlock_Format03.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .optionalOneOf( //
                                         // @formatter:off
@@ -3396,11 +3322,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         taxesBlock_Format01.setMaxSize(2);
         taxesBlock_Format01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         .optionalOneOf( //
                                         section -> section //
@@ -3437,11 +3359,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         taxesBlock_Format02.setMaxSize(3);
         taxesBlock_Format02.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .optionalOneOf( //
                                         section -> section //
@@ -3512,11 +3430,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         // @formatter:off
                         // STORNO STEUERKORREKTUR
@@ -3678,11 +3592,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .oneOf( //
                                         // @formatter:off
@@ -3743,11 +3653,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .oneOf( //
                                         // @formatter:off
@@ -3907,11 +3813,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .oneOf( //
                                         // @formatter:off
@@ -3985,11 +3887,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .oneOf( //
                                         // @formatter:off
@@ -4037,11 +3935,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         // @formatter:off
                         // VERRECHNUNGSKONTO DATUM DER ZAHLUNG BETRAG
@@ -4074,11 +3968,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // POSITION COMMANDÉ LE QUANTITÉ
@@ -4147,11 +4037,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new PortfolioTransaction();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.DELIVERY_INBOUND);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
 
                         .oneOf( //
                                         // @formatter:off
@@ -4234,11 +4120,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .oneOf( //
                                         // @formatter:off
@@ -4616,11 +4498,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         .optionalOneOf(
                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradegateAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradegateAGPDFExtractor.java
@@ -13,7 +13,6 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
-import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 
 @SuppressWarnings("nls")
@@ -51,11 +50,7 @@ public class TradegateAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -79,7 +74,7 @@ public class TradegateAGPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                         .oneOf(
-                        // @formatter:off
+                                        // @formatter:off
                                         // Daraus ergibt sich ein Mischkurs von 19,3500 EUR für insgesamt 1.560 Stück.
                                         // @formatter:on
                                         section -> section //
@@ -147,11 +142,7 @@ public class TradegateAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Wertpapier Vanguard EUR Corp.Bond U.ETF Registered Shares EUR Dis.oN
@@ -239,11 +230,7 @@ public class TradegateAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAXES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
 
                         // @formatter:off
                         // Wertpapier PFI ETFs-EO Sh.Mat.UC.ETF Registered Shares EUR Acc.o.N.
@@ -290,13 +277,11 @@ public class TradegateAGPDFExtractor extends AbstractPDFExtractor
                         .match("^.*(?<note>Order\\-\\/Ref\\.nr\\. .*)$")
                         .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
-                        .wrap((t, ctx) -> {
-                            var item = new TransactionItem(t);
+                        .wrap(t -> {
+                            if (t.getCurrencyCode() != null && t.getAmount() == 0)
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            if (t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
-
-                            return item;
+                            return new TransactionItem(t);
                         });
     }
 
@@ -313,11 +298,7 @@ public class TradegateAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.TAX_REFUND);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
 
                         // Is type --> "Belastung" change from TAX_REFUND to TAXES
                         .section("type").optional() //
@@ -341,7 +322,7 @@ public class TradegateAGPDFExtractor extends AbstractPDFExtractor
                         .section("amount") //
                         .match("^(Gutgeschriebener Betrag|Belastung) (\\-)?(?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            t.setCurrencyCode(CurrencyUnit.EUR);
+                            t.setCurrencyCode(asCurrencyCode("EUR"));
                             t.setAmount(asAmount(v.get("amount")));
                         })
 
@@ -417,11 +398,7 @@ public class TradegateAGPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositAndWithdrawalBlock);
         depositAndWithdrawalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("note", "type", "date", "amount") //
                         .documentContext("currency") //
@@ -433,7 +410,7 @@ public class TradegateAGPDFExtractor extends AbstractPDFExtractor
                                 t.setType(AccountTransaction.Type.REMOVAL);
 
                             t.setDateTime(asDate(v.get("date")));
-                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setCurrencyCode(v.get("currency"));
                             t.setAmount(asAmount(v.get("amount")));
                             t.setNote("Ref.nr. " + v.get("note"));
                         })

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UBSAGBankingAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UBSAGBankingAGPDFExtractor.java
@@ -58,11 +58,7 @@ public class UBSAGBankingAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .optionalOneOf( //
@@ -382,11 +378,7 @@ public class UBSAGBankingAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off
@@ -491,11 +483,7 @@ public class UBSAGBankingAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // Zu Lasten Konto 292-123456.40R, Valuta 30. Juni 2021

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UmweltbankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UmweltbankAGPDFExtractor.java
@@ -46,7 +46,7 @@ public class UmweltbankAGPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("Wertpapier Abrechnung Kauf");
+        final var type = new DocumentType("Wertpapier Abrechnung Kauf");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -57,11 +57,7 @@ public class UmweltbankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .oneOf( //
                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UnicreditPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UnicreditPDFExtractor.java
@@ -53,11 +53,7 @@ public class UnicreditPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -216,11 +212,7 @@ public class UnicreditPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // ACATIS GANÉ VALUE EVENT FONDS Wertpapierkennnummer  A1T73W / DE000A1T73W9

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VBankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VBankAGPDFExtractor.java
@@ -44,11 +44,7 @@ public class VBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -132,11 +128,7 @@ public class VBankAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Wertpapierbezeichnung OptoFlex Inhaber-Ant. P o.N.

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VDKBankNVPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VDKBankNVPDFExtractor.java
@@ -36,7 +36,7 @@ public class VDKBankNVPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        var type = new DocumentType("Uitvoering op");
+        final var type = new DocumentType("Uitvoering op");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
@@ -47,11 +47,7 @@ public class VDKBankNVPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "verkoop" change from BUY to SELL
                         .section("type").optional() //
@@ -174,7 +170,7 @@ public class VDKBankNVPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        var type = new DocumentType("Uitbetaling dividend");
+        final var type = new DocumentType("Uitbetaling dividend");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -185,11 +181,7 @@ public class VDKBankNVPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .oneOf( //
                                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VZVermoegenszentrumAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VZVermoegenszentrumAGPDFExtractor.java
@@ -54,11 +54,7 @@ public class VZVermoegenszentrumAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
 //                        // Is type --> "Verkauf" change from BUY to SELL
 //                        .section("type").optional() //
@@ -145,11 +141,7 @@ public class VZVermoegenszentrumAGPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Wir beziehen uns auf die in Ihrem Wertschriftendepot verwahrten Titel und rechnen die Ausschüttung wie folgt ab:

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VanguardGroupEuropePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VanguardGroupEuropePDFExtractor.java
@@ -46,11 +46,7 @@ public class VanguardGroupEuropePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -150,11 +146,7 @@ public class VanguardGroupEuropePDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Wertpapierbezeichnung FDBL Vanguard LifeStrategy 60% Equity UCITS

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VolkswagenBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/VolkswagenBankPDFExtractor.java
@@ -47,11 +47,7 @@ public class VolkswagenBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositBlock);
         depositBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -72,11 +68,7 @@ public class VolkswagenBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(removalBlock);
         removalBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.REMOVAL);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -99,11 +91,7 @@ public class VolkswagenBankPDFExtractor extends AbstractPDFExtractor
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            var accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         .section("date", "amount") //
                         .documentContext("currency") //
@@ -118,7 +106,7 @@ public class VolkswagenBankPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Abgeltungsteuer [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} \\-(?<tax>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
@@ -128,7 +116,7 @@ public class VolkswagenBankPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Solidarit.tszuschlag [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} \\-(?<tax>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));
@@ -138,7 +126,7 @@ public class VolkswagenBankPDFExtractor extends AbstractPDFExtractor
                         .documentContext("currency") //
                         .match("^[\\d]+ [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Kirchensteuer [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} \\-(?<tax>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
-                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            var tax = Money.of(v.get("currency"), asAmount(v.get("tax")));
                             t.addUnit(new Unit(Unit.Type.TAX, tax));
 
                             t.setMonetaryAmount(t.getMonetaryAmount().subtract(tax));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WealthsimpleInvestmentsIncPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WealthsimpleInvestmentsIncPDFExtractor.java
@@ -139,11 +139,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
         type.addBlock(depositRemovalBlock);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
-                .subject(() -> {
-                    AccountTransaction entry = new AccountTransaction();
-                    entry.setType(AccountTransaction.Type.DEPOSIT);
-                    return entry;
-                })
+                .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                 .section("month", "day", "type", "amount", "currency")
                 .match("^(?<month>[\\w]{3,4}) "
@@ -179,11 +175,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
         type.addBlock(buySellBlock);
         buySellBlock.set(new Transaction<BuySellEntry>()
 
-                .subject(() -> {
-                    BuySellEntry entry = new BuySellEntry();
-                    entry.setType(PortfolioTransaction.Type.BUY);
-                    return entry;
-                })
+                .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                 .section("month", "day", "type", "tickerSymbol", "name", "amount", "currency", "shares")
                 .match("^(?<month>[\\w]{3,4}) "
@@ -239,11 +231,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
         type.addBlock(dividendBlock);
         dividendBlock.set(new Transaction<AccountTransaction>()
 
-                .subject(() -> {
-                    AccountTransaction entry = new AccountTransaction();
-                    entry.setType(AccountTransaction.Type.DIVIDENDS);
-                    return entry;
-                })
+                .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                 .oneOf(
                                 section -> section
@@ -440,11 +428,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
         type.addBlock(missingTickerSymbolforDividendeBlock);
         missingTickerSymbolforDividendeBlock.set(new Transaction<AccountTransaction>()
 
-                .subject(() -> {
-                    AccountTransaction entry = new AccountTransaction();
-                    entry.setType(AccountTransaction.Type.DIVIDENDS);
-                    return entry;
-                })
+                .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                 .section("month", "day", "name", "shares", "amount")
                 .match("^(?<month>[\\w]{3,4}) "
@@ -476,11 +460,7 @@ public class WealthsimpleInvestmentsIncPDFExtractor extends AbstractPDFExtractor
         type.addBlock(feeBlock);
         feeBlock.set(new Transaction<AccountTransaction>()
 
-                .subject(() -> {
-                    AccountTransaction entry = new AccountTransaction();
-                    entry.setType(AccountTransaction.Type.FEES);
-                    return entry;
-                })
+                .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                 .section("month", "day", "amount")
                 .match("^(?<month>[\\w]{3,4}) (?<day>[\\d]{2}) Gross management fee to Wealthsimple [\\W]{1,3} \\-\\p{Sc}(?<amount>[\\.,\\d]+)$")

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WeberbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WeberbankPDFExtractor.java
@@ -46,11 +46,7 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -125,11 +121,7 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Nominale Wertpapierbezeichnung ISIN (WKN)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -55,11 +55,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DEPOSIT);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
                         // @formatter:off
                         // Einzahlung 3a
@@ -99,11 +95,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -194,11 +186,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.INTEREST);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
 
                         // @formatter:off
                         // Zins
@@ -242,11 +230,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         // @formatter:off
                         // Belastung
@@ -281,13 +265,11 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<note>Commission de gestion effective VIAC.*: [\\.,\\d]+%).*$")
                         .assign((t, v) -> t.setNote(v.get("note")))
 
-                        .wrap((t, ctx) -> {
-                            TransactionItem item = new TransactionItem(t);
-
+                        .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() == 0)
-                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
 
-                            return item;
+                            return new TransactionItem(t);
                         });
     }
 
@@ -315,11 +297,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .section("type").optional() //
                         .match("^(Dividendenart|Type of dividend|Type de dividende): " //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WitheBoxGmbHPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WitheBoxGmbHPDFExtractor.java
@@ -44,11 +44,7 @@ public class WitheBoxGmbHPDFExtractor extends AbstractPDFExtractor
         feesBlock01.setMaxSize(1);
         feesBlock01.set(new Transaction<AccountTransaction>()
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.FEES);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES))
 
                         .section("currency", "amount") //
                         .documentContext("date") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ZuercherKantonalbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ZuercherKantonalbankPDFExtractor.java
@@ -60,11 +60,7 @@ public class ZuercherKantonalbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            BuySellEntry portfolioTransaction = new BuySellEntry();
-                            portfolioTransaction.setType(PortfolioTransaction.Type.BUY);
-                            return portfolioTransaction;
-                        })
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
@@ -262,11 +258,7 @@ public class ZuercherKantonalbankPDFExtractor extends AbstractPDFExtractor
 
         pdfTransaction //
 
-                        .subject(() -> {
-                            AccountTransaction accountTransaction = new AccountTransaction();
-                            accountTransaction.setType(AccountTransaction.Type.DIVIDENDS);
-                            return accountTransaction;
-                        })
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         // @formatter:off
                         // Stück 2'000 Registered Shs Babcock International Group PLC

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/BuySellEntry.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/BuySellEntry.java
@@ -17,6 +17,12 @@ public class BuySellEntry implements CrossEntry, Annotated
         this(null, null);
     }
 
+    public BuySellEntry(Type type)
+    {
+        this(null, null);
+        setType(type);
+    }
+
     public BuySellEntry(Portfolio portfolio, Account account)
     {
         this(portfolio, new PortfolioTransaction(), account, new AccountTransaction());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/PortfolioTransaction.java
@@ -76,6 +76,12 @@ public class PortfolioTransaction extends Transaction
         // needed for xstream de-serialization
     }
 
+    public PortfolioTransaction(Type type)
+    {
+        super();
+        this.type = type;
+    }
+
     /* protobuf only */ PortfolioTransaction(String uuid)
     {
         super(uuid);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TextUtil.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/util/TextUtil.java
@@ -144,7 +144,7 @@ public final class TextUtil
             st++;
         }
 
-        while ((st < len) && Character.isWhitespace(value.charAt(len - 1)))
+        while ((st < len) && isWhitespace(value.charAt(len - 1)))
         {
             len--;
         }


### PR DESCRIPTION
Replace the verbose three-line subject lambda with the AccountTransaction(Type) convenience constructor introduced in #5614 across all PDF importers.

   **Additionally:**
   - Add BuySellEntry(PortfolioTransaction.Type) and PortfolioTransaction(Type) convenience constructors and apply the same single-line subject lambda pattern to all BuySellEntry and PortfolioTransaction subject lambdas
   - Convert the remaining three verbose AccountTransferEntry subject lambdas to method references (AccountTransferEntry::new)
   - Replace setCurrencyCode(CurrencyUnit.X) with setCurrencyCode(asCurrencyCode("X"))
   - Add missing t.getCurrencyCode() != null guard to bare t.getAmount() == 0 checks
   - Normalize all simple wrap blocks to a consistent if/return SkippedItem format, removing intermediate item variables and unused ctx parameters
   - Add final modifier to all var type = new DocumentType(...) declarations

   **Improvement Arkéa Direct Bank and ExtractorMatchers**
   - Extend `hasExDate(String)` to accept `null`, allowing dividend tests to explicitly assert that no ex-date is present in a document
   - Add `hasExDate(null)` assertions to all three dividend tests to document the absence of an ex-date in Arkéa Direct Bank documents

   **Normalize currency handling in DocumentContext**
   - Extend `hasExDate(String)` to accept `null`, allowing dividend tests to explicitly assert that no ex-date is present in a document
   - Add `hasExDate(null)` assertions to all three dividend tests to document the absence of an ex-date in Arkéa Direct Bank documents
   
   **Normalize currency handling in DocumentContext**
   - Fix missing asCurrencyCode() in ctx.put("currency", ...) in BundesschatzPDFExtractor (two document types stored the raw captured string instead of the normalized currency code)
   - Remove redundant asCurrencyCode() wrapping in 15 extractors where currency is read back via .documentContext("currency") — the value stored in the context is already normalized, so the second call was unnecessary
   (affected: ABNAMROGroup, AkfBank, AudiBank, AustrianAnadi, BarclaysBankIreland, BawagAG, BoursesDirect, Bundesschatz, Crowdestor, DKB, INGDiBa, RaiffeisenBankgruppe, SantanderConsumerBank, Tradegate, VolkswagenBank)
   
   **Normalize currency handling — fixed-currency extractors and raw section reads**
   - Introduce `private static final String XXX = "XXX"` constants and replace all `CurrencyUnit.XXX` object references and unwrapped bare string literals with `asCurrencyCode(XXX)` in fixed-currency extractors (affected:
   LimeTradingCorp, FidelityInternational, Computershare, AvivaPLC, ScorePriorityInc, Simpel, Sunrise, SutorBankGmbH, KFintech)
   - Wrap `v.put("currency", stripBlanks(...))` with `asCurrencyCode()` where currency is captured from raw PDF text (affected: Comdirect 4×, Commerzbank 1×, LibertyVorsorgeAG 7×)
   - Wrap `v.put("currency", v.get("currency1/2"))` with `asCurrencyCode()` for currency1/currency2 relay patterns (affected: Consorsbank 12×, DZBankGruppe 6×, DKB 6×, INGDiBa 6×, Postbank 6×)
   - Wrap `Money.of(v.get("currency/feeCurrency"), ...)` with `asCurrencyCode()` in BSDEXPDFExtractor where both currency fields are extracted locally from raw PDF text (8× across buy/sell sections)
   
   **Improve asCurrencyCode() in AbstractPDFExtractor and fix TextUtil.trim()**
   - Replace `currency.trim()` (Java's String.trim, strips only ASCII ≤ 0x20) with `TextUtil.trim()` (already statically imported) which additionally handles Unicode spaces such as U+00A0 (NO-BREAK SPACE) and U+FEFF
   (Zero-Width BOM)
   - Fix asymmetric bug in `TextUtil.trim()`: the trailing whitespace loop used `Character.isWhitespace()` while the leading loop used the more comprehensive `TextUtil.isWhitespace()` — U+00A0, U+202F and U+FEFF were
   therefore trimmed leading but not trailing; both loops now use `TextUtil.isWhitespace()`
   - As a side effect, `MessagesTest` now detects a stray U+202F (NARROW NO-BREAK SPACE) trailing in the Spanish translation key `AttributeSettings_LimitPrice_ColorSettings` — removed
   - Add `TextUtilTest.testTrim()` covering regular whitespace, U+00A0 and U+FEFF trimming on both sides
   - Add `AbstractPDFExtractorTest` covering: standard ISO codes, U+00A0 trimming, regular whitespace trimming, null input, and unknown-code fallback to base currency