### PR TITLE
Improve Cetesdirecto PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/cetesdirecto/CetesDirectoPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/cetesdirecto/CetesDirectoPDFExtractorTest.java
@@ -4,6 +4,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasExDate;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasIsin;
@@ -42,7 +43,7 @@ import name.abuchen.portfolio.model.Client;
 public class CetesDirectoPDFExtractorTest
 {
     @Test
-    public void testWertpapierKauf27()
+    public void testEdoCta01()
     {
         var extractor = new CetesDirectoPDFExtractor(new Client());
 
@@ -150,7 +151,8 @@ public class CetesDirectoPDFExtractorTest
 
         // check dividend transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2022-01-06T00:00"), hasShares(3.00), //
+                        hasDate("2022-01-06T00:00"), hasExDate(null), //
+                        hasShares(3.00), //
                         hasSource("EdoCta01.txt"), //
                         hasNote(null), //
                         hasAmount("MXN", 4.72), hasGrossValue("MXN", 4.72), //
@@ -174,7 +176,8 @@ public class CetesDirectoPDFExtractorTest
 
         // check dividend transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2022-01-13T00:00"), hasShares(1.00), //
+                        hasDate("2022-01-13T00:00"), hasExDate(null), //
+                        hasShares(1.00), //
                         hasSource("EdoCta01.txt"), //
                         hasNote(null), //
                         hasAmount("MXN", 1.58), hasGrossValue("MXN", 1.58), //
@@ -198,7 +201,8 @@ public class CetesDirectoPDFExtractorTest
 
         // check dividend transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2022-01-20T00:00"), hasShares(1.00), //
+                        hasDate("2022-01-20T00:00"), hasExDate(null), //
+                        hasShares(1.00), //
                         hasSource("EdoCta01.txt"), //
                         hasNote(null), //
                         hasAmount("MXN", 1.58), hasGrossValue("MXN", 1.58), //
@@ -222,7 +226,8 @@ public class CetesDirectoPDFExtractorTest
 
         // check dividend transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2022-01-27T00:00"), hasShares(5.00), //
+                        hasDate("2022-01-27T00:00"), hasExDate(null), //
+                        hasShares(5.00), //
                         hasSource("EdoCta01.txt"), //
                         hasNote(null), //
                         hasAmount("MXN", 7.89), hasGrossValue("MXN", 7.89), //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CetesDirectoPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CetesDirectoPDFExtractor.java
@@ -65,7 +65,7 @@ public class CetesDirectoPDFExtractor extends AbstractPDFExtractor
         addBankIdentifier("contacto@cetesdirecto.com");
 
         addBuySellTransaction();
-        addDividendeTransaction();
+        addDividendTransaction();
     }
 
     @Override
@@ -81,11 +81,6 @@ public class CetesDirectoPDFExtractor extends AbstractPDFExtractor
 
             var taxAmountTransactionHelper = new TaxAmountTransactionHelper();
             context.putType(taxAmountTransactionHelper);
-
-            List<TaxAmountTransactionItem> itemsToAddToFront = new ArrayList<>();
-
-            // Add items from pTaxAmountTransaction to the beginning of the list
-            taxAmountTransactionHelper.items.addAll(0, itemsToAddToFront);
 
             for (var i = 0; i < lines.length; i++)
             {
@@ -195,7 +190,7 @@ public class CetesDirectoPDFExtractor extends AbstractPDFExtractor
                         .wrap(BuySellEntryItem::new);
     }
 
-    private void addDividendeTransaction()
+    private void addDividendTransaction()
     {
         final var type = new DocumentType("Movimientos del per");
         this.addDocumentTyp(type);
@@ -241,30 +236,13 @@ public class CetesDirectoPDFExtractor extends AbstractPDFExtractor
     {
         private List<TaxAmountTransactionItem> items = new ArrayList<>();
 
-        /**
-         * Finds a TaxAmountTransactionItem in the list that has a line number
-         * greater than or equal to the specified line and matches the given
-         * date and WKN.
-         *
-         * @param line
-         *            The line number to compare against.
-         * @param dateTime
-         *            The date and time to match.
-         * @param wkn
-         *            The WKN (Wertpapierkennnummer) to match.
-         * @return An Optional containing the found item, or an empty Optional
-         *         if no match is found.
-         */
         public Optional<TaxAmountTransactionItem> findItem(int line, LocalDateTime dateTime, String wkn)
         {
             for (TaxAmountTransactionItem item : items)
             {
-                // Skip items where the line number is less than the specified
-                // line
                 if (item.line < line)
                     continue;
 
-                // Check for the matching dateTime and WKN
                 if (item.dateTime.equals(dateTime) && item.wkn.equals(wkn))
                     return Optional.of(item);
             }


### PR DESCRIPTION
- Remove dead code (itemsToAddToFront + addAll no-op) from document context initializer
- Rename addDividendeTransaction() to addDividendTransaction() to follow English naming convention
- Remove Javadoc and inline comments from TaxAmountTransactionHelper.findItem() that described what the code does rather than why
- Add missing hasExDate(null) to all four dividend assertions in the test
- Rename test method testWertpapierKauf27 → testEdoCta01 to match the source document name