### PR TITLE
Fix wrong excess return values in performance heatmap

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/PerformanceHeatmapWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/heatmap/PerformanceHeatmapWidget.java
@@ -66,7 +66,13 @@ public class PerformanceHeatmapWidget extends AbstractHeatmapWidget<Double>
 
         // build heat map model for actual interval
 
-        Interval actualInterval = performanceIndex.getActualInterval();
+        // When an excess return baseline is configured, restrict the display
+        // interval to start from the first date the primary series has actual
+        // holdings. Without this, months before the first transaction show a
+        // spurious excess return (0 - benchmarkReturn != 0).
+        Interval actualInterval = benchmark != null
+                        ? getFirstActiveInterval(performanceIndex)
+                        : performanceIndex.getActualInterval();
 
         boolean showSum = get(HeatmapOrnamentConfig.class).getValues().contains(HeatmapOrnament.SUM);
         boolean showStandardDeviation = get(HeatmapOrnamentConfig.class).getValues()
@@ -119,6 +125,20 @@ public class PerformanceHeatmapWidget extends AbstractHeatmapWidget<Double>
         }
 
         return model;
+    }
+
+    private Interval getFirstActiveInterval(PerformanceIndex index)
+    {
+        long[] totals = index.getTotals();
+        LocalDate[] dates = index.getDates();
+
+        for (int i = 0; i < totals.length; i++)
+        {
+            if (totals[i] > 0)
+                return Interval.of(i > 0 ? dates[i - 1] : dates[i], dates[dates.length - 1]);
+        }
+
+        return index.getActualInterval();
     }
 
     private double getPerformanceFor(PerformanceIndex index, YearMonth month)


### PR DESCRIPTION
    When a baseline is configured, months before the primary data series
    has any holdings showed a spurious non-zero excess return.
    This happened because the display interval spanned the full reporting
    period, so months with zero primary return were still compared against
    a non-zero benchmark return (0 - benchmarkReturn != 0).

    Fix by restricting the display interval to start from the first date
    the primary series holds actual assets, so pre-activity months are
    shown as empty cells instead of misleading excess return values.

Closes #5752
Issue: https://forum.portfolio-performance.info/t/wrong-heatmap-values-for-monthly-excess-returns-baseline/38228