### PR TITLE
Added support for PDF format containing a refund with a variation in the PDF

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/Steuerrueckerstattung09_English.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/Steuerrueckerstattung09_English.txt
@@ -1,0 +1,28 @@
+Portfolio Performance Version: 0.84.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Terzo Pension Foundation of WIR Bank
+Auberg 1
+4002 Basel
+E-Mail info@viac.ch
+Phone 0800 80 40 40
+www.viac.ch
+Contract 3.123.456.789
+Portfolio 3.123.456.789.05
+Mr
+Max Mustermann
+Blumentstrasse 11
+1234 City
+Basel, 28.05.2026
+Dividend Payment
+We have booked the following payment for you:
+Type of distribution: Refund Swiss withholding tax
+0.196 units UBS Canada
+ISIN: CH0030849613
+Distribution: CHF 0.23
+Amount CHF 0.05
+Amount credited: Value date 28.05.2026 CHF 0.05
+S. E. & O.
+Kind regards
+Terzo Pension Foundation
+Notice without signature

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/WirBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/wirbank/WirBankPDFExtractorTest.java
@@ -2692,6 +2692,41 @@ public class WirBankPDFExtractorTest
     }
 
     @Test
+    public void testSteuerrueckerstattung09()
+    {
+        var extractor = new WirBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Steuerrueckerstattung09_English.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("CH0030849613"), hasWkn(null), hasTicker(null), //
+                        hasName("UBS Canada"), //
+                        hasCurrencyCode("CHF"))));
+
+        // check tax refund transaction
+        assertThat(results, hasItem(taxRefund( //
+                        hasDate("2026-05-28T00:00"), hasShares(0.196), //
+                        hasSource("Steuerrueckerstattung09_English.txt"), //
+                        hasNote("Refund Swiss withholding tax"), //
+                        hasAmount("CHF", 0.05), hasGrossValue("CHF", 0.05), //
+                        hasTaxes("CHF", 0.00), hasFees("CHF", 0.00))));
+    }
+
+    @Test
     public void testDividendeStorno01()
     {
         var extractor = new WirBankPDFExtractor(new Client());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WirBankPDFExtractor.java
@@ -300,15 +300,9 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
                         .section("type").optional() //
-                        .match("^(Dividendenart|Aussch.ttungsart|Type of dividend|Type de dividende): " //
-                                        + "(?<type>(R.ckerstattung Quellensteuer|R.ckerstattung Verrechnungssteuer|Refund withholding tax|Remboursement d.imp.t . la source))$") //
-                        .assign((t, v) -> {
-                            if ("Rückerstattung Quellensteuer".equals(v.get("type")) //
-                                            || "Rückerstattung Verrechnungssteuer".equals(v.get("type")) //
-                                            || "Refund withholding tax".equals(v.get("type")) //
-                                            || "Remboursement d'impôt à la source".equals(v.get("type")))
-                                t.setType(AccountTransaction.Type.TAX_REFUND);
-                        })
+                        .match("^(Dividendenart|Aussch.ttungsart|Type of (dividend|distribution)|Type de dividende): " //
+                                        + "(?<type>(R.ckerstattung Quellensteuer|R.ckerstattung Verrechnungssteuer|Refund (\\w+ )?withholding tax|Remboursement d.imp.t . la source))$") //
+                        .assign((t, v) -> t.setType(AccountTransaction.Type.TAX_REFUND))
 
                         // @formatter:off
                         // Cancelation Dividend Payment
@@ -322,20 +316,27 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         // 47.817 Ant UBS ETF MSCI USA SRI
                         // ISIN: LU0629460089
                         // Ausschüttung: USD 0.72
+                        //
+                        // Type of distribution: Refund Swiss withholding tax
+                        // 0.196 units UBS Canada
+                        // ISIN: CH0030849613
+                        // Distribution: CHF 0.23
                         // @formatter:on
                         .section("name", "isin", "currency") //
-                        .find("(Dividendenart|Aussch.ttungsart|Type of dividend|Type de dividende):.*") //
+                        .find("(Dividendenart|Aussch.ttungsart|Type of (dividend|distribution)|Type de dividende):.*") //
                         .match("^[\\.,\\d]+ (Anteile|Qty|Ant|parts|units|actions)?(?<name>.*)$") //
                         .match("^ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
-                        .match("^(Aussch.ttung|Dividend payment|Dividende distribu.): (?<currency>[\\w]{3}) .*$") //
+                        .match("^(Aussch.ttung|Dividend payment|Distribution|Dividende distribu.): (?<currency>[\\w]{3}) .*$") //
                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
 
                         // @formatter:off
                         // Dividendenart: Ordentliche Dividende
                         // 47.817 Ant UBS ETF MSCI USA SRI
+                        // Type of distribution: Refund Swiss withholding tax
+                        // 0.196 units UBS Canada
                         // @formatter:on
                         .section("shares") //
-                        .find("(Dividendenart|Aussch.ttungsart|Type of dividend|Type de dividende):.*") //
+                        .find("(Dividendenart|Aussch.ttungsart|Type of (dividend|distribution)|Type de dividende):.*") //
                         .match("^(?<shares>[\\.,\\d]+) (Anteile|Qty|Ant|parts|units|actions)?.*$") //
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
@@ -397,9 +398,10 @@ public class WirBankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:off
                         // Dividendenart: Ordentliche Dividende
                         // Type of dividend: Ordinary dividend
+                        // Type of distribution: Refund Swiss withholding tax
                         // @formatter:on
                         .section("note").optional() //
-                        .match("^(Dividendenart|Aussch.ttungsart|Type of dividend|Type de dividende): (?<note>.*)") //
+                        .match("^(Dividendenart|Aussch.ttungsart|Type of (dividend|distribution)|Type de dividende): (?<note>.*)") //
                         .assign((t, v) -> t.setNote(trim(v.get("note"))))
 
                         .wrap(TransactionItem::new);


### PR DESCRIPTION
added support for a variation of a PDF containing a refund as provided at the [PP-forum](https://forum.portfolio-performance.info/t/pdf-import-for-viac-wir-bank/21814/33?u=kimmerin).