### PR TITLE
Stock split wizard: show a live example to clarify ratio direction

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -1443,6 +1443,7 @@ public class Messages extends NLS
     public static String SplitWizardDefinitionDescription;
     public static String SplitWizardDefinitionTitle;
     public static String SplitWizardErrorNewAndOldMustNotBeEqual;
+    public static String SplitWizardHintRatio;
     public static String SplitWizardLabelNewForOld;
     public static String SplitWizardLabelSplit;
     public static String SplitWizardLabelUpdateQuotes;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -2880,6 +2880,8 @@ SplitWizardDefinitionTitle = Stock Split
 
 SplitWizardErrorNewAndOldMustNotBeEqual = Split ratio (new for old) is identical.
 
+SplitWizardHintRatio = Example: {0} old share(s) become {1} new share(s)
+
 SplitWizardLabelNewForOld = for
 
 SplitWizardLabelSplit = Split

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -2873,6 +2873,8 @@ SplitWizardDefinitionTitle = Aktiensplit
 
 SplitWizardErrorNewAndOldMustNotBeEqual = Das Splitverh\u00E4ltnis (neu f\u00FCr alt) ist identisch.
 
+SplitWizardHintRatio = Beispiel: {0} alte Aktie(n) werden zu {1} neuen Aktie(n)
+
 SplitWizardLabelNewForOld = f\u00FCr
 
 SplitWizardLabelSplit = Split

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/SelectSplitPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/splits/SelectSplitPage.java
@@ -103,6 +103,8 @@ public class SelectSplitPage extends AbstractWizardPage
 
         Text oldShares = new Text(container, SWT.BORDER | SWT.RIGHT);
 
+        Label hint = new Label(container, SWT.NONE);
+
         // form layout data
 
         // measuring the width requires that the font has been applied before
@@ -114,7 +116,8 @@ public class SelectSplitPage extends AbstractWizardPage
         startingWith(comboSecurity.getControl(), labelSecurity) //
                         .thenBelow(boxExDate.getControl()).label(labelExDate) //
                         .thenBelow(newShares).width(amountWidth).label(labelSplit).thenRight(labelColon)
-                        .thenRight(oldShares).width(amountWidth);
+                        .thenRight(oldShares).width(amountWidth) //
+                        .thenBelow(hint).left(labelSplit);
 
         startingWith(labelSecurity).width(labelWidth);
 
@@ -155,6 +158,18 @@ public class SelectSplitPage extends AbstractWizardPage
 
         };
         context.addValidationStatusProvider(validator);
+
+        // live example that spells out which number is old and which is new,
+        // updated on every valid change instead of only in the page description
+        model.addPropertyChangeListener("newShares", event -> updateHint(hint)); //$NON-NLS-1$
+        model.addPropertyChangeListener("oldShares", event -> updateHint(hint)); //$NON-NLS-1$
+        updateHint(hint);
+    }
+
+    private void updateHint(Label hint)
+    {
+        hint.setText(MessageFormat.format(Messages.SplitWizardHintRatio, //
+                        model.getOldShares().toPlainString(), model.getNewShares().toPlainString()));
     }
 
     private IObservableValue<String> setupBinding(DataBindingContext context, Text input, String propertyName,


### PR DESCRIPTION
## Summary
The stock split wizard's "Split [new] for [old]" input fields are only explained by the static description text at the top of the wizard page (small, easy to skim past). The fields themselves are just labeled "Stücke (neu)" / "Stücke (alt)" with no context at the point of input, which has led to users entering the ratio backwards.

This adds a label below the ratio fields that updates live as the user types, spelling out both numbers in a full example (e.g. "Example: 1 old share(s) become 2 new share(s)"), so the direction is unambiguous at the moment of input rather than only in a description that can be missed.

## Test plan
- [x] Full `mvn verify -Plocal-dev` build: `name.abuchen.portfolio.ui` compiles, `name.abuchen.portfolio.ui.tests` passes
- [ ] Manual visual check of the wizard dialog — I don't have a way to launch/screenshot the Eclipse RCP desktop app in my environment, so this is compile + existing-test verified only, not eyeballed. Flagging that explicitly per the project's own verification guidance.