### PR TITLE
fileversions FileHelper fix path encoding issue

### DIFF
--- a/name.abuchen.portfolio.tests/src/fileversions/FileHelper.java
+++ b/name.abuchen.portfolio.tests/src/fileversions/FileHelper.java
@@ -2,6 +2,7 @@ package fileversions;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -10,9 +11,8 @@ import java.util.stream.Stream;
 
 public class FileHelper
 {
-    private static Path testDir = Paths.get(new File(
-                    ReadingHistoricClientFilesTest.class.getProtectionDomain().getCodeSource().getLocation().getFile())
-                                    .toURI());
+    private static Path testDir = Paths.get(URI.create(ReadingHistoricClientFilesTest.class.getProtectionDomain()
+                    .getCodeSource().getLocation().toString()));
 
     private FileHelper()
     {


### PR DESCRIPTION
The previous version did not properly work when spaces are in your workspace path.