### PR TITLE
Improve BLKB PDF-Importer

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BasellandschaftlicheKantonalbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BasellandschaftlicheKantonalbankPDFExtractor.java
@@ -39,12 +39,12 @@ public class BasellandschaftlicheKantonalbankPDFExtractor extends AbstractPDFExt
 
     private void addBuySellTransaction()
     {
-        DocumentType type = new DocumentType("B.rsenabrechnung \\-( Zeichnung| R.cknahme)? (Kauf|Verkauf)");
+        final var type = new DocumentType("B.rsenabrechnung \\-( Zeichnung| R.cknahme)? (Kauf|Verkauf)");
         this.addDocumentTyp(type);
 
-        Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
+        var pdfTransaction = new Transaction<BuySellEntry>();
 
-        Block firstRelevantLine = new Block("^Auftragsnummer.*$");
+        var firstRelevantLine = new Block("^Auftragsnummer.*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -70,7 +70,7 @@ public class BasellandschaftlicheKantonalbankPDFExtractor extends AbstractPDFExt
                         // Total Kurswert CHF -105.51
                         // @formatter:on
                         .section("name", "nameContinued", "wkn", "isin", "currency") //
-                        .find("Wir haben für Sie am .*") //
+                        .find("Wir haben f.r Sie am .*") //
                         .match("^[\\.'\\d]+ .*$") //
                         .match("^(?<name>.*)$") //
                         .match("^(?<nameContinued>.*)$") //
@@ -95,7 +95,7 @@ public class BasellandschaftlicheKantonalbankPDFExtractor extends AbstractPDFExt
                         // Wir haben für Sie am 11.01.2024 gezeichnet.
                         // @formatter:on
                         .section("date") //
-                        .match("^Wir haben für Sie am (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$") //
+                        .match("^Wir haben f.r Sie am (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$") //
                         .assign((t, v) -> t.setDate(asDate(v.get("date"))))
 
                         // @formatter:off


### PR DESCRIPTION
- Fix DocumentType declaration to use final var
- Replace literal umlauts (ü) with . in regex patterns to handle PDF-to-text encoding variations