### PR TITLE
Update to Eclipse R4.40

### DIFF
--- a/features/org.eclipse.swt.patch/feature.xml
+++ b/features/org.eclipse.swt.patch/feature.xml
@@ -22,7 +22,7 @@
       The org.eclipse.e4.rcp version below must be bumped on each platform upgrade.
    -->
    <requires>
-      <import feature="org.eclipse.e4.rcp" version="4.38.0.v20251126-0427" patch="true"/>
+      <import feature="org.eclipse.e4.rcp" version="4.40.0.v20260516-1214" patch="true"/>
    </requires>
 
    <plugin

--- a/portfolio-app/pom.xml
+++ b/portfolio-app/pom.xml
@@ -73,7 +73,7 @@
 		<repository>
 			<id>swt-portfolio-fork</id>
 			<layout>p2</layout>
-			<url>https://portfolio-performance.github.io/eclipse.platform.swt-fork-update-site/R4_38/</url>
+			<url>https://portfolio-performance.github.io/eclipse.platform.swt-fork-update-site/R4_40/</url>
 		</repository>
 	</repositories>
 

--- a/portfolio-target-definition/portfolio-target-definition-local-dev.target
+++ b/portfolio-target-definition/portfolio-target-definition-local-dev.target
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="portfolio-target-definition" sequenceNumber="27">
+<target name="portfolio-target-definition" sequenceNumber="28">
 <locations>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06"/>
 		<unit id="org.junit" version="4.13.2.v20240929-1000"/>
 		<unit id="org.junit.source" version="4.13.2.v20240929-1000"/>
-		<unit id="bcpg" version="1.81.0"/>
-		<unit id="bcpg.source" version="1.81.0"/>
-		<unit id="bcpkix" version="1.81.0"/>
-		<unit id="bcpkix.source" version="1.81.0"/>
-		<unit id="net.bytebuddy.byte-buddy" version="1.17.7"/>
-		<unit id="net.bytebuddy.byte-buddy.source" version="1.17.7"/>
-		<unit id="net.bytebuddy.byte-buddy-agent" version="1.17.7"/>
-		<unit id="net.bytebuddy.byte-buddy-agent.source" version="1.17.7"/>
+		<unit id="bcpg" version="1.84.0"/>
+		<unit id="bcpg.source" version="1.84.0"/>
+		<unit id="bcpkix" version="1.84.0"/>
+		<unit id="bcpkix.source" version="1.84.0"/>
+		<unit id="net.bytebuddy.byte-buddy" version="1.18.8"/>
+		<unit id="net.bytebuddy.byte-buddy.source" version="1.18.8"/>
+		<unit id="net.bytebuddy.byte-buddy-agent" version="1.18.8"/>
+		<unit id="net.bytebuddy.byte-buddy-agent.source" version="1.18.8"/>
 		<unit id="org.apache.commons.math3" version="3.6.1"/>
 		<unit id="org.apache.commons.math3.source" version="3.6.1"/>
 		<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
 		<unit id="org.hamcrest.core.source" version="2.2.0.v20230809-1000"/>
 		<unit id="org.hamcrest.library" version="2.2.0.v20230809-1000"/>
 		<unit id="org.hamcrest.library.source" version="2.2.0.v20230809-1000"/>
-		<unit id="org.mockito.mockito-core" version="5.19.0"/>
-		<unit id="org.mockito.mockito-core.source" version="5.19.0"/>
-		<unit id="slf4j.api" version="2.0.17"/>
-		<unit id="slf4j.api.source" version="2.0.17"/>
-		<unit id="slf4j.nop" version="2.0.17"/>
-		<unit id="slf4j.nop.source" version="2.0.17"/>
+		<unit id="org.mockito.mockito-core" version="5.23.0"/>
+		<unit id="org.mockito.mockito-core.source" version="5.23.0"/>
+		<unit id="slf4j.api" version="2.0.18"/>
+		<unit id="slf4j.api.source" version="2.0.18"/>
+		<unit id="slf4j.nop" version="2.0.18"/>
+		<unit id="slf4j.nop.source" version="2.0.18"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/nebula/updates/release/3.2.0/"/>
-		<unit id="org.eclipse.nebula.widgets.cdatetime.feature.feature.group" version="1.5.0.202509131601"/>
-		<unit id="org.eclipse.nebula.widgets.chips.feature.feature.group" version="1.0.0.202509131601"/>
+		<repository location="https://download.eclipse.org/nebula/updates/release/3.4.0/"/>
+		<unit id="org.eclipse.nebula.widgets.cdatetime.feature.feature.group" version="1.6.0.202606141240"/>
+		<unit id="org.eclipse.nebula.widgets.chips.feature.feature.group" version="1.0.0.202606141240"/>
 	</location>
 
 	<!-- remove babel translations --> 
@@ -41,10 +41,10 @@
 		<unit id="org.eclipse.swtchart.source" version="1.1.0.202511241716"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/eclipse/updates/4.38/R-4.38-202512010920/"/>
-		<unit id="org.eclipse.e4.rcp.feature.group" version="4.38.0.v20251126-0427"/>
-		<unit id="org.eclipse.equinox.executable.feature.group" version="3.8.3100.v20251111-0406"/>
-		<unit id="org.eclipse.platform.feature.group" version="4.38.0.v20251201-0920"/>
+		<repository location="https://download.eclipse.org/eclipse/updates/4.40/R-4.40-202606010713/"/>
+		<unit id="org.eclipse.e4.rcp.feature.group" version="4.40.0.v20260516-1214"/>
+		<unit id="org.eclipse.equinox.executable.feature.group" version="3.8.3300.v20260414-2255"/>
+		<unit id="org.eclipse.platform.feature.group" version="4.40.0.v20260601-0955"/>
 		<unit id="org.osgi.service.component.annotations" version="1.5.1.202212101352"/>
 		<unit id="org.eclipse.osgi.services" version="3.12.300.v20250707-1221"/>
 	</location>
@@ -75,19 +75,19 @@
 			<dependency>
 				<groupId>org.apache.pdfbox</groupId>
 				<artifactId>fontbox</artifactId>
-				<version>3.0.6</version>
+				<version>3.0.7</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.pdfbox</groupId>
 				<artifactId>pdfbox-io</artifactId>
-				<version>3.0.6</version>
+				<version>3.0.7</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.pdfbox</groupId>
 				<artifactId>pdfbox</artifactId>
-				<version>3.0.6</version>
+				<version>3.0.7</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -103,7 +103,7 @@
 			<dependency>
 				<groupId>org.apache.servicemix.bundles</groupId>
 				<artifactId>org.apache.servicemix.bundles.xstream</artifactId>
-				<version>1.4.20_1</version>
+				<version>1.4.21_1</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -113,7 +113,7 @@
 			<dependency>
 				<groupId>commons-logging</groupId>
 				<artifactId>commons-logging</artifactId>
-				<version>1.3.5</version>
+				<version>1.4.0</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
@@ -125,7 +125,7 @@
 			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
-				<version>1.19.0</version>
+				<version>1.22.0</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -157,7 +157,7 @@
 			<dependency>
 				<groupId>org.jsoup</groupId>
 				<artifactId>jsoup</artifactId>
-				<version>1.21.2</version>
+				<version>1.22.2</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -177,7 +177,7 @@
 			<dependency>
 				<groupId>com.google.protobuf</groupId>
 				<artifactId>protobuf-java</artifactId>
-				<version>4.33.0</version>
+				<version>4.35.1</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -193,7 +193,7 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>33.5.0-jre</version>
+				<version>33.6.0-jre</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -203,7 +203,7 @@
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>2.13.2</version>
+				<version>2.14.0</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -245,31 +245,31 @@
 			<dependency>
 				<groupId>com.twelvemonkeys.common</groupId>
 				<artifactId>common-image</artifactId>
-				<version>3.12.0</version>
+				<version>3.13.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>com.twelvemonkeys.common</groupId>
 				<artifactId>common-io</artifactId>
-				<version>3.12.0</version>
+				<version>3.13.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>com.twelvemonkeys.common</groupId>
 				<artifactId>common-lang</artifactId>
-				<version>3.12.0</version>
+				<version>3.13.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>com.twelvemonkeys.imageio</groupId>
 				<artifactId>imageio-bmp</artifactId>
-				<version>3.12.0</version>
+				<version>3.13.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>com.twelvemonkeys.imageio</groupId>
 				<artifactId>imageio-core</artifactId>
-				<version>3.12.0</version>
+				<version>3.13.1</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -289,31 +289,31 @@
 			<dependency>
 				<groupId>org.ow2.asm</groupId>
 				<artifactId>asm-analysis</artifactId>
-				<version>9.9</version>
+				<version>9.10.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.ow2.asm</groupId>
 				<artifactId>asm-commons</artifactId>
-				<version>9.9</version>
+				<version>9.10.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.ow2.asm</groupId>
 				<artifactId>asm-tree</artifactId>
-				<version>9.9</version>
+				<version>9.10.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.ow2.asm</groupId>
 				<artifactId>asm-util</artifactId>
-				<version>9.9</version>
+				<version>9.10.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.ow2.asm</groupId>
 				<artifactId>asm</artifactId>
-				<version>9.9</version>
+				<version>9.10.1</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -323,7 +323,7 @@
 			<dependency>
 				<groupId>io.github.java-diff-utils</groupId>
 				<artifactId>java-diff-utils</artifactId>
-				<version>4.16</version>
+				<version>4.17</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -333,7 +333,7 @@
 			<dependency>
 				<groupId>com.auth0</groupId>
 				<artifactId>java-jwt</artifactId>
-				<version>4.5.0</version>
+				<version>4.5.2</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -343,19 +343,19 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-annotations</artifactId>
-				<version>2.20</version>
+				<version>2.22</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-core</artifactId>
-				<version>2.20.1</version>
+				<version>2.22.0</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>2.20.1</version>
+				<version>2.22.0</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>

--- a/portfolio-target-definition/portfolio-target-definition.target
+++ b/portfolio-target-definition/portfolio-target-definition.target
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="portfolio-target-definition" sequenceNumber="27">
+<target name="portfolio-target-definition" sequenceNumber="28">
 <locations>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2025-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-06"/>
 		<unit id="org.junit" version="4.13.2.v20240929-1000"/>
 		<unit id="org.junit.source" version="4.13.2.v20240929-1000"/>
-		<unit id="bcpg" version="1.81.0"/>
-		<unit id="bcpg.source" version="1.81.0"/>
-		<unit id="bcpkix" version="1.81.0"/>
-		<unit id="bcpkix.source" version="1.81.0"/>
-		<unit id="net.bytebuddy.byte-buddy" version="1.17.7"/>
-		<unit id="net.bytebuddy.byte-buddy.source" version="1.17.7"/>
-		<unit id="net.bytebuddy.byte-buddy-agent" version="1.17.7"/>
-		<unit id="net.bytebuddy.byte-buddy-agent.source" version="1.17.7"/>
+		<unit id="bcpg" version="1.84.0"/>
+		<unit id="bcpg.source" version="1.84.0"/>
+		<unit id="bcpkix" version="1.84.0"/>
+		<unit id="bcpkix.source" version="1.84.0"/>
+		<unit id="net.bytebuddy.byte-buddy" version="1.18.8"/>
+		<unit id="net.bytebuddy.byte-buddy.source" version="1.18.8"/>
+		<unit id="net.bytebuddy.byte-buddy-agent" version="1.18.8"/>
+		<unit id="net.bytebuddy.byte-buddy-agent.source" version="1.18.8"/>
 		<unit id="org.apache.commons.math3" version="3.6.1"/>
 		<unit id="org.apache.commons.math3.source" version="3.6.1"/>
 		<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
 		<unit id="org.hamcrest.core.source" version="2.2.0.v20230809-1000"/>
 		<unit id="org.hamcrest.library" version="2.2.0.v20230809-1000"/>
 		<unit id="org.hamcrest.library.source" version="2.2.0.v20230809-1000"/>
-		<unit id="org.mockito.mockito-core" version="5.19.0"/>
-		<unit id="org.mockito.mockito-core.source" version="5.19.0"/>
-		<unit id="slf4j.api" version="2.0.17"/>
-		<unit id="slf4j.api.source" version="2.0.17"/>
-		<unit id="slf4j.nop" version="2.0.17"/>
-		<unit id="slf4j.nop.source" version="2.0.17"/>
+		<unit id="org.mockito.mockito-core" version="5.23.0"/>
+		<unit id="org.mockito.mockito-core.source" version="5.23.0"/>
+		<unit id="slf4j.api" version="2.0.18"/>
+		<unit id="slf4j.api.source" version="2.0.18"/>
+		<unit id="slf4j.nop" version="2.0.18"/>
+		<unit id="slf4j.nop.source" version="2.0.18"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/nebula/updates/release/3.2.0/"/>
-		<unit id="org.eclipse.nebula.widgets.cdatetime.feature.feature.group" version="1.5.0.202509131601"/>
-		<unit id="org.eclipse.nebula.widgets.chips.feature.feature.group" version="1.0.0.202509131601"/>
+		<repository location="https://download.eclipse.org/nebula/updates/release/3.4.0/"/>
+		<unit id="org.eclipse.nebula.widgets.cdatetime.feature.feature.group" version="1.6.0.202606141240"/>
+		<unit id="org.eclipse.nebula.widgets.chips.feature.feature.group" version="1.0.0.202606141240"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<repository location="https://download.eclipse.org/technology/babel/update-site/R0.20.0/2022-12/"/>
@@ -59,10 +59,10 @@
 		<unit id="org.eclipse.swtchart.source" version="1.1.0.202511241716"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/eclipse/updates/4.38/R-4.38-202512010920/"/>
-		<unit id="org.eclipse.e4.rcp.feature.group" version="4.38.0.v20251126-0427"/>
-		<unit id="org.eclipse.equinox.executable.feature.group" version="3.8.3100.v20251111-0406"/>
-		<unit id="org.eclipse.platform.feature.group" version="4.38.0.v20251201-0920"/>
+		<repository location="https://download.eclipse.org/eclipse/updates/4.40/R-4.40-202606010713/"/>
+		<unit id="org.eclipse.e4.rcp.feature.group" version="4.40.0.v20260516-1214"/>
+		<unit id="org.eclipse.equinox.executable.feature.group" version="3.8.3300.v20260414-2255"/>
+		<unit id="org.eclipse.platform.feature.group" version="4.40.0.v20260601-0955"/>
 		<unit id="org.osgi.service.component.annotations" version="1.5.1.202212101352"/>
 		<unit id="org.eclipse.osgi.services" version="3.12.300.v20250707-1221"/>
 	</location>
@@ -93,19 +93,19 @@
 			<dependency>
 				<groupId>org.apache.pdfbox</groupId>
 				<artifactId>fontbox</artifactId>
-				<version>3.0.6</version>
+				<version>3.0.7</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.pdfbox</groupId>
 				<artifactId>pdfbox-io</artifactId>
-				<version>3.0.6</version>
+				<version>3.0.7</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.pdfbox</groupId>
 				<artifactId>pdfbox</artifactId>
-				<version>3.0.6</version>
+				<version>3.0.7</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -121,7 +121,7 @@
 			<dependency>
 				<groupId>org.apache.servicemix.bundles</groupId>
 				<artifactId>org.apache.servicemix.bundles.xstream</artifactId>
-				<version>1.4.20_1</version>
+				<version>1.4.21_1</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -131,7 +131,7 @@
 			<dependency>
 				<groupId>commons-logging</groupId>
 				<artifactId>commons-logging</artifactId>
-				<version>1.3.5</version>
+				<version>1.4.0</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
@@ -143,7 +143,7 @@
 			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
-				<version>1.19.0</version>
+				<version>1.22.0</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -175,7 +175,7 @@
 			<dependency>
 				<groupId>org.jsoup</groupId>
 				<artifactId>jsoup</artifactId>
-				<version>1.21.2</version>
+				<version>1.22.2</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -195,7 +195,7 @@
 			<dependency>
 				<groupId>com.google.protobuf</groupId>
 				<artifactId>protobuf-java</artifactId>
-				<version>4.33.0</version>
+				<version>4.35.1</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -211,7 +211,7 @@
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>33.5.0-jre</version>
+				<version>33.6.0-jre</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -221,7 +221,7 @@
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>2.13.2</version>
+				<version>2.14.0</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -263,31 +263,31 @@
 			<dependency>
 				<groupId>com.twelvemonkeys.common</groupId>
 				<artifactId>common-image</artifactId>
-				<version>3.12.0</version>
+				<version>3.13.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>com.twelvemonkeys.common</groupId>
 				<artifactId>common-io</artifactId>
-				<version>3.12.0</version>
+				<version>3.13.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>com.twelvemonkeys.common</groupId>
 				<artifactId>common-lang</artifactId>
-				<version>3.12.0</version>
+				<version>3.13.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>com.twelvemonkeys.imageio</groupId>
 				<artifactId>imageio-bmp</artifactId>
-				<version>3.12.0</version>
+				<version>3.13.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>com.twelvemonkeys.imageio</groupId>
 				<artifactId>imageio-core</artifactId>
-				<version>3.12.0</version>
+				<version>3.13.1</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -307,31 +307,31 @@
 			<dependency>
 				<groupId>org.ow2.asm</groupId>
 				<artifactId>asm-analysis</artifactId>
-				<version>9.9</version>
+				<version>9.10.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.ow2.asm</groupId>
 				<artifactId>asm-commons</artifactId>
-				<version>9.9</version>
+				<version>9.10.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.ow2.asm</groupId>
 				<artifactId>asm-tree</artifactId>
-				<version>9.9</version>
+				<version>9.10.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.ow2.asm</groupId>
 				<artifactId>asm-util</artifactId>
-				<version>9.9</version>
+				<version>9.10.1</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>org.ow2.asm</groupId>
 				<artifactId>asm</artifactId>
-				<version>9.9</version>
+				<version>9.10.1</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -341,7 +341,7 @@
 			<dependency>
 				<groupId>io.github.java-diff-utils</groupId>
 				<artifactId>java-diff-utils</artifactId>
-				<version>4.16</version>
+				<version>4.17</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -351,7 +351,7 @@
 			<dependency>
 				<groupId>com.auth0</groupId>
 				<artifactId>java-jwt</artifactId>
-				<version>4.5.0</version>
+				<version>4.5.2</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>
@@ -361,19 +361,19 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-annotations</artifactId>
-				<version>2.20</version>
+				<version>2.22</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-core</artifactId>
-				<version>2.20.1</version>
+				<version>2.22.0</version>
 				<type>jar</type>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>2.20.1</version>
+				<version>2.22.0</version>
 				<type>jar</type>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
Bump platform to R-4.40, SWT fork to R4_40, and Orbit to 2026-06. Also update Nebula 3.4.0, BouncyCastle 1.84, Byte Buddy 1.18.8, Mockito 5.23, SLF4J 2.0.18, and PDFBox 3.0.7.