### PR TITLE
Modify BoursoBank PDF-Importer to support new transaction

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/BoursoBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/BoursoBankPDFExtractorTest.java
@@ -678,4 +678,145 @@ public class BoursoBankPDFExtractorTest
 
     }
 
+    @Test
+    public void testDividende03()
+    {
+        var extractor = new BoursoBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(8L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(8L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(16));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("FR0000053225"), hasWkn(null), hasTicker(null), //
+                        hasName("METROPOLE TV"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-04T00:00"), hasExDate(null), //
+                        hasShares(73), //
+                        hasSource("Dividende03.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 91.25), hasGrossValue("EUR", 91.25), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("FR0010411983"), hasWkn(null), hasTicker(null), //
+                        hasName("SCOR SE REGPT"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-04T00:00"), hasExDate(null), //
+                        hasShares(183), //
+                        hasSource("Dividende03.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 347.70), hasGrossValue("EUR", 347.70), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("PTZON0AM0006"), hasWkn(null), hasTicker(null), //
+                        hasName("NOS"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-06T00:00"), hasExDate(null), //
+                        hasShares(476), //
+                        hasSource("Dividende03.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 139.23), hasGrossValue("EUR", 214.20), //
+                        hasTaxes("EUR", 74.97), hasFees("EUR", 0.00))));
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("FR0000120628"), hasWkn(null), hasTicker(null), //
+                        hasName("AXA"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-11T00:00"), hasExDate(null), //
+                        hasShares(6), //
+                        hasSource("Dividende03.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 13.92), hasGrossValue("EUR", 13.92), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("FR0004007813"), hasWkn(null), hasTicker(null), //
+                        hasName("KAUFMAN ET BROAD"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-11T00:00"), hasExDate(null), //
+                        hasShares(106), //
+                        hasSource("Dividende03.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 233.20), hasGrossValue("EUR", 233.20), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("FR0000045072"), hasWkn(null), hasTicker(null), //
+                        hasName("CREDIT AGRICOLE"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-26T00:00"), hasExDate(null), //
+                        hasShares(187), //
+                        hasSource("Dividende03.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 211.31), hasGrossValue("EUR", 211.31), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("FR0010667147"), hasWkn(null), hasTicker(null), //
+                        hasName("COFACE"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-26T00:00"), hasExDate(null), //
+                        hasShares(410), //
+                        hasSource("Dividende03.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 512.50), hasGrossValue("EUR", 512.50), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("BE0003820371"), hasWkn(null), hasTicker(null), //
+                        hasName("EVS BROADCAST.EQUI"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-27T00:00"), hasExDate(null), //
+                        hasShares(5), //
+                        hasSource("Dividende03.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 2.10), hasGrossValue("EUR", 3.00), //
+                        hasTaxes("EUR", 0.90), hasFees("EUR", 0.00))));
+
+    }
+
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/Dividende03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/boursobank/Dividende03.txt
@@ -1,0 +1,66 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.82.1
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+COUPONS REMBOURSEMENTS : MAI 2026
+ 000000
+P226803
+MR pRJSdIG NapEEdr
+625 LA XeevTo qxiXWr
+80995 eXIDVUjdj
+le 29/05/2026
+Feuillet 1/2
+Références de votre compte titres
+69460 96399 31360727195 Compte PEA
+Résident Français
+ DETAIL COUPONS
+Acompte
+Date et/ou Commission
+échéance Brut fiscal Crédit d'impôt Prélèvements ¨ Net fiscal T.T.C. Net client
+coupon Quantité Nom de la valeur (code) EUR EUR EUR EUR EUR EUR
+04/05/2026 73 METROPOLE TV (FR0000053225) 91,25 91,25 91,25
+revenus d'actions et opc français ouvrant droit à
+abattement
+04/05/2026 183 SCOR SE REGPT (FR0010411983) 347,70 347,70 347,70
+revenus d'actions et opc français ouvrant droit à
+abattement
+06/05/2026 476 NOS (PTZON0AM0006) 214,20 24,50 139,23 139,23
+revenus d'actions étrangères et opc européens ouvrant
+droit à abattement
+11/05/2026 6 AXA (FR0000120628) 13,92 13,92 13,92
+revenus d'actions et opc français ouvrant droit à
+abattement
+11/05/2026 106 KAUFMAN ET BROAD (FR0004007813) 233,20 233,20 233,20
+revenus d'actions et opc français ouvrant droit à
+abattement
+26/05/2026 187 CREDIT AGRICOLE (FR0000045072) 211,31 211,31 211,31
+revenus d'actions et opc français ouvrant droit à
+abattement
+26/05/2026 410 COFACE (FR0010667147) 512,50 512,50 512,50
+revenus d'actions et opc français ouvrant droit à
+abattement
+27/05/2026 5 EVS BROADCAST.EQUI (BE0003820371) 3,00 0,37 2,10 2,10
+revenus d'actions étrangères et opc européens ouvrant
+droit à abattement
+TOTAL EUR 24,87 0,00 1 551,21 0,00 1 551,21
+¨ Comprend l'acompte sur le revenu au titre de l'impôt et/ou les divers prélèvements dont les contibutions sociales (CSG, CRDS, ...)
+ 
+Service Clientèle : 01 46 09 49 49 ou +33 146 09 49 49 depuis l'étranger, du lundi au vendredi de 8h à 20h et le samedi de 8h45 à 16h30 – www.boursobank.com
+Boursorama S.A. au capital de 53 576 889,20 € - RCS Nanterre 351 058 151 - TVA 69 351 058 151 - 44 rue Traversière - CS 80134 - 92772 Boulogne Billancourt Cedex
+Adresse du médiateur : Médiateur de l'AMF - 17, place de la Bourse - 75082 PARIS CEDEX 02 AA1
+000000 F1 P226803 1/1
+COUPONS REMBOURSEMENTS : MAI 2026
+MR gvhaDLA hPdcjuS
+164 fB rbqMaZ BbUbYo
+30029 mtTQQMBNK
+le 29/05/2026
+Feuillet 2/2
+Références de votre compte titres
+98917 80616 49900580546
+COUPONS : NETS FISCAUX  1 551,21 EUR
+REMBOURSEMENTS : BRUTS GLOBAUX  0,00 EUR
+¨ Comprend l'acompte sur le revenu au titre de l'impôt et/ou les divers prélèvements dont les contibutions sociales (CSG, CRDS, ...)
+Service Clientèle : 01 46 09 49 49 ou +33 146 09 49 49 depuis l'étranger, du lundi au vendredi de 8h à 20h et le samedi de 8h45 à 16h30 – www.boursobank.com
+Boursorama S.A. au capital de 53 576 889,20 € - RCS Nanterre 351 058 151 - TVA 69 351 058 151 - 44 rue Traversière - CS 80134 - 92772 Boulogne Billancourt Cedex
+Adresse du médiateur : Médiateur de l'AMF - 17, place de la Bourse - 75082 PARIS CEDEX 02 AA1
+000000 F2 P226803 2/1

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BoursoBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BoursoBankPDFExtractor.java
@@ -287,16 +287,6 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
     {
         transaction //
-
-                        // @formatter:off
-                        // Revenus d'actions étrangères sans abattement
-                        // TOTAL EUR 0,00 12,09 28,24 0,00 28,24
-                        // @formatter:on
-                        .section("currency", "tax").optional() //
-                        .find("Revenus.*") //
-                        .match("^TOTAL (?<currency>[A-Z]{3}) [\\,\\d\\s]+ (?<tax>[\\,\\d\\s]+) [\\,\\d\\s]+ [\\,\\d\\s]+ [\\,\\d\\s]+$") //
-                        .assign((t, v) -> processTaxEntries(t, v, type))
-
                         // @formatter:off
                         // Montant brut Commission Frais (¨) Montant net au débit de votre compte
                         // 10,99 EUR 2,02 EUR 3,03 EUR 16,04 EUR
@@ -304,7 +294,21 @@ public class BoursoBankPDFExtractor extends AbstractPDFExtractor
                         .section("currency", "tax").optional() //
                         .find("Montant.*") //
                         .match("^[\\d\\s]+,[\\d]{2} [A-Z]{3} [\\d\\s]+,[\\d]{2} [A-Z]{3} (?<tax>[\\d\\s]+,[\\d]{2}) (?<currency>[A-Z]{3}) [\\d\\s]+,[\\d]{2} [A-Z]{3}$") //
-                        .assign((t, v) -> processTaxEntries(t, v, type));
+                        .assign((t, v) -> processTaxEntries(t, v, type))
+
+                        // @formatter:off
+                        // 15/02/2024 248 ISHS DEV MK PRO US (IE00B1FZS350) 40,33 12,09 28,24 28,24
+                        // 06/05/2026 476 NOS (PTZON0AM0006) 214,20 24,50 139,23 139,23
+                        // @formatter:on
+                        .section("gross", "amount").optional() //
+                        .documentContext("currency") //
+                        .match("^[\\d]{2}\\/[\\d]{2}\\/[\\d]{4} [\\,\\d\\s]+ .* (?<gross>[\\d\\s]+,[\\d]{2}) [\\d\\s]+,[\\d]{2} [\\d\\s]+,[\\d]{2} (?<amount>[\\d\\s]+,[\\d]{2})$") //
+                        .assign((t, v) -> {
+                            var gross = Money.of(v.get("currency"), asAmount(v.get("gross")));
+                            var amount = Money.of(v.get("currency"), asAmount(v.get("amount")));
+                            var tax = gross.subtract(amount);
+                            ExtractorUtils.checkAndSetTax(tax, t, type.getCurrentContext());
+                        });
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)


### PR DESCRIPTION
https://forum.portfolio-performance.info/t/pdf-import-from-boursobank-ex-boursorama-banque/28876/11
https://forum.portfolio-performance.info/t/pdf-import-from-boursobank-ex-boursorama-banque/28876/9

Hello, this is proposition of modification of BoursoBank pdf importer.
In the aboved example, an example of Dividend with foreign taxes is presented and was not parsed until now.
The value of the foreign taxes is not available directly but is computed from the gross and net dividend values.

I am removing one matching pattern: it was related to file Dividende01.txt: dividend 1 contains a single dividend and the removed matching pattern was parsing a line related to the total tax of all dividends on the pdf. So okay for the particular case of 1 dividend, but actually incorrect when several dividends are there. The single dividende01.txt case now falls into the added parsed pattern.

There are many assert for the new Dividende03.txt, but only the two with non null taxes are the ones that were not recognized previsouly.