### PR TITLE
Move plugin versions into properties section

### DIFF
--- a/portfolio-app/pom.xml
+++ b/portfolio-app/pom.xml
@@ -1,6 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>name.abuchen.portfolio</groupId>
@@ -14,6 +13,17 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<tycho-version>5.0.2</tycho-version>
+		<maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
+		<maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
+		<maven-dependency-plugin.version>3.10.0</maven-dependency-plugin.version>
+		<maven-jarsigner-plugin.version>3.1.0</maven-jarsigner-plugin.version>
+		<maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
+		<maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
+		<sonar-maven-plugin.version>5.6.0.6792</sonar-maven-plugin.version>
+		<fix-info-plist-maven-plugin.version>1.8</fix-info-plist-maven-plugin.version>
+		<exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
+		<jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
+		<protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
 		<jarsigner.skip>true</jarsigner.skip>
 		<gpgsigner.skip>true</gpgsigner.skip>
 		<applesigner.skip>true</applesigner.skip>
@@ -73,7 +83,7 @@
 		<profile>
 			<!--
 				local-dev (activate by appending -Plocal-dev to your Maven command line)
-				
+
 			    The profile can be used for local development, to speed up the build:
 			    * use a target platform without the babel translation bundles
 			    * skip code coverage and checkstyle checks
@@ -94,7 +104,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.6.3</version>
+				<version>${maven-enforcer-plugin.version}</version>
 				<executions>
 					<execution>
 						<id>enforce-versions</id>
@@ -173,7 +183,7 @@
 						</environment>
 					</environments>
 					<filters>
-						<filter>	
+						<filter>
 							<type>eclipse-plugin</type>
 							<id>org.eclipse.ui.ide</id>
 							<removeAll />
@@ -450,7 +460,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>3.5.0</version>
+					<version>${maven-resources-plugin.version}</version>
 					<configuration>
 						<encoding>UTF-8</encoding>
 					</configuration>
@@ -458,7 +468,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-dependency-plugin</artifactId>
-					<version>3.10.0</version>
+					<version>${maven-dependency-plugin.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
@@ -518,7 +528,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jarsigner-plugin</artifactId>
-					<version>3.1.0</version>
+					<version>${maven-jarsigner-plugin.version}</version>
 					<executions>
 						<execution>
 							<id>sign</id>
@@ -550,12 +560,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-gpg-plugin</artifactId>
-					<version>3.2.8</version>
+					<version>${maven-gpg-plugin.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>3.6.0</version>
+					<version>${maven-checkstyle-plugin.version}</version>
 					<dependencies>
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>
@@ -584,17 +594,17 @@
 				<plugin>
 					<groupId>org.sonarsource.scanner.maven</groupId>
 					<artifactId>sonar-maven-plugin</artifactId>
-					<version>5.7.0.6970</version>
+					<version>${sonar-maven-plugin.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>name.abuchen</groupId>
 					<artifactId>fix-info-plist-maven-plugin</artifactId>
-					<version>1.8</version>
+					<version>${fix-info-plist-maven-plugin.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>exec-maven-plugin</artifactId>
-					<version>3.6.3</version>
+					<version>${exec-maven-plugin.version}</version>
 					<configuration>
 						<mainClass>name.abuchen.portfolio.build.MessagesTool</mainClass>
 						<classpathScope>runtime</classpathScope>
@@ -607,12 +617,12 @@
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
-					<version>0.8.14</version>
+					<version>${jacoco-maven-plugin.version}</version>
 				</plugin>
 				<plugin>
 					<groupId>com.github.os72</groupId>
 					<artifactId>protoc-jar-maven-plugin</artifactId>
-					<version>3.11.4</version>
+					<version>${protoc-jar-maven-plugin.version}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/portfolio-app/pom.xml
+++ b/portfolio-app/pom.xml
@@ -19,7 +19,7 @@
 		<maven-jarsigner-plugin.version>3.1.0</maven-jarsigner-plugin.version>
 		<maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
 		<maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
-		<sonar-maven-plugin.version>5.6.0.6792</sonar-maven-plugin.version>
+		<sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
 		<fix-info-plist-maven-plugin.version>1.8</fix-info-plist-maven-plugin.version>
 		<exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
 		<jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>


### PR DESCRIPTION
Hello!

This refactors `portfolio-app/pom.xml` so the remaining hardcoded plugin versions are declared in `<properties>` as `${<artifactId>.version}` placeholders, matching the existing `${tycho-version}` pattern. The goal, as discussed in the issue, is to make outdated plugins easier to spot via `mvn versions:display-plugin-updates`.

## Changes

* Lifted 11 plugin versions into the `<properties>` block: `maven-enforcer-plugin`, `maven-resources-plugin`, `maven-dependency-plugin`, `maven-jarsigner-plugin`, `maven-gpg-plugin`, `maven-checkstyle-plugin`, `sonar-maven-plugin`, `fix-info-plist-maven-plugin`, `exec-maven-plugin`, `jacoco-maven-plugin`, `protoc-jar-maven-plugin`.
* Used the dotted Maven convention `${<artifactId>.version}`, e.g. `${maven-resources-plugin.version}`.
* `${tycho-version}` is left as-is — already a property, shared by 8 Tycho plugins, so a short name made sense there. The new properties are 1:1 with their plugins, hence the more explicit `<artifactId>.version` form.

## Not in scope

* The checkstyle library dependency version inside `maven-checkstyle-plugin` (`13.4.2`) is intentionally left hardcoded — it is a plugin dependency, not a plugin version, and `display-plugin-updates` does not check it.

## Verification

`mvn -f portfolio-app/pom.xml clean verify -Plocal-dev` → BUILD SUCCESS, all 13 modules, 0 test failures.

Closes #3244