### PR TITLE
Modify BoursoBank PDF-Importer to support new transaction

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/BoursoBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/BoursoBankPDFExtractorTest.java
@@ -611,4 +611,71 @@ public class BoursoBankPDFExtractorTest
                         hasAmount("EUR", 28.24), hasGrossValue("EUR", 40.33), //
                         hasTaxes("EUR", 12.09), hasFees("EUR", 0.00))));
     }
+
+    @Test
+    public void testDividende02()
+    {
+        var extractor = new BoursoBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(3L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(3L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(6));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("FR0000121972"), hasWkn(null), hasTicker(null), //
+                        hasName("SCHNEIDER ELECTRIC"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-11T00:00"), hasExDate(null), //
+                        hasShares(5.00), //
+                        hasSource("Dividende02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 21.10), hasGrossValue("EUR", 21.10), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("FR0000120073"), hasWkn(null), hasTicker(null), //
+                        hasName("AIR LIQUIDE"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-18T00:00"), hasExDate(null), //
+                        hasShares(5.00), //
+                        hasSource("Dividende02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 18.50), hasGrossValue("EUR", 18.50), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("FR001400AJ45"), hasWkn(null), hasTicker(null), //
+                        hasName("MICHELIN"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-26T00:00"), hasExDate(null), //
+                        hasShares(5.00), //
+                        hasSource("Dividende02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 6.90), hasGrossValue("EUR", 6.90), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+    }
+
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/Dividende02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/Dividende02.txt
@@ -1,0 +1,37 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.83.2
+System: linux | x86_64 | 21.0.9+10-Debian-1 | Debian
+-----------------------------------------
+COUPONS REMBOURSEMENTS : MAI 2026
+ 000000
+P580369
+MR EMMANUEL MACRON, MOZART OF FINANCE
+FORTERESSE DE LA BASTILLE
+75000 PARIS
+Feuillet 1/1
+Références de votre compte titres
+99999 99999 00099999999 Compte PEA
+Résident Français
+ DETAIL COUPONS
+Acompte
+Date et/ou Commission
+échéance Brut fiscal Crédit d'impôt Prélèvements ¨ Net fiscal T.T.C. Net client
+coupon Quantité Nom de la valeur (code) EUR EUR EUR EUR EUR EUR
+11/05/2026 5 SCHNEIDER ELECTRIC (FR0000121972) 21,10 21,10 21,10
+revenus d'actions et opc français ouvrant droit à
+abattement
+18/05/2026 5 AIR LIQUIDE (FR0000120073) 18,50 18,50 18,50
+revenus d'actions et opc français ouvrant droit à
+abattement
+26/05/2026 5 MICHELIN (FR001400AJ45) 6,90 6,90 6,90
+revenus d'actions et opc français ouvrant droit à
+abattement
+TOTAL EUR 0,00 0,00 46,50 0,00 46,50
+COUPONS : NETS FISCAUX  46,50 EUR
+REMBOURSEMENTS : BRUTS GLOBAUX  0,00 EUR
+¨ Comprend l'acompte sur le revenu au titre de l'impôt et/ou les divers prélèvements dont les contibutions sociales (CSG, CRDS, ...)
+ 
+Service Clientèle : 01 46 09 49 49 ou +33 146 09 49 49 depuis l'étranger, du lundi au vendredi de 8h à 20h et le samedi de 8h45 à 16h30 – www.boursobank.com
+Boursorama S.A. au capital de 53 576 889,20 € - RCS Nanterre 351 058 151 - TVA 69 351 058 151 - 44 rue Traversière - CS 80134 - 92772 Boulogne Billancourt Cedex
+Adresse du médiateur : Médiateur de l'AMF - 17, place de la Bourse - 75082 PARIS CEDEX 02 AA1
+000000 F1 P580369 1/1

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BoursoBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BoursoBankPDFExtractor.java
@@ -247,6 +247,7 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("name", "isin") //
                         .match("^[\\d]{2}\\/[\\d]{2}\\/[\\d]{4} [\\,\\d\\s]+ (?<name>.*) \\((?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\).*$") //
+                        .documentContext("currency") //
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BoursoBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BoursoBankPDFExtractor.java
@@ -219,12 +219,21 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendeTransaction()
     {
-        final var type = new DocumentType("COUPONS");
+        final var type = new DocumentType("COUPONS",
+                        documentContext -> documentContext //
+                        // @formatter:off
+                        // coupon Quantité Nom de la valeur (code) EUR EUR EUR EUR EUR EUR
+                        // @formatter:on
+                        .section("currency")
+                                        .match("coupon Quantit. Nom de la valeur \\(code\\) .* (?<currency>[A-Z]{3})$")
+                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency")))));
+
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
 
-        var firstRelevantLine = new Block("^.* COUPONS$");
+        var firstRelevantLine = new Block(
+                        "^[\\d]{2}\\/[\\d]{2}\\/[\\d]{4} [\\,\\d\\s]+ .* \\([A-Z]{2}[A-Z0-9]{9}[0-9]\\).*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -234,15 +243,15 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
 
                         // @formatter:off
                         // 15/02/2024 248 ISHS DEV MK PRO US (IE00B1FZS350) 40,33 12,09 28,24 28,24
-                        // COUPONS : NETS FISCAUX  28,24 EUR
+                        // 11/05/2026 5 SCHNEIDER ELECTRIC (FR0000121972) 21,10 21,10 21,10
                         // @formatter:on
-                        .section("name", "isin", "currency") //
+                        .section("name", "isin") //
                         .match("^[\\d]{2}\\/[\\d]{2}\\/[\\d]{4} [\\,\\d\\s]+ (?<name>.*) \\((?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\).*$") //
-                        .match("^COUPONS : NETS FISCAUX [\\,\\d\\s]+ (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                         // @formatter:off
                         // 15/02/2024 248 ISHS DEV MK PRO US (IE00B1FZS350) 40,33 12,09 28,24 28,24
+                        // 11/05/2026 5 SCHNEIDER ELECTRIC (FR0000121972) 21,10 21,10 21,10
                         // @formatter:on
                         .section("shares") //
                         .match("^[\\d]{2}\\/[\\d]{2}\\/[\\d]{4} (?<shares>[\\,\\d\\s]+) .*$") //
@@ -250,16 +259,19 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
 
                         // @formatter:off
                         // 15/02/2024 248 ISHS DEV MK PRO US (IE00B1FZS350) 40,33 12,09 28,24 28,24
+                        // 11/05/2026 5 SCHNEIDER ELECTRIC (FR0000121972) 21,10 21,10 21,10
                         // @formatter:on
                         .section("date") //
                         .match("^(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) [\\,\\d\\s]+ .*$") //
                         .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                         // @formatter:off
-                        // COUPONS : NETS FISCAUX  28,24 EUR
+                        // 15/02/2024 248 ISHS DEV MK PRO US (IE00B1FZS350) 40,33 12,09 28,24 28,24
+                        // 11/05/2026 5 SCHNEIDER ELECTRIC (FR0000121972) 21,10 21,10 21,10
                         // @formatter:on
-                        .section("amount", "currency") //
-                        .match("^COUPONS : NETS FISCAUX (?<amount>[\\d\\s]+,[\\d]{2}) (?<currency>[A-Z]{3})$") //
+                        .section("amount") //
+                        .match("^[\\d]{2}\\/[\\d]{2}\\/[\\d]{4} [\\,\\d\\s]+ .* (?<amount>(\\d+,\\d+))$") //
+                        .documentContext("currency") //
                         .assign((t, v) -> {
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));


### PR DESCRIPTION
Closes #5763

Hello this is a proposition of update of this PDF-Importer to support the new case:
Previous dividend document had a single security dividend
This new dividend document have several of thems, only the first one was imported and with an incorrect amount (total of all dividend allocated to the first security)

Changes and explanations : 
The amount match is made on the dividend of the transaction line itself, previously it was on a line related to total dividends of the pdf (which was ok when only one security/transaction was reported but no longer ok with multiple securities)
To get several securities transactions recognized, the Block/first relevant line is changed
Within this new block, the currency information is no longer available, so the currency is now matched in document context.