### PR TITLE
Fix C24 Bank PDF import: sign and amount no longer separated by space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ workspace
 *.ipr
 
 .claude/settings.local.json
+env.sh

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/c24bankgmbh/C24BankGmbHPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/c24bankgmbh/C24BankGmbHPDFExtractorTest.java
@@ -322,4 +322,60 @@ public class C24BankGmbHPDFExtractorTest
         assertThat(results, hasItem(deposit(hasDate("2025-10-02"), hasAmount("EUR", 19.89), //
                         hasSource("Kontoauszug07.txt"), hasNote("Überweisung"))));
     }
+
+    @Test
+    public void testKontoauszug08()
+    {
+        var extractor = new C24BankGmbHPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kontoauszug08.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(30L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(30));
+        new AssertImportActions().check(results, "EUR");
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2026-05-29"), hasAmount("EUR", 2469.00), //
+                        hasSource("Kontoauszug08.txt"), hasNote("Lastschrift"))));
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2026-05-29"), hasAmount("EUR", 91.27), //
+                        hasSource("Kontoauszug08.txt"), hasNote("Online-Kartenzahlung"))));
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2026-05-28"), hasAmount("EUR", 7522.77), //
+                        hasSource("Kontoauszug08.txt"), hasNote("Überweisung"))));
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2026-05-20"), hasAmount("EUR", 20.99), //
+                        hasSource("Kontoauszug08.txt"), hasNote("Rückerstattung"))));
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2026-05-17"), hasAmount("EUR", 877.87), //
+                        hasSource("Kontoauszug08.txt"), hasNote("Kartenzahlung"))));
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2026-05-24"), hasAmount("EUR", 81.46), //
+                        hasSource("Kontoauszug08.txt"), hasNote("Echtzeitüberweisung"))));
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2026-05-24"), hasAmount("EUR", 54.15), //
+                        hasSource("Kontoauszug08.txt"), hasNote("Echtzeitüberweisung"))));
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2026-05-03"), hasAmount("EUR", 63.00), //
+                        hasSource("Kontoauszug08.txt"), hasNote("Echtzeitüberweisung"))));
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2026-05-01"), hasAmount("EUR", 91.94), //
+                        hasSource("Kontoauszug08.txt"), hasNote("Rückerstattung"))));
+    }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/c24bankgmbh/Kontoauszug08.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/c24bankgmbh/Kontoauszug08.txt
@@ -1,0 +1,173 @@
+```
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.1
+System: linux | x86_64 | 21.0.11+10 | Arch Linux
+-----------------------------------------
+ppIsID dlESje
+dJfJrRpHUrS. 26
+62268 iuXpGt
+Girokonto
+Girokonto
+IBAN: lp08213031391016339893
+BIC: jGpmaCVSFmf
+Kontoauszug 05/2026 Kontostand 1.973,24 €
+01.05.2026 - 31.05.2026
+Transaktionsübersicht
+Buchung Valuta Transaktionsinformation Betrag
+29.05. 29.05. Lastschrift -2.469,00 €
+pRNbLaYZ ZEjPysH MLVE
+PnfvIREr IlbnmOC wcqMbV 5q YhdTRDQV
+IBAN: tu31922671131617420195 / BIC: fdkbMoHAkci
+29.05. 29.05. Online-Kartenzahlung -91,27 €
+Utzv Z*13-40585-21163
+28.05. 28.05. Überweisung +7.522,77 €
+HSS pDoZtnjv MGFv
+aIFH - tBncOq yUgelmgQUK 33/9487
+IBAN: iq92248166539838096252 / BIC: nqHImmh9wMC
+28.05. 28.05. Online-Kartenzahlung -86,74 €
+BnfmLm *JcnbYLQi pLnOD
+27.05. 27.05. Online-Kartenzahlung -60,09 €
+lc isFgpkey NuLQ
+27.05. 27.05. Überweisung +9,06 €
+NDJfKo ittOZdw qcyU
+BFXax9628909
+IBAN: FO21439617865880247891 / BIC: ZbFOvmx5591
+26.05. 26.05. Lastschrift -3,64 €
+hfjOZpMkt MkSynd pHVF
+H9943503 o993358773 J624340099 xoKrlDzyt
+IBAN: nI01990340950451359464 / BIC: rXjppvdaJrq
+25.05. 25.05. Überweisung +65,95 €
+QwlwJn RnjFCHm SiEH
+dbXvs6723504
+IBAN: aH66488054563061349982 / BIC: BIvDOXb9323
+25.05. 25.05. Echtzeitüberweisung -406,00 €
+gYZGQrgV nGwDaCf nuyx jXbj
+VxjbaTDMb YKwuJJYE EbTshWbAOtpXgOosdNm
+IBAN: hS85044204364728213898 / BIC: HvABRMTnDTY
+24.05. 24.05. Echtzeitüberweisung +81,46 €
+tJFS XmEZVcqaD
+LcJLmHVOMgWPEy
+IBAN: FI44291082629228399941 / BIC: RvSqMXKt
+C24 Bank GmbH
+05/2026 Neue Mainzer Straße 14 - 18, 60311 Frankfurt am Main Seite 1 von 4
+Ust.-ID DE 322 469 451
+ffhKzu dfibda
+xPyTjQNrNiD. 39
+89734 BRTtEc
+Girokonto
+Girokonto
+IBAN: FH55290591139615628181
+BIC: TiQmijePKnh
+Buchung Valuta Transaktionsinformation Betrag
+24.05. 24.05. Echtzeitüberweisung -54,15 €
+LhbYOLhebvQuJv vQfSGz ApAn
+LARFwFiIJOHrFaq 18974128 LjOqQdfJiHsq 554581373
+IBAN: eb34863444521188234459 / BIC: muePSjcxWIk
+21.05. 21.05. Überweisung +7,72 €
+pojcef AhGsuMz IUAk
+fhNCs6460619
+IBAN: bA14946754876597516944 / BIC: BNCQRLO0675
+20.05. 20.05. Rückerstattung +20,99 €
+KUaIfw* ze5888Pd4
+18.05. 18.05. Überweisung +986,00 €
+WjDRAGMK ljQLMxI ItLB
+jnhRnoWz sERPYMH EHQToMfxP CuWpFMqLaV
+IBAN: sl58669417723781340682 / BIC: FAwJJmMCTrU
+17.05. 17.05. Kartenzahlung -877,87 €
+eTFf sdPr JCTyC
+16.05. 16.05. Online-Kartenzahlung -962,03 €
+hsI olqGh.Uxe
+16.05. 16.05. Online-Kartenzahlung -253,66 €
+nnW TywXy.zFb
+16.05. 16.05. Online-Kartenzahlung -197,18 €
+dQExNIhpB
+16.05. 16.05. Online-Kartenzahlung -563,54 €
+yVUJMS* aY36R2CG8
+16.05. 16.05. Online-Kartenzahlung -33,34 €
+NPxHCCjIflzJN.qJ DRlp
+13.05. 13.05. Online-Kartenzahlung -7,49 €
+knEZCa* gL08v9jE6
+13.05. 13.05. Lastschrift -30,99 €
+wyiguDCOtm tqHoKOw DcLL + sZ. qBh
+xA-bm.: 5177084828, SH-hL.: 3953523948/0, zvRo HjqvBAEfdFWso
+IBAN: js51168642426760897225 / BIC: FHMsfDvw
+11.05. 11.05. Lastschrift -14,98 €
+JxxZP-zcd oykCURg FJIo
+79-36-8876 / 06-71-6330
+IBAN: Zq79272322657026886070 / BIC: BcEKIuDX
+09.05. 09.05. Online-Kartenzahlung -54,97 €
+aPMx Y*80-79463-43430
+C24 Bank GmbH
+05/2026 Neue Mainzer Straße 14 - 18, 60311 Frankfurt am Main Seite 2 von 4
+Ust.-ID DE 322 469 451
+vOfHsb Fumyvq
+BNNSMIkuLCM. 10
+33242 KDCnPd
+Girokonto
+Girokonto
+IBAN: QG74544894556693945132
+BIC: ZVLyaOlDETI
+Buchung Valuta Transaktionsinformation Betrag
+06.05. 06.05. Online-Kartenzahlung -93,57 €
+EWGxIEWUBZmAD.mU mbWr
+05.05. 05.05. Überweisung +39,00 €
+QD ciqneEzK eYiG
+53o33382334 Saq sxwqrMIdjLIAmbUCdI / qHBrysEZW jP 24.91.3008/ KxmDQAIJN:
+UkZVtc, cZUhJc
+IBAN: kr83003788587407363642 / BIC: RFPHIEug
+05.05. 05.05. Überweisung +431,00 €
+zkxHFbF biTmxF uDb StiLJv wTxeNc
+atGRvONy QjAmEg wAvNc LCkUYl Dhc
+IBAN: QS35908323348644219850 / BIC: MVBMzmn3431
+03.05. 03.05. Echtzeitüberweisung -063,00 €
+pTjPZy wtuPXa
+WfFhn + VtwHgqWYrEJQJSPMnJzxYJoDxom SSn LEhSjv oI. 8 Pk GBaBNvWdjJc,
+tPshASMNivEhcy 59, 27576 YSORJI
+IBAN: au79547462737363162108 / BIC: RivtgykzFaO
+01.05. 01.05. Echtzeitüberweisung -320,00 €
+mQkscabB SiqHqWc MtFv bmAz
+Epbj oBCibRKQRpJO RrTDaqVg oEBvotf
+IBAN: Ki18370827993716171530 / BIC: IrlSRttnabD
+01.05. 01.05. Rückerstattung +91,94 €
+oQVEOH* Cv9Y66fz8
+Zusammenfassung
+Startsaldo 9.950,58 €
+Kontobelastungen -3.082,23 €
+Kontogutschriften +4.841,89 €
+Endsaldo 8.293,88 €
+C24 Bank GmbH
+05/2026 Neue Mainzer Straße 14 - 18, 60311 Frankfurt am Main Seite 3 von 4
+Ust.-ID DE 322 469 451
+aOkfoc UFewba
+iZBbXIeYDCp. 31
+86863 FEcoxG
+Girokonto
+Girokonto
+IBAN: UW06376184690943179552
+BIC: hXPfkivTfmc
+Weitere Informationen
+Einwendungen gegen den Rechnungsabschluss oder Kontobuchungen
+Für das Girokonto erfolgt jeweils am letzten Tag der Monate März, Juni, September und Dezember ein
+Rechnungsabschluss. Dieser gilt gemäß Ziffer 6 Abs. 2 unserer AGB als genehmigt, wenn Einwendungen nicht vor Ablauf
+von sechs Wochen nach dessen Zugang geltend gemacht werden. Einwendungen gegen die Richtigkeit oder
+Vollständigkeit von Kontoauszügen sind unverzüglich zu erheben. Bei Einwendungen in Textform genügt die Absendung
+innerhalb der jeweils genannten Frist.
+Ihre Kontodisposition
+Der Kontostand berücksichtigt nicht die Valuta (Wertstellung) der einzelnen Buchungen. Das bedeutet, dass der
+angezeigte Kontostand nicht dem tatsächlichen Kontoguthaben entsprechen muss und bei Verfügungen möglicherweise
+Zinsen für die Inanspruchnahme einer eingeräumten oder geduldeten Kontoüberziehung anfallen können. Bitte
+berücksichtigen Sie bei Ihrer Disposition daher ggf. die Wertstellungen der Kontoumsätze der letzten Tage.
+Es kann zu Abweichungen zwischen Ihrem Kontoauszug und der Anzeige in Ihrer App (oder dem Online-Banking)
+kommen, da Transaktionen in Echtzeit dargestellt werden, die tatsächliche Durchführung hingegen 1-2 Tage in Anspruch
+nehmen kann. Auf dem Kontoauszug werden nur vollständig durchgeführte Transaktionen abgebildet.
+Hinweis zur Einlagensicherung
+Guthaben sind als Einlagen nach Maßgabe des Einlagensicherungsgesetzes entschädigungsfähig. Nähere Informationen
+können dem "Informationsbogen für den Einleger" entnommen werden. Diesen finden Sie unter
+www.c24.de/rechtliches.
+Hinweis zur standardisierten Zahlungskontenterminologie
+Nachfolgende Begriffe entsprechen den Begriffen der standardisierten Zahlungskontenterminologie: C24 Mastercard
+(Debitkarte), Dispokredit (eingeräumte Kontoüberziehung)
+C24 Bank GmbH
+05/2026 Neue Mainzer Straße 14 - 18, 60311 Frankfurt am Main Seite 4 von 4
+Ust.-ID DE 322 469 451
+```

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/C24BankGmbHPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/C24BankGmbHPDFExtractor.java
@@ -47,7 +47,7 @@ public class C24BankGmbHPDFExtractor extends AbstractPDFExtractor
                                                         section -> section //
                                                                         .attributes("year", "taxDate", "tax", "taxCurrency") //
                                                                         .match("^(Vorl.ufiger )?Kontoauszug [\\d]{2}\\/(?<year>[\\d]{4}).*$") //
-                                                                        .match("^(?<taxDate>[\\d]{2}\\.[\\d]{2}\\.) [\\d]{2}\\.[\\d]{2}\\. Steuern [\\-|\\+] (?<tax>[\\.,\\d]+) (?<taxCurrency>\\p{Sc}).*$") //
+                                                                        .match("^(?<taxDate>[\\d]{2}\\.[\\d]{2}\\.) [\\d]{2}\\.[\\d]{2}\\. Steuern [\\-|\\+] ?(?<tax>[\\.,\\d]+) (?<taxCurrency>\\p{Sc}).*$") //
                                                                         .assign((ctx, v) -> {
                                                                             ctx.put("taxDate", v.get("taxDate") + v.get("year"));
                                                                             ctx.put("tax", v.get("tax"));
@@ -61,11 +61,13 @@ public class C24BankGmbHPDFExtractor extends AbstractPDFExtractor
         // 17.05. 17.05. Überweisung + 1.115,22 €
         // 05.08. 05.08. Echtzeitüberweisung - 2.800,00 €
         // 31.01. 31.01. Lastschrift - 3.800,00 €
+        // 29.05. 29.05. Lastschrift -2.469,00 €
+        // 28.05. 28.05. Überweisung +7.522,77 €
         // @formatter:on
         var depositRemovalBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. " //
                         + "(?!(Zinsen|Steuern))" //
                         + ".* " //
-                        + "[\\-|\\+] [\\.,\\d]+ \\p{Sc}.*$");
+                        + "[\\-|\\+] ?[\\.,\\d]+ \\p{Sc}.*$");
         type.addBlock(depositRemovalBlock);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
@@ -76,7 +78,7 @@ public class C24BankGmbHPDFExtractor extends AbstractPDFExtractor
                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.) [\\d]{2}\\.[\\d]{2}\\. " //
                                         + "(?!(Zinsen|Steuern))" //
                                         + "(?<note>.*) " //
-                                        + "(?<type>[\\-|\\+]) " //
+                                        + "(?<type>[\\-|\\+]) ?" //
                                         + "(?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}).*$") //
                         .assign((t, v) -> {
                             // @formatter:off
@@ -96,7 +98,7 @@ public class C24BankGmbHPDFExtractor extends AbstractPDFExtractor
         // @formatter:off
         // 31.05. 31.05. Zinsen + 1,93 €
         // @formatter:on
-        var interestBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. Zinsen [\\-|\\+] [\\.,\\d]+ \\p{Sc}.*$");
+        var interestBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. Zinsen [\\-|\\+] ?[\\.,\\d]+ \\p{Sc}.*$");
         type.addBlock(interestBlock);
         interestBlock.set(new Transaction<AccountTransaction>()
 
@@ -107,7 +109,7 @@ public class C24BankGmbHPDFExtractor extends AbstractPDFExtractor
                         .documentContextOptionally("taxDate", "tax", "taxCurrency") //)
                         .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.) [\\d]{2}\\.[\\d]{2}\\. " //
                                         + "(?<note>Zinsen) " //
-                                        + "(?<type>[\\-|\\+]) " //
+                                        + "(?<type>[\\-|\\+]) ?" //
                                         + "(?<amount>[\\.,\\d]+) (?<currency>\\p{Sc}).*$") //
                         .assign((t, v) -> {
                             // @formatter:off


### PR DESCRIPTION
## Summary
C24 changed their account-statement PDF format so the sign directly precedes the amount (e.g. `-2.469,00 €` instead of `- 1.508,42 €`). The extractor's regexes required a literal space between the sign and the amount, so every transaction in the statement failed to match.

- Made the space between sign and amount optional in the account-statement, interest, and tax-section patterns of `C24BankGmbHPDFExtractor`.
- Added `Kontoauszug08.txt`, a new fixture built from the anonymized PDF text attached to the issue, covering the new no-space format across deposits, removals, and several transaction types (Lastschrift, Überweisung, Echtzeitüberweisung, Online-Kartenzahlung, Kartenzahlung, Rückerstattung).

Fixes #5791

## Test plan
- [x] `testKontoauszug08` added, asserting all 30 transactions parsed (count + 9 representative transactions including the `-063,00 €` leading-zero edge case)
- [x] Full `name.abuchen.portfolio.tests` module run: 4472/4472 passing, no regressions on the 7 existing C24 fixtures or other extractors
- [x] Checkstyle clean