### PR TITLE
Keep selection when changing view settings in SecuritiesPerformanceView

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -392,6 +392,21 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                 return Optional.empty();
             return performanceRecord.explain(key);
         }
+
+        @Override
+        public int hashCode()
+        {
+            return (performanceRecord == null) ? 73 * sortOrder : performanceRecord.getSecurity().hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            return (this == obj || (obj instanceof RowElement other && sortOrder == other.sortOrder
+                            && (performanceRecord == null || performanceRecord.getSecurity()
+                                            .equals(other.performanceRecord.getSecurity()))));
+        }
+
     }
 
     /**


### PR DESCRIPTION
Currently, the selection in the SecuritiesPerformanceView is lost when the user changes, for example, the reporting period.

The change adds the methods hashCode and equals to the class RowElement (class of the items in the table), so that TableViewer automatically retains the selection.