### PR TITLE
docs: small clarifications to CONTRIBUTING.md setup steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ Install via Eclipse Marketplace (drag and drop the `Install` button to your work
 - **M2E PDE Integration** (under General Purpose Tools)
 - **Eclipse e4 Tools** (under General Purpose Tools)
 
+Note: depending on your Eclipse package, some of these may already be installed. Uncheck "Hide items that are already installed" at the bottom of the dialog to verify.
+
 **Configure Eclipse**
 
 `Menu` → `Window` → `Preferences`:
@@ -82,7 +84,7 @@ Install via Eclipse Marketplace (drag and drop the `Install` button to your work
 
 **Project Setup**
 
-1. **Fork** your repository using [GitHub's fork workflow](https://docs.github.com/en/get-started/quickstart/fork-a-repo)
+1. **Fork** the repository using [GitHub's fork workflow](https://docs.github.com/en/get-started/quickstart/fork-a-repo) to create your own copy
 2. **Import projects**: Within Eclipse, [clone and import all projects](https://www.vogella.com/tutorials/EclipseGit/article.html#exercise-clone-an-existing-repository)
 3. **Setup target platform**:
    - Open `portfolio-target-definition` project


### PR DESCRIPTION
Hello!

Two small wording tweaks in CONTRIBUTING.md, found while going through the setup as a new contributor.

## Changes

* "Fork your repository" -> "Fork the repository ... to create your own copy". The original wording was a bit confusing when reading it for the first time since, as a contributor, it's not my repository that I fork but `portfolio-performance/portfolio.`
* Added a short note under "Plugins from the Eclipse Update Site": depending on the Eclipse package, some of the listed plugins may already be installed. Pointing readers to "Hide items that are already installed" avoids the confusion of "I don't see M2E PDE Integration in the list".

## Not in scope

I also hit a separate setup issue at the "Run tests" step (#5714). Not addressing it here, since it is still under discussion and the right fix is not clear yet (doc note vs. target file update).

Closes #5714