### PR TITLE
Add annualized volatility dashboard widget

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/RiskTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/RiskTest.java
@@ -122,6 +122,22 @@ public class RiskTest
     }
 
     /**
+     * Tests the annualized volatility calculation with a set of returns.
+     * Scenario: The same return values as {@link #testVolatility()} are used.
+     * Expects: The annualized standard deviation equals the daily standard
+     * deviation scaled by the square root of 252 trading days, i.e. it is
+     * independent of the number of observations in the period.
+     */
+    @Test
+    public void testAnnualizedVolatility()
+    {
+        double[] delta = { 0.005, -1 / 300d, -0.005, 0.01, 0.01, -0.005 };
+        Volatility volatility = new Volatility(delta, index -> true);
+
+        assertThat(volatility.getAnnualizedStandardDeviation(), closeTo(0.114946904780, TOLERANCE));
+    }
+
+    /**
      * Tests the Volatility calculation while skipping the first return value.
      * Scenario: The first return value is skipped in the volatility calculation.
      * Expects: Volatility to be consistent with calculations that include the first value, within specified tolerance.

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -981,6 +981,7 @@ public class Messages extends NLS
     public static String LabelViewTaxonomyDefinition;
     public static String LabelViewTreeMap;
     public static String LabelVolatility;
+    public static String LabelVolatilityAnnualized;
     public static String LabelWatchlist;
     public static String LabelWeeksAgo;
     public static String LabelWithoutClassification;
@@ -1483,6 +1484,7 @@ public class Messages extends NLS
     public static String TooltipSharpeRatio;
     public static String TooltipTurnoverRate;
     public static String TooltipVolatility;
+    public static String TooltipVolatilityAnnualized;
     public static String TransactionFilter;
     public static String TransactionFilterBuy;
     public static String TransactionFilterBuyAndSell;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1954,6 +1954,8 @@ LabelViewTreeMap = Tree Map
 
 LabelVolatility = Volatility
 
+LabelVolatilityAnnualized = Volatility (annualized)
+
 LabelWatchlist = Watchlist
 
 LabelWeeksAgo = {0,choice,0#0 weeks ago|1#1 week ago|1<{0,number} weeks ago}
@@ -2959,6 +2961,8 @@ TooltipSharpeRatio = Sharpe Ratio\n\n(Internal rate of return - Risk free rate o
 TooltipTurnoverRate = The Portfolio Turnover Rate measures how much of the portfolio was "replaced" throughout the holding period, as a fraction of the average portfolio value.\n\nPurchases: {0}\nSales: {1}\nAverage portfolio volume: {2}\nPortfolio Turnover Rate: {3}
 
 TooltipVolatility = Volatility (or variance) is a measure for variation of price of a financial instrument over time.\n\nThe volatility is calculated using the "cumulative" data series. Therefore performance-neutral transactions have no impact. Weekends and public holidays are ignored (for example Easter and Christmas days).
+
+TooltipVolatilityAnnualized = The annualized volatility scales the standard deviation of the daily returns to one year (multiplying by the square root of 252 trading days).\n\nUnlike the "Volatility" widget, which scales to the length of the reporting period, this value is independent of the selected period and therefore comparable across periods and with externally quoted (annualized) volatility figures.\n\nIt is calculated using the "cumulative" data series. Therefore performance-neutral transactions have no impact. Weekends and public holidays are ignored (for example Easter and Christmas days).
 
 TransactionFilter = Filter data by transaction type
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
@@ -274,6 +274,17 @@ public enum WidgetFactory
                                     .withColoredValues(false) //
                                     .build()),
 
+    ANNUALIZED_VOLATILITY(Messages.LabelVolatilityAnnualized, Messages.LabelRiskIndicators, //
+                    (widget, data) -> IndicatorWidget.<Double>create(widget, data) //
+                                    .with(Values.Percent2) //
+                                    .with((ds, period) -> {
+                                        PerformanceIndex index = data.calculate(ds, period);
+                                        return index.getVolatility().getAnnualizedStandardDeviation();
+                                    }) //
+                                    .withTooltip((ds, period) -> Messages.TooltipVolatilityAnnualized) //
+                                    .withColoredValues(false) //
+                                    .build()),
+
     SHARPE_RATIO(Messages.LabelSharpeRatio, Messages.LabelRiskIndicators, //
                     (widget, data) -> IndicatorWidget.<Double>create(widget, data) //
                                     .with(Values.PercentPlain) //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/math/Risk.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/math/Risk.java
@@ -130,8 +130,11 @@ public final class Risk
 
     public static class Volatility
     {
+        private static final int TRADING_DAYS_PER_YEAR = 252;
+
         private final double stdDeviation;
         private final double semiDeviation;
+        private final double annualizedStdDeviation;
 
         public Volatility(double[] returns, IntPredicate filter)
         {
@@ -162,11 +165,13 @@ public final class Risk
             {
                 stdDeviation = 0d;
                 semiDeviation = 0d;
+                annualizedStdDeviation = 0d;
             }
             else
             {
                 stdDeviation = Math.sqrt(tempStandard / (count - 1) * count);
                 semiDeviation = Math.sqrt(tempSemi / (count - 1) * count);
+                annualizedStdDeviation = Math.sqrt(tempStandard / (count - 1) * TRADING_DAYS_PER_YEAR);
             }
         }
 
@@ -190,6 +195,20 @@ public final class Risk
         public double getStandardDeviation()
         {
             return stdDeviation;
+        }
+
+        /**
+         * Returns the annualized standard deviation: the standard deviation of
+         * the daily returns scaled to one year by the square root of the number
+         * of trading days per year (252). In contrast to
+         * {@link #getStandardDeviation()}, which scales to the length of the
+         * reporting period, this value is independent of the period and
+         * therefore comparable across periods and with externally quoted
+         * (annualized) volatility figures.
+         */
+        public double getAnnualizedStandardDeviation()
+        {
+            return annualizedStdDeviation;
         }
 
         public double getSemiDeviation()


### PR DESCRIPTION
Adds a "Volatility (annualized)" dashboard widget alongside the existing "Volatility" widget.

## Why

The existing "Volatility" widget scales the standard deviation to the length of the selected reporting period (`sigma_daily * sqrt(N)`, where `N` is the number of trading days in the period). The displayed value therefore depends on the period length and only equals the conventionally quoted *annualized* volatility when the period happens to be about one year. Since the dashboard is a monitoring view watched across arbitrary periods (e.g., YTD, since inception), the figure isn't stable across periods and isn't directly comparable to the annualized volatilities that fund fact sheets, indices, and brokers quote.

## What

A new additive `ANNUALIZED_VOLATILITY` widget that always normalizes to one year (`sigma_daily * sqrt(252)`), independent of the selected period. Weekends and holidays are already excluded from the returns (`filterReturnsForVolatilityCalculation` in `PerformanceIndex`), so trading-day annualization with `sqrt(252)` is the appropriate convention.

The existing "Volatility" widget is left unchanged. This mirrors how "True Time-Weighted Rate of Return (annualized)" sits alongside its cumulative counterpart.

- `Risk.Volatility` gains `getAnnualizedStandardDeviation()`, covered by a new `RiskTest` case.
- New `ANNUALIZED_VOLATILITY` entry in `WidgetFactory` mirroring `VOLATILITY`.
- New labels `LabelVolatilityAnnualized` / `TooltipVolatilityAnnualized`.

This is the first of two PRs discussed in #5842 (dashboard widget); a follow-up will add the matching annualized options to the Return/Volatility chart.

Part of #5842

Local run:
<img width="1920" height="1026" alt="image" src="https://github.com/user-attachments/assets/27062012-8b23-42bf-8412-ca2cae9074b6" />

Hovering over the new widget
<img width="430" height="381" alt="image" src="https://github.com/user-attachments/assets/744fa995-87f5-499b-a6d1-6c3dddbbd766" />
