### PR TITLE
Improve BISON PDF-Importer

### DIFF
--- a/.claude/rules/pdfextractors.md
+++ b/.claude/rules/pdfextractors.md
@@ -108,7 +108,7 @@ v.put("currency", asCurrencyCode("USD"));         // works but prefer named cons
 # Testing
 Test methods should be in following structure
 
-```
+```java
 @Test
 public void testWertpapierKauf01()
 {
@@ -173,9 +173,17 @@ assertThat(results, hasItem(skippedItem( //
                                 hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
 ```
 
+`deposit(...)` and `removal(...)` assertions do NOT include `hasGrossValue`, `hasTaxes`, or `hasFees` — use this compact format:
+
+```java
+assertThat(results, hasItem(deposit(hasDate("2011-10-19"), hasAmount("EUR", 100.00), //
+                hasSource("Kontoauszug01.txt"), hasNote(null))));
+```
+
 - Each method has a starting `assertThat`-Block checking the counts. All 8 assertions need to be present.
 - Use `//` to enforce line-breaks when checking securities and transactions
 - Include time (hours, minutes, seconds) in `hasDate` when the source document provides it.
 - The `ExtractorMatchers`-class contains test assertion helpers
 - The fees and taxes could consist of multiple values, do not merge or consolidate them for better understanding
+- Always use `0.00` (double literal) for zero amounts, never the integer `0`
 - Every `dividend(...)` assertion must include `hasExDate(...)`. The correct value comes from the JUnit test failure message: look for `dividend with exDate = <value>` in the mismatch output. Use that exact value. If the extractor does not extract an ex-date, the actual value will be `null`.

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/bison/BisonPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/bison/BisonPDFExtractorTest.java
@@ -188,12 +188,8 @@ public class BisonPDFExtractorTest
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
         // check deposit transaction
-        assertThat(results, hasItem(deposit( //
-                        hasDate("2021-11-29T08:49"), //
-                        hasSource("InfoReport01.txt"), //
-                        hasNote(null), //
-                        hasAmount("EUR", 250.00), hasGrossValue("EUR", 250.00), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+        assertThat(results, hasItem(deposit(hasDate("2021-11-29T08:49"), hasAmount("EUR", 250.00), //
+                        hasSource("InfoReport01.txt"), hasNote(null))));
     }
 
     @Test
@@ -235,7 +231,7 @@ public class BisonPDFExtractorTest
                         hasSource("InfoReport02.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 47.62), hasGrossValue("EUR", 47.62), //
-                        hasTaxes("EUR", 0), hasFees("EUR", 0))));
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
         // check buy sell transaction
         assertThat(results, hasItem(sale( //
@@ -243,7 +239,7 @@ public class BisonPDFExtractorTest
                         hasSource("InfoReport02.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 47.62), hasGrossValue("EUR", 47.62), //
-                        hasTaxes("EUR", 0), hasFees("EUR", 0))));
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -272,12 +268,8 @@ public class BisonPDFExtractorTest
                         hasFeedProperty(CoinGeckoQuoteFeed.COINGECKO_COIN_ID, "bitcoin"))));
 
         // check withdrawal transaction
-        assertThat(results, hasItem(removal( //
-                        hasDate("2020-11-22T09:51"), //
-                        hasSource("InfoReport03.txt"), //
-                        hasNote(null), //
-                        hasAmount("EUR", 100.00), hasGrossValue("EUR", 100.00), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+        assertThat(results, hasItem(removal(hasDate("2020-11-22T09:51"), hasAmount("EUR", 100.00), //
+                        hasSource("InfoReport03.txt"), hasNote(null))));
 
         // check buy sell transaction
         assertThat(results, hasItem(sale( //
@@ -304,11 +296,8 @@ public class BisonPDFExtractorTest
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
 
         // check deposit transactions
-        assertThat(results, hasItem(deposit( //
-                        hasDate("2020-01-16T10:30"), //
-                        hasSource("InfoReport03.txt"), //
-                        hasNote(null), //
-                        hasAmount("EUR", 100.00))));
+        assertThat(results, hasItem(deposit(hasDate("2020-01-16T10:30"), hasAmount("EUR", 100.00), //
+                        hasSource("InfoReport03.txt"), hasNote(null))));
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BisonPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BisonPDFExtractor.java
@@ -14,7 +14,7 @@ import name.abuchen.portfolio.model.PortfolioTransaction;
  * @formatter:off
  * @implNote Importer for "Info Reports" produced by the Bison App.
  *
- * @implSpec Bison only supports EUR as currency. 
+ * @implSpec Bison only supports EUR as currency.
  *           Therefore the extractor is always defaulting to EUR.
  * @formatter:on
  */


### PR DESCRIPTION
- Add deposit/removal assertion format to testing rules
- Add rule for 0.00 instead of 0 for zero amounts
- Fix zero amounts and simplify deposit/removal assertions in Bison tests