### PR TITLE
Improve Bourse Direct PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursedirect/BourseDirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursedirect/BourseDirectPDFExtractorTest.java
@@ -6,6 +6,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.fee;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasExDate;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasForexGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
@@ -224,7 +225,8 @@ public class BourseDirectPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-08-06T00:00"), hasShares(3.00), //
+                        hasDate("2025-08-06T00:00"), hasExDate(null), //
+                        hasShares(3.00), //
                         hasSource("ReleveDeCompte03.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 4.08), hasGrossValue("EUR", 4.80), //
@@ -306,7 +308,7 @@ public class BourseDirectPDFExtractorTest
     }
 
     @Test
-    public void testDividende02WithSecurityInEUR()
+    public void testReleveDeCompte05WithSecurityInEUR()
     {
         var security1 = new Security("BOOZ ALLEN CL.A", "EUR");
         security1.setIsin("US0995021062");
@@ -378,7 +380,8 @@ public class BourseDirectPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2021-03-30T00:00"), hasShares(20.00), //
+                        hasDate("2021-03-30T00:00"), hasExDate(null), //
+                        hasShares(20.00), //
                         hasSource("ReleveDeCompte06.txt"), //
                         hasNote(null), //
                         hasAmount("EUR", 9.55), hasGrossValue("EUR", 17.34), //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BourseDirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BourseDirectPDFExtractor.java
@@ -50,11 +50,6 @@ public class BourseDirectPDFExtractor extends AbstractPDFExtractor
             var taxAmountTransactionHelper = new TaxAmountTransactionHelper();
             context.putType(taxAmountTransactionHelper);
 
-            List<TaxAmountTransactionItem> itemsToAddToFront = new ArrayList<>();
-
-            // Add items from pTaxAmountTransaction to the beginning of the list
-            taxAmountTransactionHelper.items.addAll(0, itemsToAddToFront);
-
             for (var i = 0; i < lines.length; i++)
             {
                 // Extract currency from header line
@@ -75,7 +70,7 @@ public class BourseDirectPDFExtractor extends AbstractPDFExtractor
                     item.dateTime = asDate(m.group("date"));
                     item.isin = m.group("isin");
                     item.tax = asAmount(m.group("tax"));
-                    item.currency = asCurrencyCode(context.get("currency"));
+                    item.currency = context.get("currency");
 
                     taxAmountTransactionHelper.items.add(item);
                 }
@@ -358,20 +353,6 @@ public class BourseDirectPDFExtractor extends AbstractPDFExtractor
     {
         private List<TaxAmountTransactionItem> items = new ArrayList<>();
 
-        /**
-         * Finds a TaxAmountTransactionItem in the list that has a line number
-         * greater than or equal to the specified line and matches the given
-         * date and ISIN.
-         *
-         * @param line
-         *            The line number to compare against.
-         * @param date
-         *            The date to match.
-         * @param isin
-         *            The ISIN to match.
-         * @return An Optional containing the matching TaxAmountTransactionItem,
-         *         or empty if no match is found.
-         */
         public Optional<TaxAmountTransactionItem> findItem(int line, LocalDateTime date, String isin)
         {
             return items.stream()


### PR DESCRIPTION
- Remove dead code in addBuySellTransaction() (empty list with no-op addAll())
- Remove redundant asCurrencyCode() when reading already-normalized context value
- Remove multi-line Javadoc block from findItem (method name is self-explanatory)
- Add missing hasExDate(null) to both dividend test assertions