### PR TITLE
Update WirBankPDFExtractor Dividendenauschüttung Nomenklatur 2026 Deutsch

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/Steuerrueckerstattung08.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/Steuerrueckerstattung08.txt
@@ -1,0 +1,29 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Terzo Vorsorgestiftung der WIR Bank
+Auberg 1
+4002 Basel
+E-Mail info@viac.ch
+Telefon 0800 80 40 40
+www.viac.ch
+Vertrag 0.000.000.000
+Portfolio 0.000.000.000.00
+Herr
+Max Musterman
+Teststrasse 1
+1234 Test
+Basel, 29.05.2026
+Dividendenausschüttung
+Wir haben für Sie folgende Ausschüttung verbucht:
+Ausschüttungsart: Rückerstattung Verrechnungssteuer
+1.034 Anteile UBS Emerging Markets
+ISIN: CH1390275134
+Ausschüttung: CHF 16.80
+Betrag CHF 17.36
+Gutgeschriebener Betrag: Valuta 29.05.2026 CHF 17.36
+S. E. & O.
+Freundliche Grüsse
+Terzo Vorsorgestiftung
+Anzeige ohne Unterschrift

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/WirBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/WirBankPDFExtractorTest.java
@@ -2656,6 +2656,40 @@ public class WirBankPDFExtractorTest
                         hasAmount("CHF", 0.05), hasGrossValue("CHF", 0.05), //
                         hasTaxes("CHF", 0.00), hasFees("CHF", 0.00))));
     }
+    
+    @Test
+    public void testSteuerrueckerstattung08()
+    {
+        var extractor = new WirBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Steuerrueckerstattung08.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("CH1390275134"), hasWkn(null), hasTicker(null), //
+                        hasName("UBS Emerging Markets"), //
+                        hasCurrencyCode("CHF"))));
+
+        // check tax refund transaction
+        assertThat(results, hasItem(taxRefund( //
+                        hasDate("2026-05-29T00:00"), hasShares(1.034), //
+                        hasSource("Steuerrueckerstattung08.txt"), //
+                        hasNote("Rückerstattung Verrechnungssteuer"), //
+                        hasAmount("CHF", 17.36), hasGrossValue("CHF", 17.36), //
+                        hasTaxes("CHF", 0.00), hasFees("CHF", 0.00))));
+    }
 
     @Test
     public void testDividendeStorno01()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -300,10 +300,11 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .section("type").optional() //
-                        .match("^(Dividendenart|Type of dividend|Type de dividende): " //
-                                        + "(?<type>(R.ckerstattung Quellensteuer|Refund withholding tax|Remboursement d.imp.t . la source))$") //
+                        .match("^(Dividendenart|Aussch.ttungsart|Type of dividend|Type de dividende): " //
+                                        + "(?<type>(R.ckerstattung Quellensteuer|R.ckerstattung Verrechnungssteuer|Refund withholding tax|Remboursement d.imp.t . la source))$") //
                         .assign((t, v) -> {
                             if ("Rückerstattung Quellensteuer".equals(v.get("type")) //
+                                            || "Rückerstattung Verrechnungssteuer".equals(v.get("type")) //
                                             || "Refund withholding tax".equals(v.get("type")) //
                                             || "Remboursement d'impôt à la source".equals(v.get("type")))
                                 t.setType(AccountTransaction.Type.TAX_REFUND);
@@ -323,7 +324,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         // Ausschüttung: USD 0.72
                         // @formatter:on
                         .section("name", "isin", "currency") //
-                        .find("(Dividendenart|Type of dividend|Type de dividende):.*") //
+                        .find("(Dividendenart|Aussch.ttungsart|Type of dividend|Type de dividende):.*") //
                         .match("^[\\.,\\d]+ (Anteile|Qty|Ant|parts|units|actions)?(?<name>.*)$") //
                         .match("^ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
                         .match("^(Aussch.ttung|Dividend payment|Dividende distribu.): (?<currency>[\\w]{3}) .*$") //
@@ -334,7 +335,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         // 47.817 Ant UBS ETF MSCI USA SRI
                         // @formatter:on
                         .section("shares") //
-                        .find("(Dividendenart|Type of dividend|Type de dividende):.*") //
+                        .find("(Dividendenart|Aussch.ttungsart|Type of dividend|Type de dividende):.*") //
                         .match("^(?<shares>[\\.,\\d]+) (Anteile|Qty|Ant|parts|units|actions)?.*$") //
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
@@ -398,7 +399,7 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         // Type of dividend: Ordinary dividend
                         // @formatter:on
                         .section("note").optional() //
-                        .match("^(Dividendenart|Type of dividend|Type de dividende): (?<note>.*)") //
+                        .match("^(Dividendenart|Aussch.ttungsart|Type of dividend|Type de dividende): (?<note>.*)") //
                         .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
                         .wrap(TransactionItem::new);


### PR DESCRIPTION
Closes #5774 
Neue Nomenklatur Dividendenausschüttung
Nur Deutsche PDFs.
Nicht getestet, da ich nicht weiss wie.