### PR TITLE
support the use of "Abwicklungspauschale" instead of "Abwicklungskostenpauschale" in the PDF to be recogized as fee.

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Kauf22.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Kauf22.txt
@@ -1,0 +1,32 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+Herr Jeh SEITE 1 von 1
+Straße 1 DATUM 30.06.2026
+01234 Ort AUFTRAG 6fd3-cb7f
+AUSFÜHRUNG 640b-fc1a
+DEPOT 0123456789
+WERTPAPIERABRECHNUNG
+ÜBERSICHT
+Market-Order BUY am 30.06.2026 um 22:54 (Europe/Berlin).
+POSITION ANZAHL PREIS BETRAG
+NetScout Systems 13,082155 Stk. 38,25 EUR 500,39 EUR
+ISIN: US64115T1043
+GESAMT 500,39 EUR
+ABRECHNUNG
+POSITION BETRAG
+Abwicklungspauschale -1,00 EUR
+GESAMT -501,39 EUR
+BUCHUNG
+VERRECHNUNGSKONTO WERTSTELLUNG BETRAG
+DE12100123450123456789 2026-07-02 -501,39 EUR
+NetScout Systems in Girosammelverwahrung in Deutschland
+Diese Abrechnung wird maschinell erstellt und daher nicht unterschrieben.
+Wird keine Umsatzsteuer ausgewiesen, handelt es sich gemäß § 4 Nr. 8 UStG um eine umsatzsteuerfreie Leistung.
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -928,6 +928,40 @@ public class TradeRepublicPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierKauf22()
+    {
+        var extractor = new TradeRepublicPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf22.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US64115T1043"), hasWkn(null), hasTicker(null), //
+                        hasName("NetScout Systems"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-30T22:54"), hasShares(13.082155), //
+                        hasSource("Kauf22.txt"), //
+                        hasNote("Auftrag: 6fd3-cb7f | Ausführung: 640b-fc1a"), //
+                        hasAmount("EUR", 501.39), hasGrossValue("EUR", 500.39), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 1.00))));
+    }
+
+    @Test
     public void testIPOBuy01()
     {
         var extractor = new TradeRepublicPDFExtractor(new Client());
@@ -6405,6 +6439,41 @@ public class TradeRepublicPDFExtractorTest
                         hasSource("Verkauf14.txt"), //
                         hasNote("Auftrag: 6974-687e | Ausführung: 7d34-c23d"), //
                         hasAmount("EUR", 1883.20), hasGrossValue("EUR", 1884.20), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 1.00))));
+
+    }
+
+    @Test
+    public void testWertpapierVerkauf15()
+    {
+        var extractor = new TradeRepublicPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf15.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US0010551028"), hasWkn(null), hasTicker(null), //
+                        hasName("Aflac"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-06-30T21:38"), hasShares(10.00), //
+                        hasSource("Verkauf15.txt"), //
+                        hasNote("Auftrag: 694c-f111 | Ausführung: 4308-148b"), //
+                        hasAmount("EUR", 1026.50), hasGrossValue("EUR", 1027.50), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 1.00))));
 
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -6479,6 +6479,40 @@ public class TradeRepublicPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierVerkauf16()
+    {
+        var extractor = new TradeRepublicPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf16.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("LU0252633754"), hasWkn(null), hasTicker(null), //
+                        hasName("DAX EUR (Acc)"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-06-30T21:33"), hasShares(50.00), //
+                        hasSource("Verkauf16.txt"), //
+                        hasNote("Auftrag: 39d6-03a4 | Ausführung: 3b4d-76f1"), //
+                        hasAmount("EUR", 11338.82), hasGrossValue("EUR", 11377.50), //
+                        hasTaxes("EUR", 37.68), hasFees("EUR", 1.00))));
+    }
+
+    @Test
     public void testSecuritySell01()
     {
         var extractor = new TradeRepublicPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Verkauf15.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Verkauf15.txt
@@ -1,0 +1,58 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+Herr Jeh SEITE 1 von 2
+Straße 1 DATUM 30.06.2026
+01234 Ort AUFTRAG 694c-f111
+AUSFÜHRUNG 4308-148b
+DEPOT 0123456789
+WERTPAPIERABRECHNUNG
+ÜBERSICHT
+Market-Order Verkauf am 30.06.2026, um 21:38 Uhr (Europe/Berlin) mit der Lang und Schwarz Exchange, die zugleich Kontrahent der Transaktion ist.
+POSITION ANZAHL PREIS BETRAG
+Aflac 10 Stk. 102,75 EUR 1.027,50 EUR
+ISIN: US0010551028
+GESAMT 1.027,50 EUR
+ABRECHNUNG
+POSITION BETRAG
+Abwicklungspauschale -1,00 EUR
+Kapitalertragsteuer 0,00 EUR
+Solidaritätszuschlag 0,00 EUR
+GESAMT 1.026,50 EUR
+BUCHUNG
+VERRECHNUNGSKONTO WERTSTELLUNG BETRAG
+DE12100123450123456789 2026-07-02 1.026,50 EUR
+Diese Abrechnung wird maschinell erstellt und daher nicht unterschrieben.
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+Herr Jeh SEITE 2 von 2
+Straße 1 DATUM 30.06.2026
+01234 Ort AUFTRAG 694c-f111
+AUSFÜHRUNG 4308-148b
+DEPOT 0123456789
+STEUERLICHE BEHANDLUNG
+BERECHNUNG DER STEUERBEMESSUNGSGRUNDLAGE BETRAG
+Bruttogewinn 74,30 EUR
+Verlustverrechnungstopf Aktien -74,30 EUR
+STEUERBEMESSUNGSGRUNDLAGE 0,00 EUR
+BERECHNUNG DER STEUERN BETRAG
+Steuerbemessungsgrundlage 0,00 EUR
+Kapitalertragsteuer 0,00 EUR
+Solidaritätszuschlag 0,00 EUR
+GESAMTE STEUERN 0,00 EUR
+VERRECHNUNGSTÖPFE VORHER VERÄNDERUNG NACHHER
+Verlustverrechnungstopf Aktien 430,85 EUR -74,30 EUR 356,55 EUR
+Verlustverrechnungstopf Allgemein 0,00 EUR 0,00 EUR 0,00 EUR
+Freistellungsauftrag 0,00 EUR 0,00 EUR 0,00 EUR
+Quellensteuertopf 0,00 EUR 0,00 EUR 0,00 EUR
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Verkauf16.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Verkauf16.txt
@@ -1,0 +1,59 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+Herr Jeh SEITE 1 von 2
+Straße 1 DATUM 30.06.2026
+01234 Ort AUFTRAG 39d6-03a4
+AUSFÜHRUNG 3b4d-76f1
+DEPOT 0123456789
+WERTPAPIERABRECHNUNG
+ÜBERSICHT
+Market-Order Verkauf am 30.06.2026, um 21:33 Uhr (Europe/Berlin) mit der Lang und Schwarz Exchange, die zugleich Kontrahent der Transaktion ist.
+POSITION ANZAHL PREIS BETRAG
+DAX EUR (Acc) 50 Stk. 227,55 EUR 11.377,50 EUR
+ISIN: LU0252633754
+GESAMT 11.377,50 EUR
+ABRECHNUNG
+POSITION BETRAG
+Abwicklungspauschale -1,00 EUR
+Kapitalertragsteuer -35,72 EUR
+Solidaritätszuschlag -1,96 EUR
+GESAMT 11.338,82 EUR
+BUCHUNG
+VERRECHNUNGSKONTO WERTSTELLUNG BETRAG
+DE12100123450123456789 2026-07-02 11.338,82 EUR
+Diese Abrechnung wird maschinell erstellt und daher nicht unterschrieben.
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+Herr Jeh SEITE 2 von 2
+Straße 1 DATUM 30.06.2026
+01234 Ort AUFTRAG 39d6-03a4
+AUSFÜHRUNG 3b4d-76f1
+DEPOT 0123456789
+STEUERLICHE BEHANDLUNG
+BERECHNUNG DER STEUERBEMESSUNGSGRUNDLAGE BETRAG
+Bruttogewinn 285,50 EUR
+Teilfreistellung -85,65 EUR
+Abzug der bereits bezahlten Vorabpauschale -56,99 EUR
+STEUERBEMESSUNGSGRUNDLAGE 142,86 EUR
+BERECHNUNG DER STEUERN BETRAG
+Steuerbemessungsgrundlage 142,86 EUR
+Kapitalertragsteuer -35,72 EUR
+Solidaritätszuschlag -1,96 EUR
+GESAMTE STEUERN 37,68 EUR
+VERRECHNUNGSTÖPFE VORHER VERÄNDERUNG NACHHER
+Verlustverrechnungstopf Aktien 430,85 EUR 0,00 EUR 430,85 EUR
+Verlustverrechnungstopf Allgemein 0,00 EUR 0,00 EUR 0,00 EUR
+Freistellungsauftrag 0,00 EUR 0,00 EUR 0,00 EUR
+Quellensteuertopf 0,00 EUR 0,00 EUR 0,00 EUR
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -5033,9 +5033,10 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
                         // @formatter:off
                         // Abwicklungskostenpauschale -1,00 EUR
+                        // Abwicklungspauschale -1,00 EUR
                         // @formatter:on
                         .section("fee", "currency").optional() //
-                        .match("^Abwicklungskostenpauschale \\-(?<fee>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                        .match("^Abwicklungs(kosten)?pauschale \\-(?<fee>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> {
                             if (!type.getCurrentContext().getBoolean("negative"))
                                 processFeeEntries(t, v, type);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -1732,7 +1732,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
     private void addAdvanceTaxTransaction()
     {
-        final var type = new DocumentType("Vorabpauschale", "KONTO.BERSICHT");
+        final var type = new DocumentType("Vorabpauschale", "KONTO.BERSICHT|WERTPAPIERABRECHNUNG");
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<AccountTransaction>();


### PR DESCRIPTION
Traderepublic did it again and uses a variation of a word that the importer used to recognize fees. This change added that variation to the regex so that the fees of a buy/sell-transaction is correctly recognized again.

Dumps were provided at https://forum.portfolio-performance.info/t/pdf-import-von-trade-republic/5107/884?u=kimmerin