### PR TITLE
Add regression test for Trade Republic limit-sell order (verified already fixed)

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -6549,6 +6549,40 @@ public class TradeRepublicPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierVerkauf17()
+    {
+        var extractor = new TradeRepublicPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf17.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("LU0290358497"), hasWkn(null), hasTicker(null), //
+                        hasName("Euro Overnight Rate Swap EUR (Acc)"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-04-23T20:22"), hasShares(6.00), //
+                        hasSource("Verkauf17.txt"), //
+                        hasNote("Auftrag: 1bb1-635c | Ausführung: 66d8-de8d"), //
+                        hasAmount("EUR", 890.81), hasGrossValue("EUR", 893.54), //
+                        hasTaxes("EUR", 1.73), hasFees("EUR", 1.00))));
+    }
+
+    @Test
     public void testSecuritySell01()
     {
         var extractor = new TradeRepublicPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Verkauf17.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Verkauf17.txt
@@ -1,0 +1,61 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.1
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+tBkhwYA UOuLlPzgh LNeVWr flhTEOQ VSxsRZOo SEITE 1 von 2
+WPazvpejKSueGnO 56 DATUM 23.04.2026
+85442 kZCZoLeN AUFTRAG 1bb1-635c
+AUSFÜHRUNG 66d8-de8d
+DEPOT 5946652245
+WERTPAPIERABRECHNUNG
+ÜBERSICHT
+Limit-Order Verkauf am 23.04.2026, um 20:22 Uhr (Europe/Berlin) an der Lang und Schwarz Exchange.
+Der Kontrahent der Transaktion ist Lang & Schwarz TradeCenter AG & Co. KG.
+POSITION ANZAHL PREIS BETRAG
+Euro Overnight Rate Swap EUR (Acc) 6 Stk. 148,924 EUR 893,54 EUR
+ISIN: LU0290358497
+GESAMT 893,54 EUR
+ABRECHNUNG
+POSITION BETRAG
+Fremdkostenzuschlag -1,00 EUR
+Kapitalertragsteuer -1,53 EUR
+Kirchensteuer -0,12 EUR
+Solidaritätszuschlag -0,08 EUR
+GESAMT 890,81 EUR
+BUCHUNG
+VERRECHNUNGSKONTO WERTSTELLUNG BETRAG
+Mv46227363426819345051 2026-04-27 890,81 EUR
+Diese Abrechnung wird maschinell erstellt und daher nicht unterschrieben.
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+jJjAjst Ernst-wHalWPnoj mSKGRs CtdoWdM bxixsCOx SEITE 2 von 2
+IJZhRAnJvsXtMvj 13 DATUM 23.04.2026
+89512 CcvFvCwJ AUFTRAG 1bb1-635c
+AUSFÜHRUNG 66d8-de8d
+DEPOT 9751233370
+STEUERLICHE BEHANDLUNG
+BERECHNUNG DER STEUERBEMESSUNGSGRUNDLAGE BETRAG
+Bruttogewinn 15,83 EUR
+Abzug der bereits bezahlten Vorabpauschale -9,59 EUR
+STEUERBEMESSUNGSGRUNDLAGE 6,24 EUR
+BERECHNUNG DER STEUERN BETRAG
+Steuerbemessungsgrundlage 6,24 EUR
+Kapitalertragsteuer -1,53 EUR
+Kirchensteuer -0,12 EUR
+Solidaritätszuschlag -0,08 EUR
+GESAMTE STEUERN 1,73 EUR
+VERRECHNUNGSTÖPFE VORHER VERÄNDERUNG NACHHER
+Verlustverrechnungstopf Aktien 0,00 EUR 0,00 EUR 0,00 EUR
+Verlustverrechnungstopf Allgemein 0,00 EUR 0,00 EUR 0,00 EUR
+Freistellungsauftrag 0,00 EUR 0,00 EUR 0,00 EUR
+Quellensteuertopf 0,00 EUR 0,00 EUR 0,00 EUR
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke


### PR DESCRIPTION
## Summary
Investigated #5767 (Trade Republic limit-sell order import failing). The reported document uses the "Limit-Order Verkauf am DATE, um TIME Uhr (Europe/Berlin) an der Lang und Schwarz Exchange." wording, a two-page layout (WERTPAPIERABRECHNUNG + STEUERLICHE BEHANDLUNG), and a fee/tax breakdown including `Fremdkostenzuschlag` and `Kirchensteuer`.

Reconstructing the exact document from the issue and running it against the current extractor unmodified, the import **already succeeds** on master with correct values (security, shares, date, amount, gross value, taxes, fees all match). No source change was needed — this looks like it was already fixed by earlier work on the "Lang und Schwarz" / two-page tax-treatment parsing (the reporter was on 0.83.2; master is at 0.85.1-SNAPSHOT).

This PR only adds `Verkauf17.txt` and a regression test so this format stays covered.

Fixes #5767

## Test plan
- [x] `testWertpapierVerkauf17` added, asserts security, shares, date/time, amount, gross value, taxes, and fees
- [x] Full `name.abuchen.portfolio.tests` module run: all tests passing, no regressions
- [x] `TradeRepublicPDFExtractor.java` itself is untouched (test-only change)