### PR TITLE
flatex: reuse statement exchange rate for trades without Devisenkurs

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
@@ -8475,6 +8475,50 @@ public class FinTechGroupBankPDFExtractorTest
     }
 
     @Test
+    public void testFlatExDeGiroSammelabrechnung11()
+    {
+        var extractor = new FinTechGroupBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDegiroSammelabrechnung11.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(2L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, "EUR");
+
+        // check securities
+        assertThat(results, hasItem(security( //
+                        hasIsin("US84615Q1031"), hasWkn("A42D4F"), hasTicker(null), //
+                        hasName("SPACE EXPLORATION TECHS."), //
+                        hasCurrencyCode("USD"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-12T00:00"), hasShares(10.00), //
+                        hasSource("FlatExDegiroSammelabrechnung11.txt"), //
+                        hasNote("Transaktion-Nr.: 5028417943"), //
+                        hasAmount("EUR", 1166.61), hasGrossValue("EUR", 1166.61), //
+                        hasForexGrossValue("USD", 1350.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-06-12T18:02"), hasShares(10.00), //
+                        hasSource("FlatExDegiroSammelabrechnung11.txt"), //
+                        hasNote("Transaktion-Nr.: 5029322308"), //
+                        hasAmount("EUR", 1319.57), hasGrossValue("EUR", 1386.40), //
+                        hasForexGrossValue("USD", 1604.34), //
+                        hasTaxes("EUR", 51.93 + 2.85 + 4.15), hasFees("EUR", 5.90 + 2.00))));
+    }
+
+    @Test
     public void testFlatExDeGiroDepotServiceGebuehr01()
     {
         var extractor = new FinTechGroupBankPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatExDegiroSammelabrechnung11.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatExDegiroSammelabrechnung11.txt
@@ -1,0 +1,94 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+flatexDEGIRO Bank SE
+Postfach 100551
+41405 Neuss
+USt-IdNr.: DE 246 786 363
+Kundenservice:
+Tel.: +49 9221 7035898
+E-Mail: info@flatex.de
+flatexDEGIRO Bank SE -  Hammfelddamm 4 - 41460 Neuss, Deutschland
+7004800621499485171658
+ZFfoRNV fnkXswiY
+fnkXswiY. 46
+16032 ZNrQSCic
+          Frankfurt, 13.06.2026
+Sammelabrechnung (Wertpapierkauf/-verkauf)
+Ihre Depotnummer: 123231456564
+Depotinhaber:     opsfkTb bOFtIHzU
+Nr.313138095/1    Kauf          SPACE EXPLORATION TECHS. (US84615Q1031/A42D4F)
+Ordervolumen  : 42,00 St.               Handelsplatz  :              Zeichnung
+davon ausgef. : 10,00 St.               Schlusstag    :  12.06.2026, 00:00 Uhr
+Kurs          : 135,0000 USD            Kurswert      :           1.166,61 EUR
+Devisenkurs   : 1,157200                Provision     :
+Bew-Faktor    : 1,0000                  Eigene Spesen :
+Verwahrart    : GS-Verwahrung          *Fremde Spesen :
+Lagerstelle   : Clearstream Nat.
+Lagerland     : USA                     Bemessungs-
+Gewinn/Verlust: 0,00 EUR                grundlage     :               0,00 EUR
+Valuta        : 15.06.2026            **Einbeh. Steuer:               0,00 EUR
+                                        Endbetrag     :          -1.166,61 EUR
+*   Enthalten sind folgende Gebühren
+                                Courtage                :             0,00 EUR
+                                Tradinggebühr           :             0,00 EUR
+                                Regulierung             :             0,00 EUR
+                                Schlussnoten            :             0,00 EUR
+                                Finanztransaktionssteuer:             0,00 EUR
+                                Sonstige                :             0,00 EUR
+**  Enthalten sind folgende Steuern (negative Werte bedeuten Steuererstattung)
+                                Kapitalertragsteuer   :               0,00 EUR
+                                Solidaritätszuschlag  :               0,00 EUR
+                                Kirchensteuer         :               0,00 EUR
+    Evtl. Details dazu finden Sie im Steuerreport unter der Transaktion-Nr.:
+    5028417943.
+______________________________________________________________________________
+                                                                     Seite 1/2
+BLZ 101 308 00 / BIC: BIWBDE33XXX  -  Societas Europaea, Sitz Frankfurt  -  Amtsgericht Frankfurt am Main (HRB 141330)
+Vorsitzender des Aufsichtsrats: Hans-Hermann Lotter  -  Vorstand: Oliver Behrens (Vorsitzender), Dr. Benon Janos (stellv. Vorsitzender),
+ Evgeni Kaplun, Jens Möbitz, Christiane Strubel
+2000006013470330 0113303500000101
+Nr.313210686/1    Verkauf       SPACE EXPLORATION TECHS. (US84615Q1031/A42D4F)
+Ordervolumen  : 10,00 St.               Handelsplatz  :              Tradegate
+davon ausgef. : 10,00 St.               Schlusstag    :  12.06.2026, 18:02 Uhr
+Kurs          : 138,6400 EUR            Kurswert      :           1.386,40 EUR
+Devisenkurs   :                         Provision     :               5,90 EUR
+Bew-Faktor    : 1,0000                  Eigene Spesen :
+Verwahrart    : GS-Verwahrung          *Fremde Spesen :               2,00 EUR
+Lagerstelle   : Clearstream Nat.
+Lagerland     : USA                     Bemessungs-
+Gewinn/Verlust: 219,79 EUR              grundlage     :             211,89 EUR
+Valuta        : 16.06.2026            **Einbeh. Steuer:              58,93 EUR
+                                        Endbetrag     :           1.319,57 EUR
+*   Enthalten sind folgende Gebühren
+                                Courtage                :             0,00 EUR
+                                Tradinggebühr           :             0,00 EUR
+                                Regulierung             :             2,00 EUR
+                                Schlussnoten            :             0,00 EUR
+                                Finanztransaktionssteuer:             0,00 EUR
+                                Sonstige                :             0,00 EUR
+**  Enthalten sind folgende Steuern (negative Werte bedeuten Steuererstattung)
+                                Kapitalertragsteuer   :              51,93 EUR
+                                Solidaritätszuschlag  :               2,85 EUR
+                                Kirchensteuer         :               4,15 EUR
+    Evtl. Details dazu finden Sie im Steuerreport unter der Transaktion-Nr.:
+    5029322308.
+Die Verrechnung der Endbeträge erfolgt über Ihr Konto Nr.: 1009326791
+Die Wertpapiere sowie den Gegenwert werden wir entsprechend der Abrechnung mit
+dem angegebenen Valutatag buchen. Bitte prüfen Sie diese Abrechnung auf
+Richtigkeit und Vollständigkeit. Etwaige Einwendungen gegen diese Abrechnung
+müssen unverzüglich nach Zugang bei der Bank erhoben werden. Die
+Unterlassung rechtzeitiger Einwendung gilt als Genehmigung. Bitte beachten
+Sie mögliche Hinweise des Emittenten hinsichtlich vorzeitiger Fälligstellung,
+beispielsweise wegen Knock-Out, in den jeweiligen Optionsscheinbedingungen und
+informieren Sie sich rechtzeitig, welche spezielle Fälligkeitsregelung auf die
+von Ihnen gehaltenen Wertpapiere zutreffen. Kapitalerträge sind ESt-pflichtig.
+Diese Mitteilung ist maschinell erstellt und wird nicht unterschrieben.
+Für weitergehende Fragen wenden Sie sich bitte an Ihr flatex-Service-Team.
+______________________________________________________________________________
+                                                                     Seite 2/2
+BLZ 101 308 00 / BIC: BIWBDE33XXX  -  Societas Europaea, Sitz Frankfurt  -  Amtsgericht Frankfurt am Main (HRB 141330)
+Vorsitzender des Aufsichtsrats: Hans-Hermann Lotter  -  Vorstand: Oliver Behrens (Vorsitzender), Dr. Benon Janos (stellv. Vorsitzender),
+ Evgeni Kaplun, Jens Möbitz, Christiane Strubel
+2000006013470330

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -687,6 +687,37 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                                                             var fxGross = rate.convert(rate.getTermCurrency(), gross);
 
                                                             checkAndSetGrossUnit(gross, fxGross, t, type.getCurrentContext());
+                                                        }),
+                                        // @formatter:off
+                                        // If the security is in a foreign currency, but the trade was
+                                        // executed in the booking currency, the exchange rate is missing.
+                                        // In this case we use the exchange rate of a preceding transaction
+                                        // for the same currency pair in the same summary statement.
+                                        //
+                                        // Kurs          : 138,6400 EUR            Kurswert      :           1.386,40 EUR
+                                        // Devisenkurs   :                         Provision     :               5,90 EUR
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("gross", "baseCurrency") //
+                                                        .match("^.* Kurswert[:\\s]{1,}(?<gross>[\\.,\\d]+)[\\s]{1,}(?<baseCurrency>[A-Z]{3})$") //
+                                                        .match("^Devisenkurs[:\\s]{1,}[A-Z].*$") //
+                                                        .assign((t, v) -> {
+                                                            var rate = type.getCurrentContext().getType(ExtrExchangeRate.class);
+
+                                                            if (rate.isPresent())
+                                                            {
+                                                                var exchangeRate = rate.get();
+                                                                var securityCurrency = t.getPortfolioTransaction().getSecurity().getCurrencyCode();
+
+                                                                if (exchangeRate.getBaseCurrency().equals(asCurrencyCode(v.get("baseCurrency"))) //
+                                                                                && exchangeRate.getTermCurrency().equals(securityCurrency))
+                                                                {
+                                                                    var gross = Money.of(exchangeRate.getBaseCurrency(), asAmount(v.get("gross")));
+                                                                    var fxGross = exchangeRate.convert(exchangeRate.getTermCurrency(), gross);
+
+                                                                    checkAndSetGrossUnit(gross, fxGross, t, type.getCurrentContext());
+                                                                }
+                                                            }
                                                         }))
 
                         // @formatter:off


### PR DESCRIPTION
Fixes the import failure "Exchange rate of gross value is missing (transaction currency EUR and security currency USD)" for flatex `Sammelabrechnung (Wertpapierkauf/-verkauf)` documents in which the same security is bought with a printed Devisenkurs (Kurs in USD, Kurswert in EUR — e.g. a Zeichnung) and sold on a German exchange entirely in EUR with an empty `Devisenkurs` field. The buy creates the security in USD, so the EUR-booked sale requires a gross-value exchange rate that the document does not print for that trade.

**Fix**

A third variant in the forex `optionalOneOf` of `addSummaryStatementBuySellTransaction`: when the `Kurswert` line is present but the `Devisenkurs` field is empty (a column label instead of a number follows it), the extractor reuses the `ExtrExchangeRate` stored in the document context by a preceding transaction of the same statement — guarded by base currency == Kurswert currency and term currency == security currency. All-EUR statements keep hitting the guard's no-op path, and a rate for the wrong currency pair is never applied. The document context is cleared per file, so no rate can leak across documents. Worst case (e.g. the sale ordered before the buy, or an unrelated currency pair) degrades to the previous behavior instead of producing wrong values.

**Fixture**

- `FlatExDegiroSammelabrechnung11.txt` — the extracted text provided by the issue reporter (buy via Zeichnung with Kurs in USD / Kurswert in EUR / Devisenkurs 1,157200, plus the EUR-only sale of the same ISIN on Tradegate).

All 159 tests of `FinTechGroupBankPDFExtractorTest` pass.

Closes #5799

🤖 Generated with [Claude Code](https://claude.com/claude-code)