### PR TITLE
Improve Debitum Investments PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/debituminvestments/DebitumPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/debituminvestments/DebitumPDFExtractorTest.java
@@ -10,6 +10,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interest;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.skippedItem;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
@@ -26,6 +27,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
 import name.abuchen.portfolio.datatransfer.pdf.DebitumInvestmentsPDFExtractor;
 import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
@@ -84,9 +86,21 @@ public class DebitumPDFExtractorTest
         assertThat(countAccountTransactions(results), is(1L));
         assertThat(countAccountTransfers(results), is(0L));
         assertThat(countItemsWithFailureMessage(results), is(0L));
-        assertThat(countSkippedItems(results), is(0L));
-        assertThat(results.size(), is(1));
+        assertThat(countSkippedItems(results), is(2L));
+        assertThat(results.size(), is(3));
         new AssertImportActions().check(results, "EUR");
+
+        // check skipped item (DEPOSITS = 0.0)
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        deposit(hasDate("2025-12-17"), hasAmount("EUR", 0.00), //
+                                        hasSource("AccountStatement02.txt"), hasNote(null)))));
+
+        // check skipped item (WITHDRAWALS = 0.0)
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        removal(hasDate("2025-12-17"), hasAmount("EUR", 0.00), //
+                                        hasSource("AccountStatement02.txt"), hasNote(null)))));
 
         // assert transaction
         assertThat(results, hasItem(interest( //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DebitumInvestmentsPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DebitumInvestmentsPDFExtractor.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -74,9 +75,10 @@ public class DebitumInvestmentsPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .wrap(t -> {
-                            if (t.getAmount() != 0)
-                                return new TransactionItem(t);
-                            return null;
+                            if (t.getCurrencyCode() != null && t.getAmount() == 0)
+                                return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                            return new TransactionItem(t);
                         }));
 
         // @formatter:off


### PR DESCRIPTION
- Replace non-canonical wrap() returning null for zero-amount deposit/removal transactions with the canonical SkippedItem form including getCurrencyCode() != null guard
- Add import name.abuchen.portfolio.Messages to the extractor
- Update testAccountStatement02: adjust countSkippedItems from 0L to 2L and results.size() from 1 to 3 to reflect the two zero-amount DEPOSITS/WITHDRAWALS lines that are now correctly recorded as skipped items
- Add two skippedItem(Messages.MsgErrorTransactionTypeNotSupportedOrRequired, deposit/removal(...)) assertions to testAccountStatement02 to explicitly verify the skipped zero-amount transactions
- Add skippedItem, Messages imports to the test class