### PR TITLE
Fix FIL Fond Bank PDF Importer failing to parse data if the lines ends with spaces

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/filfondbank/FILFondbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/filfondbank/FILFondbankPDFExtractorTest.java
@@ -169,6 +169,129 @@ public class FILFondbankPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierKauf03()
+    {
+        var extractor = new FILFondbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(3L));
+        assertThat(countBuySell(results), is(3L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(6));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00B4X9L533"), hasWkn("A1C9KK"), hasTicker(null), //
+                        hasName("HSBC MSCI WORLD ETF"), //
+                        hasCurrencyCode("USD"))));
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE000OJ5TQP4"), hasWkn("A3EB9T"), hasTicker(null), //
+                        hasName("Future of Defense UCITS ETF Ac"), //
+                        hasCurrencyCode("USD"))));
+        assertThat(results, hasItem(security( //
+                        hasIsin("EE3600102901"), hasWkn("A0PEF0"), hasTicker(null), //
+                        hasName("Avaron Emerging Europe Fund C"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-15T11:15:38"), hasShares(9.451), //
+                        hasSource("Kauf03.txt"), //
+                        hasNote("Auftrags-Nr. 2667709223"), //
+                        hasAmount("EUR", 400.00), hasGrossValue("EUR", 400.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        hasForexGrossValue("USD", 461.23))));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-15T11:14:49"), hasShares(22.223), //
+                        hasSource("Kauf03.txt"), //
+                        hasNote("Auftrags-Nr. 2667756179"), //
+                        hasAmount("EUR", 400.00), hasGrossValue("EUR", 400.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        hasForexGrossValue("USD", 461.23))));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-15T11:14:49"), hasShares(7.711), //
+                        hasSource("Kauf03.txt"), //
+                        hasNote("Auftrags-Nr. 2667761620"), //
+                        hasAmount("EUR", 400.00), hasGrossValue("EUR", 400.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00) //
+        )));
+    }
+
+    @Test
+    public void testWertpapierKauf03WithSecurityInEUR()
+    {
+        var client = new Client();
+        addSecurity(client, "IE00B4X9L533", "A1C9KK", "HSBC MSCI WORLD ETF", "EUR");
+        addSecurity(client, "IE000OJ5TQP4", "A3EB9T", "Future of Defense UCITS ETF Ac", "EUR");
+        addSecurity(client, "EE3600102901", "A0PEF0", "Avaron Emerging Europe Fund C", "EUR");
+
+        var extractor = new FILFondbankPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf03.txt"), errors);
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(3L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, "EUR");
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-15T11:15:38"), hasShares(9.451), //
+                        hasSource("Kauf03.txt"), //
+                        hasNote("Auftrags-Nr. 2667709223"), //
+                        hasAmount("EUR", 400.00), hasGrossValue("EUR", 400.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        check(tx -> {
+                            var c = new CheckCurrenciesAction();
+                            var s = c.process((PortfolioTransaction) tx, new Portfolio());
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-15T11:14:49"), hasShares(22.223), //
+                        hasSource("Kauf03.txt"), //
+                        hasNote("Auftrags-Nr. 2667756179"), //
+                        hasAmount("EUR", 400.00), hasGrossValue("EUR", 400.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        check(tx -> {
+                            var c = new CheckCurrenciesAction();
+                            var s = c.process((PortfolioTransaction) tx, new Portfolio());
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-15T11:14:49"), hasShares(7.711), //
+                        hasSource("Kauf03.txt"), //
+                        hasNote("Auftrags-Nr. 2667761620"), //
+                        hasAmount("EUR", 400.00), hasGrossValue("EUR", 400.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        check(tx -> {
+                            var c = new CheckCurrenciesAction();
+                            var s = c.process((PortfolioTransaction) tx, new Portfolio());
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
+    }
+
+    private void addSecurity(Client client, String isin, String wkn, String name, String currency)
+    {
+        var security = new Security(name, currency);
+        security.setIsin(isin);
+        security.setWkn(wkn);
+        client.addSecurity(security);
+    }
+
+    @Test
     public void testWertpapierVerkauf01()
     {
         var extractor = new FILFondbankPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/filfondbank/Kauf03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/filfondbank/Kauf03.txt
@@ -1,0 +1,60 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Depotführung: Ihr der FFB benannte Vermittler:
+Fondsvermittlung24.de GmbH 
+Heidenkampsweg 75 
+20097 Hamburg
+Fax: 040 52473790
+Herrn info@fondsvermittlung24.de
+RunYq nwWGF 
+ZxQdq WyqX 479 
+95400 qHjmAkYM
+Es schreibt Ihnen:
+FFB Kundenbetreuung
+Kronberg im Taunus, 16. Juni 2026
+Fondsabrechnung
+Auszug 18 
+Depotinhaber pGoPV zqcjq 
+Depotnummer 5060823916 (Privatvermögen)
+Transaktion Fondsname Betrag Preis Anteile 
+Auftrags-Nr. WKN / ISIN Wechselkurs Preisdatum Bestand alt 
+Fondsgesellschaft Währungsbetrag Zwischengewinn Bestand neu 
+Verwahrart, Lagerland Rücknahmepreis
+Kauf HSBC MSCI WORLD ETF 400,00 EUR 48,8000 USD 9,451
+2667709223 A1C9KK / IE00B4X9L533 1,153073 USD 15.06.2026 309,460 
+HSBC Global Asset Management 461,23 USD 0,0000 EUR 318,911 
+(Deutschland) GmbH 
+Wertpapierrechnung, Grossbritannien 48,8000 USD 
+Abrechnungsbetrag 400,00 EUR 
+Ausgabeaufschlag / Provision (0,00 %) 0,00 EUR 
+Handelsuhrzeit 11:15:38
+Kauf Future of Defense UCITS ETF Ac 400,00 EUR 20,7550 USD 22,223
+2667756179 A3EB9T / IE000OJ5TQP4 1,153073 USD 15.06.2026 769,784 
+HANetf Management Ltd. 461,23 USD 0,0000 EUR 792,007 
+Wertpapierrechnung, Grossbritannien 20,7550 USD 
+Abrechnungsbetrag 400,00 EUR 
+Ausgabeaufschlag / Provision (0,00 %) 0,00 EUR 
+Handelsuhrzeit 11:14:49
+Kauf Avaron Emerging Europe Fund C 400,00 EUR 51,8709 EUR 7,711
+2667761620 A0PEF0 / EE3600102901 15.06.2026 95,851 
+AS Avaron Asset Management 0,0000 EUR 103,562 
+Wertpapierrechnung, Estland 51,8709 EUR 
+Abrechnungsbetrag 400,00 EUR 
+Ausgabeaufschlag / Provision (0,00 %) 0,00 EUR
+Steuerliche Informationen
+Erteilter Freistellungsauftrag 115,00 EUR gültig bis: unbefristet Verlustverrechnungstopf neu 0,00 EUR 
+davon noch verfügbar 0,00 EUR Quellensteuertopf neu 0,00 EUR
+Hinweise: 
+Auslandszahlungen, die 50.000 EUR übersteigen, sind gemäß der Außenwirtschaftsverordnung (AWV) durch Sie meldepflichtig. Weitergehende Informationen zur 
+Meldepflicht nach AWV erhalten Sie direkt von der Deutschen Bundesbank, unter www.bundesbank.de oder unter der Rufnummer 0800 1234 111. 
+Einwendungen gegen diese Fondsabrechnung wegen Unrichtigkeit oder Unvollständigkeit richten Sie bitte schriftlich spätestens einen Monat nach Zugang an: 
+FIL Fondsbank GmbH, Beschwerdemanagement, Postfach 11 06 63, 60041 Frankfurt am Main.
+Seite 1 (1)
+FIL Fondsbank GmbH Postanschrift: Vorsitzender Geschäftsführung: Sitz: Kronberg im Taunus 
+Kastanienhöhe 1 Postfach 11 06 63 des Aufsichtsrats: Jan Schepanek (Sprecher) Amtsgericht 
+61476 Kronberg im Taunus 60041 Frankfurt am Main Ferdinand-Alexander Leisten Tina Kern Königstein HRB 8336 
+info@ffb.de Telefon 069 77060-200 Matthias Weiß Umsatzsteuer-ID Nr. 
+www.ffb.de DE213709602
+ABGST_V1.0

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -928,6 +928,40 @@ public class TradeRepublicPDFExtractorTest
     }
 
     @Test
+    public void testIPOBuy01()
+    {
+        var extractor = new TradeRepublicPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "ipo01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US84615Q1031"), hasWkn(null), hasTicker(null), //
+                        hasName("SpaceX"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-12T13:28"), hasShares(1.107566), //
+                        hasSource("ipo01.txt"), //
+                        hasNote("670a-5b88"), //
+                        hasAmount("EUR", 130.32), hasGrossValue("EUR", 129.32), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 1.00))));
+    }
+
+    @Test
     public void testSecurityBuy01()
     {
         var extractor = new TradeRepublicPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/ipo01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/ipo01.txt
@@ -1,0 +1,32 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+QsjVbWSxs zvRj SEITE 1 von 1
+Musterstr. 77 DATUM 12.06.2026
+01148 cdPcgAJoe AUSFÜHRUNG 670a-5b88
+DEPOT 0275536150
+WERTPAPIERABRECHNUNG
+ÜBERSICHT
+Ausführung der Zeichnungsorder am 12.06.2026 um 13:28 am Primärmarkt.
+Der Stückpreis beträgt 135,00 USD und es wurde 0,86491 USD/EUR als Wechselkurs verwendet.
+POSITION ANZAHL PREIS BETRAG
+SpaceX 1,107566 Stk. 116,762806 EUR 129,32 EUR
+ISIN: US84615Q1031
+GESAMT 129,32 EUR
+ABRECHNUNG
+POSITION BETRAG
+Abwicklungskostenpauschale -1,00 EUR
+GESAMT -130,32 EUR
+BUCHUNG
+VERRECHNUNGSKONTO WERTSTELLUNG BETRAG
+DE11100123450187686504 2026-06-15 -130,32 EUR
+SpaceX nicht in Sammelverwahrung
+Diese Abrechnung wird maschinell erstellt und daher nicht unterschrieben.
+Wird keine Umsatzsteuer ausgewiesen, handelt es sich gemäß § 4 Nr. 8 UStG um eine umsatzsteuerfreie Leistung.
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FILFondbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FILFondbankPDFExtractor.java
@@ -42,7 +42,8 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
 
         Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
 
-        Block firstRelevantLine = new Block("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf|Steuerliche Informationen \\(Einzeltransaktion\\)).*$");
+        Block firstRelevantLine = new Block(
+                        "^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf|Steuerliche Informationen \\(Einzeltransaktion\\)).*\\s*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -52,7 +53,7 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
-                        .match("^(?<type>(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf|Steuerliche Informationen \\(Einzeltransaktion\\))).*$") //
+                        .match("^(?<type>(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf|Steuerliche Informationen \\(Einzeltransaktion\\))).*\\s*$") //
                         .assign((t, v) -> {
                             if ("Verkauf".equals(v.get("type")))
                             {
@@ -63,7 +64,7 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
-                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}: (?<type>(Kauf( aus VL\\-Sparplan)|Gesamtverkauf)?)$") //
+                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}: (?<type>(Kauf( aus VL\\-Sparplan)|Gesamtverkauf)?)\\s*$") //
                         .assign((t, v) -> {
                             if ("Gesamtverkauf".equals(v.get("type")))
                             {
@@ -79,8 +80,8 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "wkn", "isin", "currency") //
-                                                        .match("^Fondsname \\(WKN \\/ ISIN\\) (?<name>.*) \\((?<wkn>[A-Z0-9]{6}) \\/ (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\)$") //
-                                                        .match("^Abrechnungspreis [\\.,\\d]+ (?<currency>[\\w]{3})$") //
+                                                        .match("^Fondsname \\(WKN \\/ ISIN\\) (?<name>.*) \\((?<wkn>[A-Z0-9]{6}) \\/ (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\)\\s*$") //
+                                                        .match("^Abrechnungspreis [\\.,\\d]+ (?<currency>[\\w]{3})\\s*$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
                                         // Kauf UBS Emer.Mkt.Soc.Resp.UETFADIS 89,56 EUR 12,6399 USD 7,728
@@ -88,8 +89,8 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "currency", "wkn", "isin") //
-                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? (?<name>.*) [\\.,\\d]+ [\\w]{3} [\\.,\\d]+ (?<currency>[\\w]{3}) ([\\-|\\+])?[\\.,\\d]+$") //
-                                                        .match("^[\\d]+ (?<wkn>[A-Z0-9]{6}) \\/ (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) .*$") //
+                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? (?<name>.*) [\\.,\\d]+ [\\w]{3} [\\.,\\d]+ (?<currency>[\\w]{3}) ([\\-|\\+])?[\\.,\\d]+\\s*$") //
+                                                        .match("^[\\d]+ (?<wkn>[A-Z0-9]{6}) \\/ (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) .*\\s*$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
                                         // Splittkauf Betrag hausInvest 20,00 EUR 42,2300 EUR 0,474
@@ -97,8 +98,8 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "currency", "isin", "wkn") //
-                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? (?<name>.*) [\\.,\\d]+ [\\w]{3} [\\.,\\d]+ (?<currency>[\\w]{3}) ([\\-|\\+])?[\\.,\\d]+$") //
-                                                        .match("^[\\d]+ (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\/ (?<wkn>[A-Z0-9]{6}) .*$") //
+                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? (?<name>.*) [\\.,\\d]+ [\\w]{3} [\\.,\\d]+ (?<currency>[\\w]{3}) ([\\-|\\+])?[\\.,\\d]+\\s*$") //
+                                                        .match("^[\\d]+ (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\/ (?<wkn>[A-Z0-9]{6}) .*\\s*$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
 
                         .oneOf( //
@@ -107,21 +108,21 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("shares") //
-                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? .* ([\\-|\\+])?(?<shares>[\\.,\\d]+)$") //
+                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? .* ([\\-|\\+])?(?<shares>[\\.,\\d]+)\\s*$") //
                                                         .assign((t, v) -> t.setShares(asShares(v.get("shares")))),
                                         // @formatter:off
                                         // Anteile 0,263
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("shares") //
-                                                        .match("^Anteile (?<shares>[\\.,\\d]+)$") //
+                                                        .match("^Anteile (?<shares>[\\.,\\d]+)\\s*$") //
                                                         .assign((t, v) -> t.setShares(asShares(v.get("shares")))))
 
                         // @formatter:off
                         // Handelsuhrzeit 16:51:24
                         // @formatter:on
                         .section("time").optional() //
-                        .match("^Handelsuhrzeit (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})$") //
+                        .match("^Handelsuhrzeit (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})\\s*$") //
                         .assign((t, v) -> type.getCurrentContext().put("time", v.get("time")))
 
                         .oneOf( //
@@ -130,7 +131,7 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("^.*(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) [\\.,\\d]+$") //
+                                                        .match("^.*(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) [\\.,\\d]+\\s*$") //
                                                         .assign((t, v) -> {
                                                             if (type.getCurrentContext().get("time") != null)
                                                                 t.setDate(asDate(v.get("date"), type.getCurrentContext().get("time")));
@@ -144,7 +145,7 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}): (Kauf( aus VL\\-Sparplan)?|Gesamtverkauf)$") //
+                                                        .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}): (Kauf( aus VL\\-Sparplan)?|Gesamtverkauf)\\s*$") //
                                                         .assign((t, v) -> t.setDate(asDate(v.get("date")))))
 
                         // @formatter:off
@@ -154,7 +155,7 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                         // Abrechnungsbetrag 50,30 EUR (exkl. Kosten)
                         // @formatter:on
                         .section("amount", "currency") //
-                        .match("^(Abrechnungsbetrag|Auszahlungsbetrag) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})( \\((inkl|exkl)\\. Kosten\\))?$") //
+                        .match("^(Abrechnungsbetrag|Auszahlungsbetrag) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})( \\((inkl|exkl)\\. Kosten\\))?\\s*$") //
                         .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -173,9 +174,9 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("baseCurrency", "exchangeRate", "fxGross", "termCurrency") //
-                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? .* [\\.,\\d]+ (?<baseCurrency>[\\w]{3}) [\\.,\\d]+ [\\w]{3} ([\\-|\\+])?[\\.,\\d]+$") //
-                                                        .match("^[\\d]+ .* \\/ .* (?<exchangeRate>[\\.,\\d]+) [\\w]{3} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.,\\d]+$") //
-                                                        .match("^.* (?<fxGross>[\\.,\\d]+) (?<termCurrency>[\\w]{3}) [\\.,\\d]+ [\\w]{3} [\\.,\\d]+$") //
+                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? .* [\\.,\\d]+ (?<baseCurrency>[\\w]{3}) [\\.,\\d]+ [\\w]{3} ([\\-|\\+])?[\\.,\\d]+\\s*$") //
+                                                        .match("^[\\d]+ .* \\/ .* (?<exchangeRate>[\\.,\\d]+) [\\w]{3} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.,\\d]+\\s*$") //
+                                                        .match("^.* (?<fxGross>[\\.,\\d]+) (?<termCurrency>[\\w]{3}) [\\.,\\d]+ [\\w]{3} [\\.,\\d]+\\s*$") //
                                                         .assign((t, v) -> {
                                                             ExtrExchangeRate rate = asExchangeRate(v);
                                                             type.getCurrentContext().putType(rate);
@@ -192,9 +193,9 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("gross", "baseCurrency", "termCurrency", "exchangeRate") //
-                                                        .match("^Abrechnungsbetrag (?<gross>[\\.,\\d]+) (?<baseCurrency>[\\w]{3})( \\(inkl\\. Kosten\\))?$") //
-                                                        .match("^[\\.,\\d]+ (?<termCurrency>[\\w]{3})$") //
-                                                        .match("^Devisenkurs (?<exchangeRate>[\\.,\\d]+)$") //
+                                                        .match("^Abrechnungsbetrag (?<gross>[\\.,\\d]+) (?<baseCurrency>[\\w]{3})( \\(inkl\\. Kosten\\))?\\s*$") //
+                                                        .match("^[\\.,\\d]+ (?<termCurrency>[\\w]{3})\\s*$") //
+                                                        .match("^Devisenkurs (?<exchangeRate>[\\.,\\d]+)\\s*$") //
                                                         .assign((t, v) -> {
                                                             ExtrExchangeRate rate = asExchangeRate(v);
                                                             type.getCurrentContext().putType(rate);
@@ -212,21 +213,21 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("note") //
-                                                        .match("^(?<note>[\\d]+) .* \\/ .* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.,\\d]+$") //
+                                                        .match("^(?<note>[\\d]+) .* \\/ .* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.,\\d]+\\s*$") //
                                                         .assign((t, v) -> t.setNote("Auftrags-Nr. " + v.get("note"))),
                                         // @formatter:off
                                         // Auftragsnummer 2616145223
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("note") //
-                                                        .match("^Auftragsnummer (?<note>[\\d]+)$") //
+                                                        .match("^Auftragsnummer (?<note>[\\d]+)\\s*$") //
                                                         .assign((t, v) -> t.setNote("Auftrags-Nr. " + v.get("note"))))
 
                         // @formatter:off
                         // Splittkauf Betrag UBS Msci Pacific exJap.U ETF A 1,77 EUR 44,4324 USD 0,045
                         // @formatter:on
                         .section("note").optional() //
-                        .match("^(?<note>(Splittkauf|Splitkauf|Wiederanlage)) .*$") //
+                        .match("^(?<note>(Splittkauf|Splitkauf|Wiederanlage)) .*\\s*$") //
                         .assign((t, v) -> {
                             if ("Splittkauf".equals(v.get("note")))
                                 v.put("note", "Splitkauf");

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -426,10 +426,20 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("^Ausf.hrung von (Round up|Saveback) .* "
+                                                        .match("^Ausf.hrung von (Round up|Saveback) \\D* "
                                                                         + "(?<date>([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}"
                                                                         + "|[\\d]{4}\\-[\\d]{2}\\-[\\d]{2})) .*$") //
                                                         .assign((t, v) -> t.setDate(asDate(v.get("date")))),
+                                        // @formatter:off
+                                        // Ausführung der Zeichnungsorder am 12.06.2026 um 13:28 am Primärmarkt.
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date", "time") //
+                                                        .match("^Ausf.hrung der Zeichnungsorder am "
+                                                                        + "(?<date>([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}"
+                                                                        + "|[\\d]{4}\\-[\\d]{2}\\-[\\d]{2})) um (?<time>\\d{2}\\:\\d{2}).*$") //
+                                                        .assign((t, v) -> t
+                                                                        .setDate(asDate(v.get("date"), v.get("time")))),
                                         // @formatter:off
                                         // Ejecución del Saveback el 02.02.2026 en Lang und Schwarz Exchange.
                                         // @formatter:on
@@ -4416,13 +4426,27 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:off
                                         // Ausführung von Round up am 09.02.2024 an der Lang & Schwarz Exchange.
                                         // Ausführung von Saveback am 04.03.2024 an der Lang & Schwarz Exchange.
+                                        // Ausführung der Zeichnungsorder am 12.06.2026 um 13:28 am Primärmarkt.
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("^Ausf.hrung von (Round up|Saveback) .* "
+                                                        .match("^Ausf.hrung von (Round up|Saveback) \\D* "
                                                                         + "(?<date>([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}"
                                                                         + "|[\\d]{4}\\-[\\d]{2}\\-[\\d]{2})) .*$") //
                                                         .assign((t, v) -> t.setDateTime(asDate(v.get("date")))),
+
+                                        // @formatter:off
+                                        // Ausführung der Zeichnungsorder am 12.06.2026 um 13:28 am Primärmarkt.
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date", "time") //
+                                                        .match("^Ausf.hrung der Zeichnungsorder am "
+                                                                        + "(?<date>([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}"
+                                                                        + "|[\\d]{4}\\-[\\d]{2}\\-[\\d]{2})) um (?<time>\\d{2}\\:\\d{2}).*$") //
+                                                        .assign((t, v) -> t
+                                                                        .setDateTime(asDate(v.get("date"),
+                                                                                        v.get("time")))),
+
                                         // @formatter:off
                                         // Ejecución del Saveback el 02.02.2026 en Lang und Schwarz Exchange.
                                         // @formatter:on
@@ -4981,6 +5005,16 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("fee", "currency").optional() //
                         .match("^Fremdkostenzuschlag \\-(?<fee>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                        .assign((t, v) -> {
+                            if (!type.getCurrentContext().getBoolean("negative"))
+                                processFeeEntries(t, v, type);
+                        })
+
+                        // @formatter:off
+                        // Abwicklungskostenpauschale -1,00 EUR
+                        // @formatter:on
+                        .section("fee", "currency").optional() //
+                        .match("^Abwicklungskostenpauschale \\-(?<fee>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> {
                             if (!type.getCurrentContext().getBoolean("negative"))
                                 processFeeEntries(t, v, type);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -4426,7 +4426,6 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:off
                                         // Ausführung von Round up am 09.02.2024 an der Lang & Schwarz Exchange.
                                         // Ausführung von Saveback am 04.03.2024 an der Lang & Schwarz Exchange.
-                                        // Ausführung der Zeichnungsorder am 12.06.2026 um 13:28 am Primärmarkt.
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //


### PR DESCRIPTION
The regexes assume the line not ending with whitespaces leading to failing imports with some PDFs. This PR fixes that. Debug-data provided by the PP-forum at https://forum.portfolio-performance.info/t/pdf-import-von-frankfurter-fondsbank-ffb/4751/89?u=kimmerin