### PR TITLE
fixed failing import if some of the lines end with trailing spaces

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/filfondbank/FILFondbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/filfondbank/FILFondbankPDFExtractorTest.java
@@ -169,6 +169,129 @@ public class FILFondbankPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierKauf03()
+    {
+        var extractor = new FILFondbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(3L));
+        assertThat(countBuySell(results), is(3L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(6));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00B4X9L533"), hasWkn("A1C9KK"), hasTicker(null), //
+                        hasName("HSBC MSCI WORLD ETF"), //
+                        hasCurrencyCode("USD"))));
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE000OJ5TQP4"), hasWkn("A3EB9T"), hasTicker(null), //
+                        hasName("Future of Defense UCITS ETF Ac"), //
+                        hasCurrencyCode("USD"))));
+        assertThat(results, hasItem(security( //
+                        hasIsin("EE3600102901"), hasWkn("A0PEF0"), hasTicker(null), //
+                        hasName("Avaron Emerging Europe Fund C"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-15T11:15:38"), hasShares(9.451), //
+                        hasSource("Kauf03.txt"), //
+                        hasNote("Auftrags-Nr. 2667709223"), //
+                        hasAmount("EUR", 400.00), hasGrossValue("EUR", 400.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        hasForexGrossValue("USD", 461.23))));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-15T11:14:49"), hasShares(22.223), //
+                        hasSource("Kauf03.txt"), //
+                        hasNote("Auftrags-Nr. 2667756179"), //
+                        hasAmount("EUR", 400.00), hasGrossValue("EUR", 400.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        hasForexGrossValue("USD", 461.23))));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-15T11:14:49"), hasShares(7.711), //
+                        hasSource("Kauf03.txt"), //
+                        hasNote("Auftrags-Nr. 2667761620"), //
+                        hasAmount("EUR", 400.00), hasGrossValue("EUR", 400.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00) //
+        )));
+    }
+
+    @Test
+    public void testWertpapierKauf03WithSecurityInEUR()
+    {
+        var client = new Client();
+        addSecurity(client, "IE00B4X9L533", "A1C9KK", "HSBC MSCI WORLD ETF", "EUR");
+        addSecurity(client, "IE000OJ5TQP4", "A3EB9T", "Future of Defense UCITS ETF Ac", "EUR");
+        addSecurity(client, "EE3600102901", "A0PEF0", "Avaron Emerging Europe Fund C", "EUR");
+
+        var extractor = new FILFondbankPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf03.txt"), errors);
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(3L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, "EUR");
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-15T11:15:38"), hasShares(9.451), //
+                        hasSource("Kauf03.txt"), //
+                        hasNote("Auftrags-Nr. 2667709223"), //
+                        hasAmount("EUR", 400.00), hasGrossValue("EUR", 400.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        check(tx -> {
+                            var c = new CheckCurrenciesAction();
+                            var s = c.process((PortfolioTransaction) tx, new Portfolio());
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-15T11:14:49"), hasShares(22.223), //
+                        hasSource("Kauf03.txt"), //
+                        hasNote("Auftrags-Nr. 2667756179"), //
+                        hasAmount("EUR", 400.00), hasGrossValue("EUR", 400.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        check(tx -> {
+                            var c = new CheckCurrenciesAction();
+                            var s = c.process((PortfolioTransaction) tx, new Portfolio());
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-15T11:14:49"), hasShares(7.711), //
+                        hasSource("Kauf03.txt"), //
+                        hasNote("Auftrags-Nr. 2667761620"), //
+                        hasAmount("EUR", 400.00), hasGrossValue("EUR", 400.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        check(tx -> {
+                            var c = new CheckCurrenciesAction();
+                            var s = c.process((PortfolioTransaction) tx, new Portfolio());
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
+    }
+
+    private void addSecurity(Client client, String isin, String wkn, String name, String currency)
+    {
+        var security = new Security(name, currency);
+        security.setIsin(isin);
+        security.setWkn(wkn);
+        client.addSecurity(security);
+    }
+
+    @Test
     public void testWertpapierVerkauf01()
     {
         var extractor = new FILFondbankPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/filfondbank/Kauf03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/filfondbank/Kauf03.txt
@@ -1,0 +1,60 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Depotführung: Ihr der FFB benannte Vermittler:
+Fondsvermittlung24.de GmbH 
+Heidenkampsweg 75 
+20097 Hamburg
+Fax: 040 52473790
+Herrn info@fondsvermittlung24.de
+RunYq nwWGF 
+ZxQdq WyqX 479 
+95400 qHjmAkYM
+Es schreibt Ihnen:
+FFB Kundenbetreuung
+Kronberg im Taunus, 16. Juni 2026
+Fondsabrechnung
+Auszug 18 
+Depotinhaber pGoPV zqcjq 
+Depotnummer 5060823916 (Privatvermögen)
+Transaktion Fondsname Betrag Preis Anteile 
+Auftrags-Nr. WKN / ISIN Wechselkurs Preisdatum Bestand alt 
+Fondsgesellschaft Währungsbetrag Zwischengewinn Bestand neu 
+Verwahrart, Lagerland Rücknahmepreis
+Kauf HSBC MSCI WORLD ETF 400,00 EUR 48,8000 USD 9,451
+2667709223 A1C9KK / IE00B4X9L533 1,153073 USD 15.06.2026 309,460 
+HSBC Global Asset Management 461,23 USD 0,0000 EUR 318,911 
+(Deutschland) GmbH 
+Wertpapierrechnung, Grossbritannien 48,8000 USD 
+Abrechnungsbetrag 400,00 EUR 
+Ausgabeaufschlag / Provision (0,00 %) 0,00 EUR 
+Handelsuhrzeit 11:15:38
+Kauf Future of Defense UCITS ETF Ac 400,00 EUR 20,7550 USD 22,223
+2667756179 A3EB9T / IE000OJ5TQP4 1,153073 USD 15.06.2026 769,784 
+HANetf Management Ltd. 461,23 USD 0,0000 EUR 792,007 
+Wertpapierrechnung, Grossbritannien 20,7550 USD 
+Abrechnungsbetrag 400,00 EUR 
+Ausgabeaufschlag / Provision (0,00 %) 0,00 EUR 
+Handelsuhrzeit 11:14:49
+Kauf Avaron Emerging Europe Fund C 400,00 EUR 51,8709 EUR 7,711
+2667761620 A0PEF0 / EE3600102901 15.06.2026 95,851 
+AS Avaron Asset Management 0,0000 EUR 103,562 
+Wertpapierrechnung, Estland 51,8709 EUR 
+Abrechnungsbetrag 400,00 EUR 
+Ausgabeaufschlag / Provision (0,00 %) 0,00 EUR
+Steuerliche Informationen
+Erteilter Freistellungsauftrag 115,00 EUR gültig bis: unbefristet Verlustverrechnungstopf neu 0,00 EUR 
+davon noch verfügbar 0,00 EUR Quellensteuertopf neu 0,00 EUR
+Hinweise: 
+Auslandszahlungen, die 50.000 EUR übersteigen, sind gemäß der Außenwirtschaftsverordnung (AWV) durch Sie meldepflichtig. Weitergehende Informationen zur 
+Meldepflicht nach AWV erhalten Sie direkt von der Deutschen Bundesbank, unter www.bundesbank.de oder unter der Rufnummer 0800 1234 111. 
+Einwendungen gegen diese Fondsabrechnung wegen Unrichtigkeit oder Unvollständigkeit richten Sie bitte schriftlich spätestens einen Monat nach Zugang an: 
+FIL Fondsbank GmbH, Beschwerdemanagement, Postfach 11 06 63, 60041 Frankfurt am Main.
+Seite 1 (1)
+FIL Fondsbank GmbH Postanschrift: Vorsitzender Geschäftsführung: Sitz: Kronberg im Taunus 
+Kastanienhöhe 1 Postfach 11 06 63 des Aufsichtsrats: Jan Schepanek (Sprecher) Amtsgericht 
+61476 Kronberg im Taunus 60041 Frankfurt am Main Ferdinand-Alexander Leisten Tina Kern Königstein HRB 8336 
+info@ffb.de Telefon 069 77060-200 Matthias Weiß Umsatzsteuer-ID Nr. 
+www.ffb.de DE213709602
+ABGST_V1.0

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FILFondbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FILFondbankPDFExtractor.java
@@ -42,7 +42,8 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
 
         Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
 
-        Block firstRelevantLine = new Block("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf|Steuerliche Informationen \\(Einzeltransaktion\\)).*$");
+        Block firstRelevantLine = new Block(
+                        "^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf|Steuerliche Informationen \\(Einzeltransaktion\\)).*\\s*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -52,7 +53,7 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
-                        .match("^(?<type>(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf|Steuerliche Informationen \\(Einzeltransaktion\\))).*$") //
+                        .match("^(?<type>(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf|Steuerliche Informationen \\(Einzeltransaktion\\))).*\\s*$") //
                         .assign((t, v) -> {
                             if ("Verkauf".equals(v.get("type")))
                             {
@@ -63,7 +64,7 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
-                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}: (?<type>(Kauf( aus VL\\-Sparplan)|Gesamtverkauf)?)$") //
+                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}: (?<type>(Kauf( aus VL\\-Sparplan)|Gesamtverkauf)?)\\s*$") //
                         .assign((t, v) -> {
                             if ("Gesamtverkauf".equals(v.get("type")))
                             {
@@ -79,8 +80,8 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "wkn", "isin", "currency") //
-                                                        .match("^Fondsname \\(WKN \\/ ISIN\\) (?<name>.*) \\((?<wkn>[A-Z0-9]{6}) \\/ (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\)$") //
-                                                        .match("^Abrechnungspreis [\\.,\\d]+ (?<currency>[\\w]{3})$") //
+                                                        .match("^Fondsname \\(WKN \\/ ISIN\\) (?<name>.*) \\((?<wkn>[A-Z0-9]{6}) \\/ (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\)\\s*$") //
+                                                        .match("^Abrechnungspreis [\\.,\\d]+ (?<currency>[\\w]{3})\\s*$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
                                         // Kauf UBS Emer.Mkt.Soc.Resp.UETFADIS 89,56 EUR 12,6399 USD 7,728
@@ -88,8 +89,8 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "currency", "wkn", "isin") //
-                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? (?<name>.*) [\\.,\\d]+ [\\w]{3} [\\.,\\d]+ (?<currency>[\\w]{3}) ([\\-|\\+])?[\\.,\\d]+$") //
-                                                        .match("^[\\d]+ (?<wkn>[A-Z0-9]{6}) \\/ (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) .*$") //
+                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? (?<name>.*) [\\.,\\d]+ [\\w]{3} [\\.,\\d]+ (?<currency>[\\w]{3}) ([\\-|\\+])?[\\.,\\d]+\\s*$") //
+                                                        .match("^[\\d]+ (?<wkn>[A-Z0-9]{6}) \\/ (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) .*\\s*$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
                                         // @formatter:off
                                         // Splittkauf Betrag hausInvest 20,00 EUR 42,2300 EUR 0,474
@@ -97,8 +98,8 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "currency", "isin", "wkn") //
-                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? (?<name>.*) [\\.,\\d]+ [\\w]{3} [\\.,\\d]+ (?<currency>[\\w]{3}) ([\\-|\\+])?[\\.,\\d]+$") //
-                                                        .match("^[\\d]+ (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\/ (?<wkn>[A-Z0-9]{6}) .*$") //
+                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? (?<name>.*) [\\.,\\d]+ [\\w]{3} [\\.,\\d]+ (?<currency>[\\w]{3}) ([\\-|\\+])?[\\.,\\d]+\\s*$") //
+                                                        .match("^[\\d]+ (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\/ (?<wkn>[A-Z0-9]{6}) .*\\s*$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
 
                         .oneOf( //
@@ -107,21 +108,21 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("shares") //
-                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? .* ([\\-|\\+])?(?<shares>[\\.,\\d]+)$") //
+                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? .* ([\\-|\\+])?(?<shares>[\\.,\\d]+)\\s*$") //
                                                         .assign((t, v) -> t.setShares(asShares(v.get("shares")))),
                                         // @formatter:off
                                         // Anteile 0,263
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("shares") //
-                                                        .match("^Anteile (?<shares>[\\.,\\d]+)$") //
+                                                        .match("^Anteile (?<shares>[\\.,\\d]+)\\s*$") //
                                                         .assign((t, v) -> t.setShares(asShares(v.get("shares")))))
 
                         // @formatter:off
                         // Handelsuhrzeit 16:51:24
                         // @formatter:on
                         .section("time").optional() //
-                        .match("^Handelsuhrzeit (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})$") //
+                        .match("^Handelsuhrzeit (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2})\\s*$") //
                         .assign((t, v) -> type.getCurrentContext().put("time", v.get("time")))
 
                         .oneOf( //
@@ -130,7 +131,7 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("^.*(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) [\\.,\\d]+$") //
+                                                        .match("^.*(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) [\\.,\\d]+\\s*$") //
                                                         .assign((t, v) -> {
                                                             if (type.getCurrentContext().get("time") != null)
                                                                 t.setDate(asDate(v.get("date"), type.getCurrentContext().get("time")));
@@ -144,7 +145,7 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}): (Kauf( aus VL\\-Sparplan)?|Gesamtverkauf)$") //
+                                                        .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}): (Kauf( aus VL\\-Sparplan)?|Gesamtverkauf)\\s*$") //
                                                         .assign((t, v) -> t.setDate(asDate(v.get("date")))))
 
                         // @formatter:off
@@ -154,7 +155,7 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                         // Abrechnungsbetrag 50,30 EUR (exkl. Kosten)
                         // @formatter:on
                         .section("amount", "currency") //
-                        .match("^(Abrechnungsbetrag|Auszahlungsbetrag) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})( \\((inkl|exkl)\\. Kosten\\))?$") //
+                        .match("^(Abrechnungsbetrag|Auszahlungsbetrag) (?<amount>[\\.,\\d]+) (?<currency>[\\w]{3})( \\((inkl|exkl)\\. Kosten\\))?\\s*$") //
                         .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -173,9 +174,9 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("baseCurrency", "exchangeRate", "fxGross", "termCurrency") //
-                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? .* [\\.,\\d]+ (?<baseCurrency>[\\w]{3}) [\\.,\\d]+ [\\w]{3} ([\\-|\\+])?[\\.,\\d]+$") //
-                                                        .match("^[\\d]+ .* \\/ .* (?<exchangeRate>[\\.,\\d]+) [\\w]{3} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.,\\d]+$") //
-                                                        .match("^.* (?<fxGross>[\\.,\\d]+) (?<termCurrency>[\\w]{3}) [\\.,\\d]+ [\\w]{3} [\\.,\\d]+$") //
+                                                        .match("^(Splittkauf|Splitkauf|Wiederanlage|Kauf|Verkauf)( Betrag)? .* [\\.,\\d]+ (?<baseCurrency>[\\w]{3}) [\\.,\\d]+ [\\w]{3} ([\\-|\\+])?[\\.,\\d]+\\s*$") //
+                                                        .match("^[\\d]+ .* \\/ .* (?<exchangeRate>[\\.,\\d]+) [\\w]{3} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.,\\d]+\\s*$") //
+                                                        .match("^.* (?<fxGross>[\\.,\\d]+) (?<termCurrency>[\\w]{3}) [\\.,\\d]+ [\\w]{3} [\\.,\\d]+\\s*$") //
                                                         .assign((t, v) -> {
                                                             ExtrExchangeRate rate = asExchangeRate(v);
                                                             type.getCurrentContext().putType(rate);
@@ -192,9 +193,9 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("gross", "baseCurrency", "termCurrency", "exchangeRate") //
-                                                        .match("^Abrechnungsbetrag (?<gross>[\\.,\\d]+) (?<baseCurrency>[\\w]{3})( \\(inkl\\. Kosten\\))?$") //
-                                                        .match("^[\\.,\\d]+ (?<termCurrency>[\\w]{3})$") //
-                                                        .match("^Devisenkurs (?<exchangeRate>[\\.,\\d]+)$") //
+                                                        .match("^Abrechnungsbetrag (?<gross>[\\.,\\d]+) (?<baseCurrency>[\\w]{3})( \\(inkl\\. Kosten\\))?\\s*$") //
+                                                        .match("^[\\.,\\d]+ (?<termCurrency>[\\w]{3})\\s*$") //
+                                                        .match("^Devisenkurs (?<exchangeRate>[\\.,\\d]+)\\s*$") //
                                                         .assign((t, v) -> {
                                                             ExtrExchangeRate rate = asExchangeRate(v);
                                                             type.getCurrentContext().putType(rate);
@@ -212,21 +213,21 @@ public class FILFondbankPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("note") //
-                                                        .match("^(?<note>[\\d]+) .* \\/ .* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.,\\d]+$") //
+                                                        .match("^(?<note>[\\d]+) .* \\/ .* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\.,\\d]+\\s*$") //
                                                         .assign((t, v) -> t.setNote("Auftrags-Nr. " + v.get("note"))),
                                         // @formatter:off
                                         // Auftragsnummer 2616145223
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("note") //
-                                                        .match("^Auftragsnummer (?<note>[\\d]+)$") //
+                                                        .match("^Auftragsnummer (?<note>[\\d]+)\\s*$") //
                                                         .assign((t, v) -> t.setNote("Auftrags-Nr. " + v.get("note"))))
 
                         // @formatter:off
                         // Splittkauf Betrag UBS Msci Pacific exJap.U ETF A 1,77 EUR 44,4324 USD 0,045
                         // @formatter:on
                         .section("note").optional() //
-                        .match("^(?<note>(Splittkauf|Splitkauf|Wiederanlage)) .*$") //
+                        .match("^(?<note>(Splittkauf|Splitkauf|Wiederanlage)) .*\\s*$") //
                         .assign((t, v) -> {
                             if ("Splittkauf".equals(v.get("note")))
                                 v.put("note", "Splitkauf");


### PR DESCRIPTION
The regexes assume the line not ending with whitespaces leading to failing imports with some PDFs. This PR fixes that. Debug-data provided by the PP-forum at https://forum.portfolio-performance.info/t/pdf-import-von-frankfurter-fondsbank-ffb/4751/89?u=kimmerin