### PR TITLE
Add St.Galler Kantonalbank PDF importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Dividende01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Dividende01.txt
@@ -1,0 +1,34 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Enlzx Klaus-QrPqIa
+Privatkonto EUR
+Depot-Nr. 0140.3332.5804
+IBAN CH11 4051 1030 5747 6386 0
+St.Galler Kantonalbank AG
+St. Leonhardstrasse 25
+9001 St. Gallen
+www.sgkb.ch
+BIC KBSGCH22
+Ihr Kontakt:
+Ztkpe Vrasjun Elektronisch versandt
+Telefon +41 71 730 15 62 Herr
+ztkpe.vrasjun@sgkb.ch Klaus-awJIMZ dyDDJ
+ IrHjJE 36 f
+St. Gallen, 13. Februar 2026 27478 vmHfsDZpl
+Referenznummer 1746312001 DEUTSCHLAND
+Barausschüttung
+Ihr Depotbestand per Ex-Datum 11. Februar 2026:
+10'000 N-Akt TUI AG Aus Konversion
+Namenaktien Valoren-Nr.: 125205291, ISIN: DE000TUAG505
+Wir teilen Ihnen mit, dass wir die folgenden Erträgnisse unter Eingangsvorbehalt abgerechnet haben:
+Ausschüttung: EUR 0.10
+Ertragsart: Ordentliche Dividende
+Betrag EUR 1'000.00
+Quellensteuer 26.375% EUR 263.75
+Total EUR 736.25
+Zu Ihren Gunsten Valuta 13.02.2026 EUR 736.25
+Freundliche Grüsse
+St.Galler Kantonalbank AG
+237662 222528287 1746312001

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Kauf01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Kauf01.txt
@@ -1,0 +1,54 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+gVupo Klaus-KWaHxh
+Privatkonto EUR
+Depot-Nr. 0140.3332.5704
+IBAN CH11 5949 1030 8056 5914 0
+St.Galler Kantonalbank AG
+St. Leonhardstrasse 25
+9001 St. Gallen
+www.sgkb.ch
+BIC KBSGCH22
+Ihr Kontakt:
+Bqrtk Wemslo Elektronisch versandt
+Telefon +41 71 594 28 73 Herr
+bqrtk.wemslo@sgkb.ch Klaus-aBMEvQ CfKKL
+ ideavu 73 l
+St. Gallen, 24. Februar 2025 84961 ZfPanuppr
+Referenznummer 1603933135 DEUTSCHLAND
+Abrechnung: Ihr Kauf
+Wir haben für Sie am 24. Februar 2025 gekauft (Details siehe Folgeseite):
+10'000 N-Akt TUI AG Aus Konversion Valoren-Nr. 125205291
+ISIN DE000TUAG505
+Währung Betrag
+Kurs EUR 6.822613 EUR 68'226.13
+Courtage EUR 955.17
+Eidg. Stempelsteuer(CHF -96.20) EUR 102.34
+Fremde Courtage EUR 13.65
+Total EUR 69'297.29
+Zu Ihren Lasten Valuta 26.02.2025 EUR 69'297.29
+Bitte beachten Sie, dass die SGKB im Zusammenhang mit diesem Finanzdienstleistungs-Auftrag keine
+Anlageberatungs-Dienstleistungen erbracht und folglich weder eine Angemessenheits- noch Geeignetheitsprüfung
+durchgeführt hat. Die Leistungen der SGKB beschränken sich auf die Ausführung oder die Übermittlung solcher Aufträge.
+Die Titel wurden in Ihr Depot eingebucht. Wir danken für Ihren Auftrag.
+Freundliche Grüsse
+St.Galler Kantonalbank AG
+222198 205587847 1603833135 Seite 1 von 2
+nQIBe Klaus-hDQxWr
+Privatkonto EUR
+IBAN hK09 5838 7320 5908 2504 0
+Ausführungsdetails
+Die Abrechnung setzt sich wie folgt zusammen:
+Menge Ausführungszeitpunkt Börsenplatz Währung Kurs
+1'753 24.02.2025 10:35:48 Xetra EUR 6.82
+2'520 24.02.2025 10:35:48 Xetra EUR 6.822
+2'494 24.02.2025 10:35:48 Xetra EUR 6.824
+2'028 24.02.2025 10:35:48 Xetra EUR 6.826
+414 24.02.2025 10:35:48 CBOE EUROPE - DXE ORDER BOOKS (NL) EUR 6.818
+606 24.02.2025 10:35:48 CBOE EUROPE - DXE ORDER BOOKS (NL) EUR 6.818
+67 24.02.2025 10:35:48 CBOE EUROPE - DXE ORDER BOOKS (NL) EUR 6.824
+67 24.02.2025 10:35:48 CBOE EUROPE - DXE ORDER BOOKS (NL) EUR 6.826
+51 24.02.2025 10:35:48 CBOE EUROPE - DXE ORDER BOOKS (NL) EUR 6.826
+222198 205547847 1603933135 Seite 2 von 2

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/StGallerKantonalbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/StGallerKantonalbankPDFExtractorTest.java
@@ -1,0 +1,147 @@
+package name.abuchen.portfolio.datatransfer.pdf.stgallerkantonalbank;
+
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasExDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasIsin;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasName;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countItemsWithFailureMessage;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSkippedItems;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
+import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
+import name.abuchen.portfolio.datatransfer.pdf.StGallerKantonalbankPDFExtractor;
+import name.abuchen.portfolio.model.Client;
+
+@SuppressWarnings("nls")
+public class StGallerKantonalbankPDFExtractorTest
+{
+    @Test
+    public void testWertpapierKauf01()
+    {
+        var extractor = new StGallerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("DE000TUAG505"), hasWkn("125205291"), hasTicker(null), //
+                        hasName("N-Akt TUI AG Aus Konversion"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2025-02-24T10:35:48"), hasShares(10000.00), //
+                        hasSource("Kauf01.txt"), //
+                        hasNote("Referenznummer 1603933135"), //
+                        hasAmount("EUR", 69297.29), hasGrossValue("EUR", 68226.13), //
+                        hasTaxes("EUR", 102.34), hasFees("EUR", 955.17 + 13.65))));
+    }
+
+    @Test
+    public void testWertpapierVerkauf01()
+    {
+        var extractor = new StGallerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("DE000TUAG505"), hasWkn("125205291"), hasTicker(null), //
+                        hasName("N-Akt TUI AG Aus Konversion"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2025-02-20T09:00:13"), hasShares(10000.00), //
+                        hasSource("Verkauf01.txt"), //
+                        hasNote("Referenznummer 1602562989"), //
+                        hasAmount("EUR", 65967.79), hasGrossValue("EUR", 67020.00), //
+                        hasTaxes("EUR", 100.53), hasFees("EUR", 938.28 + 13.40))));
+    }
+
+    @Test
+    public void testDividende01()
+    {
+        var extractor = new StGallerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("DE000TUAG505"), hasWkn("125205291"), hasTicker(null), //
+                        hasName("N-Akt TUI AG Aus Konversion"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-02-13T00:00"), hasExDate("2026-02-11"), //
+                        hasShares(10000.00), //
+                        hasSource("Dividende01.txt"), //
+                        hasNote("Referenznummer 1746312001"), //
+                        hasAmount("EUR", 736.25), hasGrossValue("EUR", 1000.00), //
+                        hasTaxes("EUR", 263.75), hasFees("EUR", 0.00))));
+    }
+}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Verkauf01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Verkauf01.txt
@@ -1,0 +1,46 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.84.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+JRAdP Klaus-IcmnrD
+Privatkonto EUR
+Depot-Nr. 0140.3332.5704
+IBAN CH11 8212 1030 3844 8727 0
+St.Galler Kantonalbank AG
+St. Leonhardstrasse 25
+9001 St. Gallen
+www.sgkb.ch
+BIC KBSGCH22
+Ihr Kontakt:
+Nfdwe Ohlmar Elektronisch versandt
+Telefon +41 71 268 41 95 Herr
+nfdwe.ohlmar@sgkb.ch Klaus-NbBYsZ CieVv
+ cnGMNo 86 f
+St. Gallen, 20. Februar 2025 74035 TvBmJnfvE
+Referenznummer 1602562989 DEUTSCHLAND
+Abrechnung: Ihr Verkauf
+Wir haben für Sie am 20. Februar 2025 verkauft (Details siehe Folgeseite):
+10'000 N-Akt TUI AG Aus Konversion Valoren-Nr. 125205291
+ISIN DE000TUAG505
+Währung Betrag
+Kurs EUR 6.702 EUR 67'020.00
+Courtage EUR 938.28
+Eidg. Stempelsteuer(CHF -94.69) EUR 100.53
+Fremde Courtage EUR 13.40
+Total EUR 65'967.79
+Zu Ihren Gunsten Valuta 24.02.2025 EUR 65'967.79
+Bitte beachten Sie, dass die SGKB im Zusammenhang mit diesem Finanzdienstleistungs-Auftrag keine
+Anlageberatungs-Dienstleistungen erbracht und folglich weder eine Angemessenheits- noch Geeignetheitsprüfung
+durchgeführt hat. Die Leistungen der SGKB beschränken sich auf die Ausführung oder die Übermittlung solcher Aufträge.
+Die Titel wurden Ihrem Depot entnommen. Wir danken für Ihren Auftrag.
+Freundliche Grüsse
+St.Galler Kantonalbank AG
+222062 205478072 1602562989 Seite 1 von 2
+CieVv Klaus-NbBYsZ
+Privatkonto EUR
+IBAN CH11 8212 1030 3844 8727 0
+Ausführungsdetails
+Die Abrechnung setzt sich wie folgt zusammen:
+Menge Ausführungszeitpunkt Börsenplatz Währung Kurs
+10'000 20.02.2025 09:00:13 Xetra EUR 6.702
+222062 205478072 1602562989 Seite 2 von 2

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFImportAssistant.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFImportAssistant.java
@@ -136,6 +136,7 @@ public class PDFImportAssistant
         extractors.add(new SimpelPDFExtractor(client));
         extractors.add(new SolarisbankAGPDFExtractor(client));
         extractors.add(new StakeshopPtyLtdPDFExtractor(client));
+        extractors.add(new StGallerKantonalbankPDFExtractor(client));
         extractors.add(new SunrisePDFExtractor(client));
         extractors.add(new SuresseDirektBankPDFExtractor(client));
         extractors.add(new SutorBankGmbHPDFExtractor(client));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/StGallerKantonalbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/StGallerKantonalbankPDFExtractor.java
@@ -1,0 +1,247 @@
+package name.abuchen.portfolio.datatransfer.pdf;
+
+import static name.abuchen.portfolio.util.TextUtil.trim;
+
+import name.abuchen.portfolio.datatransfer.ExtractorUtils;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
+import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.BuySellEntry;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.money.Values;
+
+/**
+ * @formatter:off
+ * @implNote St.Galler Kantonalbank AG
+ *
+ * @implSpec The VALOR number is the WKN number with 5 to 9 letters.
+ * @formatter:on
+ */
+
+@SuppressWarnings("nls")
+public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
+{
+    public StGallerKantonalbankPDFExtractor(Client client)
+    {
+        super(client);
+
+        addBankIdentifier("St.Galler Kantonalbank AG");
+
+        addBuySellTransaction();
+        addDividendeTransaction();
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return "St.Galler Kantonalbank AG";
+    }
+
+    private void addBuySellTransaction()
+    {
+        final var type = new DocumentType("Abrechnung: Ihr (Kauf|Verkauf)");
+        this.addDocumentTyp(type);
+
+        var pdfTransaction = new Transaction<BuySellEntry>();
+
+        var firstRelevantLine = new Block("^Referenznummer .*$");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
+
+        pdfTransaction //
+
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
+
+                        // Is type --> "Verkauf" change from BUY to SELL
+                        .section("type").optional() //
+                        .match("^Abrechnung: Ihr (?<type>(Kauf|Verkauf))$") //
+                        .assign((t, v) -> {
+                            if ("Verkauf".equals(v.get("type")))
+                                t.setType(PortfolioTransaction.Type.SELL);
+                        })
+
+                        // @formatter:off
+                        // 10'000 N-Akt TUI AG Aus Konversion Valoren-Nr. 125205291
+                        // ISIN DE000TUAG505
+                        // Währung Betrag
+                        // Kurs EUR 6.822613 EUR 68'226.13
+                        // @formatter:on
+                        .section("name", "wkn", "isin", "currency") //
+                        .match("^[\\.'\\d]+ (?<name>.*) Valoren\\-Nr\\. (?<wkn>[A-Z0-9]{5,9})$") //
+                        .match("^ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                        .match("^Kurs (?<currency>[A-Z]{3}) [\\.'\\d]+ [A-Z]{3} [\\.'\\d]+$") //
+                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+
+                        // @formatter:off
+                        // 10'000 N-Akt TUI AG Aus Konversion Valoren-Nr. 125205291
+                        // @formatter:on
+                        .section("shares") //
+                        .match("^(?<shares>[\\.'\\d]+) .* Valoren\\-Nr\\. [A-Z0-9]{5,9}$") //
+                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+
+                        .oneOf( //
+                                        // @formatter:off
+                                        // Menge Ausführungszeitpunkt Börsenplatz Währung Kurs
+                                        // 10'000 20.02.2025 09:00:13 Xetra EUR 6.702
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date", "time") //
+                                                        .find("Menge Ausf.hrungszeitpunkt B.rsenplatz W.hrung Kurs") //
+                                                        .match("^[\\.'\\d]+ (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}\\:[\\d]{2}\\:[\\d]{2}) .*$") //
+                                                        .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time")))),
+                                        // @formatter:off
+                                        // Wir haben für Sie am 24. Februar 2025 gekauft (Details siehe Folgeseite):
+                                        // Wir haben für Sie am 20. Februar 2025 verkauft (Details siehe Folgeseite):
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date") //
+                                                        .match("^Wir haben f.r Sie am (?<date>[\\d]{1,2}\\. .* [\\d]{4}) (gekauft|verkauft).*$") //
+                                                        .assign((t, v) -> t.setDate(asDate(v.get("date")))))
+
+                        // @formatter:off
+                        // Zu Ihren Lasten Valuta 26.02.2025 EUR 69'297.29
+                        // Zu Ihren Gunsten Valuta 24.02.2025 EUR 65'967.79
+                        // @formatter:on
+                        .section("currency", "amount") //
+                        .match("^Zu Ihren (Lasten|Gunsten) Valuta [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<currency>[A-Z]{3}) (?<amount>[\\.'\\d]+)$") //
+                        .assign((t, v) -> {
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setAmount(asAmount(v.get("amount")));
+                        })
+
+                        // @formatter:off
+                        // Referenznummer 1603933135 DEUTSCHLAND
+                        // @formatter:on
+                        .section("note").optional() //
+                        .match("^(?<note>Referenznummer [\\d]+).*$") //
+                        .assign((t, v) -> t.setNote(trim(v.get("note"))))
+
+                        .wrap(BuySellEntryItem::new);
+
+        addTaxesSectionsTransaction(pdfTransaction, type);
+        addFeesSectionsTransaction(pdfTransaction, type);
+    }
+
+    private void addDividendeTransaction()
+    {
+        final var type = new DocumentType("Baraussch.ttung");
+        this.addDocumentTyp(type);
+
+        var pdfTransaction = new Transaction<AccountTransaction>();
+
+        var firstRelevantLine = new Block("^Referenznummer .*$");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
+
+        pdfTransaction //
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
+
+                        // @formatter:off
+                        // 10'000 N-Akt TUI AG Aus Konversion
+                        // Namenaktien Valoren-Nr.: 125205291, ISIN: DE000TUAG505
+                        // Ausschüttung: EUR 0.10
+                        // @formatter:on
+                        .section("name", "wkn", "isin", "currency") //
+                        .find("Ihr Depotbestand per Ex\\-Datum .*") //
+                        .match("^[\\.'\\d]+ (?<name>.*)$") //
+                        .match("^.* Valoren\\-Nr\\.: (?<wkn>[A-Z0-9]{5,9}), ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                        .match("^Aussch.ttung: (?<currency>[A-Z]{3}) [\\.'\\d]+$") //
+                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+
+                        // @formatter:off
+                        // 10'000 N-Akt TUI AG Aus Konversion
+                        // @formatter:on
+                        .section("shares") //
+                        .find("Ihr Depotbestand per Ex\\-Datum .*") //
+                        .match("^(?<shares>[\\.'\\d]+) .*$") //
+                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+
+                        // @formatter:off
+                        // Ihr Depotbestand per Ex-Datum 11. Februar 2026:
+                        // @formatter:on
+                        .section("exDate").optional() //
+                        .match("^Ihr Depotbestand per Ex\\-Datum (?<exDate>[\\d]{1,2}\\. .* [\\d]{4}):$") //
+                        .assign((t, v) -> t.setExDate(asDate(v.get("exDate"))))
+
+                        // @formatter:off
+                        // Zu Ihren Gunsten Valuta 13.02.2026 EUR 736.25
+                        // @formatter:on
+                        .section("date") //
+                        .match("^Zu Ihren Gunsten Valuta (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) [A-Z]{3} [\\.'\\d]+$") //
+                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
+
+                        // @formatter:off
+                        // Zu Ihren Gunsten Valuta 13.02.2026 EUR 736.25
+                        // @formatter:on
+                        .section("currency", "amount") //
+                        .match("^Zu Ihren Gunsten Valuta [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<currency>[A-Z]{3}) (?<amount>[\\.'\\d]+)$") //
+                        .assign((t, v) -> {
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setAmount(asAmount(v.get("amount")));
+                        })
+
+                        // @formatter:off
+                        // Referenznummer 1746312001 DEUTSCHLAND
+                        // @formatter:on
+                        .section("note").optional() //
+                        .match("^(?<note>Referenznummer [\\d]+).*$") //
+                        .assign((t, v) -> t.setNote(trim(v.get("note"))))
+
+                        .wrap(TransactionItem::new);
+
+        addTaxesSectionsTransaction(pdfTransaction, type);
+    }
+
+    private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
+    {
+        transaction //
+
+                        // @formatter:off
+                        // Eidg. Stempelsteuer(CHF -96.20) EUR 102.34
+                        // @formatter:on
+                        .section("tax", "currency").optional() //
+                        .match("^Eidg\\. Stempelsteuer ?(\\(.*\\))? (?<currency>[A-Z]{3}) (\\-)?(?<tax>[\\.'\\d]+)$") //
+                        .assign((t, v) -> processTaxEntries(t, v, type))
+
+                        // @formatter:off
+                        // Quellensteuer 26.375% EUR 263.75
+                        // @formatter:on
+                        .section("withHoldingTax", "currency").optional() //
+                        .match("^Quellensteuer [\\.,'\\d]+% (?<currency>[A-Z]{3}) (\\-)?(?<withHoldingTax>[\\.'\\d]+)$") //
+                        .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type));
+    }
+
+    private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
+    {
+        transaction //
+
+                        // @formatter:off
+                        // Courtage EUR 955.17
+                        // @formatter:on
+                        .section("fee", "currency").optional() //
+                        .match("^Courtage (?<currency>[A-Z]{3}) (\\-)?(?<fee>[\\.'\\d]+)$") //
+                        .assign((t, v) -> processFeeEntries(t, v, type))
+
+                        // @formatter:off
+                        // Fremde Courtage EUR 13.65
+                        // @formatter:on
+                        .section("fee", "currency").optional() //
+                        .match("^Fremde Courtage (?<currency>[A-Z]{3}) (\\-)?(?<fee>[\\.'\\d]+)$") //
+                        .assign((t, v) -> processFeeEntries(t, v, type));
+    }
+
+    @Override
+    protected long asAmount(String value)
+    {
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount, "de", "CH");
+    }
+
+    @Override
+    protected long asShares(String value)
+    {
+        return ExtractorUtils.convertToNumberLong(value, Values.Share, "de", "CH");
+    }
+}


### PR DESCRIPTION
Adds a PDF importer for St.Galler Kantonalbank AG (Switzerland) supporting:

- Securities buy ("Abrechnung: Ihr Kauf") and sell ("Abrechnung: Ihr Verkauf") settlements, including the execution time from the "Ausführungsdetails" page, Courtage and Fremde Courtage as fees, and Eidg. Stempelsteuer as tax
- Cash dividends ("Barausschüttung") with Quellensteuer and ex-date

Test fixtures are the anonymized documents from the linked issues.

Closes #5769
Closes #5771
Closes #5772

🤖 Generated with [Claude Code](https://claude.com/claude-code)