### PR TITLE
Improve Bank SLM AG PDF-Importer to support exDate

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/bankslm/BankSLMPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/bankslm/BankSLMPDFExtractorTest.java
@@ -1,39 +1,45 @@
 package name.abuchen.portfolio.datatransfer.pdf.bankslm;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasExDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasForexGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasIsin;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasName;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countItemsWithFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSkippedItems;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
-import static org.junit.Assert.assertNull;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
 
-import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
-import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
-import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
-import name.abuchen.portfolio.datatransfer.ImportAction.Status;
 import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
-import name.abuchen.portfolio.datatransfer.actions.CheckCurrenciesAction;
 import name.abuchen.portfolio.datatransfer.pdf.BankSLMPDFExtractor;
 import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
-import name.abuchen.portfolio.model.Account;
-import name.abuchen.portfolio.model.AccountTransaction;
-import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
-import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
-import name.abuchen.portfolio.model.Transaction.Unit;
-import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.money.Values;
 
 @SuppressWarnings("nls")
 public class BankSLMPDFExtractorTest
@@ -58,38 +64,19 @@ public class BankSLMPDFExtractorTest
         new AssertImportActions().check(results, "CHF");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertNull(security.getIsin());
-        assertThat(security.getWkn(), is("472672"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("Nokia Corp Inhaber-Aktien"));
-        assertThat(security.getCurrencyCode(), is("EUR"));
+        assertThat(results, hasItem(security( //
+                        hasIsin(null), hasWkn("472672"), hasTicker(null), //
+                        hasName("Nokia Corp Inhaber-Aktien"), //
+                        hasCurrencyCode("EUR"))));
 
         // check buy sell transaction
-        var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2013-09-03T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(17000)));
-        assertThat(entry.getSource(), is("Kauf01.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("CHF", Values.Amount.factorize(92658.45))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("CHF", Values.Amount.factorize(92031.25))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("CHF", Values.Amount.factorize(138.05))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("CHF", Values.Amount.factorize(489.15))));
-
-        var grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of("EUR", Values.Amount.factorize(74120.00))));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2013-09-03T00:00"), hasShares(17000.00), //
+                        hasSource("Kauf01.txt"), //
+                        hasNote(null), //
+                        hasAmount("CHF", 92658.45), hasGrossValue("CHF", 92031.25), //
+                        hasForexGrossValue("EUR", 74120.00), //
+                        hasTaxes("CHF", 138.05), hasFees("CHF", 489.15))));
     }
 
     @Test
@@ -118,31 +105,12 @@ public class BankSLMPDFExtractorTest
         new AssertImportActions().check(results, "CHF");
 
         // check buy sell transaction
-        var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2013-09-03T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(17000)));
-        assertThat(entry.getSource(), is("Kauf01.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("CHF", Values.Amount.factorize(92658.45))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("CHF", Values.Amount.factorize(92031.25))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("CHF", Values.Amount.factorize(138.05))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("CHF", Values.Amount.factorize(489.15))));
-
-        var c = new CheckCurrenciesAction();
-        var account = new Account();
-        account.setCurrencyCode("CHF");
-        var s = c.process(entry, account, entry.getPortfolio());
-        assertThat(s, is(Status.OK_STATUS));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2013-09-03T00:00"), hasShares(17000.00), //
+                        hasSource("Kauf01.txt"), //
+                        hasNote(null), //
+                        hasAmount("CHF", 92658.45), hasGrossValue("CHF", 92031.25), //
+                        hasTaxes("CHF", 138.05), hasFees("CHF", 489.15))));
     }
 
     @Test
@@ -165,34 +133,18 @@ public class BankSLMPDFExtractorTest
         new AssertImportActions().check(results, "CHF");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertNull(security.getIsin());
-        assertThat(security.getWkn(), is("135186"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("Bank SLM AG Namen-Aktien nom CHF 100.00"));
-        assertThat(security.getCurrencyCode(), is("CHF"));
+        assertThat(results, hasItem(security( //
+                        hasIsin(null), hasWkn("135186"), hasTicker(null), //
+                        hasName("Bank SLM AG Namen-Aktien nom CHF 100.00"), //
+                        hasCurrencyCode("CHF"))));
 
         // check buy sell transaction
-        var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-06-21T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1)));
-        assertThat(entry.getSource(), is("Kauf02.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("CHF", Values.Amount.factorize(1481.10))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("CHF", Values.Amount.factorize(1480.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("CHF", Values.Amount.factorize(1.10))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("CHF", Values.Amount.factorize(0.00))));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2016-06-21T00:00"), hasShares(1.00), //
+                        hasSource("Kauf02.txt"), //
+                        hasNote(null), //
+                        hasAmount("CHF", 1481.10), hasGrossValue("CHF", 1480.00), //
+                        hasTaxes("CHF", 1.10), hasFees("CHF", 0.00))));
     }
 
     @Test
@@ -215,34 +167,18 @@ public class BankSLMPDFExtractorTest
         new AssertImportActions().check(results, "CHF");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertNull(security.getIsin());
-        assertThat(security.getWkn(), is("24476758"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("UBS Group AG Namen-Aktien nom CHF 0.10"));
-        assertThat(security.getCurrencyCode(), is("CHF"));
+        assertThat(results, hasItem(security( //
+                        hasIsin(null), hasWkn("24476758"), hasTicker(null), //
+                        hasName("UBS Group AG Namen-Aktien nom CHF 0.10"), //
+                        hasCurrencyCode("CHF"))));
 
         // check buy sell transaction
-        var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2016-02-10T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(3000)));
-        assertThat(entry.getSource(), is("Kauf03.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("CHF", Values.Amount.factorize(43412.10))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("CHF", Values.Amount.factorize(43200.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("CHF", Values.Amount.factorize(32.40))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("CHF", Values.Amount.factorize(3.50 + 176.20))));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2016-02-10T00:00"), hasShares(3000.00), //
+                        hasSource("Kauf03.txt"), //
+                        hasNote(null), //
+                        hasAmount("CHF", 43412.10), hasGrossValue("CHF", 43200.00), //
+                        hasTaxes("CHF", 32.40), hasFees("CHF", 3.50 + 176.20))));
     }
 
     @Test
@@ -265,34 +201,18 @@ public class BankSLMPDFExtractorTest
         new AssertImportActions().check(results, "CHF");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertNull(security.getIsin());
-        assertThat(security.getWkn(), is("2489948"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("UBS AG Namen-Aktien nom CHF 0.10"));
-        assertThat(security.getCurrencyCode(), is("CHF"));
+        assertThat(results, hasItem(security( //
+                        hasIsin(null), hasWkn("2489948"), hasTicker(null), //
+                        hasName("UBS AG Namen-Aktien nom CHF 0.10"), //
+                        hasCurrencyCode("CHF"))));
 
         // check buy sell transaction
-        var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2013-08-22T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(7798)));
-        assertThat(entry.getSource(), is("Verkauf01.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("CHF", Values.Amount.factorize(142359.40))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("CHF", Values.Amount.factorize(142859.35))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("CHF", Values.Amount.factorize(107.15))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("CHF", Values.Amount.factorize(3.50 + 389.30))));
+        assertThat(results, hasItem(sale( //
+                        hasDate("2013-08-22T00:00"), hasShares(7798.00), //
+                        hasSource("Verkauf01.txt"), //
+                        hasNote(null), //
+                        hasAmount("CHF", 142359.40), hasGrossValue("CHF", 142859.35), //
+                        hasTaxes("CHF", 107.15), hasFees("CHF", 3.50 + 389.30))));
     }
 
     @Test
@@ -315,38 +235,19 @@ public class BankSLMPDFExtractorTest
         new AssertImportActions().check(results, "CHF");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertNull(security.getIsin());
-        assertThat(security.getWkn(), is("472672"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("Nokia Corp Inhaber-Aktien"));
-        assertThat(security.getCurrencyCode(), is("EUR"));
+        assertThat(results, hasItem(security( //
+                        hasIsin(null), hasWkn("472672"), hasTicker(null), //
+                        hasName("Nokia Corp Inhaber-Aktien"), //
+                        hasCurrencyCode("EUR"))));
 
         // check buy sell transaction
-        var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2013-01-24T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(11500)));
-        assertThat(entry.getSource(), is("Verkauf02.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("CHF", Values.Amount.factorize(43180.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("CHF", Values.Amount.factorize(43509.55))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("CHF", Values.Amount.factorize(65.25))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("CHF", Values.Amount.factorize(264.30))));
-
-        var grossValueUnit = entry.getPortfolioTransaction().getUnit(Unit.Type.GROSS_VALUE)
-                        .orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of("EUR", Values.Amount.factorize(35516.56))));
+        assertThat(results, hasItem(sale( //
+                        hasDate("2013-01-24T00:00"), hasShares(11500.00), //
+                        hasSource("Verkauf02.txt"), //
+                        hasNote(null), //
+                        hasAmount("CHF", 43180.00), hasGrossValue("CHF", 43509.55), //
+                        hasForexGrossValue("EUR", 35516.56), //
+                        hasTaxes("CHF", 65.25), hasFees("CHF", 264.30))));
     }
 
     @Test
@@ -375,31 +276,12 @@ public class BankSLMPDFExtractorTest
         new AssertImportActions().check(results, "CHF");
 
         // check buy sell transaction
-        var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2013-01-24T00:00")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(11500)));
-        assertThat(entry.getSource(), is("Verkauf02.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("CHF", Values.Amount.factorize(43180.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("CHF", Values.Amount.factorize(43509.55))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("CHF", Values.Amount.factorize(65.25))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("CHF", Values.Amount.factorize(264.30))));
-
-        var c = new CheckCurrenciesAction();
-        var account = new Account();
-        account.setCurrencyCode("CHF");
-        var s = c.process(entry, account, entry.getPortfolio());
-        assertThat(s, is(Status.OK_STATUS));
+        assertThat(results, hasItem(sale( //
+                        hasDate("2013-01-24T00:00"), hasShares(11500.00), //
+                        hasSource("Verkauf02.txt"), //
+                        hasNote(null), //
+                        hasAmount("CHF", 43180.00), hasGrossValue("CHF", 43509.55), //
+                        hasTaxes("CHF", 65.25), hasFees("CHF", 264.30))));
     }
 
     @Test
@@ -422,29 +304,19 @@ public class BankSLMPDFExtractorTest
         new AssertImportActions().check(results, "CHF");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("CH0001351862"));
-        assertThat(security.getWkn(), is("135186"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("Bank SLM AG Namen-Aktien nom CHF 100.00"));
-        assertThat(security.getCurrencyCode(), is("CHF"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("CH0001351862"), hasWkn("135186"), hasTicker(null), //
+                        hasName("Bank SLM AG Namen-Aktien nom CHF 100.00"), //
+                        hasCurrencyCode("CHF"))));
 
         // check dividends transaction
-        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-05-02T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(1)));
-        assertThat(transaction.getSource(), is("Dividende01.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("CHF", Values.Amount.factorize(18.20))));
-        assertThat(transaction.getGrossValue(), is(Money.of("CHF", Values.Amount.factorize(28.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("CHF", Values.Amount.factorize(9.80))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("CHF", Values.Amount.factorize(0.00))));
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2016-05-02T00:00"), hasExDate("2016-05-02T00:00"), //
+                        hasShares(1.00), //
+                        hasSource("Dividende01.txt"), //
+                        hasNote(null), //
+                        hasAmount("CHF", 18.20), hasGrossValue("CHF", 28.00), //
+                        hasTaxes("CHF", 9.80), hasFees("CHF", 0.00))));
     }
 
     @Test
@@ -467,29 +339,18 @@ public class BankSLMPDFExtractorTest
         new AssertImportActions().check(results, "EUR");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("FI0009000681"));
-        assertThat(security.getWkn(), is("472672"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("Nokia Corp Inhaber-Aktien"));
-        assertThat(security.getCurrencyCode(), is("EUR"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("FI0009000681"), hasWkn("472672"), hasTicker(null), //
+                        hasName("Nokia Corp Inhaber-Aktien"), //
+                        hasCurrencyCode("EUR"))));
 
         // check dividends transaction
-        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2016-07-05T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(17000)));
-        assertThat(transaction.getSource(), is("Dividende02.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(3094.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(4420.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(884.00 + 442.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2016-07-05T00:00"), hasExDate("2016-06-17T00:00"), //
+                        hasShares(17000.00), //
+                        hasSource("Dividende02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 3094.00), hasGrossValue("EUR", 4420.00), //
+                        hasTaxes("EUR", 884.00 + 442.00), hasFees("EUR", 0.00))));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BankSLMPDFExtractor.java
@@ -4,7 +4,6 @@ import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGros
 
 import java.math.BigDecimal;
 
-import name.abuchen.portfolio.datatransfer.ExtrExchangeRate;
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -46,12 +45,12 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        DocumentType type = new DocumentType("B.rsenabrechnung \\- (Kauf|Verkauf)");
+        final var type = new DocumentType("B.rsenabrechnung \\- (Kauf|Verkauf)");
         this.addDocumentTyp(type);
 
-        Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
+        var pdfTransaction = new Transaction<BuySellEntry>();
 
-        Block firstRelevantLine = new Block("^B.rsenabrechnung \\- (Kauf|Verkauf)$");
+        var firstRelevantLine = new Block("^B.rsenabrechnung \\- (Kauf|Verkauf)$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -79,7 +78,7 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
                         .match("^[\\.'\\d]+ (?<name1>.*)$") //
                         .match("^(?<name>.*)$") //
                         .match("^Valor: (?<wkn>[A-Z0-9]{5,9})$") //
-                        .match("^Total Kurswert (?<currency>[\\w]{3}).*$") //
+                        .match("^Total Kurswert (?<currency>[A-Z]{3}).*$") //
                         .assign((t, v) -> {
                             v.put("name", v.get("name") + " " + v.get("name1"));
 
@@ -90,7 +89,7 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
                         // 17'000 Inhaber-Aktien Nokia Corp
                         // @formatter:on
                         .section("shares") //
-                        .find("Wir haben.*")
+                        .find("Wir haben.*") //
                         .match("^(?<shares>[\\.'\\d]+) .*$") //
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
@@ -107,7 +106,7 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
                         // Netto CHF 142'359.40
                         // @formatter:on
                         .section("amount", "currency") //
-                        .match("^Netto (?<currency>[\\w]{3}) (\\-)?(?<amount>[\\.'\\d]+)$") //
+                        .match("^Netto (?<currency>[A-Z]{3}) (\\-)?(?<amount>[\\.'\\d]+)$") //
                         .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -118,14 +117,14 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
                         // Change EUR/CHF 1.241652 CHF -92'031.25
                         // @formatter:on
                         .section("fxGross", "termCurrency", "baseCurrency", "exchangeRate", "gross").optional() //
-                        .match("^Total Kurswert [\\w]{3} (\\-)?(?<fxGross>[\\.'\\d]+)$") //
-                        .match("^Change (?<baseCurrency>[\\w]{3})\\/(?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.'\\d]+) [\\w]{3} (\\-)?(?<gross>[\\.'\\d]+)$") //
+                        .match("^Total Kurswert [A-Z]{3} (\\-)?(?<fxGross>[\\.'\\d]+)$") //
+                        .match("^Change (?<baseCurrency>[A-Z]{3})\\/(?<termCurrency>[A-Z]{3}) (?<exchangeRate>[\\.'\\d]+) [A-Z]{3} (\\-)?(?<gross>[\\.'\\d]+)$") //
                         .assign((t, v) -> {
-                            ExtrExchangeRate rate = asExchangeRate(v);
+                            var rate = asExchangeRate(v);
                             type.getCurrentContext().putType(rate);
 
-                            Money gross = Money.of(rate.getTermCurrency(), asAmount(v.get("gross")));
-                            Money fxGross = Money.of(rate.getBaseCurrency(), asAmount(v.get("fxGross")));
+                            var gross = Money.of(rate.getTermCurrency(), asAmount(v.get("gross")));
+                            var fxGross = Money.of(rate.getBaseCurrency(), asAmount(v.get("fxGross")));
 
                             checkAndSetGrossUnit(gross, fxGross, t, type.getCurrentContext());
                         })
@@ -138,12 +137,12 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        DocumentType type = new DocumentType("Dividende");
+        final var type = new DocumentType("Dividende");
         this.addDocumentTyp(type);
 
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
+        var pdfTransaction = new Transaction<AccountTransaction>();
 
-        Block firstRelevantLine = new Block("^Dividende$");
+        var firstRelevantLine = new Block("^Dividende$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -163,7 +162,7 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<name>.*)$") //
                         .match("^Valor: (?<wkn>[A-Z0-9]{5,9})$") //
                         .match("^ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
-                        .match("^Brutto \\([\\.'\\d]+ \\* [\\w]{3} [\\.'\\d]+\\) (?<currency>[\\w]{3}) [\\.'\\d]+$") //
+                        .match("^Brutto \\([\\.'\\d]+ \\* [A-Z]{3} [\\.'\\d]+\\) (?<currency>[A-Z]{3}) [\\.'\\d]+$") //
                         .assign((t, v) -> {
                             v.put("name", v.get("name") + " " + v.get("name1"));
 
@@ -185,10 +184,17 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                         // @formatter:off
+                        // Namen-Aktien nom CHF 100.00 Ex Datum: 02.05.2016
+                        // @formatter:on
+                        .section("exDate").optional() //
+                        .match("^.* Ex Datum: (?<exDate>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$") //
+                        .assign((t, v) -> t.setExDate(asDate(v.get("exDate"))))
+
+                        // @formatter:off
                         // Netto CHF 18.20
                         // @formatter:on
                         .section("amount", "currency") //
-                        .match("^Netto (?<currency>[\\w]{3}) (?<amount>[\\.'\\d]+)$") //
+                        .match("^Netto (?<currency>[A-Z]{3}) (?<amount>[\\.'\\d]+)$") //
                         .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -199,14 +205,14 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
                         // Change EUR / CHF 1.067227 CHF 3'302.00
                         // @formatter:on
                         .section("gross", "termCurrency", "baseCurrency", "exchangeRate").optional() //
-                        .match("^Brutto \\([\\.'\\d]+ \\* [\\w]{3} [\\.'\\d]+\\) >[\\w]{3} (?<gross>[\\.'\\d]+)$") //
-                        .match("^Change (?<baseCurrency>[\\w]{3}) \\/ (?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.'\\d]+) [\\w]{3} (\\-)?[\\.'\\d]+$") //
+                        .match("^Brutto \\([\\.'\\d]+ \\* [A-Z]{3} [\\.'\\d]+\\) [A-Z]{3} (?<gross>[\\.'\\d]+)$") //
+                        .match("^Change (?<baseCurrency>[A-Z]{3}) \\/ (?<termCurrency>[A-Z]{3}) (?<exchangeRate>[\\.'\\d]+) [A-Z]{3} (\\-)?[\\.'\\d]+$") //
                         .assign((t, v) -> {
-                            ExtrExchangeRate rate = asExchangeRate(v);
+                            var rate = asExchangeRate(v);
                             type.getCurrentContext().putType(rate);
 
-                            Money gross = Money.of(rate.getBaseCurrency(), asAmount(v.get("gross")));
-                            Money fxGross = rate.convert(rate.getTermCurrency(), gross);
+                            var gross = Money.of(rate.getBaseCurrency(), asAmount(v.get("gross")));
+                            var fxGross = rate.convert(rate.getTermCurrency(), gross);
 
                             checkAndSetGrossUnit(gross, fxGross, t, type.getCurrentContext());
                         })
@@ -225,28 +231,28 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
                         // Eidg. Umsatzabgabe CHF -138.05
                         // @formatter:on
                         .section("currency", "tax").optional() //
-                        .match("^Eidg\\. Umsatzabgabe (?<currency>[\\w]{3}) \\-(?<tax>[\\.'\\d]+)$") //
+                        .match("^Eidg\\. Umsatzabgabe (?<currency>[A-Z]{3}) \\-(?<tax>[\\.'\\d]+)$") //
                         .assign((t, v) -> processTaxEntries(t, v, type))
 
                         // @formatter:off
                         // 35% Verrechnungssteuer CHF -9.80
-                        // @formatter:off
+                        // @formatter:on
                         .section("currency", "tax").optional() //
-                        .match("^[\\d]+% Verrechnungssteuer (?<currency>[\\w]{3}) \\-(?<tax>[\\.'\\d]+)$") //
+                        .match("^[\\d]+% Verrechnungssteuer (?<currency>[A-Z]{3}) \\-(?<tax>[\\.'\\d]+)$") //
                         .assign((t, v) -> processTaxEntries(t, v, type))
 
                         // @formatter:off
                         // 20% Quellensteuer EUR -884.00
                         // @formatter:on
                         .section("currency", "withHoldingTax").optional() //
-                        .match("^[\\d]+% Quellensteuer (?<currency>[\\w]{3}) \\-(?<withHoldingTax>[\\.'\\d]+)$") //
+                        .match("^[\\d]+% Quellensteuer (?<currency>[A-Z]{3}) \\-(?<withHoldingTax>[\\.'\\d]+)$") //
                         .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
                         // @formatter:off
                         // 10% Nichtrückforderbare Steuern EUR -442.00
                         // @formatter:on
                         .section("currency", "tax").optional() //
-                        .match("^[\\d]+% Nicht r.ckforderbare Steuern (?<currency>[\\w]{3}) \\-(?<tax>[\\.'\\d]+)$") //
+                        .match("^[\\d]+% Nicht r.ckforderbare Steuern (?<currency>[A-Z]{3}) \\-(?<tax>[\\.'\\d]+)$") //
                         .assign((t, v) -> processTaxEntries(t, v, type));
     }
 
@@ -258,21 +264,21 @@ public class BankSLMPDFExtractor extends AbstractPDFExtractor
                         // Eigene Courtage CHF -489.15
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("^Eigene Courtage (?<currency>[\\w]{3}) \\-(?<fee>[\\.'\\d]+)$") //
+                        .match("^Eigene Courtage (?<currency>[A-Z]{3}) \\-(?<fee>[\\.'\\d]+)$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // Börsengebühr Inland CHF -3.50
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("^B.rsengeb.hr Inland (?<currency>[\\w]{3}) \\-(?<fee>[\\.'\\d]+)$") //
+                        .match("^B.rsengeb.hr Inland (?<currency>[A-Z]{3}) \\-(?<fee>[\\.'\\d]+)$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // Börsengebühr CHF -3.50
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("^B.rsengeb.hr (?<currency>[\\w]{3}) \\-(?<fee>[\\.'\\d]+)$") //
+                        .match("^B.rsengeb.hr (?<currency>[A-Z]{3}) \\-(?<fee>[\\.'\\d]+)$") //
                         .assign((t, v) -> processFeeEntries(t, v, type));
     }
 


### PR DESCRIPTION
- Fix DocumentType declarations to use final var
- Fix regex bug in dividend FX section (spurious > before currency code)
- Fix wrong @Formatter:off tag (should be @Formatter:on)
- Extract ex-date from dividend documents
- Migrate tests to hasItem(purchase/sale/dividend(...)) matcher style