### PR TITLE
Add SWT feature patch for product build

### DIFF
--- a/docs/adr/0001-feature-patch-for-patched-swt.md
+++ b/docs/adr/0001-feature-patch-for-patched-swt.md
@@ -1,0 +1,46 @@
+# Ship patched SWT via a feature patch in the product build
+
+Portfolio Performance needs to ship patched macOS SWT fragments (TextKit-1 in-place-editor
+freeze fix, eclipse-platform/eclipse.platform.ui#1069) with a newer qualifier than the upstream
+Eclipse release, so that p2 can update already-installed users. The upstream p2 metadata pins the
+native SWT fragments **and** the `org.eclipse.swt` host bundle to exact versions (both the
+`org.eclipse.e4.rcp` feature and the `org.eclipse.swt` host IU require the fragments at
+`[v,v]`), which prevents re-qualified fragments from resolving cleanly.
+
+**Decision**
+
+Keep consuming the upstream `org.eclipse.e4.rcp` feature and apply an Eclipse **feature patch**
+(`org.eclipse.swt.patch`, in `features/`) that redirects e4.rcp's exact requirements on
+the SWT host + all platform fragments to re-qualified bundles. The bundles themselves (host + all
+9 platform fragments, rebuilt at the bumped qualifier from committed binaries) are published by a
+separate update-site in the SWT fork (`org.eclipse.swt.portfolio.bundles`) and consumed via the
+target platform.
+
+**Considered Options**
+
+- *Own a copy of the RCP feature*: mirroring upstream RCP content would allow the product build to
+  relax the SWT requirements directly, but the copied feature would have to stay synchronized with
+  upstream on every platform upgrade. It also would not address exact requirements declared by the
+  `org.eclipse.swt` host IU itself.
+- *Assemble the feature patch into an update-site in the SWT fork*: not possible — Tycho cannot
+  resolve a bare feature patch in a standalone p2 repository, because the patch's requirement on
+  the patched feature is `greedy=false` and nothing pulls `org.eclipse.e4.rcp.feature.group` in as
+  a root (eclipse-tycho/tycho#893; the old `deployableFeature` workaround was removed in Tycho 5).
+- *Apply the feature patch in the product build* (chosen): the product lists `org.eclipse.e4.rcp`
+  as a root, so the patch resolves naturally there. This is the idiomatic place for a feature
+  patch and keeps the Portfolio-owned content to a single small patch feature.
+
+**Consequences**
+
+- Only one line couples the patch to the platform release: the `org.eclipse.e4.rcp` version in
+  `features/org.eclipse.swt.patch/feature.xml`. Bump it on each platform upgrade.
+- The SWT fork must republish the host + **all** platform fragments at the bumped qualifier (the
+  host exact-pins every fragment at its own version), built with all target environments. Only the
+  cocoa fragment carries the code change; the rest are upstream content re-qualified.
+- The SWT fork update-site is added as an **available-but-unrooted** p2 repository in
+  `portfolio-app/pom.xml` (`<repositories>`), **not** as a target-definition root. This is
+  essential: rooting both upstream SWT and the patched SWT fork bundles in the planner-mode target
+  would be a singleton conflict (two `org.eclipse.swt` bundles). As an unrooted pom repository the
+  patched bundles are merely available, the target stays planner-consistent on the upstream SWT
+  (with its transitive deps intact), and the feature patch selects the patched SWT bundles during
+  the product build. Materialized products should contain only the patched SWT host and fragments.

--- a/features/org.eclipse.swt.patch/build.properties
+++ b/features/org.eclipse.swt.patch/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/features/org.eclipse.swt.patch/feature.xml
+++ b/features/org.eclipse.swt.patch/feature.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.swt.patch"
+      label="SWT Patch for Portfolio Performance"
+      version="0.84.0"
+      provider-name="Portfolio Performance">
+
+   <!--
+      Feature patch: overrides org.eclipse.e4.rcp's exact-version requirements on the
+      SWT host bundle and all platform fragments, redirecting them to the re-qualified
+      artifacts published by the SWT fork update-site (org.eclipse.swt.portfolio.bundles).
+      The patched fix lives in the cocoa fragment; the host and the non-cocoa fragments are
+      upstream content republished under the bumped qualifier so that the host's own exact
+      pins on the fragments still resolve on every platform. The plugins are listed at
+      version 0.0.0 so p2 binds them to the highest available version (the fork bundles).
+
+      This patch lives here (not in the SWT fork) because a feature patch only resolves
+      where the patched feature is present as a root - i.e. this product build, where
+      org.eclipse.e4.rcp is a product feature. Tycho cannot assemble a bare feature patch
+      into a standalone p2 repository (eclipse-tycho/tycho issue 893).
+
+      The org.eclipse.e4.rcp version below must be bumped on each platform upgrade.
+   -->
+   <requires>
+      <import feature="org.eclipse.e4.rcp" version="4.38.0.v20251126-0427" patch="true"/>
+   </requires>
+
+   <plugin
+         id="org.eclipse.swt"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.swt.win32.win32.x86_64"
+         os="win32"
+         ws="win32"
+         arch="x86_64"
+         fragment="true"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.swt.win32.win32.aarch64"
+         os="win32"
+         ws="win32"
+         arch="aarch64"
+         fragment="true"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.swt.gtk.linux.x86_64"
+         os="linux"
+         ws="gtk"
+         arch="x86_64"
+         fragment="true"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.swt.gtk.linux.aarch64"
+         os="linux"
+         ws="gtk"
+         arch="aarch64"
+         fragment="true"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.swt.gtk.linux.ppc64le"
+         os="linux"
+         ws="gtk"
+         arch="ppc64le"
+         fragment="true"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.swt.gtk.linux.riscv64"
+         os="linux"
+         ws="gtk"
+         arch="riscv64"
+         fragment="true"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.swt.cocoa.macosx.x86_64"
+         os="macosx"
+         ws="cocoa"
+         arch="x86_64"
+         fragment="true"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.swt.cocoa.macosx.aarch64"
+         os="macosx"
+         ws="cocoa"
+         arch="aarch64"
+         fragment="true"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/features/org.eclipse.swt.patch/pom.xml
+++ b/features/org.eclipse.swt.patch/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>name.abuchen.portfolio</groupId>
+        <artifactId>portfolio-app</artifactId>
+        <version>0.84.0</version>
+        <relativePath>../../portfolio-app</relativePath>
+    </parent>
+
+    <artifactId>org.eclipse.swt.patch</artifactId>
+    <packaging>eclipse-feature</packaging>
+
+	<properties>
+		<sonar.skip>true</sonar.skip>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>enforce-versions</id>
+						<phase>none</phase>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jarsigner-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/portfolio-app/pom.xml
+++ b/portfolio-app/pom.xml
@@ -41,6 +41,7 @@
 		<module>../name.abuchen.portfolio.ui</module>
 		<module>../name.abuchen.portfolio.ui.tests</module>
 		<module>../name.abuchen.portfolio.feature</module>
+		<module>../features/org.eclipse.swt.patch</module>
 		<module>../name.abuchen.portfolio.bootstrap</module>
 		<module>../portfolio-build-tools</module>
 		<module>../portfolio-build-tools-check</module>
@@ -51,6 +52,17 @@
 			<id>portfolio-jre</id>
 			<layout>p2</layout>
 			<url>http://portfolio-performance.github.io/bundled-jre/21.0.5</url>
+		</repository>
+		<!-- Re-qualified (patched) SWT bundles from the SWT fork update-site. Added as an
+		     available-but-unrooted p2 repository (not a target-definition root) so the
+		     patched org.eclipse.swt host + fragments coexist with the upstream SWT pulled
+		     by org.eclipse.e4.rcp, without a target-platform singleton conflict. The
+		     org.eclipse.swt.patch feature redirects e4.rcp's exact SWT requirements to
+		     these bundles in the product build. -->
+		<repository>
+			<id>swt-portfolio-fork</id>
+			<layout>p2</layout>
+			<url>https://portfolio-performance.github.io/eclipse.platform.swt-fork-update-site/R4_38/</url>
 		</repository>
 	</repositories>
 

--- a/portfolio-product/name.abuchen.portfolio.distro.product
+++ b/portfolio-product/name.abuchen.portfolio.distro.product
@@ -40,6 +40,7 @@
    <features>
       <feature id="name.abuchen.portfolio.feature"/>
       <feature id="org.eclipse.e4.rcp"/>
+      <feature id="org.eclipse.swt.patch"/>
       <feature id="org.eclipse.equinox.p2.core.feature"/>
       <feature id="org.eclipse.babel.nls_eclipse_de"/>
       <feature id="org.eclipse.babel.nls_eclipse_es"/>

--- a/portfolio-product/name.abuchen.portfolio.product
+++ b/portfolio-product/name.abuchen.portfolio.product
@@ -40,6 +40,7 @@
    <features>
       <feature id="name.abuchen.portfolio.feature"/>
       <feature id="org.eclipse.e4.rcp"/>
+      <feature id="org.eclipse.swt.patch"/>
       <feature id="org.eclipse.equinox.p2.core.feature"/>
       <feature id="org.eclipse.babel.nls_eclipse_de"/>
       <feature id="org.eclipse.babel.nls_eclipse_es"/>


### PR DESCRIPTION
Apply an Eclipse feature patch in the product build so the upstream e4.rcp feature can resolve to the re-qualified SWT fork bundles.

Keep the SWT fork repository available but unrooted to avoid target-platform singleton conflicts, and document the maintenance tradeoffs in the ADR.

Issue: #5705