### PR TITLE
Add Dynamic sorting for Taxonomies

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -1093,6 +1093,7 @@ public class Messages extends NLS
     public static String MenuTaxonomyRename;
     public static String MenuTaxonomySortByName;
     public static String MenuTaxonomySortByType;
+    public static String MenuTaxonomySortManual;
     public static String MenuTaxonomySortTreeBy;
     public static String MenuTaxonomyWeightFix;
     public static String MenuTransactionDelete;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -2178,6 +2178,8 @@ MenuTaxonomySortByName = Name
 
 MenuTaxonomySortByType = Type
 
+MenuTaxonomySortManual = Manual (drag and drop)
+
 MenuTaxonomySortTreeBy = Sort by
 
 MenuTaxonomyWeightFix = Fix weights

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_cs.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_cs.properties
@@ -2170,6 +2170,8 @@ MenuTaxonomySortByName = N\u00E1zvu
 
 MenuTaxonomySortByType = Typu
 
+MenuTaxonomySortManual = Manu\u00E1ln\u011B
+
 MenuTaxonomySortTreeBy = Se\u0159adit podle
 
 MenuTaxonomyWeightFix = Zafixovat v\u00E1hy

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
@@ -3,7 +3,6 @@ package name.abuchen.portfolio.ui.views.taxonomy;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -82,6 +81,7 @@ import name.abuchen.portfolio.ui.views.columns.NameColumn;
 import name.abuchen.portfolio.ui.views.columns.NameColumn.NameColumnLabelProvider;
 import name.abuchen.portfolio.ui.views.columns.NoteColumn;
 import name.abuchen.portfolio.ui.views.columns.SymbolColumn;
+import name.abuchen.portfolio.ui.views.taxonomy.TaxonomyModel.SortMode;
 import name.abuchen.portfolio.util.TextUtil;
 
 /* package */abstract class AbstractNodeTreeViewer extends Page implements ModificationListener
@@ -279,57 +279,6 @@ import name.abuchen.portfolio.util.TextUtil;
         }
     }
 
-    private enum SortCriterion
-    {
-        TYPE, NAME, ACTUAL
-    }
-
-    /**
-     * Sort mode of a classification. If a mode other than {@link #MANUAL} is
-     * active, the children of that classification are kept sorted dynamically,
-     * i.e. new and moved items are automatically placed according to the
-     * criteria. The mode is stored per classification and persisted with the
-     * file.
-     */
-    public enum SortMode
-    {
-        MANUAL, //
-        TYPE_NAME(SortCriterion.TYPE, SortCriterion.NAME), //
-        TYPE_ACTUAL(SortCriterion.TYPE, SortCriterion.ACTUAL), //
-        NAME(SortCriterion.NAME), //
-        ACTUAL(SortCriterion.ACTUAL);
-
-        private final SortCriterion[] criteria;
-
-        SortMode(SortCriterion... criteria)
-        {
-            this.criteria = criteria;
-        }
-
-        SortCriterion[] getCriteria()
-        {
-            return criteria;
-        }
-
-        static SortMode of(String value)
-        {
-            if (value == null)
-                return MANUAL;
-
-            try
-            {
-                return valueOf(value);
-            }
-            catch (IllegalArgumentException e)
-            {
-                return MANUAL;
-            }
-        }
-    }
-
-    /** key used to persist the sort mode on a classification's data map */
-    private static final String KEY_SORT_MODE = "sort-mode"; //$NON-NLS-1$
-
     protected static final String MENU_GROUP_DEFAULT_ACTIONS = "defaultActions"; //$NON-NLS-1$
     protected static final String MENU_GROUP_CUSTOM_ACTIONS = "customActions"; //$NON-NLS-1$
     protected static final String MENU_GROUP_DELETE_ACTIONS = "deleteActions"; //$NON-NLS-1$
@@ -419,7 +368,7 @@ import name.abuchen.portfolio.util.TextUtil;
     {
         MenuManager sorting = new MenuManager(Messages.MenuTaxonomySortTreeBy);
 
-        SortMode activeMode = getSortMode(node);
+        SortMode activeMode = getModel().getSortMode(node);
 
         addSortModeAction(sorting, Messages.MenuTaxonomySortManual, SortMode.MANUAL, node, activeMode, recursive);
         sorting.add(new Separator());
@@ -874,7 +823,8 @@ import name.abuchen.portfolio.util.TextUtil;
 
         // re-apply the sort mode of every classification so that newly added or
         // moved items are automatically placed according to each folder's mode
-        applyAutoSortRecursively(getModel().getClassificationRootNode());
+        // (recalculate() already re-sorts value-based modes)
+        getModel().applyStoredSort(getModel().getClassificationRootNode(), false);
 
         getModel().fireTaxonomyModelChange(node);
         getModel().markDirty();
@@ -1117,125 +1067,20 @@ import name.abuchen.portfolio.util.TextUtil;
     private void addSortModeAction(MenuManager menu, String label, SortMode mode, TaxonomyNode node,
                     SortMode activeMode, boolean recursive)
     {
-        Action action = new SimpleAction(label, IAction.AS_CHECK_BOX, a -> applyAutoSort(node, mode, recursive));
+        Action action = new SimpleAction(label, IAction.AS_CHECK_BOX, a -> applySortMode(node, mode, recursive));
         action.setChecked(mode == activeMode);
         menu.add(action);
     }
 
     /**
-     * Returns the sort mode stored for the given classification node.
+     * Applies the sort mode chosen in the menu to the given classification node
+     * and refreshes the tree.
      */
-    private SortMode getSortMode(TaxonomyNode node)
+    private void applySortMode(TaxonomyNode node, SortMode mode, boolean recursive)
     {
-        if (!node.isClassification())
-            return SortMode.MANUAL;
-
-        return SortMode.of((String) node.getClassification().getData(KEY_SORT_MODE));
-    }
-
-    /**
-     * Stores the sort mode on the given classification node.
-     */
-    private void setSortMode(TaxonomyNode node, SortMode mode)
-    {
-        if (!node.isClassification())
-            return;
-
-        // do not store the default -> keeps the file clean
-        node.getClassification().setData(KEY_SORT_MODE, mode == SortMode.MANUAL ? null : mode.name());
-    }
-
-    /**
-     * Activates the given sort mode for a classification node and – if a mode
-     * other than {@link SortMode#MANUAL} is chosen – sorts its children
-     * immediately. When {@code recursive} is set, the mode is applied to all
-     * descendant classifications as well.
-     */
-    private void applyAutoSort(TaxonomyNode node, SortMode mode, boolean recursive)
-    {
-        setAutoSort(node, mode, recursive);
+        getModel().setSortMode(node, mode, recursive);
 
         getModel().markDirty();
         getModel().fireTaxonomyModelChange(node);
-    }
-
-    private void setAutoSort(TaxonomyNode node, SortMode mode, boolean recursive)
-    {
-        setSortMode(node, mode);
-
-        if (mode != SortMode.MANUAL)
-            sort(node, mode.getCriteria());
-
-        if (recursive)
-        {
-            for (TaxonomyNode child : node.getChildren())
-            {
-                if (child.isClassification())
-                    setAutoSort(child, mode, true);
-            }
-        }
-    }
-
-    /**
-     * Re-applies the stored sort mode of every classification to its own
-     * children. Called after structural edits so that new or moved items are
-     * placed according to each folder's sort mode.
-     */
-    private void applyAutoSortRecursively(TaxonomyNode node)
-    {
-        if (!node.isClassification())
-            return;
-
-        SortMode mode = getSortMode(node);
-        if (mode != SortMode.MANUAL)
-            sort(node, mode.getCriteria());
-
-        for (TaxonomyNode child : node.getChildren())
-            applyAutoSortRecursively(child);
-    }
-
-    /**
-     * Sorts the children of a node, but does not fire update notifications.
-     */
-    private void sort(TaxonomyNode node, SortCriterion... criteria) // NOSONAR
-    {
-        Collections.sort(node.getChildren(), (node1, node2) -> { // NOSONAR
-            // unassigned category always stays at the end of the list
-            if (node1.isUnassignedCategory())
-                return 1;
-            if (node2.isUnassignedCategory())
-                return -1;
-
-            for (int ii = 0; ii < criteria.length; ii++)
-            {
-                switch (criteria[ii])
-                {
-                    case TYPE:
-                        if (node1.isClassification() && !node2.isClassification())
-                            return -1;
-                        if (!node1.isClassification() && node2.isClassification())
-                            return 1;
-                        break;
-                    case NAME:
-                        int cn = TextUtil.compare(node1.getName(), node2.getName());
-                        if (cn != 0)
-                            return cn;
-                        break;
-                    case ACTUAL:
-                        int ca = node2.getActual().compareTo(node1.getActual());
-                        if (ca != 0)
-                            return ca;
-                        break;
-                    default:
-
-                }
-            }
-
-            return 0;
-        });
-
-        int rank = 0;
-        for (TaxonomyNode child : node.getChildren())
-            child.setRank(rank++);
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractNodeTreeViewer.java
@@ -18,6 +18,7 @@ import jakarta.inject.Inject;
 
 import org.eclipse.e4.core.di.extensions.Preference;
 import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
@@ -283,6 +284,52 @@ import name.abuchen.portfolio.util.TextUtil;
         TYPE, NAME, ACTUAL
     }
 
+    /**
+     * Sort mode of a classification. If a mode other than {@link #MANUAL} is
+     * active, the children of that classification are kept sorted dynamically,
+     * i.e. new and moved items are automatically placed according to the
+     * criteria. The mode is stored per classification and persisted with the
+     * file.
+     */
+    public enum SortMode
+    {
+        MANUAL, //
+        TYPE_NAME(SortCriterion.TYPE, SortCriterion.NAME), //
+        TYPE_ACTUAL(SortCriterion.TYPE, SortCriterion.ACTUAL), //
+        NAME(SortCriterion.NAME), //
+        ACTUAL(SortCriterion.ACTUAL);
+
+        private final SortCriterion[] criteria;
+
+        SortMode(SortCriterion... criteria)
+        {
+            this.criteria = criteria;
+        }
+
+        SortCriterion[] getCriteria()
+        {
+            return criteria;
+        }
+
+        static SortMode of(String value)
+        {
+            if (value == null)
+                return MANUAL;
+
+            try
+            {
+                return valueOf(value);
+            }
+            catch (IllegalArgumentException e)
+            {
+                return MANUAL;
+            }
+        }
+    }
+
+    /** key used to persist the sort mode on a classification's data map */
+    private static final String KEY_SORT_MODE = "sort-mode"; //$NON-NLS-1$
+
     protected static final String MENU_GROUP_DEFAULT_ACTIONS = "defaultActions"; //$NON-NLS-1$
     protected static final String MENU_GROUP_CUSTOM_ACTIONS = "customActions"; //$NON-NLS-1$
     protected static final String MENU_GROUP_DELETE_ACTIONS = "deleteActions"; //$NON-NLS-1$
@@ -357,18 +404,33 @@ import name.abuchen.portfolio.util.TextUtil;
 
         manager.add(new Separator());
 
+        // the config menu applies the sort mode to the whole tree, i.e. every
+        // classification is set to the same mode (recursive)
+        addSortMenu(manager, getModel().getClassificationRootNode(), true);
+    }
+
+    /**
+     * Adds the "Sort by" sub menu with a check-box radio group for the sort
+     * modes. When {@code recursive} is set, choosing a mode applies it to the
+     * given node and all its descendants; otherwise it only affects the node
+     * itself. The checked entry reflects the node's currently stored mode.
+     */
+    private void addSortMenu(IMenuManager manager, TaxonomyNode node, boolean recursive)
+    {
         MenuManager sorting = new MenuManager(Messages.MenuTaxonomySortTreeBy);
-        sorting.add(new SimpleAction(
+
+        SortMode activeMode = getSortMode(node);
+
+        addSortModeAction(sorting, Messages.MenuTaxonomySortManual, SortMode.MANUAL, node, activeMode, recursive);
+        sorting.add(new Separator());
+        addSortModeAction(sorting,
                         String.join(", ", Messages.MenuTaxonomySortByType, Messages.MenuTaxonomySortByName), //$NON-NLS-1$
-                        a -> doSortRecursively(getModel().getClassificationRootNode(), SortCriterion.TYPE,
-                                        SortCriterion.NAME)));
-        sorting.add(new SimpleAction(String.join(", ", Messages.MenuTaxonomySortByType, Messages.ColumnActualValue), //$NON-NLS-1$
-                        a -> doSortRecursively(getModel().getClassificationRootNode(), SortCriterion.TYPE,
-                                        SortCriterion.ACTUAL)));
-        sorting.add(new SimpleAction(Messages.MenuTaxonomySortByName,
-                        a -> doSortRecursively(getModel().getClassificationRootNode(), SortCriterion.NAME)));
-        sorting.add(new SimpleAction(Messages.ColumnActualValue,
-                        a -> doSortRecursively(getModel().getClassificationRootNode(), SortCriterion.ACTUAL)));
+                        SortMode.TYPE_NAME, node, activeMode, recursive);
+        addSortModeAction(sorting,
+                        String.join(", ", Messages.MenuTaxonomySortByType, Messages.ColumnActualValue), //$NON-NLS-1$
+                        SortMode.TYPE_ACTUAL, node, activeMode, recursive);
+        addSortModeAction(sorting, Messages.MenuTaxonomySortByName, SortMode.NAME, node, activeMode, recursive);
+        addSortModeAction(sorting, Messages.ColumnActualValue, SortMode.ACTUAL, node, activeMode, recursive);
 
         manager.add(sorting);
     }
@@ -809,6 +871,11 @@ import name.abuchen.portfolio.util.TextUtil;
     protected void onTaxnomyNodeEdited(TaxonomyNode node)
     {
         getModel().recalculate();
+
+        // re-apply the sort mode of every classification so that newly added or
+        // moved items are automatically placed according to each folder's mode
+        applyAutoSortRecursively(getModel().getClassificationRootNode());
+
         getModel().fireTaxonomyModelChange(node);
         getModel().markDirty();
     }
@@ -885,16 +952,9 @@ import name.abuchen.portfolio.util.TextUtil;
 
             manager.add(new Separator());
 
-            MenuManager sorting = new MenuManager(Messages.MenuTaxonomySortTreeBy);
-            sorting.add(new SimpleAction(
-                            String.join(", ", Messages.MenuTaxonomySortByType, Messages.MenuTaxonomySortByName), //$NON-NLS-1$
-                            a -> doSort(node, SortCriterion.TYPE, SortCriterion.NAME)));
-            sorting.add(new SimpleAction(String.join(", ", Messages.MenuTaxonomySortByType, Messages.ColumnActualValue), //$NON-NLS-1$
-                            a -> doSort(node, SortCriterion.TYPE, SortCriterion.ACTUAL)));
-            sorting.add(new SimpleAction(Messages.MenuTaxonomySortByName, a -> doSort(node, SortCriterion.NAME)));
-            sorting.add(new SimpleAction(Messages.ColumnActualValue, a -> doSort(node, SortCriterion.ACTUAL)));
-
-            manager.add(sorting);
+            // the context menu applies the sort mode only to the selected
+            // classification (its direct children)
+            addSortMenu(manager, node, false);
 
             if (!node.isRoot() && !node.getParent().isRoot())
             {
@@ -1052,32 +1112,92 @@ import name.abuchen.portfolio.util.TextUtil;
     }
 
     /**
-     * Sorts the children of a node and fires an update notification.
+     * Adds a check-box menu item that activates the given sort mode.
      */
-    private void doSort(TaxonomyNode node, SortCriterion... criteria) // NOSONAR
+    private void addSortModeAction(MenuManager menu, String label, SortMode mode, TaxonomyNode node,
+                    SortMode activeMode, boolean recursive)
     {
-        sort(node, false, criteria);
+        Action action = new SimpleAction(label, IAction.AS_CHECK_BOX, a -> applyAutoSort(node, mode, recursive));
+        action.setChecked(mode == activeMode);
+        menu.add(action);
+    }
+
+    /**
+     * Returns the sort mode stored for the given classification node.
+     */
+    private SortMode getSortMode(TaxonomyNode node)
+    {
+        if (!node.isClassification())
+            return SortMode.MANUAL;
+
+        return SortMode.of((String) node.getClassification().getData(KEY_SORT_MODE));
+    }
+
+    /**
+     * Stores the sort mode on the given classification node.
+     */
+    private void setSortMode(TaxonomyNode node, SortMode mode)
+    {
+        if (!node.isClassification())
+            return;
+
+        // do not store the default -> keeps the file clean
+        node.getClassification().setData(KEY_SORT_MODE, mode == SortMode.MANUAL ? null : mode.name());
+    }
+
+    /**
+     * Activates the given sort mode for a classification node and – if a mode
+     * other than {@link SortMode#MANUAL} is chosen – sorts its children
+     * immediately. When {@code recursive} is set, the mode is applied to all
+     * descendant classifications as well.
+     */
+    private void applyAutoSort(TaxonomyNode node, SortMode mode, boolean recursive)
+    {
+        setAutoSort(node, mode, recursive);
 
         getModel().markDirty();
         getModel().fireTaxonomyModelChange(node);
     }
 
-    /**
-     * Sorts the children of a node recursively and fires an update
-     * notification.
-     */
-    private void doSortRecursively(TaxonomyNode node, SortCriterion... criteria) // NOSONAR
+    private void setAutoSort(TaxonomyNode node, SortMode mode, boolean recursive)
     {
-        sort(node, true, criteria);
+        setSortMode(node, mode);
 
-        getModel().markDirty();
-        getModel().fireTaxonomyModelChange(node);
+        if (mode != SortMode.MANUAL)
+            sort(node, mode.getCriteria());
+
+        if (recursive)
+        {
+            for (TaxonomyNode child : node.getChildren())
+            {
+                if (child.isClassification())
+                    setAutoSort(child, mode, true);
+            }
+        }
+    }
+
+    /**
+     * Re-applies the stored sort mode of every classification to its own
+     * children. Called after structural edits so that new or moved items are
+     * placed according to each folder's sort mode.
+     */
+    private void applyAutoSortRecursively(TaxonomyNode node)
+    {
+        if (!node.isClassification())
+            return;
+
+        SortMode mode = getSortMode(node);
+        if (mode != SortMode.MANUAL)
+            sort(node, mode.getCriteria());
+
+        for (TaxonomyNode child : node.getChildren())
+            applyAutoSortRecursively(child);
     }
 
     /**
      * Sorts the children of a node, but does not fire update notifications.
      */
-    private void sort(TaxonomyNode node, boolean recursive, SortCriterion... criteria) // NOSONAR
+    private void sort(TaxonomyNode node, SortCriterion... criteria) // NOSONAR
     {
         Collections.sort(node.getChildren(), (node1, node2) -> { // NOSONAR
             // unassigned category always stays at the end of the list
@@ -1117,14 +1237,5 @@ import name.abuchen.portfolio.util.TextUtil;
         int rank = 0;
         for (TaxonomyNode child : node.getChildren())
             child.setRank(rank++);
-
-        if (recursive)
-        {
-            for (var child : node.getChildren())
-            {
-                if (child.isClassification())
-                    sort(child, true, criteria);
-            }
-        }
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyModel.java
@@ -78,6 +78,71 @@ public final class TaxonomyModel
     public static final Predicate<TaxonomyNode> FILTER_NOT_RETIRED = node -> node.isClassification()
                     || !node.getAssignment().getInvestmentVehicle().isRetired();
 
+    /** key used to persist the sort mode on a classification's data map */
+    private static final String KEY_SORT_MODE = "sort-mode"; //$NON-NLS-1$
+
+    private enum SortCriterion
+    {
+        TYPE, NAME, ACTUAL
+    }
+
+    /**
+     * Sort mode of a classification. If a mode other than {@link #MANUAL} is
+     * active, the children of that classification are kept sorted dynamically,
+     * i.e. new and moved items are automatically placed according to the
+     * criteria. The mode is stored per classification and persisted with the
+     * file.
+     */
+    public enum SortMode
+    {
+        MANUAL, //
+        TYPE_NAME(SortCriterion.TYPE, SortCriterion.NAME), //
+        TYPE_ACTUAL(SortCriterion.TYPE, SortCriterion.ACTUAL), //
+        NAME(SortCriterion.NAME), //
+        ACTUAL(SortCriterion.ACTUAL);
+
+        private final SortCriterion[] criteria;
+
+        SortMode(SortCriterion... criteria)
+        {
+            this.criteria = criteria;
+        }
+
+        SortCriterion[] getCriteria()
+        {
+            return criteria;
+        }
+
+        /**
+         * Whether the order depends on the (actual) value of an item and hence
+         * needs to be re-applied when values change.
+         */
+        boolean isValueBased()
+        {
+            for (SortCriterion criterion : criteria)
+            {
+                if (criterion == SortCriterion.ACTUAL)
+                    return true;
+            }
+            return false;
+        }
+
+        static SortMode of(String value)
+        {
+            if (value == null)
+                return MANUAL;
+
+            try
+            {
+                return valueOf(value);
+            }
+            catch (IllegalArgumentException e)
+            {
+                return MANUAL;
+            }
+        }
+    }
+
     private final Taxonomy taxonomy;
     private final Client client;
     private final ExchangeRateProviderFactory factory;
@@ -174,6 +239,11 @@ public final class TaxonomyModel
 
         // calculate targets
         runRecalculations();
+
+        // re-apply the stored sort mode per classification -> the tree is built
+        // in rank order, but ranks can be stale (e.g. values changed while the
+        // view was closed), so folders with a sort mode are re-sorted
+        applyStoredSort(classificationRootNode, false);
     }
 
     private void addUnassigned(Client client)
@@ -252,6 +322,117 @@ public final class TaxonomyModel
     {
         this.attachedModels.forEach(m -> m.recalculate(this));
         rebalance();
+    }
+
+    /**
+     * Returns the sort mode stored on the given classification node.
+     */
+    public SortMode getSortMode(TaxonomyNode node)
+    {
+        if (!node.isClassification())
+            return SortMode.MANUAL;
+
+        return SortMode.of((String) node.getClassification().getData(KEY_SORT_MODE));
+    }
+
+    /**
+     * Stores the sort mode on the given classification node.
+     */
+    public void setSortMode(TaxonomyNode node, SortMode mode)
+    {
+        if (!node.isClassification())
+            return;
+
+        // do not store the default -> keeps the file clean
+        node.getClassification().setData(KEY_SORT_MODE, mode == SortMode.MANUAL ? null : mode.name());
+    }
+
+    /**
+     * Sets the sort mode on a classification node and – unless
+     * {@link SortMode#MANUAL} – sorts its children immediately. When
+     * {@code recursive} is set, the mode is applied to all descendant
+     * classifications as well. Does not fire an update notification.
+     */
+    public void setSortMode(TaxonomyNode node, SortMode mode, boolean recursive)
+    {
+        setSortMode(node, mode);
+
+        if (mode != SortMode.MANUAL)
+            sort(node, mode.getCriteria());
+
+        if (recursive)
+        {
+            for (TaxonomyNode child : node.getChildren())
+            {
+                if (child.isClassification())
+                    setSortMode(child, mode, true);
+            }
+        }
+    }
+
+    /**
+     * Re-applies the stored sort mode of every classification to its own
+     * children so that newly added, moved or revalued items are placed
+     * according to each folder's mode. If {@code valueModesOnly} is set, only
+     * value-based modes are re-applied. Does not fire an update notification.
+     */
+    public void applyStoredSort(TaxonomyNode node, boolean valueModesOnly)
+    {
+        if (!node.isClassification())
+            return;
+
+        SortMode mode = getSortMode(node);
+        if (mode != SortMode.MANUAL && (!valueModesOnly || mode.isValueBased()))
+            sort(node, mode.getCriteria());
+
+        for (TaxonomyNode child : node.getChildren())
+            applyStoredSort(child, valueModesOnly);
+    }
+
+    /**
+     * Sorts the children of a node according to the given criteria and updates
+     * the ranks. Does not fire an update notification.
+     */
+    private void sort(TaxonomyNode node, SortCriterion... criteria) // NOSONAR
+    {
+        Collections.sort(node.getChildren(), (node1, node2) -> { // NOSONAR
+            // unassigned category always stays at the end of the list
+            if (node1.isUnassignedCategory())
+                return 1;
+            if (node2.isUnassignedCategory())
+                return -1;
+
+            for (int ii = 0; ii < criteria.length; ii++)
+            {
+                switch (criteria[ii])
+                {
+                    case TYPE:
+                        if (node1.isClassification() && !node2.isClassification())
+                            return -1;
+                        if (!node1.isClassification() && node2.isClassification())
+                            return 1;
+                        break;
+                    case NAME:
+                        int cn = TextUtil.compare(node1.getName(), node2.getName());
+                        if (cn != 0)
+                            return cn;
+                        break;
+                    case ACTUAL:
+                        int ca = node2.getActual().compareTo(node1.getActual());
+                        if (ca != 0)
+                            return ca;
+                        break;
+                    default:
+
+                }
+            }
+
+            return 0;
+        });
+
+        int rank = 0;
+        for (TaxonomyNode child : node.getChildren())
+            child.setRank(rank++);
     }
 
     public boolean isUnassignedCategoryInChartsExcluded()
@@ -439,6 +620,9 @@ public final class TaxonomyModel
         virtualRootNode.setActual(snapshot.getMonetaryAssets());
         visitActuals(snapshot, virtualRootNode);
         runRecalculations();
+
+        // keep value-sorted folders correctly ordered when actuals change
+        applyStoredSort(classificationRootNode, true);
     }
 
     public void visitAll(NodeVisitor visitor)


### PR DESCRIPTION
Each classification can have own sort setting through context menu.
The view config menu applies the sort mode to the whole tree.

Second commit Moves sorting to Model so Taxonomy can be dynamically sorted on recalculate.

Closes #4968