### PR TITLE
Modify Credit Suisse AG PDF-Importer to support exDate

### DIFF
--- a/.claude/rules/pdfextractors.md
+++ b/.claude/rules/pdfextractors.md
@@ -27,6 +27,28 @@ PDF importers extract transactions from bank and broker PDF statements.
 Beside general good practices for regular expressions, keep in mind:
 * all special characters in the PDF document (`äöüÄÖÜß` as well as e.g. circumflex or similar) should be matched by a `.` (dot) because the PDF to text conversion can create different results
 * the special characters `$^{[(|)]}*+?\` in the PDF document are to be escaped
+* `.match(" ... ")` — always use anchors `^...$`
+* `.find(" ... ")` — do NOT add anchors (they are added automatically)
+
+**Standard patterns for common values:**
+
+| Value | Example | Pattern |
+| :--- | :--- | :--- |
+| Date | 01.01.1970 | `[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}` |
+| Date | 1.1.1970 | `[\\d]{1,2}\\.[\\d]{1,2}\\.[\\d]{4}` |
+| Time | 12:01 | `[\\d]{2}\\:[\\d]{2}` |
+| ISIN | IE00BKM4GZ66 | `[A-Z]{2}[A-Z0-9]{9}[0-9]` |
+| WKN | A111X9 | `[A-Z0-9]{6}` |
+| Valoren | 1098758 | `[A-Z0-9]{5,9}` |
+| SEDOL | B5B74S0 | `[A-Z0-9]{7}` |
+| CUSIP | 11135F101 | `[A-Z0-9]{9}` |
+| TickerSymbol | AAPL, BRK.B | `[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?` |
+| Crypto Ticker | BTC, ETH-BTC | `[A-Z0-9]{1,5}(?:[\\-\\/][A-Z0-9]{1,5})?` |
+| Amount | 751,68 | `[\\.,\\d]+` or `[\\.\\d]+,[\\d]{2}` |
+| Amount | 74'120.00 | `[\\.'\\d]+` |
+| Amount | 20 120.00 | `[\\.\\d\\s]+` |
+| Currency | EUR | `[A-Z]{3}` |
+| Currency Symbol | € or $ | `\\p{Sc}` |
 
 ## Conventions
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/creditsuisseag/CreditSuisseAGExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/creditsuisseag/CreditSuisseAGExtractorTest.java
@@ -1,35 +1,44 @@
 package name.abuchen.portfolio.datatransfer.pdf.creditsuisseag;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.feeRefund;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasExDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasIsin;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasName;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countItemsWithFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSkippedItems;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
-import static org.junit.Assert.assertNull;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
 
-import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
-import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
-import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
 import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
 import name.abuchen.portfolio.datatransfer.pdf.CreditSuisseAGPDFExtractor;
 import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
-import name.abuchen.portfolio.model.AccountTransaction;
-import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
-import name.abuchen.portfolio.model.PortfolioTransaction;
-import name.abuchen.portfolio.model.Transaction.Unit;
-import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.money.Values;
 
 @SuppressWarnings("nls")
 public class CreditSuisseAGExtractorTest
@@ -54,50 +63,26 @@ public class CreditSuisseAGExtractorTest
         new AssertImportActions().check(results, "USD");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("US46284V1017"));
-        assertThat(security.getWkn(), is("26754105"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("Registered Shs Iron Mountain Inc"));
-        assertThat(security.getCurrencyCode(), is("USD"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("US46284V1017"), hasWkn("26754105"), hasTicker(null), //
+                        hasName("Registered Shs Iron Mountain Inc"), //
+                        hasCurrencyCode("USD"))));
 
         // check buy sell transaction
-        var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2020-06-08T18:32:46")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(900)));
-        assertThat(entry.getSource(), is("Kauf01.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("USD", Values.Amount.factorize(27776.51))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("USD", Values.Amount.factorize(27272.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("USD", Values.Amount.factorize(40.91))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("USD", Values.Amount.factorize(463.60))));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2020-06-08T18:32:46"), hasShares(900.00), //
+                        hasSource("Kauf01.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 27776.51), hasGrossValue("USD", 27272.00), //
+                        hasTaxes("USD", 40.91), hasFees("USD", 463.60))));
 
         // check fee refund transaction
-        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES_REFUND));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-06-08T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(900)));
-        assertThat(transaction.getSource(), is("Kauf01.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("USD", Values.Amount.factorize(41.81))));
-        assertThat(transaction.getGrossValue(), is(Money.of("USD", Values.Amount.factorize(41.81))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("USD", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("USD", Values.Amount.factorize(0.00))));
+        assertThat(results, hasItem(feeRefund( //
+                        hasDate("2020-06-08T00:00"), hasShares(900.00), //
+                        hasSource("Kauf01.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 41.81), hasGrossValue("USD", 41.81), //
+                        hasTaxes("USD", 0.00), hasFees("USD", 0.00))));
     }
 
     @Test
@@ -120,50 +105,26 @@ public class CreditSuisseAGExtractorTest
         new AssertImportActions().check(results, "USD");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("XS1055787680"));
-        assertThat(security.getWkn(), is("24160639"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("6.25 % Fixed Rate Notes Norddeutsche"));
-        assertThat(security.getCurrencyCode(), is("USD"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("XS1055787680"), hasWkn("24160639"), hasTicker(null), //
+                        hasName("6.25 % Fixed Rate Notes Norddeutsche"), //
+                        hasCurrencyCode("USD"))));
 
         // check buy sell transaction
-        var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2019-09-16T09:31:35")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(2000)));
-        assertThat(entry.getSource(), is("Kauf02.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("USD", Values.Amount.factorize(190182.49))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("USD", Values.Amount.factorize(188486.11))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("USD", Values.Amount.factorize(282.73))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("USD", Values.Amount.factorize(1413.65))));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2019-09-16T09:31:35"), hasShares(2000.00), //
+                        hasSource("Kauf02.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 190182.49), hasGrossValue("USD", 188486.11), //
+                        hasTaxes("USD", 282.73), hasFees("USD", 1413.65))));
 
         // check fee refund transaction
-        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES_REFUND));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2019-09-16T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(2000)));
-        assertThat(transaction.getSource(), is("Kauf02.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("USD", Values.Amount.factorize(40.48))));
-        assertThat(transaction.getGrossValue(), is(Money.of("USD", Values.Amount.factorize(40.48))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("USD", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("USD", Values.Amount.factorize(0.00))));
+        assertThat(results, hasItem(feeRefund( //
+                        hasDate("2019-09-16T00:00"), hasShares(2000.00), //
+                        hasSource("Kauf02.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 40.48), hasGrossValue("USD", 40.48), //
+                        hasTaxes("USD", 0.00), hasFees("USD", 0.00))));
     }
 
     @Test
@@ -186,34 +147,18 @@ public class CreditSuisseAGExtractorTest
         new AssertImportActions().check(results, "EUR");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("GB00B03MLX29"));
-        assertThat(security.getWkn(), is("1987674"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("Akt. -A- Royal Dutch Shell PLC"));
-        assertThat(security.getCurrencyCode(), is("EUR"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("GB00B03MLX29"), hasWkn("1987674"), hasTicker(null), //
+                        hasName("Akt. -A- Royal Dutch Shell PLC"), //
+                        hasCurrencyCode("EUR"))));
 
         // check buy sell transaction
-        var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2018-04-30T17:26:53")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1000)));
-        assertThat(entry.getSource(), is("Verkauf01.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(28744.30))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(29020.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(43.53))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(232.17))));
+        assertThat(results, hasItem(sale( //
+                        hasDate("2018-04-30T17:26:53"), hasShares(1000.00), //
+                        hasSource("Verkauf01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 28744.30), hasGrossValue("EUR", 29020.00), //
+                        hasTaxes("EUR", 43.53), hasFees("EUR", 232.17))));
     }
 
     @Test
@@ -236,50 +181,26 @@ public class CreditSuisseAGExtractorTest
         new AssertImportActions().check(results, "USD");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("US88163VAD10"));
-        assertThat(security.getWkn(), is("2429251"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("6.15 % Notes Teva Pharmaceutical Finance"));
-        assertThat(security.getCurrencyCode(), is("USD"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("US88163VAD10"), hasWkn("2429251"), hasTicker(null), //
+                        hasName("6.15 % Notes Teva Pharmaceutical Finance"), //
+                        hasCurrencyCode("USD"))));
 
         // check buy sell transaction
-        var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
-
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-02-22T09:00:55")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(1000)));
-        assertThat(entry.getSource(), is("Verkauf02.txt"));
-        assertNull(entry.getNote());
-
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("USD", Values.Amount.factorize(111718.52))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("USD", Values.Amount.factorize(112732.30))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("USD", Values.Amount.factorize(168.96))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("USD", Values.Amount.factorize(844.82))));
+        assertThat(results, hasItem(sale( //
+                        hasDate("2021-02-22T09:00:55"), hasShares(1000.00), //
+                        hasSource("Verkauf02.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 111718.52), hasGrossValue("USD", 112732.30), //
+                        hasTaxes("USD", 168.96), hasFees("USD", 844.82))));
 
         // check fee refund transaction
-        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.FEES_REFUND));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-02-22T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(1000)));
-        assertThat(transaction.getSource(), is("Verkauf02.txt"));
-        assertNull(transaction.getNote());
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("USD", Values.Amount.factorize(44.69))));
-        assertThat(transaction.getGrossValue(), is(Money.of("USD", Values.Amount.factorize(44.69))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("USD", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("USD", Values.Amount.factorize(0.0))));
+        assertThat(results, hasItem(feeRefund( //
+                        hasDate("2021-02-22T00:00"), hasShares(1000.00), //
+                        hasSource("Verkauf02.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 44.69), hasGrossValue("USD", 44.69), //
+                        hasTaxes("USD", 0.00), hasFees("USD", 0.00))));
     }
 
     @Test
@@ -302,29 +223,19 @@ public class CreditSuisseAGExtractorTest
         new AssertImportActions().check(results, "USD");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("XS1055787680"));
-        assertThat(security.getWkn(), is("24160639"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("6.25 % FIXED RATE NOTES NORDDEUTSCHE"));
-        assertThat(security.getCurrencyCode(), is("USD"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("XS1055787680"), hasWkn("24160639"), hasTicker(null), //
+                        hasName("6.25 % FIXED RATE NOTES NORDDEUTSCHE"), //
+                        hasCurrencyCode("USD"))));
 
         // check dividends transaction
-        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-04-12T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(2000)));
-        assertThat(transaction.getSource(), is("Dividende01.txt"));
-        assertThat(transaction.getNote(), is("Semesterzinsen"));
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("USD", Values.Amount.factorize(6250.00))));
-        assertThat(transaction.getGrossValue(), is(Money.of("USD", Values.Amount.factorize(6250.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("USD", Values.Amount.factorize(0.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("USD", Values.Amount.factorize(0.00))));
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2021-04-12T00:00"), hasExDate(null), //
+                        hasShares(2000.00), //
+                        hasSource("Dividende01.txt"), //
+                        hasNote("Semesterzinsen"), //
+                        hasAmount("USD", 6250.00), hasGrossValue("USD", 6250.00), //
+                        hasTaxes("USD", 0.00), hasFees("USD", 0.00))));
     }
 
     @Test
@@ -347,28 +258,18 @@ public class CreditSuisseAGExtractorTest
         new AssertImportActions().check(results, "USD");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("US46284V1017"));
-        assertThat(security.getWkn(), is("26754105"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("REGISTERED SHS IRON MOUNTAIN INC"));
-        assertThat(security.getCurrencyCode(), is("USD"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("US46284V1017"), hasWkn("26754105"), hasTicker(null), //
+                        hasName("REGISTERED SHS IRON MOUNTAIN INC"), //
+                        hasCurrencyCode("USD"))));
 
         // check dividends transaction
-        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2021-01-06T00:00")));
-        assertThat(transaction.getShares(), is(Values.Share.factorize(900)));
-        assertThat(transaction.getSource(), is("Dividende02.txt"));
-        assertThat(transaction.getNote(), is("Quartalsdividende"));
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("USD", Values.Amount.factorize(389.65))));
-        assertThat(transaction.getGrossValue(), is(Money.of("USD", Values.Amount.factorize(556.65))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX), is(Money.of("USD", Values.Amount.factorize(167.00))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("USD", Values.Amount.factorize(0.00))));
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2021-01-06T00:00"), hasExDate("2020-12-14T00:00"), //
+                        hasShares(900.00), //
+                        hasSource("Dividende02.txt"), //
+                        hasNote("Quartalsdividende"), //
+                        hasAmount("USD", 389.65), hasGrossValue("USD", 556.65), //
+                        hasTaxes("USD", 167.00), hasFees("USD", 0.00))));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CreditSuisseAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/CreditSuisseAGPDFExtractor.java
@@ -33,7 +33,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
         addBankIdentifier("CREDIT SUISSE");
 
         addBuySellTransaction();
-        addDividendeTransaction();
+        addDividendTransaction();
     }
 
     @Override
@@ -44,12 +44,12 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        DocumentType type = new DocumentType("(Ihr Kauf|Ihr Verkauf)");
+        final var type = new DocumentType("(Ihr Kauf|Ihr Verkauf)");
         this.addDocumentTyp(type);
 
-        Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
+        var pdfTransaction = new Transaction<BuySellEntry>();
 
-        Block firstRelevantLine = new Block("^Ihr (Kauf|Verkauf) .*$");
+        var firstRelevantLine = new Block("^Ihr (Kauf|Verkauf) .*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -57,10 +57,12 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
 
                         .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
-                        // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
                         .match("^Ihr (?<type>(Kauf|Verkauf)) .*$") //
                         .assign((t, v) -> {
+                            // @formatter:off
+                            // Is type --> "Verkauf" change from BUY to SELL
+                            // @formatter:on
                             if ("Verkauf".equals(v.get("type")))
                                 t.setType(PortfolioTransaction.Type.SELL);
                         })
@@ -73,9 +75,9 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "wkn", "isin", "currency") //
-                                                        .match("^[\\.,\\d]+ (?<name>.*) [\\w]{3} [\\.,\\d]+$") //
+                                                        .match("^[\\.,\\d]+ (?<name>.*) [A-Z]{3} [\\.,\\d]+$") //
                                                         .match("^Valor (?<wkn>[A-Z0-9]{5,9}),.* ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
-                                                        .match("^zum Kurs von (?<currency>[\\w]{3}) [\\.,\\d]+$") //
+                                                        .match("^zum Kurs von (?<currency>[A-Z]{3}) [\\.,\\d]+$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
                                         // USD 200,000 6.25 % Fixed Rate Notes Norddeutsche
@@ -86,9 +88,9 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "wkn", "isin", "currency") //
-                                                        .match("^[\\w]{3} [\\.,\\d]+ (?<name>.*)$") //
+                                                        .match("^[A-Z]{3} [\\.,\\d]+ (?<name>.*)$") //
                                                         .match("^Valor (?<wkn>[A-Z0-9]{5,9}),.* ISIN (?<isin>[\\w]{12})$") //
-                                                        .match("^Kurswert (?<currency>[\\w]{3}) [\\.,\\d]+$") //
+                                                        .match("^Kurswert (?<currency>[A-Z]{3}) [\\.,\\d]+$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
 
                         .oneOf( //
@@ -97,12 +99,12 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("shares") //
-                                                        .match("^[\\w]{3} (?<shares>[\\.,\\d]+) [\\.,\\d]+ %.*$") //
+                                                        .match("^[A-Z]{3} (?<shares>[\\.,\\d]+) [\\.,\\d]+ %.*$") //
                                                         .assign((t, v) -> {
                                                             // @formatter:off
                                                             // Percentage quotation, workaround for bonds
                                                             // @formatter:on
-                                                            BigDecimal shares = asExchangeRate(v.get("shares"));
+                                                            var shares = asExchangeRate(v.get("shares"));
                                                             t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
                                                         }),
                                         // @formatter:off
@@ -110,7 +112,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("shares") //
-                                                        .match("^(?<shares>[\\.,\\d]+) (?<name>.*) [\\w]{3} [\\.,\\d]+$")
+                                                        .match("^(?<shares>[\\.,\\d]+) (?<name>.*) [A-Z]{3} [\\.,\\d]+$")
                                                         .assign((t, v) -> t.setShares(asShares(v.get("shares")))))
 
                         // @formatter:off
@@ -139,7 +141,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                         // Gutschrift EUR 28,744.30
                         // @formatter:on
                         .section("currency", "amount") //
-                        .match("^(Belastung|Gutschrift) (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$") //
+                        .match("^(Belastung|Gutschrift) (?<currency>[A-Z]{3}) (?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -156,7 +158,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                         // Internet-Vergünstigung USD 44.69
                         // @formatter:on
                         .section("feeRefund", "currency").optional() //
-                        .match("^Internet\\-Verg.nstigung (?<currency>[\\w]{3}) (\\- )?(?<feeRefund>[\\.,\\d]+)$") //
+                        .match("^Internet\\-Verg.nstigung (?<currency>[A-Z]{3}) (\\- )?(?<feeRefund>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             t.setAmount(t.getPortfolioTransaction().getAmount() + asAmount(v.get("feeRefund")));
                         })
@@ -168,14 +170,14 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
         addFeeReturnBlock(type);
     }
 
-    private void addDividendeTransaction()
+    private void addDividendTransaction()
     {
-        DocumentType type = new DocumentType("Ertragsabrechnung");
+        final var type = new DocumentType("Ertragsabrechnung");
         this.addDocumentTyp(type);
 
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
-        
-        Block firstRelevantLine = new Block("^Ertragsabrechnung .*$");
+        var pdfTransaction = new Transaction<AccountTransaction>();
+
+        var firstRelevantLine = new Block("^Ertragsabrechnung .*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -193,7 +195,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                                                         .attributes("name", "wkn", "isin", "currency") //
                                                         .match("^[\\.,\\d]+ (?<name>.*)$") //
                                                         .match("^Valor (?<wkn>[A-Z0-9]{5,9}),.* ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
-                                                        .match("^Dividende (?<currency>[\\w]{3}) [\\.,\\d]+$") //
+                                                        .match("^Dividende (?<currency>[A-Z]{3}) [\\.,\\d]+$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
                                         // USD 200,000 6.25 % FIXED RATE NOTES NORDDEUTSCHE
@@ -203,7 +205,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("currency", "name", "wkn", "isin") //
-                                                        .match("^(?<currency>[\\w]{3}) [\\.,\\d]+ (?<name>.*)$") //
+                                                        .match("^(?<currency>[A-Z]{3}) [\\.,\\d]+ (?<name>.*)$") //
                                                         .match("^Valor (?<wkn>[A-Z0-9]{5,9}),.* ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
 
@@ -213,12 +215,12 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("shares") //
-                                                        .match("^[\\w]{3} (?<shares>[\\.,\\d]+) [\\.,\\d]+ %.*$") //
+                                                        .match("^[A-Z]{3} (?<shares>[\\.,\\d]+) [\\.,\\d]+ %.*$") //
                                                         .assign((t, v) -> {
                                                             // @formatter:off
                                                             // Percentage quotation, workaround for bonds
                                                             // @formatter:on
-                                                            BigDecimal shares = asExchangeRate(v.get("shares"));
+                                                            var shares = asExchangeRate(v.get("shares"));
                                                             t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
                                                         }),
                                         // @formatter:off
@@ -236,11 +238,20 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                         .match("^Valuta (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$") //
                         .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
+                        .optionalOneOf( //
+                                        // @formatter:off
+                                        // Ex-Datum 14.12.2020
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("exDate") //
+                                                        .match("^Ex\\-Datum (?<exDate>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$") //
+                                                        .assign((t, v) -> t.setExDate(asDate(v.get("exDate")))))
+
                         // @formatter:off
                         // Bruttoertrag USD 6,250.00
                         // @formatter:on
                         .section("currency", "amount") //
-                        .match("^Gutschrift (?<currency>[\\w]{3}) (?<amount>[\\.,\\d]+)$") //
+                        .match("^Gutschrift (?<currency>[A-Z]{3}) (?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -262,7 +273,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
 
     private void addFeeReturnBlock(DocumentType type)
     {
-        Block block = new Block("^Ihr (Kauf|Verkauf) .*$");
+        var block = new Block("^Ihr (Kauf|Verkauf) .*$");
         type.addBlock(block);
         block.set(new Transaction<AccountTransaction>()
 
@@ -276,9 +287,9 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "wkn", "isin", "currency") //
-                                                        .match("^[\\.,\\d]+ (?<name>.*) [\\w]{3} [\\.,\\d]+$") //
+                                                        .match("^[\\.,\\d]+ (?<name>.*) [A-Z]{3} [\\.,\\d]+$") //
                                                         .match("^Valor (?<wkn>[A-Z0-9]{5,9}),.* ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
-                                                        .match("^zum Kurs von (?<currency>[\\w]{3}) [\\.,\\d]+$") //
+                                                        .match("^zum Kurs von (?<currency>[A-Z]{3}) [\\.,\\d]+$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
                                         // USD 200,000 6.25 % Fixed Rate Notes Norddeutsche
@@ -289,9 +300,9 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "wkn", "isin", "currency") //
-                                                        .match("^[\\w]{3} [\\.,\\d]+ (?<name>.*)$") //
+                                                        .match("^[A-Z]{3} [\\.,\\d]+ (?<name>.*)$") //
                                                         .match("^Valor (?<wkn>[A-Z0-9]{5,9}),.* ISIN (?<isin>[\\w]{12})$") //
-                                                        .match("^Kurswert (?<currency>[\\w]{3}) [\\.,\\d]+$") //
+                                                        .match("^Kurswert (?<currency>[A-Z]{3}) [\\.,\\d]+$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
 
                         .oneOf( //
@@ -300,12 +311,12 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("shares") //
-                                                        .match("^[\\w]{3} (?<shares>[\\.,\\d]+) [\\.,\\d]+ % (?<name>.*)$") //
+                                                        .match("^[A-Z]{3} (?<shares>[\\.,\\d]+) [\\.,\\d]+ % (?<name>.*)$") //
                                                         .assign((t, v) -> {
                                                             // @formatter:off
                                                             // Percentage quotation, workaround for bonds
                                                             // @formatter:on
-                                                            BigDecimal shares = asExchangeRate(v.get("shares"));
+                                                            var shares = asExchangeRate(v.get("shares"));
                                                             t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
                                                         }),
                                         // @formatter:off
@@ -313,7 +324,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("shares") //
-                                                        .match("^(?<shares>[\\.,\\d]+) (?<name>.*) [\\w]{3} [\\.,\\d]+$")
+                                                        .match("^(?<shares>[\\.,\\d]+) (?<name>.*) [A-Z]{3} [\\.,\\d]+$")
                                                         .assign((t, v) -> t.setShares(asShares(v.get("shares")))))
 
                         // @formatter:off
@@ -328,7 +339,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                         // Internet-Vergünstigung USD 44.69
                         // @formatter:on
                         .section("currency", "amount").optional() //
-                        .match("^Internet-Verg.nstigung (?<currency>[\\w]{3}) (-\\ )?(?<amount>[\\.,\\d]+)$") //
+                        .match("^Internet-Verg.nstigung (?<currency>[A-Z]{3}) (-\\ )?(?<amount>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -337,7 +348,7 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
                         .wrap(t -> {
                             if (t.getCurrencyCode() != null && t.getAmount() != 0)
                                 return new TransactionItem(t);
-                            
+
                             // The addFeeReturnBlock optionally creates a fee
                             // refund in case the customer was granted a fee
                             // reduction ("Internet-Vergünstigung"). We do not
@@ -350,39 +361,39 @@ public class CreditSuisseAGPDFExtractor extends AbstractPDFExtractor
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
     {
         transaction //
-        
+
                         // @formatter:off
                         // Eidgenössische Umsatzabgabe USD 40.91
                         // @formatter:on
                         .section("currency", "tax").optional() //
-                        .match("^Eidgen.ssische Umsatzabgabe (?<currency>[\\w]{3}) (\\- )?(?<tax>[\\.,\\d]+)$") //
+                        .match("^Eidgen.ssische Umsatzabgabe (?<currency>[A-Z]{3}) (\\- )?(?<tax>[\\.,\\d]+)$") //
                         .assign((t, v) -> processTaxEntries(t, v, type))
 
                         // @formatter:off
                         // Quellensteuer USD - 167.00
                         // @formatter:on
                         .section("currency", "withHoldingTax").optional() //
-                        .match("^Quellensteuer (?<currency>[\\w]{3}) (\\- )?(?<withHoldingTax>[\\.,\\d]+)$") //
+                        .match("^Quellensteuer (?<currency>[A-Z]{3}) (\\- )?(?<withHoldingTax>[\\.,\\d]+)$") //
                         .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type));
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
     {
         transaction //
-        
+
                         // @formatter:off
                         // Kommission Schweiz/Ausland USD 463.60
                         // Kommission Schweiz USD 1,413.65
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("^Kommission .* (?<currency>[\\w]{3}) (\\- )?(?<fee>[\\.,\\d]+)$") //
+                        .match("^Kommission .* (?<currency>[A-Z]{3}) (\\- )?(?<fee>[\\.,\\d]+)$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // Kosten und Abgaben Ausland USD 2.00
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("^Kosten und Abgaben (?<currency>[\\w]{3}) (\\- )?(?<fee>[\\.,\\d]+)$") //
+                        .match("^Kosten und Abgaben (?<currency>[A-Z]{3}) (\\- )?(?<fee>[\\.,\\d]+)$") //
                         .assign((t, v) -> processFeeEntries(t, v, type));
     }
 


### PR DESCRIPTION
- Rename addDividendeTransaction() to addDividendTransaction() to follow English naming convention
- Replace explicit type declarations with final var / var for DocumentType, Transaction<T>, Block, and BigDecimal local variables throughout
- Move type-switch comment // Is type --> "Verkauf" change from BUY to SELL inside the assign() lambda and wrap with @formatter:off/on
- Replace [\\w]{3} with [A-Z]{3} for all currency regex patterns
- Convert all 6 test methods from legacy stream/cast format (SecurityItem.class::isInstance, BuySellEntryItem, TransactionItem, Money.of, Values.Amount.factorize, LocalDateTime.parse, assertNull) to modern Hamcrest matchers (security(...), purchase(...), sale(...), dividend(...), feeRefund(...))
- Add missing hasExDate(...) to both dividend assertions (null for Dividende01, 2020-12-14T00:00 for Dividende02)
- Remove unused imports