### PR TITLE
Add time machine to taxonomy pie, donut and tree map charts

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyModel.java
@@ -9,6 +9,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -92,6 +93,15 @@ public final class TaxonomyModel
     private Client filteredClient;
     private ClientSnapshot snapshot;
 
+    /**
+     * The date for which the {@link ClientSnapshot} - and therefore all actual
+     * values - is calculated. If empty, the current date is used. It is set via
+     * the time machine to view the portfolio composition at a past point in
+     * time. We do not store the current date here because the view can be kept
+     * open for more than 24 hours.
+     */
+    private Optional<LocalDate> snapshotDate = Optional.empty();
+
     private TaxonomyNode virtualRootNode;
     private TaxonomyNode.ClassificationNode classificationRootNode;
     private TaxonomyNode unassignedNode;
@@ -124,7 +134,7 @@ public final class TaxonomyModel
         this.converter = new CurrencyConverterImpl(factory, client.getBaseCurrency());
 
         this.filteredClient = client;
-        this.snapshot = ClientSnapshot.create(client, converter, LocalDate.now());
+        this.snapshot = ClientSnapshot.create(client, converter, snapshotDate.orElse(LocalDate.now()));
 
         this.attachedModels.add(new RecalculateTargetsAttachedModel());
         this.attachedModels.add(new ExpectedReturnsAttachedModel());
@@ -303,12 +313,12 @@ public final class TaxonomyModel
     {
         this.expansionStateRebalancing = expansionStateRebalancing;
     }
-    
+
     public void setColoringStrategy(String coloringStrategy)
     {
         this.coloringStrategy = coloringStrategy;
     }
-    
+
     public String getColoringStrategy()
     {
         return coloringStrategy;
@@ -418,10 +428,29 @@ public final class TaxonomyModel
             this.converter = new CurrencyConverterImpl(factory, filteredClient.getBaseCurrency());
 
         this.filteredClient = filteredClient;
-        this.snapshot = ClientSnapshot.create(filteredClient, converter, LocalDate.now());
+        this.snapshot = ClientSnapshot.create(filteredClient, converter, snapshotDate.orElse(LocalDate.now()));
 
         recalculate();
         fireTaxonomyModelChange(getVirtualRootNode());
+    }
+
+    /**
+     * Sets the date for which the snapshot - and therefore all actual values -
+     * is calculated. An empty value resets to the current date. Used by the
+     * time machine of the taxonomy charts without a time axis.
+     */
+    public void updateSnapshotDate(Optional<LocalDate> snapshotDate)
+    {
+        this.snapshotDate = Objects.requireNonNull(snapshotDate);
+        this.snapshot = ClientSnapshot.create(filteredClient, converter, snapshotDate.orElse(LocalDate.now()));
+
+        recalculate();
+        fireTaxonomyModelChange(getVirtualRootNode());
+    }
+
+    public Optional<LocalDate> getSnapshotDate()
+    {
+        return snapshotDate;
     }
 
     public Client getFilteredClient()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/TaxonomyView.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.ui.views.taxonomy;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -35,6 +36,7 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Taxonomy;
 import name.abuchen.portfolio.model.TaxonomyJSONExporter;
 import name.abuchen.portfolio.money.ExchangeRateProviderFactory;
+import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.filter.ClientFilter;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
@@ -46,6 +48,7 @@ import name.abuchen.portfolio.ui.util.JSONExporterDialog;
 import name.abuchen.portfolio.ui.util.ReportingPeriodDropDown;
 import name.abuchen.portfolio.ui.util.ReportingPeriodDropDown.ReportingPeriodListener;
 import name.abuchen.portfolio.ui.util.SimpleAction;
+import name.abuchen.portfolio.ui.util.TimeMachineDropDown;
 import name.abuchen.portfolio.ui.views.panes.HistoricalPricesPane;
 import name.abuchen.portfolio.ui.views.panes.InformationPanePage;
 import name.abuchen.portfolio.ui.views.panes.SecurityEventsPane;
@@ -151,6 +154,7 @@ public class TaxonomyView extends AbstractFinanceView implements PropertyChangeL
     private Taxonomy taxonomy;
     private ClientFilterDropDown clientFilterDropDown;
     private ReportingPeriodDropDown reportingPeriodDropDown;
+    private TimeMachineDropDown timeMachineDropDown;
 
     private Composite container;
     private List<Action> viewActions = new ArrayList<>();
@@ -191,7 +195,7 @@ public class TaxonomyView extends AbstractFinanceView implements PropertyChangeL
         if (this.clientFilterDropDown.hasActiveFilter())
             listener.accept(this.clientFilterDropDown.getSelectedFilter());
 
-        this.clientFilterDropDown.getClientFilterMenu().addListener(filter -> updateTitle(getDefaultTitle()));
+        this.clientFilterDropDown.getClientFilterMenu().addListener(filter -> updateViewTitle());
 
         this.identifierView = TaxonomyView.class.getSimpleName() + "-VIEW-" + taxonomy.getId(); //$NON-NLS-1$
         this.identifierUnassigned = TaxonomyView.class.getSimpleName() + "-UNASSIGNED-" + taxonomy.getId(); //$NON-NLS-1$
@@ -225,7 +229,7 @@ public class TaxonomyView extends AbstractFinanceView implements PropertyChangeL
     @Override
     public void propertyChange(PropertyChangeEvent event)
     {
-        updateTitle(getDefaultTitle());
+        updateViewTitle();
     }
 
     @Override
@@ -271,6 +275,7 @@ public class TaxonomyView extends AbstractFinanceView implements PropertyChangeL
         toolBar.add(new Separator());
 
         addReportingPeriodDropDown(toolBar);
+        addTimeMachineDropDown(toolBar);
 
         toolBar.add(new FilterDropDown(getPreferenceStore()));
         toolBar.add(clientFilterDropDown);
@@ -282,6 +287,60 @@ public class TaxonomyView extends AbstractFinanceView implements PropertyChangeL
     {
         reportingPeriodDropDown = new ReportingPeriodDropDown(getPart(), this);
         toolBar.add(reportingPeriodDropDown);
+    }
+
+    private void addTimeMachineDropDown(ToolBarManager toolBar)
+    {
+        timeMachineDropDown = new TimeMachineDropDown(date -> applyTimeMachine());
+        toolBar.add(timeMachineDropDown);
+    }
+
+    /**
+     * The time machine only affects the charts without a time axis (pie, donut
+     * and tree map). On all other pages the snapshot is always calculated for
+     * the current date.
+     */
+    private boolean isTimeMachineApplicable(Page page)
+    {
+        return page instanceof PieChartViewer || page instanceof DonutViewer || page instanceof TreeMapViewer;
+    }
+
+    /**
+     * Applies the time machine to the currently active page. The drop-down is
+     * only enabled on the charts without a time axis; for the other pages the
+     * effective snapshot date falls back to the current date. As all pages
+     * share the same {@link TaxonomyModel}, the snapshot is only recalculated
+     * when the effective date actually changes.
+     */
+    private void applyTimeMachine()
+    {
+        boolean applicable = getCurrentPage().map(this::isTimeMachineApplicable).orElse(false);
+        timeMachineDropDown.setEnabled(applicable);
+
+        Optional<LocalDate> effectiveDate = applicable ? timeMachineDropDown.getTimeMachineDate() : Optional.empty();
+        if (!effectiveDate.equals(model.getSnapshotDate()))
+            model.updateSnapshotDate(effectiveDate);
+
+        updateViewTitle();
+    }
+
+    /**
+     * Updates the view title and appends the time machine date when it is
+     * active on the currently shown page.
+     */
+    private void updateViewTitle()
+    {
+        var suffix = "";
+
+        if (timeMachineDropDown != null)
+        {
+            Optional<LocalDate> snapshotDate = timeMachineDropDown.getTimeMachineDate();
+            boolean applicable = getCurrentPage().map(this::isTimeMachineApplicable).orElse(false);
+            if (applicable && snapshotDate.isPresent())
+                suffix = " | " + Values.Date.format(snapshotDate.get());
+        }
+
+        updateTitle(getDefaultTitle() + suffix);
     }
 
     private void addSearchButton(ToolBarManager toolBar)
@@ -462,6 +521,7 @@ public class TaxonomyView extends AbstractFinanceView implements PropertyChangeL
                 viewActions.get(ii).setChecked(index == ii);
 
             reportingPeriodDropDown.setEnabled(page instanceof ReportingPeriodListener);
+            applyTimeMachine();
 
             getPart().getPreferenceStore().setValue(identifierView, index);
         }


### PR DESCRIPTION
**Closes #5850**

Adds the time machine (as-of date picker) to the taxonomy view, so the portfolio composition can be inspected at a past point in time. It is enabled for the three views that show a single snapshot and have no time axis:

* Pie chart
* Donut chart
* Tree map

This mirrors the time machine that already exists on the Statement of Assets / Holdings view.

Before, there was no easy way to see how the allocation across a taxonomy looked at an earlier date.

`TaxonomyModel` now holds the snapshot date as an `Optional<LocalDate>` (empty = today) and creates its `ClientSnapshot` for that date. A new `updateSnapshotDate(...)` rebuilds the snapshot, recalculates the actual values and fires the usual model-change event, so the charts refresh through the existing mechanism. `TaxonomyView` adds a `TimeMachineDropDown` next to the reporting-period drop-down.

The selected date is appended to the view title, e.g. Asset Allocation | 2025-03-14.

**How to test**

* Open any taxonomy view (e.g. Asset Allocation).
* Switch to the pie, donut or tree map view — the time machine icon becomes active.
* Pick a past date → the chart shows the composition as of that date, and the date appears in the title.
* Switch to the definition/re-balancing tables or the stacked charts → the drop-down greys out and current values are shown; switching back to a chart restores the selected date.
* Verify a client filter change keeps the selected date.