### PR TITLE
KBC/Bolero: support multiple dividends and new exchange-rate format

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/kbcgroupnv/Dividende05.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/kbcgroupnv/Dividende05.txt
@@ -1,0 +1,55 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.83.2
+System: macosx | aarch64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+kbpCXEw-RKF yHynjfNyQ ZfiFBV-YN
+Overzicht transacties en rekeninguittreksels voor klantnummer 5827558
+29/05/2026
+EUR-REKENING - 199
+Borderel 067498551
+Buiten beurs (OTC)
+Uitvoeringsdatum : 29/05/2026 Uitvoeringstijdstip : 02:37:36 Valuta : 29/05/2026
+Uw Uitbetaling dividenden van 1.000 ISHARES PLCS P GL.CLEAN ENERGY T.-D 19,20 USD
+aan 0,0192 USD
+Buitenlandse bronheffing (basisbedrag 19,2 USD) 0,00 USD
+Roerende voorheffing (basisbedrag 19,2 USD) 5,76 USD
+Kosten incassostelling (basisbedrag 13,44 USD) 0,22 USD
+BTW (basisbedrag 0,22 USD) 0,05 USD
+Netto 13,17 USD
+1 EUR = 1,172292 USD
+Netto credit 11,23 EUR
+Wettelijke fiscale informatie Basisbedrag RV 16,38 EUR
+Roerende voorheffing 30,00% 4,91 EUR
+Waardecode 0957698519
+A
+Cash Dividend IE00B1XNHC34ex 2026-05-21 pd 2026-05-29
+pioPLKM-qTA PirNJucoa viFdXp-Si Pagina 1
+2_7_2_1_99_2__________________________________________________________________________________
+KBC BANK NV Documentreferte: 424
+Havenlaan 2, 1080 Brussels, Belgium VAT BE 0462.920.226
+Account N° BE77 4096 5474 0142 - BIC KREDBEBB
+Borderel 067784648
+Buiten beurs (OTC)
+Uitvoeringsdatum : 29/05/2026 Uitvoeringstijdstip : 09:57:53 Valuta : 29/05/2026
+Uw Uitbetaling dividenden van 25 CP SOFINA (BR) 27.05.26 aan 3,66 EUR 91,50 EUR
+Roerende voorheffing (basisbedrag 91,5 EUR) 27,45 EUR
+Netto credit 64,05 EUR
+Wettelijke fiscale informatie Basisbedrag RV 91,50 EUR
+Roerende voorheffing 30,00% 27,45 EUR
+Waardecode 0003717517
+A
+Cash Dividend BE0003717312ex 2026-05-27 pd 2026-05-29
+Rekeninguittreksel Nr 307 Vorig Saldo: 25.558,71 EUR
+29/05/2026 Uitbetaling dividenden ISHARES PLCS P Valuta 29/05/2026 11,23 EUR
+GL.CLEAN ENERGY
+29/05/2026 Uitbetaling dividenden CP SOFINA (BR) Valuta 29/05/2026 64,05 EUR
+27.05.26
+Nieuw Saldo* 25.633,99 EUR
+*Dit deposito komt in aanmerking voor depositobescherming. Meer info:
+www.kbc.be/depositobescherming
+Heb je nog vragen ? Gelieve je te richten tot de Bolero orderdesk
+REJLZWO-ftu TjqiPFGAQ owYVXJ-zF Pagina 2
+5_3_2_2_97_2__________________________________________________________________________________
+KBC BANK NV Documentreferte: 424
+Havenlaan 2, 1080 Brussels, Belgium VAT BE 0462.920.226
+Account N° BE77 4096 5474 0142 - BIC KREDBEBB

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/kbcgroupnv/KBCGroupNVPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/kbcgroupnv/KBCGroupNVPDFExtractorTest.java
@@ -7,6 +7,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.fee;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasExDate;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasForexGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
@@ -396,7 +397,8 @@ public class KBCGroupNVPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2024-01-24T00:00"), hasShares(2065.00), //
+                        hasDate("2024-01-24T02:35:28"), hasExDate(null), //
+                        hasShares(2065.00), //
                         hasSource("Dividende01.txt"), //
                         hasNote("Borderel 003308592"), //
                         hasAmount("EUR", 2862.79), hasGrossValue("EUR", 4173.16), //
@@ -430,7 +432,8 @@ public class KBCGroupNVPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-03-14T00:00"), hasShares(2130.00), //
+                        hasDate("2025-03-14T02:39:42"), hasExDate(null), //
+                        hasShares(2130.00), //
                         hasSource("Dividende02.txt"), //
                         hasNote("Borderel 019817049"), //
                         hasAmount("USD", 6.37), hasGrossValue("USD", 12.14), //
@@ -464,7 +467,8 @@ public class KBCGroupNVPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-03-14T00:00"), hasShares(2130.00), //
+                        hasDate("2025-03-14T02:39:42"), hasExDate(null), //
+                        hasShares(2130.00), //
                         hasSource("Dividende02.txt"), //
                         hasNote("Borderel 019817049"), //
                         hasAmount("USD", 6.37), hasGrossValue("USD", 12.14), //
@@ -506,7 +510,8 @@ public class KBCGroupNVPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2024-01-02T00:00"), hasShares(43.00), //
+                        hasDate("2024-01-02T02:38:33"), hasExDate(null), //
+                        hasShares(43.00), //
                         hasSource("Dividende03.txt"), //
                         hasNote("Borderel 000167639"), //
                         hasAmount("USD", 10.23), hasGrossValue("USD", 17.20), //
@@ -540,7 +545,8 @@ public class KBCGroupNVPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2024-01-02T00:00"), hasShares(43.00), //
+                        hasDate("2024-01-02T02:38:33"), hasExDate(null), //
+                        hasShares(43.00), //
                         hasSource("Dividende03.txt"), //
                         hasNote("Borderel 000167639"), //
                         hasAmount("USD", 10.23), hasGrossValue("USD", 17.20), //
@@ -582,11 +588,119 @@ public class KBCGroupNVPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-01-29T00:00"), hasShares(912.00), //
+                        hasDate("2025-01-29T02:35:19"), hasExDate(null), //
+                        hasShares(912.00), //
                         hasSource("Dividende04.txt"), //
                         hasNote("Borderel 006631462"), //
                         hasAmount("EUR", 1276.04), hasGrossValue("EUR", 1860.12), //
                         hasTaxes("EUR", 558.04 + 4.52), hasFees("EUR", 21.52))));
+    }
+
+    @Test
+    public void testDividende05()
+    {
+        var extractor = new KBCGroupNVPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende05.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(2L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(2L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(4));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00B1XNHC34"), hasWkn(null), hasTicker(null), //
+                        hasName("ISHARES PLCS P GL.CLEAN ENERGY T.-D"), //
+                        hasCurrencyCode("USD"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("BE0003717312"), hasWkn(null), hasTicker(null), //
+                        hasName("CP SOFINA (BR) 27.05.26"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-29T02:37:36"), hasExDate(null), //
+                        hasShares(1000.00), //
+                        hasSource("Dividende05.txt"), //
+                        hasNote("Borderel 067498551"), //
+                        hasAmount("EUR", 11.23), hasGrossValue("EUR", 16.37), //
+                        hasForexGrossValue("USD", 19.20), //
+                        hasTaxes("EUR", 0.00 + 4.91 + 0.04), hasFees("EUR", 0.19))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-29T09:57:53"), hasExDate(null), //
+                        hasShares(25.00), //
+                        hasSource("Dividende05.txt"), //
+                        hasNote("Borderel 067784648"), //
+                        hasAmount("EUR", 64.05), hasGrossValue("EUR", 91.50), //
+                        hasTaxes("EUR", 27.45), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende05WithSecurityInEUR()
+    {
+        var security = new Security("ISHARES PLCS P GL.CLEAN ENERGY T.-D", "EUR");
+        security.setIsin("IE00B1XNHC34");
+
+        var client = new Client();
+        client.addSecurity(security);
+
+        var extractor = new KBCGroupNVPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende05.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(2L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("BE0003717312"), hasWkn(null), hasTicker(null), //
+                        hasName("CP SOFINA (BR) 27.05.26"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-29T02:37:36"), hasExDate(null), //
+                        hasShares(1000.00), //
+                        hasSource("Dividende05.txt"), //
+                        hasNote("Borderel 067498551"), //
+                        hasAmount("EUR", 11.23), hasGrossValue("EUR", 16.37), //
+                        hasTaxes("EUR", 0.00 + 4.91 + 0.04), hasFees("EUR", 0.19), //
+                        check(tx -> {
+                            var c = new CheckCurrenciesAction();
+                            var account = new Account();
+                            account.setCurrencyCode("EUR");
+                            var s = c.process((AccountTransaction) tx, account);
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-05-29T09:57:53"), hasExDate(null), //
+                        hasShares(25.00), //
+                        hasSource("Dividende05.txt"), //
+                        hasNote("Borderel 067784648"), //
+                        hasAmount("EUR", 64.05), hasGrossValue("EUR", 91.50), //
+                        hasTaxes("EUR", 27.45), hasFees("EUR", 0.00))));
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KBCGroupNVPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/KBCGroupNVPDFExtractor.java
@@ -312,12 +312,28 @@ public class KBCGroupNVPDFExtractor extends AbstractPDFExtractor
                         .match("^.* van (?<shares>[\\.,\\d]+) .*$") //
                         .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
-                        // @formatter:off
-                        // 24/01/2024 Uitbetaling dividenden ISHAR.III CORE EUR Valuta 24/01/2024 2.862,79 EUR
-                        // @formatter:on
-                        .section("date") //
-                        .match("^(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) Uitbetaling dividenden.*$") //
-                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
+                        .oneOf( //
+                                        // @formatter:off
+                                        // 24/01/2024 02:35:28 Valuta 24/01/2024
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date", "time") //
+                                                        .match("^(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}) Valuta [\\d]{2}\\/[\\d]{2}\\/[\\d]{4}.*$") //
+                                                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"), v.get("time")))),
+                                        // @formatter:off
+                                        // Uitvoeringsdatum : 29/01/2025 Uitvoeringstijdstip : 02:35:19 Valuta : 29/01/2025
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date", "time") //
+                                                        .match("^Uitvoeringsdatum : (?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) Uitvoeringstijdstip : (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$") //
+                                                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"), v.get("time")))),
+                                        // @formatter:off
+                                        // 24/01/2024 Uitbetaling dividenden ISHAR.III CORE EUR Valuta 24/01/2024 2.862,79 EUR
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date") //
+                                                        .match("^(?<date>[\\d]{2}\\/[\\d]{2}\\/[\\d]{4}) Uitbetaling dividenden.*$") //
+                                                        .assign((t, v) -> t.setDateTime(asDate(v.get("date")))))
 
                         // @formatter:off
                         // Netto credit 2.862,79 EUR
@@ -364,6 +380,25 @@ public class KBCGroupNVPDFExtractor extends AbstractPDFExtractor
                                                             var fxGross = rate.convert(rate.getBaseCurrency(), gross);
 
                                                             checkAndSetGrossUnit(gross, fxGross, t, type.getCurrentContext());
+                                                        }),
+                                        // @formatter:off
+                                        // Uw Uitbetaling dividenden van 1.000 ISHARES PLCS P GL.CLEAN ENERGY T.-D 19,20 USD
+                                        // aan 0,0192 USD
+                                        // 1 EUR = 1,172292 USD
+                                        // Netto credit 11,23 EUR
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("fxGross", "baseCurrency", "exchangeRate", "termCurrency") //
+                                                        .match("^Uw Uitbetaling dividenden van [\\.,\\d]+ .* (?<fxGross>[\\.,\\d]+) [A-Z]{3}$") //
+                                                        .match("^[\\.,\\d]+ (?<baseCurrency>[A-Z]{3}) = (?<exchangeRate>[\\.,\\d]+) (?<termCurrency>[A-Z]{3})$") //
+                                                        .assign((t, v) -> {
+                                                            var rate = asExchangeRate(v);
+                                                            type.getCurrentContext().putType(rate);
+
+                                                            var fxGross = Money.of(rate.getTermCurrency(), asAmount(v.get("fxGross")));
+                                                            var gross = rate.convert(rate.getBaseCurrency(), fxGross);
+
+                                                            checkAndSetGrossUnit(gross, fxGross, t, type.getCurrentContext());
                                                         }))
 
                         // @formatter:off
@@ -372,6 +407,8 @@ public class KBCGroupNVPDFExtractor extends AbstractPDFExtractor
                         .section("note").optional() //
                         .match("^(?<note>Borderel [\\d]+)$") //
                         .assign((t, v) -> t.setNote(trim(v.get("note"))))
+
+                        .conclude(ExtractorUtils.fixGrossValueA())
 
                         .wrap(TransactionItem::new);
 


### PR DESCRIPTION
Fixes the import failure for KBC/Bolero "Overzicht transacties en rekeninguittreksels" documents containing several dividend borderels. The dividend date section only matched the account-statement lines ("dd/MM/yyyy Uitbetaling dividenden …") at the end of the document — those lines are outside every borderel block except the last one, so the first dividend failed with a missing-date error, and a later block could even pick up the statement line of a preceding dividend.

**Fix**

- The date section is now a three-variant `oneOf`, mirroring the buy/sell section: the execution timestamp inside each borderel block ("dd/MM/yyyy HH:mm:ss Valuta …" or "Uitvoeringsdatum : … Uitvoeringstijdstip : …") wins, with the previous account-statement line kept as a fallback. As a consequence, the existing dividend test cases now assert the execution timestamps instead of `T00:00` (duplicate detection compares dates only, so re-imports are unaffected).
- A third variant in the forex `optionalOneOf` handles the exchange-rate format without the `Wisselkoers` prefix ("1 EUR = 1,172292 USD"), where the gross dividend is printed in the security currency (19,20 USD) and the net credit in the account currency (11,23 EUR).
- Added `.conclude(ExtractorUtils.fixGrossValueA())` to normalize the gross-value unit: converting the taxes and the fee individually yields a gross value of 16,37 EUR while direct conversion of 19,20 USD gives 16,38 EUR. This is a no-op for the existing test documents.
- `hasExDate(null)` added to all dividend assertions.

**Fixture**

- `Dividende05.txt` — the extracted text provided by the issue reporter (two dividend borderels: 1.000 ISHARES GL. CLEAN ENERGY paid in USD and credited as 11,23 EUR, and 25 CP SOFINA entirely in EUR), covered by `testDividende05` and `testDividende05WithSecurityInEUR`.

All 19 tests of `KBCGroupNVPDFExtractorTest` pass.

Closes #5757

🤖 Generated with [Claude Code](https://claude.com/claude-code)