### PR TITLE
Support for a variant on the Comdirect PDF for a sale

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/ComdirectPDFExtractorTest.java
@@ -1169,6 +1169,40 @@ public class ComdirectPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierVerkauf05()
+    {
+        var extractor = new ComdirectPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf05.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US02079K3059"), hasWkn("A14Y6F"), hasTicker(null), //
+                        hasName("Alphabet Inc. Reg. Shs Cap.Stk Cl. A DL-,001"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-06-08T21:46"), hasShares(7), //
+                        hasSource("Verkauf05.txt"), //
+                        hasNote("Ord.-Nr.: 000526703524-001 | R.-Nr.: 708040026946D3A5"), //
+                        hasAmount("EUR", 2193.43), hasGrossValue("EUR", 2206.75), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 13.32))));
+    }
+
+    @Test
     public void testWertpapierVerkauf04WithSecurityInEUR()
     {
         // This is a manipulated PDF debug to check if a fee refund works with a
@@ -2230,6 +2264,49 @@ public class ComdirectPDFExtractorTest
                         hasNote("Ord.-Nr.: 000445114393-001 | R.-Nr.: 670602616376D085"), //
                         hasAmount("EUR", 1529.81), hasGrossValue("EUR", 1589.44), //
                         hasTaxes("EUR", 59.63), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testWertpapierVerkaufMitSteuerbehandlung23()
+    {
+        var extractor = new ComdirectPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "VerkaufMitSteuerbehandlung23.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("LU0460391732"), hasWkn("DBX0DZ"), hasTicker(null), //
+                        hasName("Xtr.BBG Comm.ex-Agr.+Livest.Sw Inhaber-Anteile 2C EUR Hgd oN"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-07-07T00:00"), hasShares(2.799), //
+                        hasSource("VerkaufMitSteuerbehandlung23.txt"), //
+                        hasNote("Ord.-Nr.: 511445411424 | R.-Nr.: 324696388726h801"), //
+                        hasAmount("EUR", 130.85), hasGrossValue("EUR", 130.85), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check tax refund transaction
+        assertThat(results, hasItem(taxRefund( //
+                        hasDate("2026-07-07T00:00"), hasShares(2.799), //
+                        hasSource("VerkaufMitSteuerbehandlung23.txt"), //
+                        hasNote("Ref.-Nr.: 0tsYra6xyu5195BC"), //
+                        hasAmount("EUR", 1.08), hasGrossValue("EUR", 1.08), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Verkauf05.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/Verkauf05.txt
@@ -1,0 +1,57 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Ihren Auftrag haben wir gemäß unseren produktbezogenen
+Geschäftsbedingungen "Trading" wie nachstehend ausgeführt.
+Die Wertpapiere haben wir der Abrechnung entsprechend gebucht.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und
+Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.
+25449 Quickborn
+Telefon : 04106-708 25 00
+97762 010
+Depotnr.: xxx
+BLZ: xxx
+xxx
+xxx
+xxx
+GESCHÄFTSABRECHNUNG VOM 08.06.2026
+*
+Wertpapierverkauf
+Geschäftsnummer : 92 211272
+Ordernummer : 000526703524-001 Rechnungsnummer : 708040026946D3A5
+Geschäftstag : 08.06.2026 Abwicklung : Live Trading
+Handelszeit : 21:46 Uhr (MEZ/MESZ)
+Wertpapier-Bezeichnung WPKNR/ISIN
+Alphabet Inc. A14Y6F
+Reg. Shs Cap.Stk Cl. A DL-,001 US02079K3059
+Nennwert Zum Preis von
+St. 7 EUR 315,25
+Kurswert : EUR 2.206,75
+--------------------------------------------------------------------------------
+Eigene Entgelte
+Abwickl.entgelt Clearstream : EUR 2,90-
+Provision : EUR 10,42-
+Summe Entgelte : EUR 13,32-
+--------------------------------------------------------------------------------
+IBAN Valuta Zu Ihren Gunsten vor Steuern
+DE96 2004 1144 0628 7734 00 EUR 10.06.2026 EUR 2.193,43
+Verwahrungs-Art: WERTPAPIERRECHNUNG USA/KANADA (AKV)
+Ihre Wertpapier-Order wurde über das Online Banking erteilt.
+Informationen zur steuerlichen Behandlung dieses Geschäftsvorgangs und den auf
+Ihrem Konto gebuchten Endbetrag finden Sie auf der separaten Steuermitteilung.
+Bei Fragen geben Sie bitte die Ordernummer an.
+Ihre comdirect
+Diese Abrechnung wird von der Bank nicht unterschrieben
+Die Leistung ist gemäß §4 Nr.8 UStG umsatzsteuerfrei. USt-Id-Nr.: DE 114 103 514
+A113
+DO15DD/16/04/2010
+Kundennr. /BLZ Bezeichnung
+xxx
+xxx
+xxx
+xxx
+abweichend wirtschaftlich Berechtigter
+----
+xxx

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/VerkaufMitSteuerbehandlung23.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/comdirect/VerkaufMitSteuerbehandlung23.txt
@@ -1,0 +1,94 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.85.0
+System: macosx | aarch64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Ihren Auftrag haben wir gemäß unseren produktbezogenen
+Geschäftsbedingungen "Trading" wie nachstehend ausgeführt.
+Die Wertpapiere haben wir der Abrechnung entsprechend gebucht.
+Wir bitten Sie, diese Abrechnung auf ihre Richtigkeit und
+Vollständigkeit zu überprüfen und etwaige Einwendungen
+unverzüglich zu erheben.
+25449 Quickborn
+Telefon : 04106-708 25 00
+58571 010
+Depotnr.: 1523700 00
+BLZ: 200 411 77
+Florian CsLVNmfZo MOdctD
+Zur OfpwbawSgLDuw 74
+63998 Bad dKNwUxYmzb
+GESCHÄFTSABRECHNUNG VOM 07.07.2026
+*
+Wertpapierverkauf
+Geschäftsnummer : 91 312076
+511445411424 Rechnungsnummer : 324696388726h801
+Geschäftstag : 07.07.2026 Ausführungsplatz : TRADEGATE
+(Kommissionsgeschäft)
+Wertpapier-Bezeichnung WPKNR/ISIN
+Xtr.BBG Comm.ex-Agr.+Livest.Sw DBX0DZ
+Inhaber-Anteile 2C EUR Hgd oN LU0460391732
+Nennwert Zum Kurs von
+St. 2,799 EUR 46,7491
+Kurswert : EUR 130,85
+IBAN Valuta Zu Ihren Gunsten vor Steuern
+DE04 1308 3274 8933 8130 00 EUR 09.07.2026 EUR 130,85
+Verwahrungs-Art: WERTPAPIERRECHNUNG IRLAND (AKV)
+Informationen zur steuerlichen Behandlung dieses Geschäftsvorgangs und den auf
+Ihrem Konto gebuchten Endbetrag finden Sie auf der separaten Steuermitteilung.
+Ihre comdirect
+Diese Abrechnung wird von der Bank nicht unterschrieben
+Die Leistung ist gemäß §4 Nr.8 UStG umsatzsteuerfrei. USt-Id-Nr.: DE 114 103 514 A113
+DO15DD/16/04/2010
+Kundennr. /BLZ Bezeichnung
+Florian LpGxlJPfX CUIvNs
+7209669
+Zur UJWTXUgZjkLzr 50
+031 254 58 60703 Bad obrwurZlEV
+abweichend wirtschaftlich Berechtigter
+----
+comdirect
+25451 Quickborn
+010 58571
+Telefon: 04106 - 708 25 00
+Herrn Datum: 07.07.2026
+Florian CYChyfhoG EULKOb Depotnummer: 2306475 00
+Zur LZkDwZaPDAdcg 02
+04299 Bad BCyPEWXdrf Referenz-Nummer: 0tsYra6xyu5195BC
+Steuerliche Behandlung: Verkauf Investmentfonds Nr. 91312076 vom 07.07.2026
+Stk. -2,799 XTR.BBG COMM.X-AGR+LST.2C , WKN / ISIN: DBX0DZ / LU0460391732
+Zu Ihren Gunsten vor Steuern: EUR 130,85
+Steuerbemessungsgrundlage nach Verlustverrechnung (8) EUR -4,12
+Kapitalertragsteuer (8) EUR 1,03
+Solidaritätszuschlag EUR 0,05
+Kirchensteuer E_U_R_______________0_,_0_0_
+erstattete Steuern E_U_R_______________1_,_0_8_
+Zu Ihren Gunsten nach Steuern: EUR 131,93
+Die Gutschrift erfolgt mit Valuta 09.07.2026 auf Konto EUR mit der IBAN DE04 5428 0778 5269 2767 00
+(8) Aufgrund des mit diesem Geschäft realisierten Verlustes erstatten wir Ihnen bereits abgeführte Steuern.
+KEINE STEUERBESCHEINIGUNG ...
+Bisher einbehaltene bzw. angerechnete Steuer in EUR (4)
+in 2026 einbehaltene einbehaltener einbehaltene angerechnete
+Kapitalertragsteuer Solidaritätszuschlag Kirchensteuer ausländische Quellensteuer
+vor Ermittlung 339,09 18,62 0,00 323,66
+nach Ermittlung 338,06 18,57 0,00 323,66
+Verrechnungssalden in EUR (4)
+Gewinne / Verluste sonstige anrechenbare verfügbarer
+in 2026 aus Aktien Gewinne / Verluste ausländische Quellensteuer Freistellungsauftrag
+vor Ermittlung -6.783,97 3.553,98 0,00 0,00
+nach Ermittlung -6.783,97 3.549,86 0,00 0,00
+Hinweise zur Ermittlung der Steuerbemessungsgrundlage:
+Veräußerungserlös EUR 130,85
+abzüglich Anschaffungskosten EUR -134,97
+abzüglich besitzzeitanteilige akkumulierte Vorabpauschale E_U_R_________________0_,_0_0
+Veräußerungsergebnis EUR -4,12
+Teilfreistellung (0%) EUR 0,00
+fiktives Veräußerungsergebnis aus Merkposten (nach Teilfreistellung) EUR 0,00
+erhaltene Zwischengewinne (ggf. Ersatzwert) EUR 0,00
+noch nicht dem Steuerabzug unterworfene akkumulierte thesaurierte
+Erträge/Mehrbetrag/Schätzwert EUR 0,00
+fiktives Veräußerungsergebnis aus Übergangsregelung E_U_R_________________0_,_0_0
+Summe Merkposten 31.12.2017 E_U_R__________________0_,_0_0
+Steuerbemessungsgrundlage vor Verlustverrechnung EUR -4,12
+Ihre comdirect
+Diese Abrechnung ist maschinell erstellt und wird nicht unterschrieben.
+(4) Die ausgewiesenen EUR-Beträge spiegeln den Stand zum Abrechnungszeitpunkt wider.
+KEINE STEUERBESCHEINIGUNG

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ComdirectPDFExtractor.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -33,6 +34,7 @@ import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.util.Pair;
+import name.abuchen.portfolio.util.TextUtil;
 
 /**
  * @formatter:off
@@ -347,7 +349,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("currency", "gross", "baseCurrency") //
-                                                        .match("^.*Kurswert [\\s]*:[\s]{1,}(?<currency>[A-Z]{3})[\\s]{1,}(?<gross>[\\.,\\d]+).*$")
+                                                        .match("^.*Kurswert [\\s]*:[\\s]{1,}(?<currency>[A-Z]{3})[\\s]{1,}(?<gross>[\\.,\\d]+).*$")
                                                         .find(".*Zu Ihren Lasten.*") //
                                                         .match("^.*[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}[\\s]{1,}(?<baseCurrency>[A-Z]{3})[\\s]{1,}[\\.,\\d]+\\-.*$") //
                                                         .assign((t, v) -> {
@@ -545,8 +547,8 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("name", "wkn", "nameContinued", "isin", "currency") //
                                                         .find("Wertpapier\\-Bezeichnung.*") //
-                                                        .match("^(?<name>.*)[\s]{1,}(?<wkn>[A-Z0-9]{6}).*$") //
-                                                        .match("^(?<nameContinued>.*)[\s]{1,}(?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]).*$") //
+                                                        .match("^(?<name>.*)[\\s]{1,}(?<wkn>[A-Z0-9]{6}).*$") //
+                                                        .match("^(?<nameContinued>.*)[\\s]{1,}(?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]).*$") //
                                                         .match("^[\\s]*St\\.[\\s]{1,}[\\.,\\d]+[\\s]{1,}(?<currency>[A-Z]{3}).*$") //
                                                         .assign((t, v) -> {
                                                             v.put("name", trim(replaceMultipleBlanks(v.get("name"))));
@@ -843,7 +845,7 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
-                                                        .match("^[\\s]*p[\\s]*e[\\s]*r[\s]{1,}(?<date>[\\.,\\d\\s]+)[\\s]{1,}.*[\\s]{1,}(?:[A-Z0-9][\\s]*){6}$") //
+                                                        .match("^[\\s]*p[\\s]*e[\\s]*r[\\s]{1,}(?<date>[\\.,\\d\\s]+)[\\s]{1,}.*[\\s]{1,}(?:[A-Z0-9][\\s]*){6}$") //
                                                         .match("^[\\s]*S[\\s]*T[\\s]*K[\\s]{1,}[\\.,\\d\\s]+[\\s]{1,}.*[\\s]{1,}[A-Z0-9\\s]+$") //
                                                         .match("^[A-Z]{3} [\\.,\\d]+[\\s]{1,}Thesaurierung pro St.ck.*$") //
                                                         .assign((t, v) -> t.setDateTime(asDate(stripBlanks(v.get("date"))))))
@@ -1341,17 +1343,26 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                                         // S ol id a ri tä t sz u s c hl a g                                                                      E  U   R                                  0 , 0 0
                                         // K irc h e n s te u e r                                                                              _E  _U   R_  _  _  _   _  _  _   _  _  _  _   _  _  _   _  0_ _, 0_ 0_
                                         // e r s ta t te t e S t e ue r n                                                                                                                     _E _U _R _ _ _ _ _ _ _  __  __  _ _ _0_,__0 _3
+                                        //
+                                        // Zu Ihren Gunsten vor Steuern: EUR 130,85
+                                        // Steuerbemessungsgrundlage nach Verlustverrechnung (8) EUR -4,12
+                                        // Kapitalertragsteuer (8) EUR 1,03
+                                        // Solidaritätszuschlag EUR 0,05
+                                        // Kirchensteuer E_U_R_______________0_,_0_0_
+                                        // erstattete Steuern E_U_R_______________1_,_0_8_
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("currencyRefundedTaxes", "refundedTaxes") //
-                                                        .match("^[\\s]*Z[\\s]*u[\\s]*I[\\s]*h[\\s]*r[\\s]*e[\\s]*n[\\s]*(G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n|L[\\s]*a[\\s]*s[\\s]*t[\\s]*e[\\s]*n)[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?:[A-Z][\\s]*){3}[\\-\\s]{1,}[\\.,\\d\\s]+.*$") //
-                                                        .match("^[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*b[\\s]*e[\\s]*m[\\s]*e[\\s]*s[\\s]*s[\\s]*u[\\s]*n[\\s]*g[\\s]*s[\\s]*g[\\s]*r[\\s]*u[\\s]*n[\\s]*d[\\s]*l[\\s]*a[\\s]*g[\\s]*e[\\s]*n[\\s]*a[\\s]*c[\\s]*h[\\s]*V[\\s]*e[\\s]*r[\\s]*l[\\s]*u[\\s]*s[\\s]*t[\\s]*v[\\s]*e[\\s]*r[\\s]*r[\\s]*e[\\s]*c[\\s]*h[\\s]*n[\\s]*u[\\s]*n[\\s]*g[\\s]{1,}([\\(\\s\\d\\)]+)?[\\s]{1,}(?:[A-Z][\\s]*){3}[\\-\\s]{1,}[\\.,\\d\\s]+.*$") //
-                                                        .match("^[\\s]*e[\\s]*r[\\s]*s[\\s]*t[\\s]*a[\\s]*t[\\s]*t[\\s]*e[\\s]*t[\\s]*e[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n [\\s]{1,}[A-Z_\\s]+[\\-_\\s]{1,}[\\.,\\d_\\s]+[\\s]{1,}(?<currencyRefundedTaxes>[A-Z_\\s]+)[\\-_\\s]{1,}(?<refundedTaxes>[\\.,\\d_\\s]+)$") //
+                                                        .prepareLine(TextUtil::stripBlanksAndUnderscores)
+                                                        .match("^ZuIhren(Gunsten|Lasten)vorSteuern:(?:[A-Z]){3}\\-?[\\.,\\d]+.*$") //
+                                                        .match("^SteuerbemessungsgrundlagenachVerlustverrechnung([\\(\\d\\)]+)?(?:[A-Z]){3}\\-?[\\.,\\d]+.*$") //
+                                                        .match("^erstatteteSteuern(?<currencyRefundedTaxes>[A-Z]+)\\-?(?<refundedTaxes>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
                                                             t.setType(AccountTransaction.Type.TAX_REFUND);
 
-                                                            t.setCurrencyCode(asCurrencyCode(stripBlanksAndUnderscores(v.get("currencyRefundedTaxes"))));
-                                                            t.setAmount(asAmount(stripBlanksAndUnderscores(v.get("refundedTaxes"))));
+                                                            t.setCurrencyCode(asCurrencyCode(
+                                                                            v.get("currencyRefundedTaxes")));
+                                                            t.setAmount(asAmount(v.get("refundedTaxes")));
                                                         }))
 
                         .optionalOneOf( //
@@ -1421,12 +1432,14 @@ public class ComdirectPDFExtractor extends AbstractPDFExtractor
                         // @formatter:off
                         // 643  R  e  f e  r e  n  z  - N   u mmer:    2 G   I G   7  N   0  V  BSQ00112
                         // 38342 qSrhP                       R   e  f e  r e  n  z  - Nummer:     1   Z  I L  B  M   LW99T00 0
+                        // 04299 Bad BCyPEWXdrf Referenz-Nummer: 0tsYra6xyu5195BC
                         // @formatter:on
                         .section("note").optional() //
-                        .match("^.*R[\\s]*e[\\s]*f[\\s]*e[\\s]*r[\\s]*e[\\s]*n[\\s]*z[\\s]*\\-[\\s]*N[\\s]*u[\\s]*m[\\s]*m[\\s]*e[\\s]*r[\\s]*:[\\s]{1,}(?<note>.*)$")
+                        .prepareLine(TextUtil::stripBlanksAndUnderscores) //
+                        .match("^.*Referenz\\-Nummer:(?<note>.*)$")
                         .assign((t, v) -> {
-                            var note = stripBlanks(v.get("note"));
-                            note = (note != null && note.length() > 16) ? note.substring(0, 16) : (note != null ? note : "");
+                            var note = Objects.toString(stripBlanks(v.get("note")), "");
+                            note = note.length() > 16 ? note.substring(0, 16) : note;
 
                             if (t.getType().isCredit())
                                 t.setNote(concatenate(t.getNote(), "Ref.-Nr.: " + note, " | "));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFParser.java
@@ -18,6 +18,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -702,6 +703,7 @@ import name.abuchen.portfolio.model.TypedMap;
 
         private List<Pattern> pattern = new ArrayList<>();
         private BiConsumer<T, ParsedData> assignment;
+        private UnaryOperator<String> linePreparation;
 
         public Section(Transaction<T> transaction, String[] attributes)
         {
@@ -768,6 +770,12 @@ import name.abuchen.portfolio.model.TypedMap;
             return this;
         }
 
+        public Section<T> prepareLine(UnaryOperator<String> function)
+        {
+            this.linePreparation = function;
+            return this;
+        }
+
         public Transaction<T> assign(BiConsumer<T, ParsedData> assignment)
         {
             this.assignment = assignment;
@@ -787,7 +795,11 @@ import name.abuchen.portfolio.model.TypedMap;
             for (var ii = lineNo; ii <= lineNoEnd; ii++)
             {
                 var p = pattern.get(patternNo);
-                var m = p.matcher(lines[ii]);
+                var line = lines[ii];
+                if (linePreparation != null)
+                    line = linePreparation.apply(line);
+                var m = p.matcher(line);
+
                 if (m.matches())
                 {
 


### PR DESCRIPTION
This is a fix to support a variation of a PDF dump provided by the [forum](https://forum.portfolio-performance.info/t/pdf-import-von-comdirect/1647/633).

I've initially tried to fix the regex in its original form but gave up because

````
.match("^[\\s]*Z[\\s]*u[\\s]*I[\\s]*h[\\s]*r[\\s]*e[\\s]*n[\\s]*(G[\\s]*u[\\s]*n[\\s]*s[\\s]*t[\\s]*e[\\s]*n|L[\\s]*a[\\s]*s[\\s]*t[\\s]*e[\\s]*n)[\\s]*v[\\s]*o[\\s]*r[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n[\\s]*:[\\s]{1,}(?:[A-Z][\\s]*){3}[\\-\\s]{1,}[\\.,\\d\\s]+.*$") //
.match("^[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*b[\\s]*e[\\s]*m[\\s]*e[\\s]*s[\\s]*s[\\s]*u[\\s]*n[\\s]*g[\\s]*s[\\s]*g[\\s]*r[\\s]*u[\\s]*n[\\s]*d[\\s]*l[\\s]*a[\\s]*g[\\s]*e[\\s]*n[\\s]*a[\\s]*c[\\s]*h[\\s]*V[\\s]*e[\\s]*r[\\s]*l[\\s]*u[\\s]*s[\\s]*t[\\s]*v[\\s]*e[\\s]*r[\\s]*r[\\s]*e[\\s]*c[\\s]*h[\\s]*n[\\s]*u[\\s]*n[\\s]*g[\\s]{1,}([\\(\\s\\d\\)]+)?[\\s]{1,}(?:[A-Z][\\s]*){3}[\\-\\s]{1,}[\\.,\\d\\s]+.*$") //
.match("^[\\s]*e[\\s]*r[\\s]*s[\\s]*t[\\s]*a[\\s]*t[\\s]*t[\\s]*e[\\s]*t[\\s]*e[\\s]*S[\\s]*t[\\s]*e[\\s]*u[\\s]*e[\\s]*r[\\s]*n [\\s]{1,}[A-Z_\\s]+[\\-_\\s]{1,}[\\.,\\d_\\s]+[\\s]{1,}(?<currencyRefundedTaxes>[A-Z_\\s]+)[\\-_\\s]{1,}(?<refundedTaxes>[\\.,\\d_\\s]+)$") //
````

I mean... there are limits. The third regex is actually wrong and only worked by coincidence because it checks for two monetary amounts and currency and not only one. Only because spaces and underscores are added to the mix, it got matched.

My solution is now to add a "line-preprocessor" that for lines like these - where spaces and other stuff aren't part of the extracted values  - simply strip away these characters before attempting to do a regex-match-check. The resulting list of match-lines is now significantly simpler:

````
.prepareLine(TextUtil::stripBlanksAndUnderscores)
.match("^ZuIhren(Gunsten|Lasten)vorSteuern:(?:[A-Z]){3}\\-?[\\.,\\d]+.*$") //
.match("^SteuerbemessungsgrundlagenachVerlustverrechnung([\\(\\d\\)]+)?(?:[A-Z]){3}\\-?[\\.,\\d]+.*$") //
.match("^erstatteteSteuern(?<currencyRefundedTaxes>[A-Z]+)\\-?(?<refundedTaxes>[\\.,\\d]+)$") //
````

and immediately worked with the new dump (after I've removed the second monetary amount and currency from the third match-operation.