### PR TITLE
Fix: IBFlex dividend payments – parsing of thousand separator

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
@@ -3709,6 +3709,12 @@ public class IBFlexStatementExtractorTest
         gbdv.setWkn("12345678");
         client.addSecurity(gbdv);
 
+        var krdiv = new Security("Korean Dividend Test Security", "KRW");
+        krdiv.setTickerSymbol("KRDIV");
+        krdiv.setIsin("KR0000000001");
+        krdiv.setWkn("76543210");
+        client.addSecurity(krdiv);
+
         var referenceAccount = new Account("A");
         referenceAccount.setCurrencyCode("EUR");
         client.addAccount(referenceAccount);
@@ -3724,7 +3730,7 @@ public class IBFlexStatementExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L)); // Securities already exist
         assertThat(countBuySell(results), is(0L));
-        assertThat(countAccountTransactions(results), is(4L));
+        assertThat(countAccountTransactions(results), is(5L));
 
         // Find the first dividend transaction (HIDR - USD->GBP)
         List<AccountTransaction> transactions = results.stream() //
@@ -3733,7 +3739,7 @@ public class IBFlexStatementExtractorTest
                         .filter(t -> t.getType() == AccountTransaction.Type.DIVIDENDS) //
                         .toList();
 
-        assertThat(transactions.size(), is(4));
+        assertThat(transactions.size(), is(5));
 
         // Test first transaction: HIDR (USD->GBP)
         AccountTransaction hidrTransaction = transactions.stream() //
@@ -3869,5 +3875,17 @@ public class IBFlexStatementExtractorTest
         BigDecimal gbxToUsd = new BigDecimal("0.01").multiply(BigDecimal.ONE.divide(new BigDecimal("0.7722"), 10, RoundingMode.HALF_DOWN));
         BigDecimal gbdvExpectedRate = BigDecimal.ONE.divide(gbxToUsd, 10, RoundingMode.HALF_DOWN);
         assertThat(gbdvUnit.getExchangeRate().subtract(gbdvExpectedRate).abs().compareTo(eqqqTolerance) < 0, is(true));
+
+        // Test fifth transaction: grouped per-share dividend value
+        AccountTransaction krdivTransaction = transactions.stream() //
+                        .filter(t -> "KRDIV".equals(t.getSecurity().getTickerSymbol())) //
+                        .findFirst() //
+                        .orElseThrow(() -> new AssertionError("KRDIV dividend transaction not found"));
+
+        assertThat(krdivTransaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+        assertThat(krdivTransaction.getDateTime(), is(LocalDateTime.parse("2025-03-27T00:00")));
+        assertThat(krdivTransaction.getCurrencyCode(), is("KRW"));
+        assertThat(krdivTransaction.getAmount(), is(Values.Amount.factorize(3100)));
+        assertThat(krdivTransaction.getShares(), is(Values.Share.factorize(2)));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/testIBFlexStatementFile29.xml
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/testIBFlexStatementFile29.xml
@@ -22,5 +22,11 @@
 <ConversionRate reportDate="20250326" fromCurrency="USD" toCurrency="GBP" rate="0.7722" />
 </ConversionRates>
 </FlexStatement>
+<FlexStatement accountId="U1234567" fromDate="20250201" toDate="20250331" period="LastQuarter" whenGenerated="20250327;120000">
+<AccountInformation accountId="U1234567" acctAlias="C" model="" currency="EUR" name="John Doe" accountType="Individual" customerType="Individual" />
+<CashTransactions>
+<CashTransaction accountId="U1234567" acctAlias="" model="" currency="KRW" fxRateToBase="0.00064" assetCategory="STK" subCategory="COMMON" symbol="KRDIV" description="KRDIV(KR0000000001) CASH DIVIDEND KRW 1,550 PER SHARE (Return of Capital)" conid="76543210" securityID="KR0000000001" securityIDType="ISIN" isin="KR0000000001" amount="3100" type="Dividends" reportDate="20250327" />
+</CashTransactions>
+</FlexStatement>
 </FlexStatements>
 </FlexQueryResponse>

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractor.java
@@ -1376,7 +1376,7 @@ public class IBFlexStatementExtractor implements Extractor
         private void calculateShares(Transaction transaction, Element element)
         {
             long numShares = 0;
-            double amount = Double.parseDouble(element.getAttribute("amount"));
+            BigDecimal amount = asDecimal(element.getAttribute("amount"));
 
             // Regular expression pattern to match the Dividend per Share and
             // calculate the number of shares
@@ -1385,8 +1385,9 @@ public class IBFlexStatementExtractor implements Extractor
 
             if (mDividendShare.find())
             {
-                double dividendPerShares = Double.parseDouble(mDividendShare.group("dividendPerShares"));
-                numShares = Math.round(amount / dividendPerShares) * Values.Share.factor();
+                BigDecimal dividendPerShares = asDecimal(mDividendShare.group("dividendPerShares"));
+                numShares = amount.divide(dividendPerShares, Values.MC).setScale(0, RoundingMode.HALF_UP).longValue()
+                                * Values.Share.factor();
             }
 
             transaction.setShares(numShares);
@@ -1560,6 +1561,11 @@ public class IBFlexStatementExtractor implements Extractor
     }
 
     protected BigDecimal asExchangeRate(String value)
+    {
+        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, "en", "US");
+    }
+
+    protected BigDecimal asDecimal(String value)
     {
         return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, "en", "US");
     }


### PR DESCRIPTION
My IBKR XML file recently contained a dividend payment >1000 currency units (`CASH DIVIDEND KRW 1,550 PER SHARE`) and the importer choked on it.

> **Error These files could not be imported.**
> For input string: "1,550"

The issue seems to be that the parser does not expect thousand separators.

Here is a fix to address that.