### PR TITLE
Recognize "Return of capital" documents in Scalable Capital PDF import

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/Dividende13.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/Dividende13.txt
@@ -1,0 +1,28 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.83.2
+System: macosx | aarch64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Scalable Capital Bank GmbH • Seitzstraße 8e • 80538 Munich • Germany
+lmWZg hcaho
+Rue de nAmWMNCDZSIY 40
+59265 uZeAWhv Date 06.05.2026
+France Page 1 / 1
+Return of capital
+Entitled security Engie S.A.
+ISIN FR0010208488
+Entitled quantity 340
+Ex day 30.04.2026
+Clearing account Ee45338942362681039165 (nGOibWCSBWN)
+Clearing account movement
+Booking Value date Type Amount / pcs. Entitled quantity Total amount
+06.05.2026 05.05.2026 Credit 0.32 EUR 340 108.46 EUR
+Total 108.46 EUR
+Please ensure your compliance with the German foreign trade reporting regulations to the German Bundesbank (AWV-Meldung).
+Please note that the income from capital assets are fully subject to income tax in Germany.
+Calculation of tax-relevant income
+Type Amount
+Profit or loss 108.46 EUR
+Taxable amount 0.00 EUR
+Scalable Capital Bank GmbH • Seitzstraße 8e, 80538 Munich, Germany • HRB 217778 • Amtsgericht München • VAT ID: DE300434774 Page
+Managing Directors: Florian Prucker, Martin Krebs, Dirk Franzmeyer, Dr. Andreas Schranzhofer 1 / 1
+Supervisory Board: Patrick Olson (Chairman)

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/ScalableCapitalPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/scalablecapital/ScalableCapitalPDFExtractorTest.java
@@ -1916,6 +1916,41 @@ public class ScalableCapitalPDFExtractorTest
     }
 
     @Test
+    public void testDividende13()
+    {
+        var extractor = new ScalableCapitalPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende13.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("FR0010208488"), hasWkn(null), hasTicker(null), //
+                        hasName("Engie S.A."), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction (return of capital, not taxable)
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-05T00:00"), hasExDate("2026-04-30T00:00"), //
+                        hasShares(340), //
+                        hasSource("Dividende13.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 108.46), hasGrossValue("EUR", 108.46), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
     public void testRechnungsabschluss01()
     {
         var extractor = new ScalableCapitalPDFExtractor(new Client());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ScalableCapitalPDFExtractor.java
@@ -283,7 +283,7 @@ public class ScalableCapitalPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendTransaction()
     {
-        final var type = new DocumentType("(Dividende|Zinszahlung|Dividend|Kapitalr.ckzahlung)", //
+        final var type = new DocumentType("(Dividende|Zinszahlung|Dividend|Kapitalr.ckzahlung|Return of capital)", //
                         "(Kauf|Buy|Kopen|Acquisto|Verkauf|Sell|Sparplan|Sparplanausf.hrung|Laufzeitende|Knock Out)");
         this.addDocumentTyp(type);
 


### PR DESCRIPTION
## Summary
Scalable Capital rejected "Return of capital" corporate action notices outright with "Unbekannter oder nicht unterstützter Buchungstyp", because the dividend document-type detection only matched `Dividende|Zinszahlung|Dividend|Kapitalrückzahlung`.

The existing dividend block already handles the exact line format these documents use (`Entitled security` / `ISIN` / `Entitled quantity` / `... Credit ... Total`), since it's shared with the English-language dividend notices (see the `E.ON SE` example already covered by `Dividende12.txt`). The only gap was the top-level document-type gate never letting "Return of capital" documents reach that code at all.

- Added `Return of capital` as an accepted document type in `ScalableCapitalPDFExtractor`.
- Added `Dividende13.txt`, built from the anonymized text in the issue, covering the non-taxable case specifically (no `Taxes` line before `Total`, `Taxable amount 0.00 EUR`).

Fixes #5673

## Test plan
- [x] `testDividende13` added: security, shares, date/ex-date, amount, gross value, and zero taxes/fees
- [x] Full `name.abuchen.portfolio.tests` module run: 4472/4472 passing, no regressions on the other 12 Scalable Capital dividend fixtures
- [x] Checkstyle clean