### PR TITLE
docs: document workaround for missing org.eclipse.pde.junit.runtime

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,7 @@ Note: depending on your Eclipse package, some of these may already be installed.
 4. **Add Launch Configuration view**: `Menu` → `Window` → `Show View` → `Other...` → `Debug` → `Launch Configuration`
 5. **Run the application**: Select `Eclipse Application` → `PortfolioPerformance` and right-click *Run*
 6. **Run tests**: Select `JUnit Plug-in Tests` → `PortfolioPerformance_Tests` or `PortfolioPerformance_UI_Tests`
+   - If you get `Required plug-in 'org.eclipse.pde.junit.runtime' could not be found`, add your running Eclipse installation as a location in the target. Open `portfolio-target-definition.target` in the Target Editor (same as in step 3), click `Add...` → `Installation` → enter `${eclipse_home}` (works cross-platform) → Finish. Save the file. Keep this change in your working tree only, do not commit it. This bundle is part of the Eclipse PDE tooling rather than the application's runtime, so it intentionally isn't in `portfolio-target-definition.target`. CI uses Maven/Tycho, which has its own test runner, so this only affects running tests from inside Eclipse.
 
 **Optional Language Packs**
 


### PR DESCRIPTION
Hello!

Follow-up to #5714: this adds a short note at step 6 of the setup.

## Change

A single sub-bullet under "Run tests" in `CONTRIBUTING.md`, explaining:

* The error contributors might hit when running tests from Eclipse
* That the missing bundle is part of Eclipse PDE tooling, not the application's runtime (so it doesn't belong in `portfolio-target-definition.target`)
* How to add the running Eclipse installation as a target location using `${eclipse_home}` (cross-platform)
* That the local change should not be committed

Tested locally: `PortfolioPerformance_Tests` runs cleanly (4359/4359) after applying the workaround.

Thanks for the suggestion @Nirus2000 

Closes #5714