### PR TITLE
skip transaction if processing a second page only containing summary informations

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/Dividende14.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/Dividende14.txt
@@ -1,0 +1,63 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+d a 
+Raiffeisenbank Stockerau eGen 
+Rathausplatz 2, 2000 Stockerau 
+b 
+BLZ: 32842     UID: ATU16346103 
+a 
+a 
+Abrechnung Ereignis a 
+29438080 - 22.06.2026 a 
+Depot-Nr.: 60.999.999 
+Max Mustermann
+Donaustraße 1
+2000 Stockerau 063/78 
+Private Banking 
+Wir haben für Sie am 22.06.2026 unten angeführtes Geschäft abgerechnet: 
+Geschäftsart: Ertrag 
+261 Stk    
+Titel: AT0000821103 UNIQA Insurance Group AG 
+Stamm-Aktien o.N. 
+Dividende: 0,72 EUR 
+Verwahrart: SV 
+Positionsdaten: Loco: AT Österreich 
+Bruttobetrag: 187,92 EUR  
+KESt: -51,68 EUR  
+Zu Gunsten IBAN AT99 3284 2000 0099 9999 136,24 EUR  
+Valuta 22.06.2026 
+Extag: 18.06.2026 
+Record-Tag: 19.06.2026 
+Ausgangssituation: 
+KESt-Neubestand mit Anschaffungskosten nach dem gleitenden  
+Durchschnittsverfahren § 27a Abs. 4 Zi 3 EStG 261 Stk 
+steuerlicher Anschaffungswert: 1.786,86 EUR 
+KESt-Neubestand mit Anschaffungskosten nach dem gleitenden  
+Durchschnittsverfahren § 27a Abs. 4 Zi 3 EStG 261 Stk 
+Ertrag: 187,92 EUR 
+22.06.2026 1 / 2 
+Dieser Beleg wurde durch die depotführende Bank erstellt.  
+Ohne Unterschrift. Bitte geben Sie Unstimmigkeiten sofort bekannt. 
+Raiffeisenbank Stockerau eGen 
+Rathausplatz 2, 2000 Stockerau 
+b 
+BLZ: 32842     UID: ATU16346103 
+a 
+a 
+Abrechnung Ereignis a 
+29438080 - 22.06.2026 a 
+Depot-Nr.: 60.999.999 
+Max Mustermann
+063/78 
+Private Banking 
+Steuerrelevante Daten (alle Beträge in EUR): 
+Bemessungsgrundlage KESt 
+Einkünfte/Verlustüberhang bisher 4.157,28 696,43 
+Bruttoeinkünfte/Verlust 187,92 51,68 
+Verlustausgleich (KESt-Gutschrift) 
+Einkünfte/Verlustüberhang aktuell 4.345,20 748,11 
+22.06.2026 2 / 2 
+Dieser Beleg wurde durch die depotführende Bank erstellt.  
+Ohne Unterschrift. Bitte geben Sie Unstimmigkeiten sofort bekannt. 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/RaiffeisenbankgruppePDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/RaiffeisenbankgruppePDFExtractorTest.java
@@ -1662,6 +1662,46 @@ public class RaiffeisenbankgruppePDFExtractorTest
     }
 
     @Test
+    public void testDividende14()
+    {
+        var extractor = new RaiffeisenBankgruppePDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende14.txt"), errors);
+
+        errors.forEach(Exception::printStackTrace);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, "EUR");
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem("second page without transaction")));
+        
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("AT0000821103"), hasWkn(null), hasTicker(null), //
+                        hasName("UNIQA Insurance Group AG Stamm-Aktien o.N."), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-06-22T00:00"), hasExDate("2026-06-18T00:00"), //
+                        hasShares(261.00), //
+                        hasSource("Dividende14.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 136.24), hasGrossValue("EUR", 187.92), //
+                        hasTaxes("EUR", 51.68), hasFees("EUR", 0.00))));
+    }
+
+    @Test
     public void testKontoauszug01()
     {
         var extractor = new RaiffeisenBankgruppePDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/RaiffeisenbankgruppePDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/RaiffeisenbankgruppePDFExtractorTest.java
@@ -1678,13 +1678,10 @@ public class RaiffeisenbankgruppePDFExtractorTest
         assertThat(countAccountTransactions(results), is(1L));
         assertThat(countAccountTransfers(results), is(0L));
         assertThat(countItemsWithFailureMessage(results), is(0L));
-        assertThat(countSkippedItems(results), is(1L));
-        assertThat(results.size(), is(3));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
         new AssertImportActions().check(results, "EUR");
 
-        // check skipped item
-        assertThat(results, hasItem(skippedItem("second page without transaction")));
-        
         // check security
         assertThat(results, hasItem(security( //
                         hasIsin("AT0000821103"), hasWkn(null), hasTicker(null), //
@@ -1699,6 +1696,7 @@ public class RaiffeisenbankgruppePDFExtractorTest
                         hasNote(null), //
                         hasAmount("EUR", 136.24), hasGrossValue("EUR", 187.92), //
                         hasTaxes("EUR", 51.68), hasFees("EUR", 0.00))));
+
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
@@ -468,9 +468,13 @@ import name.abuchen.portfolio.model.TypedMap;
                     {
                         try
                         {
+                            var prevSkipReason = ctx.getSkipReason();
                             section.parse(filename, documentContext, lines, lineNo, lineNoEnd, ctx, target);
 
                             // if parsing was successful, then return
+
+                            if (prevSkipReason != null)
+                                ctx.skipTransaction(null); // reset skip marker
                             return;
                         }
                         catch (DuplicateSecurityException e)
@@ -484,7 +488,7 @@ import name.abuchen.portfolio.model.TypedMap;
                         }
                     }
 
-                    if (!isOptional)
+                    if (!isOptional && ctx.getSkipReason() == null)
                         throw new IllegalArgumentException(MessageFormat.format(
                                         Messages.MsgErrorNoneOfSubSectionsMatched, String.valueOf(subSections.size()),
                                         String.join(";\n", errors), lineNo + 1, //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
@@ -211,7 +211,7 @@ import name.abuchen.portfolio.model.TypedMap;
         List<LineSpan> split(String[] lines);
     }
 
-    private static class PatternSplittingStrategy implements SplittingStrategy
+    public static class PatternSplittingStrategy implements SplittingStrategy
     {
         private Pattern startsWith;
         private Pattern endsWith;
@@ -260,7 +260,7 @@ import name.abuchen.portfolio.model.TypedMap;
             return spans;
         }
 
-        private int findBlockEnd(String[] lines, int startLine, int endLine)
+        protected int findBlockEnd(String[] lines, int startLine, int endLine)
         {
             for (var lineNo = startLine; lineNo <= endLine; lineNo++)
             {
@@ -468,13 +468,9 @@ import name.abuchen.portfolio.model.TypedMap;
                     {
                         try
                         {
-                            var prevSkipReason = ctx.getSkipReason();
                             section.parse(filename, documentContext, lines, lineNo, lineNoEnd, ctx, target);
 
                             // if parsing was successful, then return
-
-                            if (prevSkipReason != null)
-                                ctx.skipTransaction(null); // reset skip marker
                             return;
                         }
                         catch (DuplicateSecurityException e)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
@@ -267,7 +267,8 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
 
         var pdfTransaction = new Transaction<AccountTransaction>();
 
-        var firstRelevantLine = new Block("^.*(Private Banking|Abrechnungsnr|Gesch.ftsart|Anlageverm.gen).*$", "^(Den Betrag buchen|Der Betrag wird|Dieser Beleg (tr.gt|wurde|wird)).*$");
+        var firstRelevantLine = new Block("^.*(Private Banking|Abrechnungsnr|Gesch.ftsart|Anlageverm.gen).*$",
+                        "^(Den Betrag buchen|Der Betrag wird|Dieser Beleg (tr.gt|wurde|wird)).*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -275,6 +276,12 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
 
                         .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
+                        .optionalOneOf( //
+                                        section -> section //
+                                                        .attributes("dummy") //
+                                                        .match("^Eink.nfte/Verlust.berhang aktuell (?<dummy>.*)$") //
+                                                        .assign((t, v) -> v.getTransactionContext().skipTransaction(
+                                                                        "second page without transaction")))
                         .oneOf( //
                                         // @formatter:off
                                         // Titel: AT0000A1TW21 RAIFF.-EMERGINGMARKETS-AKTIEN RZ(A)
@@ -303,7 +310,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                                                         .attributes("isin", "name", "name1", "currency") //
                                                         .match("^Titel: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) (?<name>.*)$") //
                                                         .match("^(?<name1>.*)$") //
-                                                        .match("^(Dividende|Ertrag): [\\.,\\d]+ (?<currency>[A-Z]{3})[\\s]*$") //
+                                                        .match("^(Dividende|Ertrag): [\\.,\\d]+ (?<currency>[A-Z]{3})\\s*$") //
                                                         .assign((t, v) -> {
                                                             if (!v.get("name1").startsWith("Dividende:") //
                                                                             || !v.get("name1").startsWith("Ertrag:") //
@@ -503,6 +510,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                                                         .attributes("note") //
                                                         .match("^.*Referenz: (?<note>[\\d]+).*$") //
                                                         .assign((t, v) -> t.setNote("Ref.-Nr.: " + trim(v.get("note")))))
+
                         // @formatter:off
                         // Ex-Tag 01.12.2021 Art der Dividende Quartalsdividende
                         // @formatter:on

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
@@ -310,7 +310,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                                                         .attributes("isin", "name", "name1", "currency") //
                                                         .match("^Titel: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) (?<name>.*)$") //
                                                         .match("^(?<name1>.*)$") //
-                                                        .match("^(Dividende|Ertrag): [\\.,\\d]+ (?<currency>[A-Z]{3})\\s*$") //
+                                                        .match("^(Dividende|Ertrag): [\\.,\\d]+ (?<currency>[A-Z]{3})[\\s]*$") //
                                                         .assign((t, v) -> {
                                                             if (!v.get("name1").startsWith("Dividende:") //
                                                                             || !v.get("name1").startsWith("Ertrag:") //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
@@ -5,13 +5,17 @@ import static name.abuchen.portfolio.util.TextUtil.concatenate;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.ParsedData;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.PatternSplittingStrategy;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.AccountTransaction.Type;
@@ -267,8 +271,25 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
 
         var pdfTransaction = new Transaction<AccountTransaction>();
 
-        var firstRelevantLine = new Block("^.*(Private Banking|Abrechnungsnr|Gesch.ftsart|Anlageverm.gen).*$",
-                        "^(Den Betrag buchen|Der Betrag wird|Dieser Beleg (tr.gt|wurde|wird)).*$");
+        PatternSplittingStrategy strategy = new PatternSplittingStrategy(
+                        "^.*(Private Banking|Abrechnungsnr|Gesch.ftsart|Anlageverm.gen).*$",
+                        "^(Den Betrag buchen|Der Betrag wird|Dieser Beleg (tr.gt|wurde|wird)).*$")
+        {
+            @Override
+            protected int findBlockEnd(String[] lines, int startLine, int endLine)
+            {
+                Pattern secondPagePattern = Pattern.compile("^Steuerrelevante Daten.*$");
+                int ret = super.findBlockEnd(lines, startLine, endLine);
+                if (ret == -1)
+                    return ret;
+
+                return Arrays.stream(lines, startLine, endLine) //
+                                .map(secondPagePattern::matcher) //
+                                .anyMatch(Matcher::matches) ? -1 : ret;
+            }
+
+        };
+        var firstRelevantLine = new Block(strategy);
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -276,12 +297,6 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
 
                         .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
-                        .optionalOneOf( //
-                                        section -> section //
-                                                        .attributes("dummy") //
-                                                        .match("^Eink.nfte/Verlust.berhang aktuell (?<dummy>.*)$") //
-                                                        .assign((t, v) -> v.getTransactionContext().skipTransaction(
-                                                                        "second page without transaction")))
                         .oneOf( //
                                         // @formatter:off
                                         // Titel: AT0000A1TW21 RAIFF.-EMERGINGMARKETS-AKTIEN RZ(A)


### PR DESCRIPTION
Extended PDF import to skip processing of a page if it only contains summy information and no actual transaction. Amended the parse-logic in PDFParser to not throw an IllegalArgumentException in case a skip took place.

PDF-Export provided at https://forum.portfolio-performance.info/t/pdf-import-von-raiffeisenbank-bankgruppe/12535/161?u=kimmerin