### PR TITLE
Add per-element ownership weights to client filters

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilterTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilterTest.java
@@ -40,6 +40,7 @@ import name.abuchen.portfolio.snapshot.AccountSnapshot;
 public class PortfolioClientFilterTest
 {
     private static final int HALF = Classification.ONE_HUNDRED_PERCENT / 2;
+    private static final int EIGHTY = Classification.ONE_HUNDRED_PERCENT * 8 / 10;
 
     private Client client;
 
@@ -385,6 +386,47 @@ public class PortfolioClientFilterTest
         assertThat(account.getTransactions().stream() //
                         .filter(t -> t.getType() == AccountTransaction.Type.DEPOSIT) //
                         .anyMatch(t -> t.getAmount() == Values.Amount.factorize(5)), is(true));
+    }
+
+    @Test
+    public void testFullSecuritiesAccountWithReferenceAccountAtFiftyKeepsSecurityCashFlowAndCorrection()
+    {
+        Portfolio portfolioA = client.getPortfolios().get(0);
+        Account referenceA = portfolioA.getReferenceAccount();
+
+        Client result = new PortfolioClientFilter(Arrays.asList(portfolioA), Arrays.asList(referenceA),
+                        Map.of(referenceA, HALF)).filter(client);
+
+        Account account = result.getAccounts().get(0);
+
+        assertThat(account.getTransactions().stream() //
+                        .filter(t -> t.getType() == AccountTransaction.Type.DIVIDENDS) //
+                        .anyMatch(t -> t.getAmount() == Values.Amount.factorize(10)), is(true));
+        assertThat(account.getTransactions().stream() //
+                        .filter(t -> t.getType() == AccountTransaction.Type.REMOVAL) //
+                        .anyMatch(t -> t.getAmount() == Values.Amount.factorize(5)), is(true));
+    }
+
+    @Test
+    public void testIncludedAccountWithMixedCandidatePortfolioWeightsUsesMaximumWithCorrection()
+    {
+        Portfolio portfolioA = client.getPortfolios().get(0);
+        Portfolio portfolioB = client.getPortfolios().get(1);
+        Account referenceA = portfolioA.getReferenceAccount();
+
+        portfolioB.setReferenceAccount(referenceA);
+
+        Client result = new PortfolioClientFilter(Arrays.asList(portfolioA, portfolioB), Arrays.asList(referenceA),
+                        Map.of(referenceA, HALF, portfolioA, HALF, portfolioB, EIGHTY)).filter(client);
+
+        Account account = result.getAccounts().get(0);
+
+        assertThat(account.getTransactions().stream() //
+                        .filter(t -> t.getType() == AccountTransaction.Type.DIVIDENDS) //
+                        .anyMatch(t -> t.getAmount() == Values.Amount.factorize(8)), is(true));
+        assertThat(account.getTransactions().stream() //
+                        .filter(t -> t.getType() == AccountTransaction.Type.REMOVAL) //
+                        .anyMatch(t -> t.getAmount() == Values.Amount.factorize(3)), is(true));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilterTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilterTest.java
@@ -1,14 +1,18 @@
 package name.abuchen.portfolio.snapshot.filter;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.junit.Before;
@@ -21,6 +25,7 @@ import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.AccountTransferEntry;
+import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
@@ -34,6 +39,8 @@ import name.abuchen.portfolio.snapshot.AccountSnapshot;
 @SuppressWarnings("nls")
 public class PortfolioClientFilterTest
 {
+    private static final int HALF = Classification.ONE_HUNDRED_PERCENT / 2;
+
     private Client client;
 
     /**
@@ -287,4 +294,151 @@ public class PortfolioClientFilterTest
         assertThat(dividendTx.size(), is(2));
     }
 
+    @Test
+    public void testCanonicalFormAndWeightAccessors()
+    {
+        Portfolio p = client.getPortfolios().get(0);
+
+        var def = new PortfolioClientFilter(Arrays.asList(p), Collections.emptyList());
+
+        // an explicit 100% entry must be normalized away (canonical form) so it
+        // stays equal to the default filter
+        var explicit = new PortfolioClientFilter(Arrays.asList(p), Collections.emptyList(),
+                        Map.of(p, Classification.ONE_HUNDRED_PERCENT));
+        assertThat(explicit, is(def));
+        assertThat(explicit.hashCode(), is(def.hashCode()));
+        assertThat(def.getWeight(p), is(Classification.ONE_HUNDRED_PERCENT));
+
+        var half = new PortfolioClientFilter(new ArrayList<>(Arrays.asList(p)),
+                        new ArrayList<>(Collections.emptyList()), new HashMap<>());
+        half.setWeight(p, HALF);
+        assertThat(half.getWeight(p), is(HALF));
+        assertThat(half, is(not(def)));
+
+        // setting back to 100% removes the entry -> equal to default again
+        half.setWeight(p, Classification.ONE_HUNDRED_PERCENT);
+        assertThat(half, is(def));
+
+        // removeElement drops the weight; absent -> 100%
+        half.setWeight(p, HALF);
+        half.removeElement(p);
+        assertThat(half.getWeight(p), is(Classification.ONE_HUNDRED_PERCENT));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetWeightRejectsZero()
+    {
+        Portfolio p = client.getPortfolios().get(0);
+        new PortfolioClientFilter(new ArrayList<>(Arrays.asList(p)), new ArrayList<>()).setWeight(p, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetWeightRejectsAboveHundredPercent()
+    {
+        Portfolio p = client.getPortfolios().get(0);
+        new PortfolioClientFilter(new ArrayList<>(Arrays.asList(p)), new ArrayList<>()).setWeight(p,
+                        Classification.ONE_HUNDRED_PERCENT + 1);
+    }
+
+    @Test
+    public void testAccountAtFiftyPercentScalesAllCashFlows()
+    {
+        Account accountA = client.getAccounts().get(0);
+
+        Client result = new PortfolioClientFilter(Collections.emptyList(), Arrays.asList(accountA),
+                        Map.of(accountA, HALF)).filter(client);
+
+        Account account = result.getAccounts().get(0);
+
+        // deposit 100 -> 50, buy 100 -> removal 50, dividend 10 -> deposit 5
+        // => funds 50 - 50 + 5 = 5
+        assertThat(AccountSnapshot.create(account, new TestCurrencyConverter(), LocalDate.parse("2016-09-03"))
+                        .getFunds(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5))));
+    }
+
+    @Test
+    public void testSecuritiesAccountAtFiftyWithFullReferenceAccount()
+    {
+        Portfolio portfolioA = client.getPortfolios().get(0);
+        Account referenceA = portfolioA.getReferenceAccount();
+
+        Client result = new PortfolioClientFilter(Arrays.asList(portfolioA), Arrays.asList(referenceA),
+                        Map.of(portfolioA, HALF)).filter(client);
+
+        Portfolio portfolio = result.getPortfolios().get(0);
+        Account account = result.getAccounts().get(0);
+
+        // the buy is split: common part at 50% (amount 50, half a share)
+        assertThat(portfolio.getTransactions().stream() //
+                        .filter(t -> t.getType() == PortfolioTransaction.Type.BUY) //
+                        .anyMatch(t -> t.getAmount() == Values.Amount.factorize(50)), is(true));
+        // ... with a 50 removal in the (fully owned) reference account
+        assertThat(account.getTransactions().stream() //
+                        .filter(t -> t.getType() == AccountTransaction.Type.REMOVAL) //
+                        .anyMatch(t -> t.getAmount() == Values.Amount.factorize(50)), is(true));
+
+        // dividend booked at the portfolio weight (5) + a balancing deposit (5)
+        // so the fully-owned account keeps its cash but only 5 counts as income
+        assertThat(account.getTransactions().stream() //
+                        .filter(t -> t.getType() == AccountTransaction.Type.DIVIDENDS) //
+                        .anyMatch(t -> t.getAmount() == Values.Amount.factorize(5)), is(true));
+        assertThat(account.getTransactions().stream() //
+                        .filter(t -> t.getType() == AccountTransaction.Type.DEPOSIT) //
+                        .anyMatch(t -> t.getAmount() == Values.Amount.factorize(5)), is(true));
+    }
+
+    @Test
+    public void testPortfolioTransferWithMismatchedWeightsCreatesDeliveryDelta()
+    {
+        Portfolio portfolioA = client.getPortfolios().get(0);
+        Portfolio portfolioB = client.getPortfolios().get(1);
+
+        PortfolioTransferEntry entry = new PortfolioTransferEntry(portfolioA, portfolioB);
+        entry.setDate(LocalDateTime.parse("2016-04-01T00:00"));
+        entry.setAmount(Values.Amount.factorize(10));
+        entry.setShares(Values.Share.factorize(1));
+        entry.setSecurity(client.getSecurities().get(0));
+        entry.insert();
+
+        // source A @ 100% -> target B @ 50%: linked transfer of half a share +
+        // an outbound delivery of the excess half on the higher-weighted source
+        Client result = new PortfolioClientFilter(Arrays.asList(portfolioA, portfolioB), Collections.emptyList(),
+                        Map.of(portfolioB, HALF)).filter(client);
+
+        Portfolio a = byName(result.getPortfolios(), "A");
+        Portfolio b = byName(result.getPortfolios(), "B");
+
+        assertThat(transferDate(a.getTransactions(), PortfolioTransaction.Type.TRANSFER_OUT,
+                        Values.Share.factorize(0.5)), is(true));
+        assertThat(transferDate(a.getTransactions(), PortfolioTransaction.Type.DELIVERY_OUTBOUND,
+                        Values.Share.factorize(0.5)), is(true));
+        assertThat(transferDate(b.getTransactions(), PortfolioTransaction.Type.TRANSFER_IN,
+                        Values.Share.factorize(0.5)), is(true));
+        // target is not the higher-weighted side -> no inbound delivery delta
+        assertThat(result.getPortfolios().stream().flatMap(p -> p.getTransactions().stream())
+                        .filter(t -> t.getDateTime().equals(LocalDateTime.parse("2016-04-01T00:00")))
+                        .anyMatch(t -> t.getType() == PortfolioTransaction.Type.DELIVERY_INBOUND), is(false));
+
+        // reverse direction A @ 50% -> target B @ 100%: inbound delivery delta
+        // on B
+        Client reverse = new PortfolioClientFilter(Arrays.asList(portfolioA, portfolioB), Collections.emptyList(),
+                        Map.of(portfolioA, HALF)).filter(client);
+        Portfolio bReverse = byName(reverse.getPortfolios(), "B");
+        assertThat(transferDate(bReverse.getTransactions(), PortfolioTransaction.Type.DELIVERY_INBOUND,
+                        Values.Share.factorize(0.5)), is(true));
+    }
+
+    private static Portfolio byName(List<Portfolio> portfolios, String name)
+    {
+        return portfolios.stream().filter(p -> name.equals(p.getName())).findFirst().orElseThrow();
+    }
+
+    private static boolean transferDate(List<PortfolioTransaction> transactions, PortfolioTransaction.Type type,
+                    long shares)
+    {
+        return transactions.stream() //
+                        .filter(t -> t.getType() == type) //
+                        .filter(t -> t.getDateTime().equals(LocalDateTime.parse("2016-04-01T00:00"))) //
+                        .anyMatch(t -> t.getShares() == shares);
+    }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/EditClientFilterDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/EditClientFilterDialog.java
@@ -3,9 +3,7 @@ package name.abuchen.portfolio.ui.dialogs;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import org.eclipse.jface.action.Action;
@@ -18,6 +16,7 @@ import org.eclipse.jface.layout.TreeColumnLayout;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.util.LocalSelectionTransfer;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.ColumnPixelData;
 import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
 import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -44,9 +43,11 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Tree;
 
-import name.abuchen.portfolio.model.Account;
+import name.abuchen.portfolio.model.Adaptable;
+import name.abuchen.portfolio.model.Adaptor;
+import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.Client;
-import name.abuchen.portfolio.model.Portfolio;
+import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.filter.PortfolioClientFilter;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
@@ -58,18 +59,85 @@ import name.abuchen.portfolio.ui.util.viewers.ColumnEditingSupport;
 import name.abuchen.portfolio.ui.util.viewers.CopyPasteSupport;
 import name.abuchen.portfolio.ui.util.viewers.ShowHideColumnHelper;
 import name.abuchen.portfolio.ui.util.viewers.StringEditingSupport;
+import name.abuchen.portfolio.ui.util.viewers.ValueEditingSupport;
 
 public class EditClientFilterDialog extends Dialog
 {
+    /**
+     * Wraps a child element (Account or Portfolio) of a filter together with
+     * its owning filter item, so the tree's editable weight column can read and
+     * write the per-element ownership percentage.
+     */
+    public static class WeightedElement implements Adaptable
+    {
+        private final Object element;
+        private final ClientFilterMenu.Item item;
+        private final PortfolioClientFilter filter;
+
+        public WeightedElement(Object element, ClientFilterMenu.Item item, PortfolioClientFilter filter)
+        {
+            this.element = element;
+            this.item = item;
+            this.filter = filter;
+        }
+
+        public Object getElement()
+        {
+            return element;
+        }
+
+        @Override
+        public <T> T adapt(Class<T> type)
+        {
+            return Adaptor.adapt(type, element);
+        }
+
+        public int getWeight()
+        {
+            return filter.getWeight(element);
+        }
+
+        public void setWeight(int weight)
+        {
+            filter.setWeight(element, weight);
+            item.setUUIDs(ClientFilterMenu.buildUUIDs(filter));
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.valueOf(element);
+        }
+
+        // value equality on the owning filter item + the wrapped element (not
+        // the weight) so that a WeightedElement recreated on tree refresh
+        // equals
+        // the previous instance -- this keeps JFace selection and expansion
+        // stable even though the children are created dynamically
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(item, element);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj)
+                return true;
+            if (obj == null || getClass() != obj.getClass())
+                return false;
+            WeightedElement other = (WeightedElement) obj;
+            return Objects.equals(item, other.item) && Objects.equals(element, other.element);
+        }
+    }
+
     public static class ContentProvider implements ITreeContentProvider
     {
-        private final Map<String, Object> uuid2object = new HashMap<>();
         private List<ClientFilterMenu.Item> items = new ArrayList<>();
 
         public ContentProvider(Client client)
         {
-            client.getPortfolios().forEach(p -> uuid2object.put(p.getUUID(), p));
-            client.getAccounts().forEach(a -> uuid2object.put(a.getUUID(), a));
         }
 
         @SuppressWarnings("unchecked")
@@ -88,11 +156,10 @@ public class EditClientFilterDialog extends Dialog
         @Override
         public Object[] getChildren(Object parentElement)
         {
-            if (parentElement instanceof ClientFilterMenu.Item item)
+            if (parentElement instanceof ClientFilterMenu.Item item
+                            && item.getFilter() instanceof PortfolioClientFilter filter)
             {
-                String[] uuids = item.getUUIDs().split(","); //$NON-NLS-1$
-
-                return Arrays.stream(uuids).map(uuid2object::get).filter(Objects::nonNull).toArray();
+                return Arrays.stream(filter.getAllElements()).map(e -> new WeightedElement(e, item, filter)).toArray();
             }
             else
             {
@@ -156,15 +223,15 @@ public class EditClientFilterDialog extends Dialog
 
         treeViewer = new TreeViewer(treeArea, SWT.BORDER);
         final Tree tree = treeViewer.getTree();
-        tree.setHeaderVisible(false);
+        tree.setHeaderVisible(true);
         tree.setLinesVisible(false);
 
         ColumnEditingSupport.prepare(treeViewer);
         ColumnViewerToolTipSupport.enableFor(treeViewer, ToolTip.NO_RECREATE);
         CopyPasteSupport.enableFor(treeViewer);
 
-        ShowHideColumnHelper columns = new ShowHideColumnHelper(EditClientFilterDialog.class.toString(), preferences,
-                        treeViewer, layout);
+        ShowHideColumnHelper columns = new ShowHideColumnHelper(EditClientFilterDialog.class.toString() + "$v2", //$NON-NLS-1$
+                        preferences, treeViewer, layout);
 
         Column column = new Column(Messages.ColumnName, SWT.NONE, 100);
         column.setLabelProvider(new ColumnLabelProvider()
@@ -180,6 +247,8 @@ public class EditClientFilterDialog extends Dialog
             {
                 if (element instanceof ClientFilterMenu.Item)
                     return Images.GROUPEDACCOUNTS.image();
+                else if (element instanceof WeightedElement weighted)
+                    return LogoManager.instance().getDefaultColumnImage(weighted.getElement(), client.getSettings());
                 else
                     return LogoManager.instance().getDefaultColumnImage(element, client.getSettings());
             }
@@ -189,10 +258,28 @@ public class EditClientFilterDialog extends Dialog
 
         columns.addColumn(column);
 
+        column = new Column(Messages.ColumnWeight, SWT.RIGHT, 80);
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object element)
+            {
+                if (element instanceof WeightedElement weighted)
+                    return Values.WeightPercent.format(weighted.getWeight());
+                return null;
+            }
+        });
+        new ValueEditingSupport(WeightedElement.class, "weight", Values.WeightPercent, //$NON-NLS-1$
+                        n -> n.intValue() >= 1 && n.intValue() <= Classification.ONE_HUNDRED_PERCENT)
+                                        .addListener((e, n, o) -> treeViewer.refresh(e)).attachTo(column);
+        columns.addColumn(column);
+
         columns.createColumns();
 
-        // retrofit the column width to 100%
+        // name column grabs the available width; the weight column stays fixed
         layout.setColumnData(tree.getColumn(0), new ColumnWeightData(100));
+        if (tree.getColumnCount() > 1)
+            layout.setColumnData(tree.getColumn(1), new ColumnPixelData(80));
 
         treeViewer.setContentProvider(new ContentProvider(client));
         treeViewer.setInput(items);
@@ -322,7 +409,7 @@ public class EditClientFilterDialog extends Dialog
 
                             // important step: update UUIDs because this is
                             // basic information in settings
-                            selectedFilterElement.setUUIDs(ClientFilterMenu.buildUUIDs(filter.getAllElements()));
+                            selectedFilterElement.setUUIDs(ClientFilterMenu.buildUUIDs(filter));
                             treeViewer.refresh();
                         }
                     }
@@ -331,8 +418,7 @@ public class EditClientFilterDialog extends Dialog
         }
 
         if ((treeViewer.getStructuredSelection().getFirstElement() instanceof ClientFilterMenu.Item)
-                        || (treeViewer.getStructuredSelection().getFirstElement() instanceof Portfolio)
-                        || (treeViewer.getStructuredSelection().getFirstElement() instanceof Account))
+                        || (treeViewer.getStructuredSelection().getFirstElement() instanceof WeightedElement))
         {
             manager.add(new Action(Messages.MenuReportingPeriodDelete)
             {
@@ -362,14 +448,15 @@ public class EditClientFilterDialog extends Dialog
                         {
                             // child node clicked (portfolio or account)
                             items.forEach(it -> {
-                                if (it == p.getFirstSegment() && it.getFilter() instanceof PortfolioClientFilter filter)
+                                if (it == p.getFirstSegment() && it.getFilter() instanceof PortfolioClientFilter filter
+                                                && p.getLastSegment() instanceof WeightedElement weighted)
                                 { // found parent item --> now remove selected
                                   // child item
-                                    filter.removeElement(p.getLastSegment());
+                                    filter.removeElement(weighted.getElement());
 
                                     // important step: update UUIDs because this
                                     // is basic information in settings
-                                    it.setUUIDs(ClientFilterMenu.buildUUIDs(filter.getAllElements()));
+                                    it.setUUIDs(ClientFilterMenu.buildUUIDs(filter));
                                 }
                             });
                         }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/ClientFilterMenu.java
@@ -26,6 +26,7 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Display;
 
 import name.abuchen.portfolio.model.Account;
+import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ConfigurationSet;
 import name.abuchen.portfolio.model.ConfigurationSet.Configuration;
@@ -262,19 +263,68 @@ public final class ClientFilterMenu implements IMenuListener
         if (uuids == null || uuids.isEmpty())
             return Optional.empty();
 
-        String[] ids = uuids.split(","); //$NON-NLS-1$
-        if (ids.length == 0)
+        String[] tokens = uuids.split(","); //$NON-NLS-1$
+        if (tokens.length == 0)
             return Optional.empty();
 
         Map<String, Object> uuid2object = new HashMap<>();
         client.getPortfolios().forEach(p -> uuid2object.put(p.getUUID(), p));
         client.getAccounts().forEach(a -> uuid2object.put(a.getUUID(), a));
 
-        return Optional.of(buildItem(id, name,
-                        Arrays.stream(ids).map(uuid2object::get).filter(Objects::nonNull).toArray()));
+        // lenient parsing: a token is "uuid" or "uuid:weight". An unknown UUID
+        // is dropped; a malformed or out-of-range weight is ignored (element
+        // kept at 100%). The persistence layer must never throw when loading.
+        var elements = new ArrayList<Object>();
+        var weights = new HashMap<Object, Integer>();
+
+        for (var token : tokens)
+        {
+            String uuid = token;
+            Integer weight = null;
+
+            int separator = token.indexOf(':');
+            if (separator >= 0)
+            {
+                uuid = token.substring(0, separator);
+                weight = parseWeight(token.substring(separator + 1));
+            }
+
+            var element = uuid2object.get(uuid);
+            if (element == null)
+                continue;
+
+            elements.add(element);
+            if (weight != null)
+                weights.put(element, weight);
+        }
+
+        if (elements.isEmpty())
+            return Optional.empty();
+
+        return Optional.of(buildItem(id, name, elements.toArray(), weights));
+    }
+
+    private static Integer parseWeight(String value)
+    {
+        try
+        {
+            int weight = Integer.parseInt(value.trim());
+            if (weight < 1 || weight > Classification.ONE_HUNDRED_PERCENT)
+                return null;
+            return weight;
+        }
+        catch (NumberFormatException e)
+        {
+            return null;
+        }
     }
 
     private static Item buildItem(String ident, String label, Object[] selected)
+    {
+        return buildItem(ident, label, selected, Collections.emptyMap());
+    }
+
+    private static Item buildItem(String ident, String label, Object[] selected, Map<Object, Integer> weights)
     {
         List<Portfolio> portfolios = Arrays.stream(selected).filter(Portfolio.class::isInstance).map(o -> (Portfolio) o)
                         .toList();
@@ -284,16 +334,24 @@ public final class ClientFilterMenu implements IMenuListener
         if (label.isEmpty())
             label = Arrays.stream(selected).map(String::valueOf).collect(Collectors.joining(", ")); //$NON-NLS-1$
 
-        String uuids = buildUUIDs(selected);
+        PortfolioClientFilter filter = new PortfolioClientFilter(portfolios, accounts, weights);
 
-        return new Item(ident, label, uuids, new PortfolioClientFilter(portfolios, accounts));
+        return new Item(ident, label, buildUUIDs(filter), filter);
     }
 
-    public static String buildUUIDs(Object[] selected)
+    /**
+     * Serializes the elements of the filter as a comma-separated list of
+     * {@code uuid} or {@code uuid:weight} tokens. The weight suffix is only
+     * emitted when the element is weighted below 100%, keeping the string clean
+     * and backward-compatible.
+     */
+    public static String buildUUIDs(PortfolioClientFilter filter)
     {
-        return Arrays.stream(selected)
-                        .map(o -> o instanceof Account account ? account.getUUID() : ((Portfolio) o).getUUID())
-                        .collect(Collectors.joining(",")); //$NON-NLS-1$
+        return Arrays.stream(filter.getAllElements()).map(o -> {
+            String uuid = o instanceof Account account ? account.getUUID() : ((Portfolio) o).getUUID();
+            int weight = filter.getWeight(o);
+            return weight == Classification.ONE_HUNDRED_PERCENT ? uuid : uuid + ":" + weight; //$NON-NLS-1$
+        }).collect(Collectors.joining(",")); //$NON-NLS-1$
     }
 
     public boolean hasActiveFilter()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/GroupedAccountsListView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/GroupedAccountsListView.java
@@ -4,9 +4,11 @@ import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
 
@@ -44,12 +46,14 @@ import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
 
 import name.abuchen.portfolio.model.Account;
+import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.ConfigurationSet;
 import name.abuchen.portfolio.model.ConfigurationSet.Configuration;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyConverterImpl;
 import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
+import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.AccountSnapshot;
 import name.abuchen.portfolio.snapshot.ClientSnapshot;
@@ -59,6 +63,7 @@ import name.abuchen.portfolio.snapshot.filter.PortfolioClientFilter;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.dialogs.EditClientFilterDialog.ContentProvider;
+import name.abuchen.portfolio.ui.dialogs.EditClientFilterDialog.WeightedElement;
 import name.abuchen.portfolio.ui.dialogs.ListSelectionDialog;
 import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
 import name.abuchen.portfolio.ui.util.ClientFilterMenu;
@@ -74,6 +79,7 @@ import name.abuchen.portfolio.ui.util.viewers.CopyPasteSupport;
 import name.abuchen.portfolio.ui.util.viewers.LocaleSenstiveViewerComparator;
 import name.abuchen.portfolio.ui.util.viewers.ShowHideColumnHelper;
 import name.abuchen.portfolio.ui.util.viewers.StringEditingSupport;
+import name.abuchen.portfolio.ui.util.viewers.ValueEditingSupport;
 import name.abuchen.portfolio.ui.views.columns.NameColumn;
 import name.abuchen.portfolio.ui.views.columns.NameColumn.NameColumnLabelProvider;
 import name.abuchen.portfolio.ui.views.columns.NoteColumn;
@@ -199,7 +205,13 @@ public class GroupedAccountsListView extends AbstractFinanceView implements Modi
     {
         // update currency converter (in case the base currency changes)
         converter = converter.with(getClient().getBaseCurrency());
+
+        // the weighted child elements are recreated on refresh, so capture the
+        // selection and restore it afterwards (WeightedElement has value
+        // equality, so the recreated row matches the previous selection)
+        IStructuredSelection selection = groupedAccounts.getStructuredSelection();
         groupedAccounts.refresh();
+        groupedAccounts.setSelection(selection, true);
     }
 
     @Override
@@ -292,7 +304,7 @@ public class GroupedAccountsListView extends AbstractFinanceView implements Modi
                         .addListener(this).attachTo(column);
         column.setRemovable(false);
         // top level nodes order is manually sorted by the user via drag & drop
-        column.setSorter(ColumnViewerSorter.create(o -> switch (o)
+        column.setSorter(ColumnViewerSorter.create(o -> switch (unwrap(o))
         {
             case Portfolio portfolio -> portfolio.getName();
             case Account account -> account.getName();
@@ -301,22 +313,43 @@ public class GroupedAccountsListView extends AbstractFinanceView implements Modi
 
         groupedAccountColumns.addColumn(column);
 
-        column = new Column("volume", Messages.ColumnBalance, SWT.RIGHT, 100); //$NON-NLS-1$
+        column = new Column("weight", Messages.ColumnWeight, SWT.RIGHT, 80); //$NON-NLS-1$
         column.setLabelProvider(new ColumnLabelProvider()
         {
             @Override
             public String getText(Object element)
             {
+                return element instanceof WeightedElement weighted ? Values.WeightPercent.format(weighted.getWeight())
+                                : null;
+            }
+        });
+        new ValueEditingSupport(WeightedElement.class, "weight", Values.WeightPercent, //$NON-NLS-1$
+                        n -> n.intValue() >= 1 && n.intValue() <= Classification.ONE_HUNDRED_PERCENT) //
+                                        .addListener(this).attachTo(column);
+        groupedAccountColumns.addColumn(column);
+
+        column = new Column("volume", Messages.ColumnBalance, SWT.RIGHT, 100); //$NON-NLS-1$
+        column.setLabelProvider(new ColumnLabelProvider()
+        {
+            @Override
+            public String getText(Object e)
+            {
+                // the balance of a single element is linear in its weight, so
+                // we scale the (cheap) unweighted snapshot instead of
+                // materializing a weighted pseudo element here
+                var element = unwrap(e);
+                var weight = weightOf(e);
                 if (element instanceof Portfolio portfolio)
                 {
                     PortfolioSnapshot snapshot = PortfolioSnapshot.create(portfolio, converter, LocalDate.now());
-                    return Values.Money.format(snapshot.getValue(), getClient().getBaseCurrency());
+                    return Values.Money.format(scale(snapshot.getValue(), weight), getClient().getBaseCurrency());
                 }
                 else if (element instanceof Account account)
                 {
                     AccountSnapshot snapshot = AccountSnapshot.create(account, converter, LocalDate.now());
                     // show unconverted amount
-                    return Values.Money.format(snapshot.getUnconvertedFunds(), getClient().getBaseCurrency());
+                    return Values.Money.format(scale(snapshot.getUnconvertedFunds(), weight),
+                                    getClient().getBaseCurrency());
                 }
                 else if (element instanceof ClientFilterMenu.Item groupedAccount)
                 {
@@ -330,15 +363,18 @@ public class GroupedAccountsListView extends AbstractFinanceView implements Modi
         });
         // add a sorter
         column.setSorter(ColumnViewerSorter.create(o -> {
-            if (o instanceof Portfolio portfolio)
+            var element = unwrap(o);
+            var weight = weightOf(o);
+            if (element instanceof Portfolio portfolio)
             {
                 PortfolioSnapshot snapshot = PortfolioSnapshot.create(portfolio, converter, LocalDate.now());
-                return snapshot.getValue();
+                return scale(snapshot.getValue(), weight);
             }
-            else if (o instanceof Account account)
+            else if (element instanceof Account account)
             {
                 AccountSnapshot snapshot = AccountSnapshot.create(account, converter, LocalDate.now());
-                return snapshot.getFunds(); // converted amount to sort
+                // converted amount to sort
+                return scale(snapshot.getFunds(), weight);
             }
             return null;
         }));
@@ -353,7 +389,11 @@ public class GroupedAccountsListView extends AbstractFinanceView implements Modi
         groupedAccounts.setContentProvider(new ContentProvider(getClient()));
 
         groupedAccounts.addSelectionChangedListener(event -> {
-            Object treeItem = event.getStructuredSelection().getFirstElement();
+            // feed the weighted pseudo element to the information panes (which
+            // expect Account/Portfolio/Item) so they reflect the ownership
+            // percentage; for a full-weight or non-weighted element this is the
+            // underlying model object
+            Object treeItem = weighted(event.getStructuredSelection().getFirstElement());
             setInformationPaneInput(treeItem);
         });
 
@@ -453,12 +493,12 @@ public class GroupedAccountsListView extends AbstractFinanceView implements Modi
             }));
 
         }
-        else if (element instanceof Portfolio || element instanceof Account)
+        else if (element instanceof WeightedElement weighted)
         {
             var filterItem = (ClientFilterMenu.Item) treeSelection.getPathsFor(element)[0].getFirstSegment();
 
             manager.add(new SimpleAction(Messages.ChartSeriesPickerRemove, a -> {
-                deleteElementInFilter(element, filterItem);
+                deleteElementInFilter(weighted.getElement(), filterItem);
                 storeChangedFilter();
                 if (element instanceof ClientFilterMenu.Item && groupedAccounts.getTree().getItemCount() > 0
                                 && !items.isEmpty())
@@ -483,7 +523,7 @@ public class GroupedAccountsListView extends AbstractFinanceView implements Modi
             filter.removeElement(element);
             // important step: update UUIDs because this is basic
             // information in settings
-            filterItem.setUUIDs(ClientFilterMenu.buildUUIDs(filter.getAllElements()));
+            filterItem.setUUIDs(ClientFilterMenu.buildUUIDs(filter));
         }
     }
 
@@ -529,9 +569,62 @@ public class GroupedAccountsListView extends AbstractFinanceView implements Modi
 
                 // important step: update UUIDs because this is
                 // basic information in settings
-                selectedFilterElement.setUUIDs(ClientFilterMenu.buildUUIDs(filter.getAllElements()));
+                selectedFilterElement.setUUIDs(ClientFilterMenu.buildUUIDs(filter));
             }
         }
+    }
+
+    private static Object unwrap(Object element)
+    {
+        return element instanceof WeightedElement weighted ? weighted.getElement() : element;
+    }
+
+    private static int weightOf(Object element)
+    {
+        return element instanceof WeightedElement weighted ? weighted.getWeight() : Classification.ONE_HUNDRED_PERCENT;
+    }
+
+    private static Money scale(Money money, int weight)
+    {
+        return weight == Classification.ONE_HUNDRED_PERCENT ? money
+                        : money.multiplyAndRound(weight / (double) Classification.ONE_HUNDRED_PERCENT);
+    }
+
+    /**
+     * Materializes the weighted view of a child element: builds a
+     * single-element {@link PortfolioClientFilter} carrying the element's
+     * ownership weight, applies it to the client and returns the resulting
+     * (scaled) {@code ReadOnlyPortfolio}/{@code ReadOnlyAccount}. For a
+     * full-weight element, an {@code Item}, or a non-weighted element the input
+     * is returned unchanged. Used only for the information pane (the balance
+     * column scales the unweighted snapshot instead).
+     */
+    private Object weighted(Object element)
+    {
+        if (!(element instanceof WeightedElement weightedElement))
+            return element;
+
+        var underlying = weightedElement.getElement();
+        var weight = weightedElement.getWeight();
+        if (weight == Classification.ONE_HUNDRED_PERCENT)
+            return underlying;
+
+        Object pseudo;
+        if (underlying instanceof Portfolio portfolio)
+        {
+            var filtered = new PortfolioClientFilter(List.of(portfolio), Collections.emptyList(),
+                            Map.<Object, Integer>of(portfolio, weight)).filter(getClient());
+            pseudo = filtered.getPortfolios().get(0);
+        }
+        else
+        {
+            var account = (Account) underlying;
+            var filtered = new PortfolioClientFilter(Collections.emptyList(), List.of(account),
+                            Map.<Object, Integer>of(account, weight)).filter(getClient());
+            pseudo = filtered.getAccounts().get(0);
+        }
+
+        return pseudo;
     }
 
     // //////////////////////////////////////////////////////////////

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Client.java
@@ -31,7 +31,7 @@ public class Client
         String WATCHLISTS = "watchlists"; //$NON-NLS-1$
     }
 
-    public static final int CURRENT_VERSION = 69;
+    public static final int CURRENT_VERSION = 70;
     public static final int VERSION_WITH_CURRENCY_SUPPORT = 29;
     public static final int VERSION_WITH_UNIQUE_FILTER_KEY = 57;
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/ClientFactory.java
@@ -947,6 +947,8 @@ public class ClientFactory
                 removeSourceAttributeFromTaxonomy(client);
             case 68: // NOSONAR
                 // added exDate date field
+            case 69: // NOSONAR
+                // add (optional) weight to client filter
 
                 client.setVersion(Client.CURRENT_VERSION);
                 break;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientClassificationFilter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientClassificationFilter.java
@@ -1,7 +1,8 @@
 package name.abuchen.portfolio.snapshot.filter;
 
+import static name.abuchen.portfolio.snapshot.filter.ClientFilterHelper.value;
+
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -535,23 +536,5 @@ public class ClientClassificationFilter implements ClientFilter
                     throw new UnsupportedOperationException();
             }
         }
-    }
-
-    private static Unit value(Unit unit, BigDecimal weight)
-    {
-        if (weight.equals(Classification.ONE_HUNDRED_PERCENT_BD))
-            return unit;
-        else
-            return unit.split(weight.divide(Classification.ONE_HUNDRED_PERCENT_BD, Values.MC).doubleValue());
-    }
-
-    private static long value(long value, BigDecimal weight)
-    {
-        if (weight.equals(Classification.ONE_HUNDRED_PERCENT_BD))
-            return value;
-        else
-            return BigDecimal.valueOf(value) //
-                            .multiply(weight, Values.MC).divide(Classification.ONE_HUNDRED_PERCENT_BD, Values.MC)
-                            .setScale(0, RoundingMode.HALF_EVEN).longValue();
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientFilterHelper.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/ClientFilterHelper.java
@@ -8,6 +8,7 @@ import name.abuchen.portfolio.model.AccountTransferEntry;
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.PortfolioTransferEntry;
+import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Values;
 
 /* protected */ class ClientFilterHelper
@@ -39,6 +40,52 @@ import name.abuchen.portfolio.money.Values;
         targetPortfolio.internalAddTransaction(copy.getTargetTransaction());
     }
 
+    /**
+     * Recreates a portfolio (security) transfer between two included portfolios
+     * that may carry different ownership weights. The shares/amount common to
+     * both sides (the lower weight) are recreated as a linked transfer; the
+     * excess on the higher-weighted side becomes an additional security
+     * delivery (DELIVERY_OUTBOUND on the source, DELIVERY_INBOUND on the
+     * target) because the surplus is a security movement, not cash.
+     */
+    /* package */ static void recreateTransfer(PortfolioTransferEntry transferEntry, ReadOnlyPortfolio sourcePortfolio,
+                    ReadOnlyPortfolio targetPortfolio, int sourceWeight, int targetWeight)
+    {
+        int common = Math.min(sourceWeight, targetWeight);
+
+        recreateTransfer(transferEntry, sourcePortfolio, targetPortfolio, weightToBigDecimal(common));
+
+        var t = transferEntry.getSourceTransaction();
+
+        if (sourceWeight > common)
+            sourcePortfolio.internalAddTransaction(
+                            excessDelivery(t, PortfolioTransaction.Type.DELIVERY_OUTBOUND, sourceWeight - common));
+
+        if (targetWeight > common)
+            targetPortfolio.internalAddTransaction(
+                            excessDelivery(t, PortfolioTransaction.Type.DELIVERY_INBOUND, targetWeight - common));
+    }
+
+    private static PortfolioTransaction excessDelivery(PortfolioTransaction t, PortfolioTransaction.Type type,
+                    int weight)
+    {
+        var w = weightToBigDecimal(weight);
+
+        var delivery = new PortfolioTransaction();
+        delivery.setType(type);
+        delivery.setDateTime(t.getDateTime());
+        delivery.setCurrencyCode(t.getCurrencyCode());
+        delivery.setSecurity(t.getSecurity());
+        delivery.setNote(t.getNote());
+        delivery.setShares(value(t.getShares(), w));
+        delivery.setAmount(value(t.getAmount(), w));
+
+        // keep all units (including taxes), scaled proportionally
+        t.getUnits().forEach(u -> delivery.addUnit(value(u, w)));
+
+        return delivery;
+    }
+
     /* package */ static void recreateTransfer(AccountTransferEntry transferEntry, ReadOnlyAccount sourceAccount,
                     ReadOnlyAccount targetAccount)
     {
@@ -61,13 +108,70 @@ import name.abuchen.portfolio.money.Values;
         targetAccount.internalAddTransaction(copy.getTargetTransaction());
     }
 
-    private static long value(long value, BigDecimal weight)
+    /**
+     * Recreates a cash transfer between two included accounts that may carry
+     * different ownership weights. The amount common to both sides (the lower
+     * weight) is recreated as a linked transfer; the excess on the
+     * higher-weighted side becomes a DEPOSIT (target side) or REMOVAL (source
+     * side) because the surplus is cash that crossed an ownership boundary.
+     */
+    /* package */ static void recreateTransfer(AccountTransferEntry transferEntry, ReadOnlyAccount sourceAccount,
+                    ReadOnlyAccount targetAccount, int sourceWeight, int targetWeight)
+    {
+        if (sourceWeight == targetWeight && sourceWeight == Classification.ONE_HUNDRED_PERCENT)
+        {
+            recreateTransfer(transferEntry, sourceAccount, targetAccount);
+            return;
+        }
+
+        int common = Math.min(sourceWeight, targetWeight);
+        var commonWeight = weightToBigDecimal(common);
+
+        var source = transferEntry.getSourceTransaction();
+        var target = transferEntry.getTargetTransaction();
+
+        var copy = new AccountTransferEntry(sourceAccount, targetAccount);
+        copy.setDate(source.getDateTime());
+        copy.setNote(source.getNote());
+        copy.getSourceTransaction().setCurrencyCode(source.getCurrencyCode());
+        copy.getTargetTransaction().setCurrencyCode(target.getCurrencyCode());
+        copy.getSourceTransaction().setAmount(value(source.getAmount(), commonWeight));
+        copy.getTargetTransaction().setAmount(value(target.getAmount(), commonWeight));
+
+        sourceAccount.internalAddTransaction(copy.getSourceTransaction());
+        targetAccount.internalAddTransaction(copy.getTargetTransaction());
+
+        if (sourceWeight > common)
+            sourceAccount.internalAddTransaction(new AccountTransaction(source.getDateTime(), source.getCurrencyCode(),
+                            value(source.getAmount(), weightToBigDecimal(sourceWeight - common)), null,
+                            AccountTransaction.Type.REMOVAL));
+
+        if (targetWeight > common)
+            targetAccount.internalAddTransaction(new AccountTransaction(target.getDateTime(), target.getCurrencyCode(),
+                            value(target.getAmount(), weightToBigDecimal(targetWeight - common)), null,
+                            AccountTransaction.Type.DEPOSIT));
+    }
+
+    private static BigDecimal weightToBigDecimal(int weight)
+    {
+        return BigDecimal.valueOf(weight);
+    }
+
+    /* package */ static Unit value(Unit unit, BigDecimal weight)
+    {
+        if (weight.equals(Classification.ONE_HUNDRED_PERCENT_BD))
+            return unit;
+        else
+            return unit.split(weight.divide(Classification.ONE_HUNDRED_PERCENT_BD, Values.MC).doubleValue());
+    }
+
+    /* package */ static long value(long value, BigDecimal weight)
     {
         if (weight.equals(Classification.ONE_HUNDRED_PERCENT_BD))
             return value;
         else
             return BigDecimal.valueOf(value) //
-                            .multiply(weight, Values.MC)
+                            .multiply(weight, Values.MC) //
                             .divide(Classification.ONE_HUNDRED_PERCENT_BD, Values.MC)
                             .setScale(0, RoundingMode.HALF_EVEN).longValue();
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilter.java
@@ -183,6 +183,13 @@ public class PortfolioClientFilter implements ClientFilter
 
         Set<Security> usedSecurities = new HashSet<>();
 
+        // index of (reference account -> security -> highest ownership weight
+        // among included portfolios that book that security there), built as a
+        // side effect of the portfolio pass below so that resolving a security
+        // weight for an account transaction is an O(1) lookup instead of a full
+        // re-scan of every portfolio per account transaction.
+        Map<Account, Map<Security, Integer>> securityWeightIndex = new HashMap<>();
+
         // keep track of transactions processed for a portfolio where the
         // reference account is not included in the filter (otherwise if
         // multiple portfolio share the same reference account, transactions are
@@ -191,7 +198,8 @@ public class PortfolioClientFilter implements ClientFilter
 
         for (Portfolio portfolio : portfolios)
         {
-            adaptPortfolioTransactions(portfolio, portfolio2pseudo, account2pseudo, usedSecurities);
+            adaptPortfolioTransactions(portfolio, portfolio2pseudo, account2pseudo, usedSecurities,
+                            securityWeightIndex);
 
             if (!accounts.contains(portfolio.getReferenceAccount()))
                 collectSecurityRelevantTx(portfolio, account2pseudo.get(portfolio.getReferenceAccount()),
@@ -199,7 +207,7 @@ public class PortfolioClientFilter implements ClientFilter
         }
 
         for (Account account : accounts)
-            adaptAccountTransactions(account, account2pseudo, usedSecurities);
+            adaptAccountTransactions(account, account2pseudo, usedSecurities, securityWeightIndex);
 
         for (Security security : usedSecurities)
             pseudoClient.internalAddSecurity(security);
@@ -208,14 +216,25 @@ public class PortfolioClientFilter implements ClientFilter
     }
 
     private void adaptPortfolioTransactions(Portfolio portfolio, Map<Portfolio, ReadOnlyPortfolio> portfolio2pseudo,
-                    Map<Account, ReadOnlyAccount> account2pseudo, Set<Security> usedSecurities)
+                    Map<Account, ReadOnlyAccount> account2pseudo, Set<Security> usedSecurities,
+                    Map<Account, Map<Security, Integer>> securityWeightIndex)
     {
         ReadOnlyPortfolio pseudoPortfolio = portfolio2pseudo.get(portfolio);
         BigDecimal portfolioWeight = getWeightBD(portfolio);
 
+        var referenceAccount = portfolio.getReferenceAccount();
+        var perSecurity = referenceAccount == null ? null
+                        : securityWeightIndex.computeIfAbsent(referenceAccount, k -> new HashMap<>());
+
         for (PortfolioTransaction t : portfolio.getTransactions())
         {
-            usedSecurities.add(t.getSecurity());
+            var security = t.getSecurity();
+            usedSecurities.add(security);
+
+            // fold the (reference account, security) -> max weight index into
+            // this pass instead of re-scanning all portfolios per account tx
+            if (perSecurity != null && security != null)
+                perSecurity.merge(security, getWeight(portfolio), Math::max);
 
             Object crossOwner = t.getCrossEntry() != null ? t.getCrossEntry().getCrossOwner(t) : null;
 
@@ -402,7 +421,7 @@ public class PortfolioClientFilter implements ClientFilter
     }
 
     private void adaptAccountTransactions(Account account, Map<Account, ReadOnlyAccount> account2pseudo,
-                    Set<Security> usedSecurities)
+                    Set<Security> usedSecurities, Map<Account, Map<Security, Integer>> securityWeightIndex)
     {
         ReadOnlyAccount pseudoAccount = account2pseudo.get(account);
         BigDecimal accountWeight = getWeightBD(account);
@@ -444,12 +463,12 @@ public class PortfolioClientFilter implements ClientFilter
                 case TAX_REFUND:
                 case FEES_REFUND:
                     addSecurityRelatedAccountTx(account, pseudoAccount, t, usedSecurities, accountWeight,
-                                    AccountTransaction.Type.DEPOSIT);
+                                    AccountTransaction.Type.DEPOSIT, securityWeightIndex);
                     break;
                 case TAXES:
                 case FEES:
                     addSecurityRelatedAccountTx(account, pseudoAccount, t, usedSecurities, accountWeight,
-                                    AccountTransaction.Type.REMOVAL);
+                                    AccountTransaction.Type.REMOVAL, securityWeightIndex);
                     break;
                 case DEPOSIT:
                 case REMOVAL:
@@ -472,7 +491,8 @@ public class PortfolioClientFilter implements ClientFilter
      * weight is booked as a balancing deposit/removal. Taxes are preserved.
      */
     private void addSecurityRelatedAccountTx(Account account, ReadOnlyAccount pseudoAccount, AccountTransaction t,
-                    Set<Security> usedSecurities, BigDecimal accountWeight, AccountTransaction.Type fallbackType)
+                    Set<Security> usedSecurities, BigDecimal accountWeight, AccountTransaction.Type fallbackType,
+                    Map<Account, Map<Security, Integer>> securityWeightIndex)
     {
         var security = t.getSecurity();
 
@@ -490,7 +510,8 @@ public class PortfolioClientFilter implements ClientFilter
             return;
         }
 
-        var securityWeight = BigDecimal.valueOf(resolveSecurityWeight(account, security, getWeight(account)));
+        var securityWeight = BigDecimal
+                        .valueOf(resolveSecurityWeight(securityWeightIndex, account, security, getWeight(account)));
 
         // book the security-related part at the portfolio weight (keeps the
         // type, security reference and units including taxes)
@@ -513,27 +534,20 @@ public class PortfolioClientFilter implements ClientFilter
      * Resolves the ownership weight to apply to a security-related transaction
      * that sits in {@code account}. Candidates are included portfolios whose
      * reference account is {@code account} and whose transaction history
-     * contains the security. If candidates carry differing weights, the highest
-     * candidate weight is used as a conservative heuristic. If there is no
-     * candidate, the account's own weight is used as a defensive fallback.
+     * contains the security; their highest weight is used as a conservative
+     * heuristic. The candidates are pre-indexed in {@code securityWeightIndex}
+     * during the portfolio pass. If there is no candidate, the account's own
+     * weight is used as a defensive fallback.
      */
-    private int resolveSecurityWeight(Account account, Security security, int accountWeight)
+    private int resolveSecurityWeight(Map<Account, Map<Security, Integer>> securityWeightIndex, Account account,
+                    Security security, int accountWeight)
     {
-        Set<Integer> weights = new HashSet<>();
+        var perSecurity = securityWeightIndex.get(account);
+        if (perSecurity == null)
+            return accountWeight;
 
-        for (Portfolio portfolio : portfolios)
-        {
-            if (portfolio.getReferenceAccount() == account && holdsSecurity(portfolio, security))
-                weights.add(getWeight(portfolio));
-        }
-
-        return weights.isEmpty() ? accountWeight : weights.stream().mapToInt(Integer::intValue).max()
-                        .orElse(accountWeight);
-    }
-
-    private static boolean holdsSecurity(Portfolio portfolio, Security security)
-    {
-        return portfolio.getTransactions().stream().anyMatch(tx -> security.equals(tx.getSecurity()));
+        var weight = perSecurity.get(security);
+        return weight == null ? accountWeight : weight.intValue();
     }
 
     /**

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilter.java
@@ -513,9 +513,9 @@ public class PortfolioClientFilter implements ClientFilter
      * Resolves the ownership weight to apply to a security-related transaction
      * that sits in {@code account}. Candidates are included portfolios whose
      * reference account is {@code account} and whose transaction history
-     * contains the security. If exactly one weight applies, it is used; if the
-     * candidates carry differing weights (ambiguous) or there is no candidate,
-     * the account's own weight is used (no security split).
+     * contains the security. If candidates carry differing weights, the highest
+     * candidate weight is used as a conservative heuristic. If there is no
+     * candidate, the account's own weight is used as a defensive fallback.
      */
     private int resolveSecurityWeight(Account account, Security security, int accountWeight)
     {
@@ -527,7 +527,8 @@ public class PortfolioClientFilter implements ClientFilter
                 weights.add(getWeight(portfolio));
         }
 
-        return weights.size() == 1 ? weights.iterator().next().intValue() : accountWeight;
+        return weights.isEmpty() ? accountWeight : weights.stream().mapToInt(Integer::intValue).max()
+                        .orElse(accountWeight);
     }
 
     private static boolean holdsSecurity(Portfolio portfolio, Security security)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/filter/PortfolioClientFilter.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.snapshot.filter;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -16,25 +17,66 @@ import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.AccountTransferEntry;
 import name.abuchen.portfolio.model.BuySellEntry;
+import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.PortfolioTransferEntry;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.money.Values;
 
 /**
  * Filters the Client to include only transactions related to the given
- * portfolios and accounts.
+ * portfolios and accounts. Each portfolio or account can additionally carry an
+ * ownership <em>weight</em> (a percentage in the
+ * {@link Classification#ONE_HUNDRED_PERCENT} scale); when an element is
+ * weighted below 100% all of its transactions are scaled accordingly, so that a
+ * shared account or securities account can be analyzed for one owner's share.
+ * The default weight is 100%, in which case the result is identical to the
+ * unweighted filter.
  */
 public class PortfolioClientFilter implements ClientFilter
 {
     private final List<Portfolio> portfolios;
     private final List<Account> accounts;
 
+    /**
+     * Ownership weight per element (Portfolio or Account) in the
+     * {@link Classification#ONE_HUNDRED_PERCENT} scale. Canonical form: the
+     * default 100% is <em>never</em> stored (absent ⇒ 100%), so that two
+     * behaviorally identical filters compare equal.
+     */
+    private final Map<Object, Integer> element2weight;
+
     public PortfolioClientFilter(List<Portfolio> portfolios, List<Account> accounts)
+    {
+        this(portfolios, accounts, Collections.emptyMap());
+    }
+
+    public PortfolioClientFilter(List<Portfolio> portfolios, List<Account> accounts, Map<Object, Integer> weights)
     {
         this.portfolios = new ArrayList<>(Objects.requireNonNull(portfolios));
         this.accounts = new ArrayList<>(Objects.requireNonNull(accounts));
+        this.element2weight = new HashMap<>();
+
+        if (weights != null && !weights.isEmpty())
+        {
+            var members = new HashSet<Object>();
+            members.addAll(this.portfolios);
+            members.addAll(this.accounts);
+
+            for (var entry : weights.entrySet()) // NOSONAR
+            {
+                var weight = entry.getValue();
+                // canonical-form normalization: drop non-members, invalid, and
+                // the default 100% (absence already means 100%)
+                if (weight == null || !members.contains(entry.getKey()))
+                    continue;
+                if (weight.intValue() < 1 || weight.intValue() >= Classification.ONE_HUNDRED_PERCENT)
+                    continue;
+                element2weight.put(entry.getKey(), weight);
+            }
+        }
     }
 
     public PortfolioClientFilter(Portfolio portfolio)
@@ -51,6 +93,7 @@ public class PortfolioClientFilter implements ClientFilter
     {
         portfolios.remove(element);
         accounts.remove(element);
+        element2weight.remove(element);
     }
 
     public void addElement(Object element)
@@ -62,7 +105,7 @@ public class PortfolioClientFilter implements ClientFilter
         else
             throw new IllegalArgumentException("element is null or of wrong type: " + element); //$NON-NLS-1$
     }
-    
+
     public boolean hasElement(Object element)
     {
         if (element instanceof Portfolio portfolio)
@@ -76,6 +119,40 @@ public class PortfolioClientFilter implements ClientFilter
     public Object[] getAllElements()
     {
         return Stream.concat(portfolios.stream(), accounts.stream()).toArray();
+    }
+
+    /**
+     * Returns the ownership weight (in the
+     * {@link Classification#ONE_HUNDRED_PERCENT} scale) of the given element.
+     * Returns 100% for non-members and for elements without an explicit weight.
+     */
+    public int getWeight(Object element)
+    {
+        var weight = element2weight.get(element);
+        return weight == null ? Classification.ONE_HUNDRED_PERCENT : weight.intValue();
+    }
+
+    /**
+     * Sets the ownership weight of an element. The element must be a current
+     * member; the weight must be in {@code [1, ONE_HUNDRED_PERCENT]}. Setting
+     * it to 100% removes the entry (canonical form).
+     */
+    public void setWeight(Object element, int weight)
+    {
+        if (!hasElement(element))
+            throw new IllegalArgumentException("element is not part of the filter: " + element); //$NON-NLS-1$
+        if (weight < 1 || weight > Classification.ONE_HUNDRED_PERCENT)
+            throw new IllegalArgumentException("weight out of range: " + weight); //$NON-NLS-1$
+
+        if (weight == Classification.ONE_HUNDRED_PERCENT)
+            element2weight.remove(element);
+        else
+            element2weight.put(element, weight);
+    }
+
+    private BigDecimal getWeightBD(Object element)
+    {
+        return BigDecimal.valueOf(getWeight(element));
     }
 
     @Override
@@ -134,46 +211,49 @@ public class PortfolioClientFilter implements ClientFilter
                     Map<Account, ReadOnlyAccount> account2pseudo, Set<Security> usedSecurities)
     {
         ReadOnlyPortfolio pseudoPortfolio = portfolio2pseudo.get(portfolio);
+        BigDecimal portfolioWeight = getWeightBD(portfolio);
 
         for (PortfolioTransaction t : portfolio.getTransactions())
         {
             usedSecurities.add(t.getSecurity());
 
+            Object crossOwner = t.getCrossEntry() != null ? t.getCrossEntry().getCrossOwner(t) : null;
+
             switch (t.getType())
             {
                 case BUY:
-                    if (accounts.contains(t.getCrossEntry().getCrossOwner(t)))
+                    if (accounts.contains(crossOwner))
                         recreateBuySell((BuySellEntry) t.getCrossEntry(), pseudoPortfolio,
-                                        account2pseudo.get(t.getCrossEntry().getCrossOwner(t)));
+                                        account2pseudo.get(crossOwner), portfolio, (Account) crossOwner);
                     else
                         pseudoPortfolio.internalAddTransaction(
-                                        convertTo(t, PortfolioTransaction.Type.DELIVERY_INBOUND));
+                                        convertTo(t, PortfolioTransaction.Type.DELIVERY_INBOUND, portfolioWeight));
                     break;
                 case TRANSFER_IN:
-                    if (portfolios.contains(t.getCrossEntry().getCrossOwner(t)))
+                    if (portfolios.contains(crossOwner))
                         ClientFilterHelper.recreateTransfer((PortfolioTransferEntry) t.getCrossEntry(),
-                                        portfolio2pseudo.get(t.getCrossEntry().getCrossOwner(t)), pseudoPortfolio);
+                                        portfolio2pseudo.get(crossOwner), pseudoPortfolio, getWeight(crossOwner),
+                                        getWeight(portfolio));
                     else
                         pseudoPortfolio.internalAddTransaction(
-                                        convertTo(t, PortfolioTransaction.Type.DELIVERY_INBOUND));
+                                        convertTo(t, PortfolioTransaction.Type.DELIVERY_INBOUND, portfolioWeight));
                     break;
                 case SELL:
-                    if (accounts.contains(t.getCrossEntry().getCrossOwner(t)))
+                    if (accounts.contains(crossOwner))
                         recreateBuySell((BuySellEntry) t.getCrossEntry(), pseudoPortfolio,
-                                        account2pseudo.get(t.getCrossEntry().getCrossOwner(t)));
+                                        account2pseudo.get(crossOwner), portfolio, (Account) crossOwner);
                     else
                         pseudoPortfolio.internalAddTransaction(
-                                        convertTo(t, PortfolioTransaction.Type.DELIVERY_OUTBOUND));
+                                        convertTo(t, PortfolioTransaction.Type.DELIVERY_OUTBOUND, portfolioWeight));
                     break;
                 case TRANSFER_OUT:
                     // regular transfer handled by TRANSFER_IN
-                    if (!portfolios.contains(t.getCrossEntry().getCrossOwner(t)))
+                    if (!portfolios.contains(crossOwner))
                         pseudoPortfolio.internalAddTransaction(
-                                        convertTo(t, PortfolioTransaction.Type.DELIVERY_OUTBOUND));
+                                        convertTo(t, PortfolioTransaction.Type.DELIVERY_OUTBOUND, portfolioWeight));
                     break;
-                case DELIVERY_INBOUND:
-                case DELIVERY_OUTBOUND:
-                    pseudoPortfolio.internalAddTransaction(t);
+                case DELIVERY_INBOUND, DELIVERY_OUTBOUND:
+                    pseudoPortfolio.internalAddTransaction(scaled(t, portfolioWeight));
                     break;
                 default:
                     throw new UnsupportedOperationException();
@@ -182,24 +262,84 @@ public class PortfolioClientFilter implements ClientFilter
     }
 
     private void recreateBuySell(BuySellEntry buySell, ReadOnlyPortfolio readOnlyPortfolio,
-                    ReadOnlyAccount readOnlyAccount)
+                    ReadOnlyAccount readOnlyAccount, Portfolio portfolio, Account account)
     {
         PortfolioTransaction t = buySell.getPortfolioTransaction();
 
-        BuySellEntry copy = new BuySellEntry(readOnlyPortfolio, readOnlyAccount);
+        var portfolioWeight = getWeightBD(portfolio);
+        var accountWeight = getWeightBD(account);
 
+        if (portfolioWeight.equals(accountWeight))
+        {
+            // both sides share the same weight -> a single scaled buy/sell
+            var copy = new BuySellEntry(readOnlyPortfolio, readOnlyAccount);
+            copy.setDate(t.getDateTime());
+            copy.setCurrencyCode(t.getCurrencyCode());
+            copy.setSecurity(t.getSecurity());
+            copy.setType(t.getType());
+            copy.setNote(t.getNote());
+            copy.setShares(ClientFilterHelper.value(t.getShares(), portfolioWeight));
+            copy.setAmount(ClientFilterHelper.value(t.getAmount(), portfolioWeight));
+
+            t.getUnits().forEach(
+                            u -> copy.getPortfolioTransaction().addUnit(ClientFilterHelper.value(u, portfolioWeight)));
+
+            readOnlyPortfolio.internalAddTransaction(copy.getPortfolioTransaction());
+            readOnlyAccount.internalAddTransaction(copy.getAccountTransaction());
+            return;
+        }
+
+        // weights differ -> keep the common (lower-weighted) part as a linked
+        // buy/sell and emit the excess: a deposit/removal in the account if the
+        // account is the higher-weighted side, an additional delivery in the
+        // portfolio if the security is. Taxes are preserved (unlike
+        // ClientClassificationFilter, which is a pre-tax view).
+
+        long securityAmount = ClientFilterHelper.value(t.getAmount(), portfolioWeight);
+        long accountAmount = ClientFilterHelper.value(t.getAmount(), accountWeight);
+
+        long commonAmount = Math.min(securityAmount, accountAmount);
+        var commonWeight = securityAmount == 0L ? portfolioWeight
+                        : BigDecimal.valueOf(commonAmount).divide(BigDecimal.valueOf(securityAmount), Values.MC)
+                                        .multiply(portfolioWeight, Values.MC);
+
+        var copy = new BuySellEntry(readOnlyPortfolio, readOnlyAccount);
         copy.setDate(t.getDateTime());
         copy.setCurrencyCode(t.getCurrencyCode());
         copy.setSecurity(t.getSecurity());
         copy.setType(t.getType());
         copy.setNote(t.getNote());
-        copy.setShares(t.getShares());
-        copy.setAmount(t.getAmount());
+        copy.setShares(ClientFilterHelper.value(t.getShares(), commonWeight));
+        copy.setAmount(commonAmount);
 
-        t.getUnits().forEach(u -> copy.getPortfolioTransaction().addUnit(u));
+        t.getUnits().forEach(u -> copy.getPortfolioTransaction().addUnit(ClientFilterHelper.value(u, commonWeight)));
 
         readOnlyPortfolio.internalAddTransaction(copy.getPortfolioTransaction());
         readOnlyAccount.internalAddTransaction(copy.getAccountTransaction());
+
+        if (accountAmount - commonAmount > 0)
+        {
+            var at = new AccountTransaction(t.getDateTime(), t.getCurrencyCode(), accountAmount - commonAmount, null,
+                            t.getType() == PortfolioTransaction.Type.BUY ? AccountTransaction.Type.REMOVAL
+                                            : AccountTransaction.Type.DEPOSIT);
+            readOnlyAccount.internalAddTransaction(at);
+        }
+
+        if (securityAmount - commonAmount > 0)
+        {
+            var tp = new PortfolioTransaction();
+            tp.setDateTime(t.getDateTime());
+            tp.setCurrencyCode(t.getCurrencyCode());
+            tp.setSecurity(t.getSecurity());
+            tp.setShares(ClientFilterHelper.value(t.getShares(), portfolioWeight.subtract(commonWeight)));
+            tp.setType(t.getType() == PortfolioTransaction.Type.BUY ? PortfolioTransaction.Type.DELIVERY_INBOUND
+                            : PortfolioTransaction.Type.DELIVERY_OUTBOUND);
+            tp.setAmount(securityAmount - commonAmount);
+
+            t.getUnits().forEach(u -> tp.addUnit(ClientFilterHelper.value(u, portfolioWeight.subtract(commonWeight))));
+
+            readOnlyPortfolio.internalAddTransaction(tp);
+        }
     }
 
     private void collectSecurityRelevantTx(Portfolio portfolio, ReadOnlyAccount pseudoAccount,
@@ -207,6 +347,8 @@ public class PortfolioClientFilter implements ClientFilter
     {
         if (portfolio.getReferenceAccount() == null)
             return;
+
+        var portfolioWeight = getWeightBD(portfolio);
 
         for (AccountTransaction t : portfolio.getReferenceAccount().getTransactions()) // NOSONAR
         {
@@ -225,9 +367,10 @@ public class PortfolioClientFilter implements ClientFilter
                 case DIVIDENDS:
                     if (!processedDividendTx.contains(t))
                     {
-                        pseudoAccount.internalAddTransaction(t);
+                        pseudoAccount.internalAddTransaction(scaled(t, portfolioWeight));
                         pseudoAccount.internalAddTransaction(new AccountTransaction(t.getDateTime(),
-                                        t.getCurrencyCode(), t.getAmount(), null, AccountTransaction.Type.REMOVAL));
+                                        t.getCurrencyCode(), ClientFilterHelper.value(t.getAmount(), portfolioWeight),
+                                        null, AccountTransaction.Type.REMOVAL));
                         processedDividendTx.add(t);
                     }
                     break;
@@ -235,9 +378,10 @@ public class PortfolioClientFilter implements ClientFilter
                 case FEES:
                     if (!processedDividendTx.contains(t))
                     {
-                        pseudoAccount.internalAddTransaction(t);
+                        pseudoAccount.internalAddTransaction(scaled(t, portfolioWeight));
                         pseudoAccount.internalAddTransaction(new AccountTransaction(t.getDateTime(),
-                                        t.getCurrencyCode(), t.getAmount(), null, AccountTransaction.Type.DEPOSIT));
+                                        t.getCurrencyCode(), ClientFilterHelper.value(t.getAmount(), portfolioWeight),
+                                        null, AccountTransaction.Type.DEPOSIT));
                         processedDividendTx.add(t);
                     }
                     break;
@@ -261,53 +405,57 @@ public class PortfolioClientFilter implements ClientFilter
                     Set<Security> usedSecurities)
     {
         ReadOnlyAccount pseudoAccount = account2pseudo.get(account);
+        BigDecimal accountWeight = getWeightBD(account);
 
         for (AccountTransaction t : account.getTransactions())
         {
+            Object crossOwner = t.getCrossEntry() != null ? t.getCrossEntry().getCrossOwner(t) : null;
+
             switch (t.getType())
             {
                 case BUY:
-                    if (!portfolios.contains(t.getCrossEntry().getCrossOwner(t)))
-                        pseudoAccount.internalAddTransaction(convertTo(t, AccountTransaction.Type.REMOVAL));
+                    if (!portfolios.contains(crossOwner))
+                        pseudoAccount.internalAddTransaction(
+                                        convertTo(t, AccountTransaction.Type.REMOVAL, accountWeight));
                     // regular buy is handled via portfolio transactions
                     break;
                 case SELL:
-                    if (!portfolios.contains(t.getCrossEntry().getCrossOwner(t)))
-                        pseudoAccount.internalAddTransaction(convertTo(t, AccountTransaction.Type.DEPOSIT));
+                    if (!portfolios.contains(crossOwner))
+                        pseudoAccount.internalAddTransaction(
+                                        convertTo(t, AccountTransaction.Type.DEPOSIT, accountWeight));
                     // regular sell is handled via portfolio transactions
                     break;
                 case TRANSFER_IN:
-                    if (accounts.contains(t.getCrossEntry().getCrossOwner(t)))
+                    if (accounts.contains(crossOwner))
                         ClientFilterHelper.recreateTransfer((AccountTransferEntry) t.getCrossEntry(),
-                                        account2pseudo.get(t.getCrossEntry().getCrossOwner(t)), pseudoAccount);
+                                        account2pseudo.get(crossOwner), pseudoAccount, getWeight(crossOwner),
+                                        getWeight(account));
                     else
-                        pseudoAccount.internalAddTransaction(convertTo(t, AccountTransaction.Type.DEPOSIT));
+                        pseudoAccount.internalAddTransaction(
+                                        convertTo(t, AccountTransaction.Type.DEPOSIT, accountWeight));
                     break;
                 case TRANSFER_OUT:
                     // regular transfer handled by TRANSFER_IN
-                    if (!accounts.contains(t.getCrossEntry().getCrossOwner(t)))
-                        pseudoAccount.internalAddTransaction(convertTo(t, AccountTransaction.Type.REMOVAL));
+                    if (!accounts.contains(crossOwner))
+                        pseudoAccount.internalAddTransaction(
+                                        convertTo(t, AccountTransaction.Type.REMOVAL, accountWeight));
                     break;
                 case DIVIDENDS:
                 case TAX_REFUND:
                 case FEES_REFUND:
-                    if (t.getSecurity() == null || usedSecurities.contains(t.getSecurity()))
-                        pseudoAccount.internalAddTransaction(t);
-                    else
-                        pseudoAccount.internalAddTransaction(convertTo(t, AccountTransaction.Type.DEPOSIT));
+                    addSecurityRelatedAccountTx(account, pseudoAccount, t, usedSecurities, accountWeight,
+                                    AccountTransaction.Type.DEPOSIT);
                     break;
                 case TAXES:
                 case FEES:
-                    if (t.getSecurity() == null || usedSecurities.contains(t.getSecurity()))
-                        pseudoAccount.internalAddTransaction(t);
-                    else
-                        pseudoAccount.internalAddTransaction(convertTo(t, AccountTransaction.Type.REMOVAL));
+                    addSecurityRelatedAccountTx(account, pseudoAccount, t, usedSecurities, accountWeight,
+                                    AccountTransaction.Type.REMOVAL);
                     break;
                 case DEPOSIT:
                 case REMOVAL:
                 case INTEREST:
                 case INTEREST_CHARGE:
-                    pseudoAccount.internalAddTransaction(t);
+                    pseudoAccount.internalAddTransaction(scaled(t, accountWeight));
                     break;
                 default:
                     throw new UnsupportedOperationException();
@@ -315,28 +463,128 @@ public class PortfolioClientFilter implements ClientFilter
         }
     }
 
-    private PortfolioTransaction convertTo(PortfolioTransaction t, PortfolioTransaction.Type type)
+    /**
+     * Handles a security-related account transaction (dividend, tax, fee or
+     * refund). If the security is not part of the filter, it is converted to a
+     * plain cash flow scaled by the account weight. Otherwise the security part
+     * is booked at the <em>portfolio</em> weight (resolved via the
+     * reference-account relationship) and the difference up to the account
+     * weight is booked as a balancing deposit/removal. Taxes are preserved.
+     */
+    private void addSecurityRelatedAccountTx(Account account, ReadOnlyAccount pseudoAccount, AccountTransaction t,
+                    Set<Security> usedSecurities, BigDecimal accountWeight, AccountTransaction.Type fallbackType)
+    {
+        var security = t.getSecurity();
+
+        if (security == null)
+        {
+            // general fee/tax/refund without a security -> scale by account
+            // weight
+            pseudoAccount.internalAddTransaction(scaled(t, accountWeight));
+            return;
+        }
+
+        if (!usedSecurities.contains(security))
+        {
+            pseudoAccount.internalAddTransaction(convertTo(t, fallbackType, accountWeight));
+            return;
+        }
+
+        var securityWeight = BigDecimal.valueOf(resolveSecurityWeight(account, security, getWeight(account)));
+
+        // book the security-related part at the portfolio weight (keeps the
+        // type, security reference and units including taxes)
+        pseudoAccount.internalAddTransaction(scaled(t, securityWeight));
+
+        long securityAmount = ClientFilterHelper.value(t.getAmount(), securityWeight);
+        long accountAmount = ClientFilterHelper.value(t.getAmount(), accountWeight);
+
+        long delta = accountAmount - securityAmount;
+        if (delta != 0)
+        {
+            AccountTransaction.Type deltaType = delta > 0 ^ t.getType().isDebit() ? AccountTransaction.Type.DEPOSIT
+                            : AccountTransaction.Type.REMOVAL;
+            pseudoAccount.internalAddTransaction(new AccountTransaction(t.getDateTime(), t.getCurrencyCode(),
+                            Math.abs(delta), null, deltaType));
+        }
+    }
+
+    /**
+     * Resolves the ownership weight to apply to a security-related transaction
+     * that sits in {@code account}. Candidates are included portfolios whose
+     * reference account is {@code account} and whose transaction history
+     * contains the security. If exactly one weight applies, it is used; if the
+     * candidates carry differing weights (ambiguous) or there is no candidate,
+     * the account's own weight is used (no security split).
+     */
+    private int resolveSecurityWeight(Account account, Security security, int accountWeight)
+    {
+        Set<Integer> weights = new HashSet<>();
+
+        for (Portfolio portfolio : portfolios)
+        {
+            if (portfolio.getReferenceAccount() == account && holdsSecurity(portfolio, security))
+                weights.add(getWeight(portfolio));
+        }
+
+        return weights.size() == 1 ? weights.iterator().next().intValue() : accountWeight;
+    }
+
+    private static boolean holdsSecurity(Portfolio portfolio, Security security)
+    {
+        return portfolio.getTransactions().stream().anyMatch(tx -> security.equals(tx.getSecurity()));
+    }
+
+    /**
+     * Returns the transaction scaled by the given weight, keeping its type,
+     * security and units (taxes included). Returns the original transaction
+     * unchanged at 100% so that the unweighted filter is byte-identical.
+     */
+    private PortfolioTransaction scaled(PortfolioTransaction t, BigDecimal weight)
+    {
+        if (weight.equals(Classification.ONE_HUNDRED_PERCENT_BD))
+            return t;
+        return convertTo(t, t.getType(), weight);
+    }
+
+    private AccountTransaction scaled(AccountTransaction t, BigDecimal weight)
+    {
+        if (weight.equals(Classification.ONE_HUNDRED_PERCENT_BD))
+            return t;
+
+        AccountTransaction clone = new AccountTransaction();
+        clone.setType(t.getType());
+        clone.setDateTime(t.getDateTime());
+        clone.setCurrencyCode(t.getCurrencyCode());
+        clone.setSecurity(t.getSecurity());
+        clone.setAmount(ClientFilterHelper.value(t.getAmount(), weight));
+        clone.setShares(ClientFilterHelper.value(t.getShares(), weight));
+        t.getUnits().forEach(u -> clone.addUnit(ClientFilterHelper.value(u, weight)));
+        return clone;
+    }
+
+    private PortfolioTransaction convertTo(PortfolioTransaction t, PortfolioTransaction.Type type, BigDecimal weight)
     {
         PortfolioTransaction clone = new PortfolioTransaction();
         clone.setType(type);
         clone.setDateTime(t.getDateTime());
         clone.setCurrencyCode(t.getCurrencyCode());
         clone.setSecurity(t.getSecurity());
-        clone.setAmount(t.getAmount());
-        clone.setShares(t.getShares());
-        clone.addUnits(t.getUnits());
+        clone.setAmount(ClientFilterHelper.value(t.getAmount(), weight));
+        clone.setShares(ClientFilterHelper.value(t.getShares(), weight));
+        t.getUnits().forEach(u -> clone.addUnit(ClientFilterHelper.value(u, weight)));
         return clone;
     }
 
-    private AccountTransaction convertTo(AccountTransaction t, AccountTransaction.Type type)
+    private AccountTransaction convertTo(AccountTransaction t, AccountTransaction.Type type, BigDecimal weight)
     {
         AccountTransaction clone = new AccountTransaction();
         clone.setType(type);
         clone.setDateTime(t.getDateTime());
         clone.setCurrencyCode(t.getCurrencyCode());
         clone.setSecurity(null); // no security for REMOVAL or DEPOSIT
-        clone.setAmount(t.getAmount());
-        clone.setShares(t.getShares());
+        clone.setAmount(ClientFilterHelper.value(t.getAmount(), weight));
+        clone.setShares(ClientFilterHelper.value(t.getShares(), weight));
 
         // do *not* copy units as REMOVAL and DEPOSIT have never units
         return clone;
@@ -349,6 +597,7 @@ public class PortfolioClientFilter implements ClientFilter
         int result = 1;
         result = prime * result + ((accounts == null) ? 0 : accounts.hashCode());
         result = prime * result + ((portfolios == null) ? 0 : portfolios.hashCode());
+        result = prime * result + element2weight.hashCode();
         return result;
     }
 
@@ -364,6 +613,7 @@ public class PortfolioClientFilter implements ClientFilter
 
         PortfolioClientFilter other = (PortfolioClientFilter) obj;
 
-        return accounts.equals(other.accounts) && portfolios.equals(other.portfolios);
+        return accounts.equals(other.accounts) && portfolios.equals(other.portfolios)
+                        && element2weight.equals(other.element2weight);
     }
 }


### PR DESCRIPTION
Allow each portfolio or account in a custom ClientFilter to carry an ownership percentage, so a shared account or securities account can be analyzed for one member's share. PortfolioClientFilter scales all transactions of a weighted element (preserving taxes), persists the weight via a backward-compatible uuid:weight suffix, and exposes an editable percentage column in the filter dialog and the grouped accounts view.

Issue: https://forum.portfolio-performance.info/t/multiple-portfolio-stakeholders/39369
Issue: https://forum.portfolio-performance.info/t/familienmitglieder-in-portfolio-performance/7752/17