### PR TITLE
Fix one-way validation status binding for error labels

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BindingHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/BindingHelper.java
@@ -225,7 +225,8 @@ public class BindingHelper
         IObservableValue<String> statusTarget = WidgetProperties.text().observe(errorLabel);
         IObservableValue<IStatus> statusModel = new AggregateValidationStatus(context,
                         AggregateValidationStatus.MAX_SEVERITY);
-        context.bindValue(statusTarget, statusModel, null,
+        context.bindValue(statusTarget, statusModel,
+                        new UpdateValueStrategy<String, IStatus>(UpdateValueStrategy.POLICY_NEVER),
                         new UpdateValueStrategy<IStatus, String>().setConverter(new StatusTextConverter()));
     }
 


### PR DESCRIPTION
BindingHelper.createErrorLabel(...) displays an AggregateValidationStatus as label text. The binding only needs to update the UI from the validation status. The previous binding allowed the reverse direction as well, causing Eclipse Data Binding to try converting the label text from String back to IStatus.

This change makes the binding explicitly one-way by disabling target-to-model updates for the error label.

https://forum.portfolio-performance.info/t/exchange-rates-are-not-updated-since-2015/33052/