### PR TITLE
Improve detection of number format in bank documents

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorUtilsConvertToNumberLongTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorUtilsConvertToNumberLongTest.java
@@ -43,6 +43,13 @@ public class ExtractorUtilsConvertToNumberLongTest
     @Test
     public void testConvertToNumberLong()
     {
+        long actualOutput = ExtractorUtils.convertToNumberLong(input, Values.Amount, locale);
+        assertEquals(expectedOutput, actualOutput);
+    }
+
+    @Test
+    public void testConvertToNumberLongWithLanguageAndCountry()
+    {
         long actualOutput = ExtractorUtils.convertToNumberLong(input, Values.Amount, locale.getLanguage(),
                         locale.getCountry());
         assertEquals(expectedOutput, actualOutput);
@@ -51,6 +58,6 @@ public class ExtractorUtilsConvertToNumberLongTest
     @Test(expected = IllegalArgumentException.class)
     public void testConvertToNumberLongWithInvalidInput()
     {
-        ExtractorUtils.convertToNumberLong("abc", Values.Amount, locale.getLanguage(), locale.getCountry());
+        ExtractorUtils.convertToNumberLong("abc", Values.Amount, locale);
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorUtilsGuessNumberLocaleTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorUtilsGuessNumberLocaleTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.Optional;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,12 +21,15 @@ public class ExtractorUtilsGuessNumberLocaleTest
     private final String input;
     private final Locale fallback;
     private final Locale expected;
+    private final Optional<Locale> expectedReliable;
 
-    public ExtractorUtilsGuessNumberLocaleTest(String input, Locale fallback, Locale expected)
+    public ExtractorUtilsGuessNumberLocaleTest(String input, Locale fallback, Locale expected,
+                    Optional<Locale> expectedReliable)
     {
         this.input = input;
         this.fallback = fallback;
         this.expected = expected;
+        this.expectedReliable = expectedReliable;
     }
 
     @Parameters(name = "{index}: guess {0} (fallback {1}) should be {2}")
@@ -33,37 +37,39 @@ public class ExtractorUtilsGuessNumberLocaleTest
     {
         return Arrays.asList(new Object[][] { //
                         // both separators -> right-most one is the decimal
-                        { "1,234.56", Locale.GERMANY, Locale.US }, //
-                        { "1.234,56", Locale.US, Locale.GERMANY }, //
+                        { "1,234.56", Locale.GERMANY, Locale.US, Optional.of(Locale.US) }, //
+                        { "1.234,56", Locale.US, Locale.GERMANY, Optional.of(Locale.GERMANY) }, //
 
                         // a lone dot is a decimal point
-                        { "63.726878", Locale.GERMANY, Locale.US }, //
-                        { "0.0353", Locale.GERMANY, Locale.US }, //
-                        { "1.25", Locale.GERMANY, Locale.US }, //
-                        { "0.353", Locale.GERMANY, Locale.US }, //
-                        { "77.638", Locale.GERMANY, Locale.US}, //
-                        { "1.262", Locale.GERMANY, Locale.US }, //
-                        { "1.000", Locale.GERMANY, Locale.US }, //
-                        { "1.000", Locale.US, Locale.US }, //
+                        { "63.726878", Locale.GERMANY, Locale.US, Optional.of(Locale.US) }, //
+                        { "0.0353", Locale.GERMANY, Locale.US, Optional.of(Locale.US) }, //
+                        { "1.25", Locale.GERMANY, Locale.US, Optional.of(Locale.US) }, //
+
+                        // exactly three digits after a lone separator is ambiguous
+                        { "0.353", Locale.GERMANY, Locale.US, Optional.empty() }, //
+                        { "77.638", Locale.GERMANY, Locale.US, Optional.empty() }, //
+                        { "1.262", Locale.GERMANY, Locale.US, Optional.empty() }, //
+                        { "1.000", Locale.GERMANY, Locale.US, Optional.empty() }, //
+                        { "1.000", Locale.US, Locale.US, Optional.empty() }, //
 
                         // single comma is a decimal point
-                        { "1,25", Locale.US, Locale.GERMANY }, //
-                        { "0,353", Locale.US, Locale.GERMANY }, //
-                        { "1,000", Locale.US, Locale.GERMANY }, //
-                        { "1,000", Locale.GERMANY, Locale.GERMANY }, //
-                        { "35,000", Locale.GERMANY, Locale.GERMANY }, //
+                        { "1,25", Locale.US, Locale.GERMANY, Optional.of(Locale.GERMANY) }, //
+                        { "0,353", Locale.US, Locale.GERMANY, Optional.empty() }, //
+                        { "1,000", Locale.US, Locale.GERMANY, Optional.empty() }, //
+                        { "1,000", Locale.GERMANY, Locale.GERMANY, Optional.empty() }, //
+                        { "35,000", Locale.GERMANY, Locale.GERMANY, Optional.empty() }, //
 
                         // repeated separator -> grouping
-                        { "1.234.567", Locale.US, Locale.GERMANY }, //
-                        { "1,234,567", Locale.GERMANY, Locale.US }, //
+                        { "1.234.567", Locale.US, Locale.GERMANY, Optional.of(Locale.GERMANY) }, //
+                        { "1,234,567", Locale.GERMANY, Locale.US, Optional.of(Locale.US) }, //
 
                         // Swiss apostrophe grouping
-                        { "12'345.67", Locale.GERMANY, CH }, //
-                        { "1'234'567", Locale.US, CH }, //
+                        { "12'345.67", Locale.GERMANY, CH, Optional.of(CH) }, //
+                        { "1'234'567", Locale.US, CH, Optional.of(CH) }, //
 
                         // no separator -> fallback
-                        { "1234", Locale.GERMANY, Locale.GERMANY }, //
-                        { "1234", Locale.US, Locale.US }, //
+                        { "1234", Locale.GERMANY, Locale.GERMANY, Optional.empty() }, //
+                        { "1234", Locale.US, Locale.US, Optional.empty() }, //
         });
     }
 
@@ -71,5 +77,13 @@ public class ExtractorUtilsGuessNumberLocaleTest
     public void testGuessNumberLocale()
     {
         assertEquals(expected, ExtractorUtils.guessNumberLocale(input, fallback));
+    }
+
+    @Test
+    public void testGuessNumberLocaleReliable()
+    {
+        var actual = ExtractorUtils.detectNumberLocale(input);
+
+        assertEquals(expectedReliable, actual);
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorUtilsGuessNumberLocaleTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ExtractorUtilsGuessNumberLocaleTest.java
@@ -1,0 +1,75 @@
+package name.abuchen.portfolio.datatransfer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+@SuppressWarnings("nls")
+public class ExtractorUtilsGuessNumberLocaleTest
+{
+    private static final Locale CH = Locale.of("de", "CH");
+
+    private final String input;
+    private final Locale fallback;
+    private final Locale expected;
+
+    public ExtractorUtilsGuessNumberLocaleTest(String input, Locale fallback, Locale expected)
+    {
+        this.input = input;
+        this.fallback = fallback;
+        this.expected = expected;
+    }
+
+    @Parameters(name = "{index}: guess {0} (fallback {1}) should be {2}")
+    public static Collection<Object[]> data()
+    {
+        return Arrays.asList(new Object[][] { //
+                        // both separators -> right-most one is the decimal
+                        { "1,234.56", Locale.GERMANY, Locale.US }, //
+                        { "1.234,56", Locale.US, Locale.GERMANY }, //
+
+                        // a lone dot is a decimal point
+                        { "63.726878", Locale.GERMANY, Locale.US }, //
+                        { "0.0353", Locale.GERMANY, Locale.US }, //
+                        { "1.25", Locale.GERMANY, Locale.US }, //
+                        { "0.353", Locale.GERMANY, Locale.US }, //
+                        { "77.638", Locale.GERMANY, Locale.US}, //
+                        { "1.262", Locale.GERMANY, Locale.US }, //
+                        { "1.000", Locale.GERMANY, Locale.US }, //
+                        { "1.000", Locale.US, Locale.US }, //
+
+                        // single comma is a decimal point
+                        { "1,25", Locale.US, Locale.GERMANY }, //
+                        { "0,353", Locale.US, Locale.GERMANY }, //
+                        { "1,000", Locale.US, Locale.GERMANY }, //
+                        { "1,000", Locale.GERMANY, Locale.GERMANY }, //
+                        { "35,000", Locale.GERMANY, Locale.GERMANY }, //
+
+                        // repeated separator -> grouping
+                        { "1.234.567", Locale.US, Locale.GERMANY }, //
+                        { "1,234,567", Locale.GERMANY, Locale.US }, //
+
+                        // Swiss apostrophe grouping
+                        { "12'345.67", Locale.GERMANY, CH }, //
+                        { "1'234'567", Locale.US, CH }, //
+
+                        // no separator -> fallback
+                        { "1234", Locale.GERMANY, Locale.GERMANY }, //
+                        { "1234", Locale.US, Locale.US }, //
+        });
+    }
+
+    @Test
+    public void testGuessNumberLocale()
+    {
+        assertEquals(expected, ExtractorUtils.guessNumberLocale(input, fallback));
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
@@ -511,6 +511,52 @@ public class ExtractorUtils
         return fallback;
     }
 
+    /**
+     * Reliably detects the locale of a formatted number so that it can be
+     * parsed with {@link #convertToNumberLong} /
+     * {@link #convertToNumberBigDecimal}. Returns {@link Optional#empty()} if
+     * the value does not contain enough information.
+     */
+    public static Optional<Locale> detectNumberLocale(String value)
+    {
+        var v = trim(value).replaceAll("\\s", "");
+
+        if (v.indexOf('\'') >= 0)
+            return Optional.of(Locale.of("de", "CH"));
+
+        var hasDot = v.indexOf('.') >= 0;
+        var hasComma = v.indexOf(',') >= 0;
+
+        if (hasDot && hasComma)
+            return Optional.of(v.lastIndexOf('.') > v.lastIndexOf(',') ? Locale.US : Locale.GERMANY);
+
+        if (hasDot)
+        {
+            // repeated dot = grouping
+            if (v.indexOf('.') != v.lastIndexOf('.'))
+                return Optional.of(Locale.GERMANY);
+
+            if (v.length() - v.lastIndexOf('.') - 1 == 3)
+                return Optional.empty();
+
+            return Optional.of(Locale.US);
+        }
+
+        if (hasComma)
+        {
+            // repeated comma = grouping
+            if (v.indexOf(',') != v.lastIndexOf(','))
+                return Optional.of(Locale.US);
+
+            if (v.length() - v.lastIndexOf(',') - 1 == 3)
+                return Optional.empty();
+
+            return Optional.of(Locale.GERMANY);
+        }
+
+        return Optional.empty();
+    }
+
     public static LocalDateTime asDate(String value, Locale... hints)
     {
         // starting with Java 8, the abbreviation Mrz is not supported out of

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
@@ -451,6 +451,62 @@ public class ExtractorUtils
         return convertToNumberLong(value, Values.Share, language, country);
     }
 
+    public static long convertToNumberLong(String value, Values<Long> valueType, Locale locale)
+    {
+        return convertToNumberLong(value, valueType, locale.getLanguage(), locale.getCountry());
+    }
+
+    public static BigDecimal convertToNumberBigDecimal(String value, Values<Long> valueType, Locale locale)
+    {
+        return convertToNumberBigDecimal(value, valueType, locale.getLanguage(), locale.getCountry());
+    }
+
+    /**
+     * Guesses the locale of a formatted number so that it can be parsed with
+     * {@link #convertToNumberLong} / {@link #convertToNumberBigDecimal}.
+     *
+     * @formatter:off
+     * Detection order:
+     *  - Swiss apostrophe group separator (12'345.67)             -> de/CH
+     *  - both '.' and ',' present: the right-most one is decimal  -> '.' last = en/US, ',' last = de/DE
+     *  - a single separator that repeats (1.234.567)             -> it is the group separator: dots = de/DE, commas = en/US
+     *  - a single dot (0.5, 1.262, 63.726878)                    -> decimal point en/US
+     *  - a single comma otherwise (1,25)                         -> decimal point de/DE
+     *  - no separator                                            -> fallback
+     * @formatter:on
+     */
+    public static Locale guessNumberLocale(String value, Locale fallback)
+    {
+        var v = trim(value).replaceAll("\\s", "");
+
+        if (v.indexOf('\'') >= 0)
+            return Locale.of("de", "CH");
+
+        var hasDot = v.indexOf('.') >= 0;
+        var hasComma = v.indexOf(',') >= 0;
+
+        if (hasDot && hasComma)
+            return v.lastIndexOf('.') > v.lastIndexOf(',') ? Locale.US : Locale.GERMANY;
+
+        if (hasDot)
+        {
+            // repeated dot = grouping
+            if (v.indexOf('.') != v.lastIndexOf('.'))
+                return Locale.GERMANY;
+            return Locale.US;
+        }
+
+        if (hasComma)
+        {
+            // repeated comma = grouping
+            if (v.indexOf(',') != v.lastIndexOf(','))
+                return Locale.US;
+            return Locale.GERMANY;
+        }
+
+        return fallback;
+    }
+
     public static LocalDateTime asDate(String value, Locale... hints)
     {
         // starting with Java 8, the abbreviation Mrz is not supported out of

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
@@ -345,8 +345,12 @@ public class ExtractorUtils
 
     public static long convertToNumberLong(String value, Values<Long> valueType, String language, String country)
     {
-        var newNumberFormat = (DecimalFormat) NumberFormat
-                        .getInstance(Locale.forLanguageTag(language + "-" + country));
+        return convertToNumberLong(value, valueType, Locale.forLanguageTag(language + "-" + country));
+    }
+
+    public static long convertToNumberLong(String value, Values<Long> valueType, Locale locale)
+    {
+        var newNumberFormat = (DecimalFormat) NumberFormat.getInstance(locale);
 
         /**
          * @formatter:off
@@ -369,7 +373,7 @@ public class ExtractorUtils
          */
         value = trim(value).replaceAll("\\s", "");
 
-        if ("CH".equals(country))
+        if ("CH".equals(locale.getCountry()))
         {
             /***
              * The group separator for language format German, region
@@ -446,14 +450,14 @@ public class ExtractorUtils
         }
     }
 
+    public static long asShares(String value, Locale locale)
+    {
+        return convertToNumberLong(value, Values.Share, locale);
+    }
+    
     public static long asShares(String value, String language, String country)
     {
         return convertToNumberLong(value, Values.Share, language, country);
-    }
-
-    public static long convertToNumberLong(String value, Values<Long> valueType, Locale locale)
-    {
-        return convertToNumberLong(value, valueType, locale.getLanguage(), locale.getCountry());
     }
 
     public static BigDecimal convertToNumberBigDecimal(String value, Values<Long> valueType, Locale locale)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -314,6 +314,11 @@ public abstract class AbstractPDFExtractor implements Extractor
         }
     }
 
+    protected long asShares(String value, Locale locale)
+    {
+        return ExtractorUtils.asShares(value, locale.getLanguage(), locale.getCountry());
+    }
+
     protected long asShares(String value, String language, String country)
     {
         return ExtractorUtils.asShares(value, language, country);
@@ -350,6 +355,11 @@ public abstract class AbstractPDFExtractor implements Extractor
         {
             throw new IllegalArgumentException(e);
         }
+    }
+
+    protected long asAmount(String value, Locale locale)
+    {
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount, locale);
     }
 
     protected long asAmount(String value, String language, String country)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
@@ -5,6 +5,7 @@ import static name.abuchen.portfolio.util.TextUtil.concatenate;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
+import java.util.Locale;
 
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
@@ -1546,38 +1547,14 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        var language = "de";
-        var country = "DE";
-
-        var lastDot = value.lastIndexOf(".");
-        var lastComma = value.lastIndexOf(",");
-
-        // returns the greater of two int values
-        if (Math.max(lastDot, lastComma) == lastDot)
-        {
-            language = "en";
-            country = "US";
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Amount, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        var language = "de";
-        var country = "DE";
-
-        var lastDot = value.lastIndexOf(".");
-        var lastComma = value.lastIndexOf(",");
-
-        // returns the greater of two int values
-        if (Math.max(lastDot, lastComma) == lastDot)
-        {
-            language = "en";
-            country = "US";
-        }
-
-        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, language, country);
+        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BondoraCapitalPDFExtractor.java
@@ -3,9 +3,13 @@ package name.abuchen.portfolio.datatransfer.pdf;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.util.Locale;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
+import name.abuchen.portfolio.datatransfer.ExtractorUtils;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.ParsedData;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
@@ -16,6 +20,9 @@ import name.abuchen.portfolio.model.Client;
 @SuppressWarnings("nls")
 public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
 {
+    private static final String NUMBER_LOCALE_LANGUAGE = "numberLocaleLanguage";
+    private static final String NUMBER_LOCALE_COUNTRY = "numberLocaleCountry";
+
     public BondoraCapitalPDFExtractor(Client client)
     {
         super(client);
@@ -31,7 +38,53 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
 
     private void addAccountStatementTransaction()
     {
-        final var type = new DocumentType("(?m)^(Zusammenfassung|Summary)$");
+        final var type = new DocumentType("(?m)^(Zusammenfassung|Summary)$", (context, lines) -> {
+            Locale documentLocale = null;
+            var isConflicting = false;
+
+            var summaryNumberLine = Pattern.compile(
+                            ".*\\b(Opening|Zu Beginn|Payments in|Einzahlungen|Payments out|Auszahlungen|Ergebnis)\\b.*");
+            var moneyValue = Pattern.compile( //
+                            "(?:\\p{Sc}\\s*)?(?<amount>-?[\\d][\\.,'\\d\\s]*)(?:\\s*\\p{Sc})?");
+            var transactionLine = Pattern.compile(
+                            "^([\\d]{1,2}[\\.\\-/][\\d]{1,2}[\\.\\-/][\\d]{4}|[\\d]{4}[\\.\\-/][\\d]{1,2}[\\.\\-/][\\d]{1,2}) .*$");
+
+            for (var line : lines)
+            {
+                if (transactionLine.matcher(line).matches())
+                    break;
+
+                if (!summaryNumberLine.matcher(line).matches())
+                    continue;
+
+                var matcher = moneyValue.matcher(line);
+                while (matcher.find())
+                {
+                    var locale = ExtractorUtils.detectNumberLocale(matcher.group("amount"));
+                    if (locale.isEmpty())
+                        continue;
+
+                    if (documentLocale == null)
+                    {
+                        documentLocale = locale.get();
+                    }
+                    else if (!documentLocale.equals(locale.get()))
+                    {
+                        isConflicting = true;
+                        break;
+                    }
+                }
+
+                if (isConflicting)
+                    break;
+            }
+
+            if (!isConflicting && documentLocale != null)
+            {
+                context.put(NUMBER_LOCALE_LANGUAGE, documentLocale.getLanguage());
+                context.put(NUMBER_LOCALE_COUNTRY, documentLocale.getCountry());
+            }
+        });
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();
@@ -71,7 +124,7 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .oneOf( //
-                                        // @formatter:off
+                        // @formatter:off
                                         // 06.02.2022 Go & Grow Zinsen 0,22 € 1.228,18 €
                                         // 07.02.2022 Überweisen 1.000 € 2.228,18 €
                                         // 27.11.2023 SEPA-Banküberweisung 50 € 1.064,4 €
@@ -83,6 +136,8 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date", "note", "amount") //
+                                                        .documentContextOptionally(NUMBER_LOCALE_LANGUAGE,
+                                                                        NUMBER_LOCALE_COUNTRY) //
                                                         .match("^(?<date>([\\d]{1,2}\\.[\\d]{2}\\.[\\d]{4}|[\\d]{4}\\.[\\d]{2}\\.[\\d]{2})) " //
                                                                         + "(?<note>(.berweisen" //
                                                                         + "|SEPA\\-Bank.berweisung" //
@@ -99,17 +154,12 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date")));
 
-                                                            var language = "de";
-                                                            var country = "DE";
+                                                            var locale = ExtractorUtils
+                                                                            .detectNumberLocale(v.get("amount")) //
+                                                                            .or(() -> localeFromDocumentContext(v)) //
+                                                                            .orElse(Locale.GERMANY);
 
-                                                            var apostrophe = v.get("amount").indexOf("\'");
-                                                            if (apostrophe >= 0)
-                                                            {
-                                                                language = "de";
-                                                                country = "CH";
-                                                            }
-
-                                                            t.setAmount(asAmount(v.get("amount"), language, country));
+                                                            t.setAmount(asAmount(v.get("amount"), locale));
                                                             t.setCurrencyCode(asCurrencyCode("EUR"));
                                                             t.setNote(trim(v.get("note")));
                                                         }),
@@ -123,7 +173,9 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                         // 2/4/2025 SEPA payment €1,000 €1,000
                                         // @formatter:on
                                         section -> section //
-                                                        .attributes("date", "note", "amount") //
+                                                        .attributes("date", "note", "amount", "balance") //
+                                                        .documentContextOptionally(NUMBER_LOCALE_LANGUAGE,
+                                                                        NUMBER_LOCALE_COUNTRY) //
                                                         .match("^(?<date>([\\d]{1,2}\\/[\\d]{1,2}\\/[\\d]{4}|[\\d]{4}\\/[\\d]{1,2}\\/[\\d]{1,2})) " //
                                                                         + "(?<note>(.berweisen" //
                                                                         + "|SEPA\\-Bank.berweisung" //
@@ -136,29 +188,18 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                                                         + "|Withdrawal)) " //
                                                                         + "(\\p{Sc})?(\\W)?" //
                                                                         + "(?<amount>[\\.,\\d]+)" //
-                                                                        + "(\\W)?(\\p{Sc})(\\W)?(\\-)?[\\.,\\d]+(\\W)?(\\p{Sc})?$") //
+                                                                        + "(\\W)?(\\p{Sc})(\\W)?(?<balance>\\-?[\\.,\\d]+)(\\W)?(\\p{Sc})?$") //
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date"), Locale.UK));
 
-                                                            var language = "de";
-                                                            var country = "DE";
+                                                            var locale = ExtractorUtils
+                                                                            .detectNumberLocale(v.get("amount")) //
+                                                                            .or(() -> ExtractorUtils.detectNumberLocale(
+                                                                                            v.get("balance"))) //
+                                                                            .or(() -> localeFromDocumentContext(v)) //
+                                                                            .orElse(Locale.UK);
 
-                                                            var lastDot = v.get("amount").lastIndexOf(".");
-                                                            var lastComma = v.get("amount").lastIndexOf(",");
-
-                                                            if (Math.max(lastDot, lastComma) == lastDot)
-                                                            {
-                                                                language = "en";
-                                                                country = "US";
-                                                            }
-                                                            else if ((lastComma >= 0 && (v.get("amount").length() - lastComma - 1) >= 3) //
-                                                                            || (lastDot >= 0 && (v.get("amount").length() - lastDot - 1) >= 3))
-                                                            {
-                                                                language = "en";
-                                                                country = "US";
-                                                            }
-
-                                                            t.setAmount(asAmount(v.get("amount"), language, country));
+                                                            t.setAmount(asAmount(v.get("amount"), locale));
                                                             t.setCurrencyCode(asCurrencyCode("EUR"));
                                                             t.setNote(trim(v.get("note")));
                                                         }),
@@ -183,11 +224,22 @@ public class BondoraCapitalPDFExtractor extends AbstractPDFExtractor
                                                                         + "(\\W)?(\\p{Sc})(\\W)?(\\-)?[\\.,\\d]+(\\W)?(\\p{Sc})?$") //
                                                         .assign((t, v) -> {
                                                             t.setDateTime(asDate(v.get("date")));
-                                                            t.setAmount(asAmount(v.get("amount"), "de", "DE"));
+                                                            t.setAmount(asAmount(v.get("amount"), Locale.GERMANY));
                                                             t.setCurrencyCode(asCurrencyCode("EUR"));
                                                             t.setNote(trim(v.get("note")));
                                                         }))
 
                         .wrap(TransactionItem::new);
+    }
+
+    private Optional<Locale> localeFromDocumentContext(ParsedData values)
+    {
+        var language = values.get(NUMBER_LOCALE_LANGUAGE);
+        var country = values.get(NUMBER_LOCALE_COUNTRY);
+
+        if (language == null || country == null)
+            return Optional.empty();
+
+        return Optional.of(Locale.of(language, country));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DegiroPDFExtractor.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -2190,84 +2191,21 @@ public class DegiroPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        String language = "de";
-        String country = "DE";
-
-        int apostrophe = value.indexOf("\'");
-        if (apostrophe >= 0)
-        {
-            language = "de";
-            country = "CH";
-        }
-        else
-        {
-            int lastDot = value.lastIndexOf(".");
-            int lastComma = value.lastIndexOf(",");
-
-            // returns the greater of two int values
-            if (Math.max(lastDot, lastComma) == lastDot)
-            {
-                language = "en";
-                country = "US";
-            }
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Amount, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 
     @Override
     protected long asShares(String value)
     {
-        String language = "de";
-        String country = "DE";
-
-        int apostrophe = value.indexOf("\'");
-        if (apostrophe >= 0)
-        {
-            language = "de";
-            country = "CH";
-        }
-        else
-        {
-            int lastDot = value.lastIndexOf(".");
-            int lastComma = value.lastIndexOf(",");
-
-            // returns the greater of two int values
-            if (Math.max(lastDot, lastComma) == lastDot)
-            {
-                language = "en";
-                country = "US";
-            }
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Share, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Share,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        String language = "de";
-        String country = "DE";
-
-        int apostrophe = value.indexOf("\'");
-        if (apostrophe >= 0)
-        {
-            language = "de";
-            country = "CH";
-        }
-        else
-        {
-            int lastDot = value.lastIndexOf(".");
-            int lastComma = value.lastIndexOf(",");
-
-            // returns the greater of two int values
-            if (Math.max(lastDot, lastComma) == lastDot)
-            {
-                language = "en";
-                country = "US";
-            }
-        }
-
-        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, language, country);
+        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ErsteBankPDFExtractor.java
@@ -9,6 +9,7 @@ import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Locale;
 import java.util.Map;
 
 import name.abuchen.portfolio.datatransfer.ExtrExchangeRate;
@@ -1272,57 +1273,21 @@ public class ErsteBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        String language = "de";
-        String country = "DE";
-
-        int lastDot = value.lastIndexOf(".");
-        int lastComma = value.lastIndexOf(",");
-
-        // returns the greater of two int values
-        if (Math.max(lastDot, lastComma) == lastDot)
-        {
-            language = "en";
-            country = "US";
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Amount, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 
     @Override
     protected long asShares(String value)
     {
-        String language = "de";
-        String country = "DE";
-
-        int lastDot = value.lastIndexOf(".");
-        int lastComma = value.lastIndexOf(",");
-
-        // returns the greater of two int values
-        if (Math.max(lastDot, lastComma) == lastDot)
-        {
-            language = "en";
-            country = "US";
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Share, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Share,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        String language = "de";
-        String country = "DE";
-
-        int lastDot = value.lastIndexOf(".");
-        int lastComma = value.lastIndexOf(",");
-
-        // returns the greater of two int values
-        if (Math.max(lastDot, lastComma) == lastDot)
-        {
-            language = "en";
-            country = "US";
-        }
-
-        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, language, country);
+        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EstateGuruPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/EstateGuruPDFExtractor.java
@@ -2,6 +2,8 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
+import java.util.Locale;
+
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -198,19 +200,7 @@ public class EstateGuruPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        var language = "de";
-        var country = "DE";
-
-        var lastDot = value.lastIndexOf(".");
-        var lastComma = value.lastIndexOf(",");
-
-        // returns the greater of two int values
-        if (Math.max(lastDot, lastComma) == lastDot)
-        {
-            language = "en";
-            country = "US";
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Amount, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import name.abuchen.portfolio.Messages;
@@ -3939,38 +3940,14 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        var language = "de";
-        var country = "DE";
-
-        var lastDot = value.lastIndexOf(".");
-        var lastComma = value.lastIndexOf(",");
-
-        // returns the greater of two int values
-        if (Math.max(lastDot, lastComma) == lastDot)
-        {
-            language = "en";
-            country = "US";
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Amount, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 
     @Override
     protected long asShares(String value)
     {
-        var language = "de";
-        var country = "DE";
-
-        var lastDot = value.lastIndexOf(".");
-        var lastComma = value.lastIndexOf(",");
-
-        // returns the greater of two int values
-        if (Math.max(lastDot, lastComma) == lastDot)
-        {
-            language = "en";
-            country = "US";
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Share, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Share,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KeytradeBankPDFExtractor.java
@@ -4,6 +4,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGros
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
+import java.util.Locale;
 
 import name.abuchen.portfolio.datatransfer.ExtrExchangeRate;
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
@@ -501,57 +502,21 @@ public class KeytradeBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        String language = "de";
-        String country = "DE";
-
-        int lastDot = value.lastIndexOf(".");
-        int lastComma = value.lastIndexOf(",");
-
-        // returns the greater of two int values
-        if (Math.max(lastDot, lastComma) == lastDot)
-        {
-            language = "en";
-            country = "US";
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Amount, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 
     @Override
     protected long asShares(String value)
     {
-        String language = "de";
-        String country = "DE";
-
-        int lastDot = value.lastIndexOf(".");
-        int lastComma = value.lastIndexOf(",");
-
-        // returns the greater of two int values
-        if (Math.max(lastDot, lastComma) == lastDot)
-        {
-            language = "en";
-            country = "US";
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Share, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Share,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        String language = "de";
-        String country = "DE";
-
-        int lastDot = value.lastIndexOf(".");
-        int lastComma = value.lastIndexOf(",");
-
-        // returns the greater of two int values
-        if (Math.max(lastDot, lastComma) == lastDot)
-        {
-            language = "en";
-            country = "US";
-        }
-
-        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, language, country);
+        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
@@ -5,6 +5,7 @@ import static name.abuchen.portfolio.util.TextUtil.concatenate;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
+import java.util.Locale;
 
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
@@ -1376,57 +1377,15 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        var language = "de";
-        var country = "DE";
-
-        var apostrophe = value.indexOf("\'");
-        if (apostrophe >= 0)
-        {
-            language = "de";
-            country = "CH";
-        }
-        else
-        {
-            var lastDot = value.lastIndexOf(".");
-            var lastComma = value.lastIndexOf(",");
-
-            // returns the greater of two int values
-            if (Math.max(lastDot, lastComma) == lastDot)
-            {
-                language = "en";
-                country = "US";
-            }
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Amount, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        var language = "de";
-        var country = "DE";
-
-        var apostrophe = value.indexOf("\'");
-        if (apostrophe >= 0)
-        {
-            language = "de";
-            country = "CH";
-        }
-        else
-        {
-            var lastDot = value.lastIndexOf(".");
-            var lastComma = value.lastIndexOf(",");
-
-            // returns the greater of two int values
-            if (Math.max(lastDot, lastComma) == lastDot)
-            {
-                language = "en";
-                country = "US";
-            }
-        }
-
-        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, language, country);
+        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 
     /**

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SaxoBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SaxoBankPDFExtractor.java
@@ -7,6 +7,7 @@ import static name.abuchen.portfolio.util.TextUtil.concatenate;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
+import java.util.Locale;
 
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
@@ -702,84 +703,21 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        var language = "de";
-        var country = "DE";
-
-        var apostrophe = value.indexOf("\'");
-        if (apostrophe >= 0)
-        {
-            language = "de";
-            country = "CH";
-        }
-        else
-        {
-            var lastDot = value.lastIndexOf(".");
-            var lastComma = value.lastIndexOf(",");
-
-            // returns the greater of two int values
-            if (Math.max(lastDot, lastComma) == lastDot)
-            {
-                language = "en";
-                country = "US";
-            }
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Amount, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 
     @Override
     protected long asShares(String value)
     {
-        var language = "de";
-        var country = "DE";
-
-        var apostrophe = value.indexOf("\'");
-        if (apostrophe >= 0)
-        {
-            language = "de";
-            country = "CH";
-        }
-        else
-        {
-            var lastDot = value.lastIndexOf(".");
-            var lastComma = value.lastIndexOf(",");
-
-            // returns the greater of two int values
-            if (Math.max(lastDot, lastComma) == lastDot)
-            {
-                language = "en";
-                country = "US";
-            }
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Share, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Share,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        var language = "de";
-        var country = "DE";
-
-        var apostrophe = value.indexOf("\'");
-        if (apostrophe >= 0)
-        {
-            language = "de";
-            country = "CH";
-        }
-        else
-        {
-            var lastDot = value.lastIndexOf(".");
-            var lastComma = value.lastIndexOf(",");
-
-            // returns the greater of two int values
-            if (Math.max(lastDot, lastComma) == lastDot)
-            {
-                language = "en";
-                country = "US";
-            }
-        }
-
-        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, language, country);
+        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.datatransfer.pdf;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
+import java.util.Locale;
 import java.util.Map;
 
 import name.abuchen.portfolio.Messages;
@@ -946,19 +947,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        var language = "de";
-        var country = "DE";
-
-        var lastDot = value.lastIndexOf(".");
-        var lastComma = value.lastIndexOf(",");
-
-        // returns the greater of two int values
-        if (Math.max(lastDot, lastComma) == lastDot)
-        {
-            language = "en";
-            country = "US";
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Amount, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SolarisbankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SolarisbankAGPDFExtractor.java
@@ -2,6 +2,8 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
+import java.util.Locale;
+
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
@@ -117,19 +119,7 @@ public class SolarisbankAGPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        String language = "de";
-        String country = "DE";
-
-        int lastDot = value.lastIndexOf(".");
-        int lastComma = value.lastIndexOf(",");
-
-        // returns the greater of two int values
-        if (Math.max(lastDot, lastComma) == lastDot)
-        {
-            language = "en";
-            country = "US";
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Amount, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -6,6 +6,7 @@ import static name.abuchen.portfolio.util.TextUtil.trim;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -5102,38 +5103,14 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asAmount(String value)
     {
-        var language = "de";
-        var country = "DE";
-
-        var lastDot = value.lastIndexOf(".");
-        var lastComma = value.lastIndexOf(",");
-
-        // returns the greater of two int values
-        if (Math.max(lastDot, lastComma) == lastDot)
-        {
-            language = "en";
-            country = "US";
-        }
-
-        return ExtractorUtils.convertToNumberLong(value, Values.Amount, language, country);
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 
     @Override
     protected BigDecimal asExchangeRate(String value)
     {
-        var language = "de";
-        var country = "DE";
-
-        var lastDot = value.lastIndexOf(".");
-        var lastComma = value.lastIndexOf(",");
-
-        // returns the greater of two int values
-        if (Math.max(lastDot, lastComma) == lastDot)
-        {
-            language = "en";
-            country = "US";
-        }
-
-        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, language, country);
+        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -304,11 +304,16 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // Tencent Holdings Ltd. 0,3773 titre(s) 53,00 EUR 20,00 EUR
                                         // zjBAM Corp. 125 Pz. 29,75 EUR 3.718,75 EUR
                                         // Vonovia SE 0,781379 tít. 24,06 EUR 18,80 EUR
+                                        // Lev MSCI USA EUR (Acc) 200 Stk. 26 EUR
                                         // @formatter:on
                                         section -> section //
-                                                        .attributes("shares") //
-                                                        .match("^.* (?<shares>[\\.,\\d]+) (Stk\\.|titre\\(s\\)|Pz\\.|t.t\\.) .*$") //
-                                                        .assign((t, v) -> t.setShares(asShares(v.get("shares")))),
+                                                        .attributes("shares", "sample") //
+                                                        .match("^.* (?<shares>[\\.,\\d]+) (Stk\\.|titre\\(s\\)|Pz\\.|t.t\\.) (.* )?(?<sample>[\\.,'\\d]+) [A-Z]{3}$") //
+                                                        .assign((t, v) -> {
+                                                            // use the monetary amount to detect the format for the shares
+                                                            var locale = ExtractorUtils.guessNumberLocale(v.get("sample"), Locale.GERMANY);
+                                                            t.setShares(asShares(v.get("shares"), locale));
+                                                        }),
                                         // @formatter:off
                                         // Berkshire Hathaway Inc. 0.3367 Pcs. 297.00 EUR 100.00 EUR
                                         // @formatter:on
@@ -896,9 +901,13 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // Vonovia SE 0,781379 tít. 24,06 EUR 18,80 EUR
                                         // @formatter:on
                                         section -> section //
-                                                        .attributes("shares") //
-                                                        .match("^.* (?<shares>[\\.,\\d]+) (Stk\\.|titre\\(s\\)|Pz\\.|t.t\\.) .*$") //
-                                                        .assign((t, v) -> t.setShares(asShares(v.get("shares")))),
+                                                        .attributes("shares", "sample") //
+                                                        .match("^.* (?<shares>[\\.,\\d]+) (Stk\\.|titre\\(s\\)|Pz\\.|t.t\\.) (.* )?(?<sample>[\\.,'\\d]+) [A-Z]{3}$") //
+                                                        .assign((t, v) -> {
+                                                            // use the monetary amount to detect the format for the shares
+                                                            var locale = ExtractorUtils.guessNumberLocale(v.get("sample"), Locale.GERMANY);
+                                                            t.setShares(asShares(v.get("shares"), locale));
+                                                        }),
                                         // @formatter:off
                                         // Berkshire Hathaway Inc. 0.3367 Pcs. 297.00 EUR 100.00 EUR
                                         // @formatter:on
@@ -1423,9 +1432,13 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // Apple Inc. 0.0929 Pcs. 0.24 USD 0.02 USD
                                         // @formatter:on
                                         section -> section //
-                                                        .attributes("shares") //
-                                                        .match("^.* (?<shares>[\\.,\\d]+) (Stk\\.|titre\\(s\\)|Pz\\.) [\\.,\\d]+ [A-Z]{3} [\\.,\\d]+ [A-Z]{3}$") //
-                                                        .assign((t, v) -> t.setShares(asShares(v.get("shares")))),
+                                                        .attributes("shares", "sample") //
+                                                        .match("^.* (?<shares>[\\.,\\d]+) (Stk\\.|titre\\(s\\)|Pz\\.) [\\.,\\d]+ [A-Z]{3} (?<sample>[\\.,\\d]+) [A-Z]{3}$") //
+                                                        .assign((t, v) -> {
+                                                            // use the monetary amount to detect the format for the shares
+                                                            var locale = ExtractorUtils.guessNumberLocale(v.get("sample"), Locale.GERMANY);
+                                                            t.setShares(asShares(v.get("shares"), locale));
+                                                        }),
                                         // @formatter:off
                                         // IE00BK1PV551 123 Stücke 0.36 USD
                                         // NL0011683594 90.537929 Stücke 0.87 EUR
@@ -4300,9 +4313,13 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // Vonovia SE 0,781379 tít. 24,06 EUR 18,80 EUR
                                         // @formatter:on
                                         section -> section //
-                                                        .attributes("shares") //
-                                                        .match("^.* (?<shares>[\\.,\\d]+) (Stk\\.|titre\\(s\\)|Pz\\.|t.t\\.) .*$") //
-                                                        .assign((t, v) -> t.setShares(asShares(v.get("shares")))),
+                                                        .attributes("shares", "sample") //
+                                                        .match("^.* (?<shares>[\\.,\\d]+) (Stk\\.|titre\\(s\\)|Pz\\.|t.t\\.) (.* )?(?<sample>[\\.,'\\d]+) [A-Z]{3}$") //
+                                                        .assign((t, v) -> {
+                                                            // use the monetary amount to detect the format for the shares
+                                                            var locale = ExtractorUtils.guessNumberLocale(v.get("sample"), Locale.GERMANY);
+                                                            t.setShares(asShares(v.get("shares"), locale));
+                                                        }),
                                         // @formatter:off
                                         // Berkshire Hathaway Inc. 0.3367 Pcs. 297.00 EUR 100.00 EUR
                                         // @formatter:on
@@ -4662,9 +4679,13 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // Apple Inc. 1,92086 titre(s) 0,25 USD 0,48 USD
                                         // @formatter:on
                                         section -> section //
-                                                        .attributes("shares") //
-                                                        .match("^.* (?<shares>[\\.,\\d]+) (Stk\\.|titre\\(s\\)|Pz\\.) [\\.,\\d]+ [A-Z]{3} [\\.,\\d]+ [A-Z]{3}$") //
-                                                        .assign((t, v) -> t.setShares(asShares(v.get("shares")))),
+                                                        .attributes("shares", "sample") //
+                                                        .match("^.* (?<shares>[\\.,\\d]+) (Stk\\.|titre\\(s\\)|Pz\\.) [\\.,\\d]+ [A-Z]{3} (?<sample>[\\.,\\d]+) [A-Z]{3}$") //
+                                                        .assign((t, v) -> {
+                                                            // use the monetary amount to detect the format for the shares
+                                                            var locale = ExtractorUtils.guessNumberLocale(v.get("sample"), Locale.GERMANY);
+                                                            t.setShares(asShares(v.get("shares"), locale));
+                                                        }),
                                         // @formatter:off
                                         // IE00BK1PV551 123 Stücke 0.36 USD
                                         // NL0011683594 90.537929 Stücke 0.87 EUR
@@ -5093,10 +5114,6 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
     @Override
     protected long asShares(String value)
     {
-        if (value.matches("^(0\\.\\d+|\\d+\\.\\d{1,2}|\\d+\\.\\d{4,})$"))
-        {
-            return asShares(value, "en", "US"); //
-        }
         return super.asShares(value);
     }
 


### PR DESCRIPTION
  - Introduce shared number-format guessing
    Adds central locale detection for formatted numbers, including a reliable detection variant that returns no locale for ambiguous cases. Also adds Locale-based amount/share conversion overloads so importers can
    pass detected formats directly.

  - Apply number-format guessing to Trade Republic
    Updates Trade Republic to derive the share-number format from a monetary amount on the same line. This removes importer-specific share heuristics and makes mixed German/US formats more robust.

  - Apply reliable number-format detection to Bondora
    Detects Bondora statement number formats from unambiguous summary/header amounts and, for slash-date transactions, also considers the balance as a local format sample. Ambiguous values are ignored so the importer
    falls back to its existing structural defaults.