### PR TITLE
Time Machine: allow typing the date in the date selection dialog

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/DateSelectionDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/DateSelectionDialog.java
@@ -14,6 +14,7 @@ import org.eclipse.swt.widgets.DateTime;
 import org.eclipse.swt.widgets.Shell;
 
 import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.util.DatePicker;
 
 public class DateSelectionDialog extends Dialog
 {
@@ -57,14 +58,29 @@ public class DateSelectionDialog extends Dialog
     {
         Composite container = (Composite) super.createDialogArea(parent);
 
-        DateTime dateTime = new DateTime(container, SWT.CALENDAR | SWT.BORDER);
-        dateTime.setDate(selection.getYear(), selection.getMonthValue() - 1, selection.getDayOfMonth());
-        dateTime.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
+        var datePicker = new DatePicker(container, false);
+        datePicker.setSelection(selection);
+        GridDataFactory.fillDefaults().grab(true, false).align(SWT.CENTER, SWT.CENTER)
+                        .applyTo(datePicker.getControl());
+
+        var calendar = new DateTime(container, SWT.CALENDAR | SWT.BORDER);
+        calendar.setDate(selection.getYear(), selection.getMonthValue() - 1, selection.getDayOfMonth());
+
+        datePicker.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
+            selection = datePicker.getSelection();
             // DateTime widget has zero-based months
-            selection = LocalDate.of(dateTime.getYear(), dateTime.getMonth() + 1, dateTime.getDay());
+            calendar.setDate(selection.getYear(), selection.getMonthValue() - 1, selection.getDayOfMonth());
             DateSelectionDialog.this.getButton(OK).setEnabled(validator.test(selection));
         }));
-        GridDataFactory.fillDefaults().grab(true, true).align(SWT.CENTER, SWT.FILL).applyTo(dateTime);
+
+        calendar.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
+            // DateTime widget has zero-based months
+            selection = LocalDate.of(calendar.getYear(), calendar.getMonth() + 1, calendar.getDay());
+            datePicker.setSelection(selection);
+            DateSelectionDialog.this.getButton(OK).setEnabled(validator.test(selection));
+        }));
+
+        GridDataFactory.fillDefaults().grab(true, true).align(SWT.CENTER, SWT.FILL).applyTo(calendar);
 
         return container;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/DatePicker.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/DatePicker.java
@@ -11,6 +11,7 @@ import org.eclipse.nebula.widgets.cdatetime.CDateTime;
 import org.eclipse.nebula.widgets.cdatetime.CDateTimeBuilder;
 import org.eclipse.nebula.widgets.cdatetime.Footer;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.DateTime;
@@ -30,23 +31,33 @@ public class DatePicker
 
     public DatePicker(Composite parent)
     {
+        this(parent, true);
+    }
+
+    public DatePicker(Composite parent, boolean dropDown)
+    {
         boolean isLinux = Platform.OS_LINUX.equals(Platform.getOS());
 
         if (isLinux)
         {
-            CDateTime boxDate = new CDateTime(parent, CDT.BORDER | CDT.DROP_DOWN);
+            CDateTime boxDate = new CDateTime(parent, dropDown ? CDT.BORDER | CDT.DROP_DOWN : CDT.BORDER);
             boxDate.setFormat(CDT.DATE_MEDIUM);
-            boxDate.setButtonImage(Images.CALENDAR_OFF.image());
 
-            CDateTimeBuilder builder = CDateTimeBuilder.getStandard();
-            builder.setFooter(Footer.Today());
-            boxDate.setBuilder(builder);
+            if (dropDown)
+            {
+                boxDate.setButtonImage(Images.CALENDAR_OFF.image());
+
+                CDateTimeBuilder builder = CDateTimeBuilder.getStandard();
+                builder.setFooter(Footer.Today());
+                boxDate.setBuilder(builder);
+            }
 
             this.control = boxDate;
         }
         else
         {
-            this.control = new DateTime(parent, SWT.DATE | SWT.DROP_DOWN | SWT.BORDER);
+            this.control = new DateTime(parent, dropDown ? SWT.DATE | SWT.DROP_DOWN | SWT.BORDER
+                            : SWT.DATE | SWT.BORDER);
         }
     }
 
@@ -92,6 +103,14 @@ public class DatePicker
             // DateTime widget has zero-based months
             return LocalDate.of(dateTime.getYear(), dateTime.getMonth() + 1, dateTime.getDay());
         }
+    }
+
+    public void addSelectionListener(SelectionListener listener)
+    {
+        if (control instanceof CDateTime cdatetime)
+            cdatetime.addSelectionListener(listener);
+        else
+            ((DateTime) control).addSelectionListener(listener);
     }
 
     public void setLayoutData(Object layoutData)


### PR DESCRIPTION
The Time Machine's "Pick other date" dialog only offered a calendar grid, so selecting a date a few years back required many clicks through the months. This change adds a typeable date field above the calendar: the date — including the year — can now be entered directly, and the field and the calendar stay in sync in both directions.

The field reuses the existing cross-platform `DatePicker` widget (native `DateTime` on macOS/Windows, `CDateTime` on Linux), created without its drop-down calendar button since the dialog already shows a calendar. `DatePicker` gains a field-only constructor variant and an `addSelectionListener` method; the one-argument constructor is unchanged, so all existing `DatePicker` and `DateSelectionDialog` callers keep their current behavior.

<img width="240" height="284" alt="PP datepicker with manual override" src="https://github.com/user-attachments/assets/43c85b18-ef6d-413c-a4e7-697d9a476c44" />

Issue: https://forum.portfolio-performance.info/t/direkte-datumseingabe-in-portfolio-time-machine/38803
