### PR TITLE
Add regression test for Trade Republic USD dividend with US withholding tax (verified already fixed)

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Dividende32.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Dividende32.txt
@@ -1,0 +1,64 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.83.2
+System: macosx | aarch64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+XXXXXX SEITE 1 von 2
+XXXXXX DATUM 29.05.2026
+XXXXXX DEPOT XXXXXXXXXX
+DIVIDENDE
+ÜBERSICHT
+Dividende mit Ex-Datum 20.05.2026.
+POSITION ANZAHL ERTRAG BETRAG
+Gladstone Capital 6.22 USD
+41.471821 Stücke 0.15 USD
+US3765358789
+GESAMT 6.22 USD
+ABRECHNUNG
+POSITION BETRAG
+Quellensteuer für US-Emittenten -0.93 USD
+Zwischensumme 5.29 USD
+Zwischensumme 1.1617 USD/EUR 4.55 EUR
+Kapitalertragsteuer 1.1617 USD/EUR -0.54 EUR
+Solidaritätszuschlag 1.1617 USD/EUR -0.03 EUR
+GESAMT 3.98 EUR
+BUCHUNG
+VERRECHNUNGSKONTO DATUM DER ZAHLUNG BETRAG
+XXXXXXXXXXXXX 29.05.2026 3.98 EUR
+US3765358789 in Wertpapierrechnung
+Diese Abrechnung wird maschinell erstellt und daher nicht unterschrieben.
+Wird keine Umsatzsteuer ausgewiesen, handelt es sich um eine umsatzsteuerfreie Leistung gemäß § 4 Nr. 8 UStG
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+XXXXXXX SEITE 2 von 2
+XXXXXXX DATUM 29.05.2026
+XXXXXXX DEPOT XXXXXX
+STEUERLICHE BEHANDLUNG
+BERECHNUNG DER STEUERBEMESSUNGSGRUNDLAGE BETRAG
+Kapitalertrag 6,22 USD
+Zwischensumme 1.1617 EUR/USD 5,35 EUR
+STEUERBEMESSUNGSGRUNDLAGE 5,35 EUR
+BERECHNUNG DER STEUERN BETRAG
+Kapitalertrag 6,22 USD
+Quellensteuer für US-Emittenten -0,93 USD
+Steuerbemessungsgrundlage 5,35 EUR
+Kapitalertragsteuer -1,34 EUR
+Quellensteuertopf Gutschrift 0,80 EUR
+Solidaritätszuschlag -0,07 EUR
+Anpassung Solidaritätszuschlag (Quellensteuertopf Gutschrift) 0,04 EUR
+GESAMTE STEUERN 1,37 EUR
+VERRECHNUNGSTÖPFE
+VERRECHNUNGSTÖPFE VORHER VERÄNDERUNG NACHHER
+Verlustverrechnungstopf Aktien 0,00 EUR 0,00 EUR 0,00 EUR
+Verlustverrechnungstopf Allgemein 0,00 EUR 0,00 EUR 0,00 EUR
+Freistellungsauftrag 0,00 EUR 0,00 EUR 0,00 EUR
+Quellensteuertopf 0,00 EUR 0,00 EUR 0,00 EUR
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -9240,6 +9240,43 @@ public class TradeRepublicPDFExtractorTest
     }
 
     @Test
+    public void testDividende32()
+    {
+        var extractor = new TradeRepublicPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende32.txt"), errors);
+
+        errors.forEach(Exception::printStackTrace);
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US3765358789"), hasWkn(null), hasTicker(null), //
+                        hasName("Gladstone Capital"), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-29"), hasExDate("2026-05-20"), //
+                        hasShares(41.471821), //
+                        hasSource("Dividende32.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 3.98), hasGrossValue("EUR", 5.35), //
+                        hasForexGrossValue("USD", 6.22), //
+                        hasTaxes("EUR", 1.37), hasFees("EUR", 0.00))));
+    }
+
+    @Test
     public void testDividend01()
     {
         var extractor = new TradeRepublicPDFExtractor(new Client());


### PR DESCRIPTION
## Summary
Investigated #5737 (Trade Republic import failing, no further description given). The reported document is a USD dividend (Gladstone Capital) with US withholding tax (`Quellensteuer für US-Emittenten`), Kapitalertragsteuer and Solidaritätszuschlag, across a two-page WERTPAPIERABRECHNUNG + STEUERLICHE BEHANDLUNG layout. Notably, page 1 uses US-formatted (dot-decimal) amounts while page 2 uses German-formatted (comma-decimal) amounts for the same figures — a mixed-locale quirk within a single PDF.

Reconstructing the exact document from the issue and running it against the current extractor unmodified, the import **already succeeds** on master with correct values (security, shares, date, ex-date, amount, forex gross value, taxes all match, cross-checked against both pages' independently-computed totals). No source change was needed (the reporter was on 0.83.2; master is at 0.85.1-SNAPSHOT).

This PR only adds `Dividende32.txt` and a regression test so this format stays covered.

Fixes #5737

## Test plan
- [x] `testDividende32` added, asserts security, shares, date/ex-date, amount, forex gross value, and taxes
- [x] Full `name.abuchen.portfolio.tests` module run: all tests passing, no regressions
- [x] `TradeRepublicPDFExtractor.java` itself is untouched (test-only change)