### PR TITLE
Make the regex to recognize more strict so that it doesn't accidentially match if the security name contains one of the phrases

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Kauf23.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Kauf23.txt
@@ -1,0 +1,32 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+tLLSq WIqcoCB PAGE 1 from 1
+VCM lrLM IsSW 8 DATE 24.06.2026
+0818 fFVSzlhC ORDER 6446-f769
+EXECUTION bd57-fac1
+SECURITIES ACCOUNT 0963152201
+SECURITIES SETTLEMENT
+OVERVIEW
+Market-Order Buy on 24.06.2026 at 19:21 (Europe/Berlin) on Trade Republic Bank GmbH.
+POSITION QUANTITY PRICE AMOUNT
+Developed Markets Dividend Leaders EUR (Dist) 4.827186 Pcs. 51.79 EUR 250.00 EUR
+ISIN: NL0011683594
+TOTAL 250.00 EUR
+BILLING
+POSITION AMOUNT
+External cost surcharge -1.00 EUR
+TOTAL -251.00 EUR
+BOOKING
+CLEARING ACCOUNT VALUE DATE AMOUNT
+MR36979482499516112254 2026-06-26 -251.00 EUR
+Developed Markets Dividend Leaders EUR (Dist) in collective safe custody in Germany
+This statement is generated automatically and therefore not signed.
+If no VAT is shown, it is according to § 4 No. 8 UStG for a sales tax-free service.
+Trade Republic Bank GmbH www.traderepublic.com Headquarters: Berlin Directors
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin VAT-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -962,6 +962,42 @@ public class TradeRepublicPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierKauf23()
+    {
+        var extractor = new TradeRepublicPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf23.txt"), errors);
+
+        errors.forEach(Exception::printStackTrace);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("NL0011683594"), hasWkn(null), hasTicker(null), //
+                        hasName("Developed Markets Dividend Leaders EUR (Dist)"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-24T19:21"), hasShares(4.827186), //
+                        hasSource("Kauf23.txt"), //
+                        hasNote("Order: 6446-f769 | Execution: bd57-fac1"), //
+                        hasAmount("EUR", 251.00), hasGrossValue("EUR", 250.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 1.00))));
+    }
+
+    @Test
     public void testIPOBuy01()
     {
         var extractor = new TradeRepublicPDFExtractor(new Client());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -1267,7 +1267,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendTransaction()
     {
-        final var type = new DocumentType("(?i)(AUSSCH.TTUNG" //
+        final var type = new DocumentType("(?im)^(AUSSCH.TTUNG" //
                         + "|(STORNIERUNG DER )?DIVIDENDE( EN ESP.CES)?" //
                         + "|REINVESTIERUNG" //
                         + "|STORNO DIVIDENDE" //


### PR DESCRIPTION
With the fix to handle multipage PDFs the regex for recognizing dividend-PDFs accidentially triggered if the name of the share contained one of the phrases ("dividend" in this case. I've changed the regex to be a multi-line-pattern to make sure that it only matches if the phrase is at the beginning of the line.