### PR TITLE
TradeRepublic PDF import parse fix

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Dividende30.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Dividende30.txt
@@ -1,0 +1,60 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.83.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+xxxxxx SEITE 1 von 2
+xxxxx DATUM 22.05.2026
+xxxxx DEPOT xxxxxxxx
+DIVIDENDE
+ÜBERSICHT
+Dividende mit Ex-Datum 18.05.2026.
+POSITION ANZAHL ERTRAG BETRAG
+Global Quality Dividends USD (Dist) 2.25 USD
+63.726878 Stücke 0.0353 USD
+IE0005AJA0P1
+GESAMT 2.25 USD
+ABRECHNUNG
+POSITION BETRAG
+Zwischensumme 2.25 USD
+Zwischensumme 1.1599 USD/EUR 1.94 EUR
+Kapitalertragsteuer 1.1599 USD/EUR -0.34 EUR
+Solidaritätszuschlag 1.1599 USD/EUR -0.02 EUR
+GESAMT 1.58 EUR
+BUCHUNG
+VERRECHNUNGSKONTO DATUM DER ZAHLUNG BETRAG
+xxxxxxxxxxxxxxx 22.05.2026 1.58 EUR
+IE0005AJA0P1 in Wertpapierrechnung
+Diese Abrechnung wird maschinell erstellt und daher nicht unterschrieben.
+Wird keine Umsatzsteuer ausgewiesen, handelt es sich um eine umsatzsteuerfreie Leistung gemäß § 4 Nr. 8 UStG
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+xxxxxxx SEITE 2 von 2
+xxxxxxx DATUM 22.05.2026
+xxxxxxx DEPOT xxxxxxxx
+STEUERLICHE BEHANDLUNG
+BERECHNUNG DER STEUERBEMESSUNGSGRUNDLAGE BETRAG
+Kapitalertrag 2,25 USD
+Zwischensumme 1.1599 EUR/USD 1,94 EUR
+Teilfreistellung -0,59 EUR
+STEUERBEMESSUNGSGRUNDLAGE 1,35 EUR
+BERECHNUNG DER STEUERN BETRAG
+Steuerbemessungsgrundlage 1,35 EUR
+Kapitalertragsteuer -0,34 EUR
+Solidaritätszuschlag -0,02 EUR
+GESAMTE STEUERN 0,36 EUR
+VERRECHNUNGSTÖPFE
+VERRECHNUNGSTÖPFE VORHER VERÄNDERUNG NACHHER
+Verlustverrechnungstopf Aktien 0,00 EUR 0,00 EUR 0,00 EUR
+Verlustverrechnungstopf Allgemein 0,00 EUR 0,00 EUR 0,00 EUR
+Freistellungsauftrag 0,00 EUR 0,00 EUR 0,00 EUR
+Quellensteuertopf 0,00 EUR 0,00 EUR 0,00 EUR
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Dividende31.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Dividende31.txt
@@ -1,0 +1,59 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.0
+System: macosx | aarch64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+RQMKZd XyqTYa SEITE 1 von 2
+lqGEQy xjrQMm 60 DATUM 04.06.2026
+72537 MgEfXoooBQwp DEPOT 9749142896
+DIVIDENDE
+ÜBERSICHT
+Dividende mit Ex-Datum 16.04.2026.
+POSITION ANZAHL ERTRAG BETRAG
+Diageo 1.05 GBP
+7.000000 Stücke 0.1494 GBP
+GB0002374006
+GESAMT 1.05 GBP
+ABRECHNUNG
+POSITION BETRAG
+Zwischensumme 1.05 GBP
+Zwischensumme 0.86493 GBP/EUR 1.21 EUR
+Kapitalertragsteuer 0.86493 GBP/EUR -0.30 EUR
+Solidaritätszuschlag 0.86493 GBP/EUR -0.01 EUR
+GESAMT 0.90 EUR
+BUCHUNG
+VERRECHNUNGSKONTO DATUM DER ZAHLUNG BETRAG
+DE34100123450126461601 04.06.2026 0.90 EUR
+GB0002374006 in Wertpapierrechnung
+Diese Abrechnung wird maschinell erstellt und daher nicht unterschrieben.
+Wird keine Umsatzsteuer ausgewiesen, handelt es sich um eine umsatzsteuerfreie Leistung gemäß § 4 Nr. 8 UStG
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+gEjZsw CHhNxv SEITE 2 von 2
+cNpIiw QIsHDu 09 DATUM 04.06.2026
+04128 EkfLYfzWCacH DEPOT 6901872638
+STEUERLICHE BEHANDLUNG
+BERECHNUNG DER STEUERBEMESSUNGSGRUNDLAGE BETRAG
+Kapitalertrag 1,05 GBP
+Zwischensumme 0.86493 EUR/GBP 1,21 EUR
+STEUERBEMESSUNGSGRUNDLAGE 1,21 EUR
+BERECHNUNG DER STEUERN BETRAG
+Steuerbemessungsgrundlage 1,21 EUR
+Kapitalertragsteuer -0,30 EUR
+Solidaritätszuschlag -0,01 EUR
+GESAMTE STEUERN 0,31 EUR
+VERRECHNUNGSTÖPFE
+VERRECHNUNGSTÖPFE VORHER VERÄNDERUNG NACHHER
+Verlustverrechnungstopf Aktien 2.229,39 EUR 0,00 EUR 2.229,39 EUR
+Verlustverrechnungstopf Allgemein 0,00 EUR 0,00 EUR 0,00 EUR
+Freistellungsauftrag 0,00 EUR 0,00 EUR 0,00 EUR
+Quellensteuertopf 0,00 EUR 0,00 EUR 0,00 EUR
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Sparplan12.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Sparplan12.txt
@@ -1,0 +1,29 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.83.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+Max Mustermann SEITE 1 von 1
+Musterstraße 2 DATUM 03.06.2026
+5020 Ort AUSFÜHRUNG 69cc-a952
+SPARPLAN bf7b-be8f
+DEPOT 0154431601
+WERTPAPIERABRECHNUNG SPARPLAN
+ÜBERSICHT
+Sparplanausführung am 02.06.2026 an der Lang und Schwarz Exchange.
+Der Kontrahent der Transaktion ist Lang & Schwarz TradeCenter AG & Co. KG.
+POSITION ANZAHL DURCHSCHNITTSKURS BETRAG
+Core MSCI World USD (Acc) 3.226355 Stk. 123.9789 EUR 400.00 EUR
+ISIN: IE00B4L5Y983
+GESAMT 400.00 EUR
+BUCHUNG
+VERRECHNUNGSKONTO WERTSTELLUNG BETRAG
+DE54120700700120530047 2026-06-04 -400.00 EUR
+Core MSCI World USD (Acc) nicht in Sammelverwahrung
+Diese Abrechnung wird maschinell erstellt und daher nicht unterschrieben.
+Wird keine Umsatzsteuer ausgewiesen, handelt es sich gemäß § 4 Nr. 8 UStG um eine umsatzsteuerfreie Leistung.
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -76,7 +76,7 @@ import name.abuchen.portfolio.online.impl.CoinGeckoQuoteFeed;
 @SuppressWarnings("nls")
 public class TradeRepublicPDFExtractorTest
 {
-    TradeRepublicPDFExtractor extractor = new TradeRepublicPDFExtractor(new Client())
+    TradeRepublicPDFExtractor cryptExtractor = new TradeRepublicPDFExtractor(new Client())
     {
         @Override
         protected List<SecuritySearchProvider> lookupCryptoProvider()
@@ -1136,7 +1136,7 @@ public class TradeRepublicPDFExtractorTest
     {
         List<Exception> errors = new ArrayList<>();
 
-        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf01.txt"), errors);
+        var results = cryptExtractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf01.txt"), errors);
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
@@ -1170,7 +1170,7 @@ public class TradeRepublicPDFExtractorTest
     {
         List<Exception> errors = new ArrayList<>();
 
-        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf02.txt"), errors);
+        var results = cryptExtractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf02.txt"), errors);
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
@@ -1204,7 +1204,7 @@ public class TradeRepublicPDFExtractorTest
     {
         List<Exception> errors = new ArrayList<>();
 
-        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf03.txt"), errors);
+        var results = cryptExtractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf03.txt"), errors);
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
@@ -1238,7 +1238,7 @@ public class TradeRepublicPDFExtractorTest
     {
         List<Exception> errors = new ArrayList<>();
 
-        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf04.txt"), errors);
+        var results = cryptExtractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf04.txt"), errors);
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
@@ -1272,7 +1272,7 @@ public class TradeRepublicPDFExtractorTest
     {
         List<Exception> errors = new ArrayList<>();
 
-        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf05.txt"), errors);
+        var results = cryptExtractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf05.txt"), errors);
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
@@ -1306,7 +1306,7 @@ public class TradeRepublicPDFExtractorTest
     {
         List<Exception> errors = new ArrayList<>();
 
-        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf06.txt"), errors);
+        var results = cryptExtractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf06.txt"), errors);
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
@@ -1340,7 +1340,7 @@ public class TradeRepublicPDFExtractorTest
     {
         List<Exception> errors = new ArrayList<>();
 
-        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf07.txt"), errors);
+        var results = cryptExtractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf07.txt"), errors);
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
@@ -1374,7 +1374,7 @@ public class TradeRepublicPDFExtractorTest
     {
         List<Exception> errors = new ArrayList<>();
 
-        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf08.txt"), errors);
+        var results = cryptExtractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf08.txt"), errors);
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
@@ -1408,7 +1408,7 @@ public class TradeRepublicPDFExtractorTest
     {
         List<Exception> errors = new ArrayList<>();
 
-        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf09.txt"), errors);
+        var results = cryptExtractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoKauf09.txt"), errors);
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
@@ -1442,7 +1442,7 @@ public class TradeRepublicPDFExtractorTest
     {
         List<Exception> errors = new ArrayList<>();
 
-        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoVerkauf01.txt"), errors);
+        var results = cryptExtractor.extract(PDFInputFile.loadTestCase(getClass(), "CryptoVerkauf01.txt"), errors);
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
@@ -8918,6 +8918,85 @@ public class TradeRepublicPDFExtractorTest
                         hasNote(null), //
                         hasAmount("EUR", 0.02), hasGrossValue("EUR", 0.03), //
                         hasTaxes("EUR", 0.01), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende30()
+    {
+        var extractor = new TradeRepublicPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende30.txt"), errors);
+
+        errors.forEach(Exception::printStackTrace);
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE0005AJA0P1"), hasWkn(null), hasTicker(null), //
+                        hasName("Global Quality Dividends USD (Dist)"), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-22T00:00"),
+                        // hasExDate("2025-05-18T00:00"), //
+                        hasShares(63.726878), //
+                        hasSource("Dividende30.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 1.58), //
+                        hasGrossValue("EUR", 1.94), //
+                        hasForexGrossValue("USD", 2.25), //
+                        hasTaxes("EUR", 0.36), //
+                        hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende30WithSecurityInEUR()
+    {
+        var security = new Security("Global Quality Dividends USD (Dist)", "EUR");
+        security.setIsin("IE0005AJA0P1");
+
+        var client = new Client();
+        client.addSecurity(security);
+
+        var extractor = new TradeRepublicPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende30.txt"), errors);
+
+        errors.forEach(Exception::printStackTrace);
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "EUR");
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-22T00:00"),
+                        // hasExDate("2025-05-18T00:00"), //
+                        hasShares(63.726878), //
+                        hasSource("Dividende30.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 1.58), //
+                        hasGrossValue("EUR", 1.94), //
+                        hasTaxes("EUR", 0.36), //
+                        hasFees("EUR", 0.00))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -10623,6 +10623,40 @@ public class TradeRepublicPDFExtractorTest
     }
 
     @Test
+    public void testSparplan12()
+    {
+        var extractor = new TradeRepublicPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Sparplan12.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00B4L5Y983"), hasWkn(null), hasTicker(null), //
+                        hasName("Core MSCI World USD (Acc)"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-02T00:00"), hasShares(3.226355), //
+                        hasSource("Sparplan12.txt"), //
+                        hasNote("Sparplan: bf7b-be8f | Ausführung: 69cc-a952"), //
+                        hasAmount("EUR", 400.00), hasGrossValue("EUR", 400.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
     public void testPianoDinvestimento01()
     {
         var extractor = new TradeRepublicPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -9000,6 +9000,85 @@ public class TradeRepublicPDFExtractorTest
     }
 
     @Test
+    public void testDividende31()
+    {
+        var extractor = new TradeRepublicPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende31.txt"), errors);
+
+        errors.forEach(Exception::printStackTrace);
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("GB0002374006"), hasWkn(null), hasTicker(null), //
+                        hasName("Diageo"), //
+                        hasCurrencyCode("GBP"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-06-04T00:00"),
+                        // hasExDate("2025-05-18T00:00"), //
+                        hasShares(7), //
+                        hasSource("Dividende31.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 0.90), //
+                        hasGrossValue("EUR", 1.21), //
+                        hasForexGrossValue("GBP", 1.05), //
+                        hasTaxes("EUR", 0.31), //
+                        hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende31WithSecurityInEUR()
+    {
+        var security = new Security("Diageo", "EUR");
+        security.setIsin("GB0002374006");
+
+        var client = new Client();
+        client.addSecurity(security);
+
+        var extractor = new TradeRepublicPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende31.txt"), errors);
+
+        errors.forEach(Exception::printStackTrace);
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "EUR");
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-06-04T00:00"),
+                        // hasExDate("2025-05-18T00:00"), //
+                        hasShares(7), //
+                        hasSource("Dividende31.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 0.90), //
+                        hasGrossValue("EUR", 1.21), //
+                        hasTaxes("EUR", 0.31), //
+                        hasFees("EUR", 0.00))));
+    }
+
+    @Test
     public void testDividend01()
     {
         var extractor = new TradeRepublicPDFExtractor(new Client());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
@@ -253,12 +253,8 @@ import name.abuchen.portfolio.model.TypedMap;
                     endLine = findBlockEnd(lines, startLine, endLine);
                     if (endLine == -1)
                         continue;
-                    spans.add(new LineSpan(startLine, endLine));
                 }
-                else
-                {
-                    spans.add(new LineSpan(startLine, endLine));
-                }
+                spans.add(new LineSpan(startLine, endLine));
             }
 
             return spans;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -1240,13 +1240,18 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
         addFeesSectionsTransaction(pdfTransaction, type);
     }
 
+    private static final String BLOCK_ENDSWITH = "^(Diese Abrechnung wird maschinell erstellt und daher nicht unterschrieben\\." //
+                    + "|Ce document est .*"
+                    + "|Questo regolamento viene creato automaticamente e quindi non . firmato\\."
+                    + "|This statement is generated automatically and therefore not signed\\.)$";
+
     private void addDividendTransaction()
     {
-        final var type = new DocumentType("(AUSSCH.TTUNG" //
-                        + "|DIVIDENDE" //
+        final var type = new DocumentType("(?i)(AUSSCH.TTUNG" //
+                        + "|(STORNIERUNG DER )?DIVIDENDE( EN ESP.CES)?" //
                         + "|REINVESTIERUNG" //
                         + "|STORNO DIVIDENDE" //
-                        + "|DIVIDEND" //
+                        + "|(CASH )?DIVIDEND" //
                         + "|DIVIDENDO" //
                         + "|DISTRIBUZIONE" //
                         + "|Distribution" //
@@ -1256,7 +1261,16 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         var pdfTransaction = new Transaction<AccountTransaction>();
 
-        var firstRelevantLine = new Block(); //
+        var firstRelevantLine = new Block("(?i)(AUSSCH.TTUNG" //
+                        + "|(STORNIERUNG DER )?DIVIDENDE( EN ESP.CES)?" //
+                        + "|REINVESTIERUNG" //
+                        + "|STORNO DIVIDENDE" //
+                        + "|(CASH )?DIVIDEND" //
+                        + "|DIVIDENDO" //
+                        + "|DISTRIBUZIONE" //
+                        + "|Distribution" //
+                        + "|KAPITALREDUKTION)", //
+                        BLOCK_ENDSWITH); //
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -1499,7 +1513,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // Dividendo con l'ex-tag 12.05.2023.
                                         // Distribuzione con l'ex-tag 17.08.2023. 
                                         // Ausschüttung mit dem Ex-Tag 12.09.2019.
-                                        // Dividende mit Ex-Datum22.05.2024.
+                                        // Dividende mit Ex-Datum 22.05.2024.
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("exDate") //
@@ -4492,7 +4506,8 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
     {
         var pdfTransaction = new Transaction<AccountTransaction>();
 
-        var firstRelevantLine = new Block("^TRADE REPUBLIC BANK GMBH.*$");
+        var firstRelevantLine = new Block("^TRADE REPUBLIC BANK GMBH.*$", //
+                        BLOCK_ENDSWITH);
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -5099,6 +5099,16 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
     }
 
     @Override
+    protected long asShares(String value)
+    {
+        if (value.matches("^\\d+\\.\\d{4,}$"))
+        {
+            return asShares(value, "en", "US"); //
+        }
+        return super.asShares(value);
+    }
+
+    @Override
     protected long asAmount(String value)
     {
         var language = "de";

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -1504,6 +1504,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // Dividendo con l'ex-tag 12.05.2023.
                                         // Distribuzione con l'ex-tag 17.08.2023. 
                                         // Ausschüttung mit dem Ex-Tag 12.09.2019.
+                                        // Dividende mit Ex-Datum22.05.2024.
                                         // Dividende mit Ex-Datum 22.05.2024.
                                         // @formatter:on
                                         section -> section //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -1261,16 +1261,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
         var pdfTransaction = new Transaction<AccountTransaction>();
 
-        var firstRelevantLine = new Block("(?i)(AUSSCH.TTUNG" //
-                        + "|(STORNIERUNG DER )?DIVIDENDE( EN ESP.CES)?" //
-                        + "|REINVESTIERUNG" //
-                        + "|STORNO DIVIDENDE" //
-                        + "|(CASH )?DIVIDEND" //
-                        + "|DIVIDENDO" //
-                        + "|DISTRIBUZIONE" //
-                        + "|Distribution" //
-                        + "|KAPITALREDUKTION)", //
-                        BLOCK_ENDSWITH); //
+        var firstRelevantLine = new Block("^TRADE REPUBLIC BANK GMBH.*$", BLOCK_ENDSWITH);
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -4506,8 +4497,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
     {
         var pdfTransaction = new Transaction<AccountTransaction>();
 
-        var firstRelevantLine = new Block("^TRADE REPUBLIC BANK GMBH.*$", //
-                        BLOCK_ENDSWITH);
+        var firstRelevantLine = new Block("^TRADE REPUBLIC BANK GMBH.*$", BLOCK_ENDSWITH);
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -5101,7 +5101,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asShares(String value)
     {
-        if (value.matches("^\\d+\\.\\d{4,}$"))
+        if (value.matches("^(0\\.\\d+|\\d+\\.\\d{1,2}|\\d+\\.\\d{4,})$"))
         {
             return asShares(value, "en", "US"); //
         }


### PR DESCRIPTION
added test for new type of PDF containing a trailing page with tax-informations leading to parse error. Fixed parse error

The dump has been provided at https://forum.portfolio-performance.info/t/pdf-import-von-trade-republic/5107/837?u=kimmerin