### PR TITLE
fixed bug found by sonar (and a couple more) in FormattingPreferenceStore

### DIFF
--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/preferences/FormattingPreferenceStoreTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/preferences/FormattingPreferenceStoreTest.java
@@ -1,0 +1,246 @@
+package name.abuchen.portfolio.ui.preferences;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.stream.Collectors;
+
+import org.eclipse.jface.util.IPropertyChangeListener;
+import org.junit.Test;
+
+import name.abuchen.portfolio.model.Client;
+
+@SuppressWarnings("nls")
+public class FormattingPreferenceStoreTest
+{
+
+    @Test
+    public void testAsString()
+    {
+        var store = new ClientPropertiesPreferenceStore(new Client());
+
+        assertThat(store.asString(null), is(""));
+        assertThat(store.asString("  "), is("  "));
+        assertThat(store.asString(" abc "), is(" abc "));
+    }
+
+    @Test
+    public void testAsDouble()
+    {
+        var store = new ClientPropertiesPreferenceStore(new Client());
+
+        assertThat(store.asDouble(null), is(0d));
+        assertThat(store.asDouble("  "), is(0d));
+        assertThat(store.asDouble(" abc "), is(0d));
+        assertThat(store.asDouble(" 123.45 "), is(123.45d));
+        assertThat(store.asDouble(" -123.45 "), is(-123.45d));
+    }
+
+    @Test
+    public void testAsFloat()
+    {
+        var store = new ClientPropertiesPreferenceStore(new Client());
+
+        assertThat(store.asFloat(null), is(0f));
+        assertThat(store.asFloat("  "), is(0f));
+        assertThat(store.asFloat(" abc "), is(0f));
+        assertThat(store.asFloat(" 123.45 "), is(123.45f));
+        assertThat(store.asFloat(" -123.45 "), is(-123.45f));
+    }
+
+    @Test
+    public void testAsInt()
+    {
+        var store = new ClientPropertiesPreferenceStore(new Client());
+
+        assertThat(store.asInt(null), is(0));
+        assertThat(store.asInt("  "), is(0));
+        assertThat(store.asInt(" abc "), is(0));
+        assertThat(store.asInt(" 123.45 "), is(0));
+        assertThat(store.asInt(" -123.45 "), is(0));
+        assertThat(store.asInt(" 123 "), is(123));
+        assertThat(store.asInt(" -123 "), is(-123));
+    }
+
+    @Test
+    public void testAsLong()
+    {
+        var store = new ClientPropertiesPreferenceStore(new Client());
+
+        assertThat(store.asLong(null), is(0L));
+        assertThat(store.asLong("  "), is(0L));
+        assertThat(store.asLong(" abc "), is(0L));
+        assertThat(store.asLong(" 123.45 "), is(0L));
+        assertThat(store.asLong(" -123.45 "), is(0L));
+        assertThat(store.asLong(" 123 "), is(123L));
+        assertThat(store.asLong(" -123 "), is(-123L));
+    }
+
+    @Test
+    public void testAsBoolean()
+    {
+        var store = new ClientPropertiesPreferenceStore(new Client());
+
+        assertThat(store.asBoolean(null), is(false));
+        assertThat(store.asBoolean("  "), is(false));
+        assertThat(store.asBoolean(" abc "), is(false));
+        assertThat(store.asBoolean(" true "), is(true));
+        assertThat(store.asBoolean(" false "), is(false));
+        assertThat(store.asBoolean(" 1 "), is(false));
+        assertThat(store.asBoolean(" -1 "), is(false));
+    }
+
+    @Test
+    public void testSetGetValues()
+    {
+        var messages = new LinkedList<String>();
+        var store = new ClientPropertiesPreferenceStore(new Client());
+        IPropertyChangeListener listener = e -> {
+            messages.add("event triggered: " + e.getProperty() + " " + e.getOldValue() + " -> " + e.getNewValue());
+        };
+        store.addPropertyChangeListener(listener);
+
+        checkInitialValues(store);
+
+        checkAndResetNeedSaving(store, false);
+
+        store.setDefault("dfltbool", true);
+        store.setDefault("dfltint", 1);
+        store.setDefault("dfltlong", 2L);
+        store.setDefault("dfltfloat", 3.4);
+        store.setDefault("dfltdouble", 5.6);
+        store.setDefault("dfltstring", " some string ");
+
+        checkAndResetNeedSaving(store, false);
+
+        setNonDefaultValues(store, true);
+        var msgs = messages.stream().collect(Collectors.joining("\n"));
+        messages.clear();
+        assertThat(msgs, is("""
+                        event triggered: bool false -> true
+                        event triggered: int 0 -> 7
+                        event triggered: long 0 -> 8
+                        event triggered: float 0.0 -> 9.1
+                        event triggered: double 0.0 -> 10.2
+                        event triggered: string  ->  some non-default string \
+                        """));
+
+        checkChangedValues(store);
+
+        setNonDefaultValues(store, false);
+        assertThat(messages.stream().collect(Collectors.joining("\n")), is(""));
+        checkChangedValues(store);
+
+        store.putValue("somekey", "some value");
+        assertThat(messages.stream().collect(Collectors.joining("\n")), is(""));
+        assertThat(store.getString("somekey"), is("some value"));
+
+        store.removePropertyChangeListener(listener);
+        store.setValue("somekey", "some new value");
+        assertThat(messages.stream().collect(Collectors.joining("\n")), is(""));
+        assertThat(store.getString("somekey"), is("some new value"));
+    }
+
+    private void checkChangedValues(ClientPropertiesPreferenceStore store)
+    {
+        assertThat(store.getDefaultBoolean("dfltbool"), is(true));
+        assertThat(store.getDefaultInt("dfltint"), is(1));
+        assertThat(store.getDefaultLong("dfltlong"), is(2L));
+        assertThat(store.getDefaultFloat("dfltfloat"), is(3.4f));
+        assertThat(store.getDefaultDouble("dfltdouble"), is(5.6d));
+        assertThat(store.getDefaultString("dfltstring"), is(" some string "));
+
+        assertThat(store.getBoolean("bool"), is(true));
+        assertThat(store.getInt("int"), is(7));
+        assertThat(store.getLong("long"), is(8L));
+        assertThat(store.getFloat("float"), is(9.1f));
+        assertThat(store.getDouble("double"), is(10.2d));
+        assertThat(store.getString("string"), is(" some non-default string "));
+    }
+
+    private void checkInitialValues(ClientPropertiesPreferenceStore store)
+    {
+        assertThat(store.getDefaultBoolean("dfltbool"), is(false));
+        assertThat(store.getDefaultInt("dfltint"), is(0));
+        assertThat(store.getDefaultLong("dfltlong"), is(0L));
+        assertThat(store.getDefaultFloat("dfltfloat"), is(0f));
+        assertThat(store.getDefaultDouble("dfltdouble"), is(0d));
+        assertThat(store.getDefaultString("dfltstring"), is(""));
+
+        assertThat(store.getBoolean("bool"), is(false));
+        assertThat(store.getInt("int"), is(0));
+        assertThat(store.getLong("long"), is(0L));
+        assertThat(store.getFloat("float"), is(0f));
+        assertThat(store.getDouble("double"), is(0d));
+        assertThat(store.getString("string"), is(""));
+    }
+
+    private void setNonDefaultValues(ClientPropertiesPreferenceStore store, boolean expDirty)
+    {
+        store.setValue("bool", true);
+        checkAndResetNeedSaving(store, expDirty);
+        store.setValue("int", 7);
+        checkAndResetNeedSaving(store, expDirty);
+        store.setValue("long", 8L);
+        checkAndResetNeedSaving(store, expDirty);
+        store.setValue("float", 9.1f);
+        checkAndResetNeedSaving(store, expDirty);
+        store.setValue("double", 10.2d);
+        checkAndResetNeedSaving(store, expDirty);
+        store.setValue("string", " some non-default string ");
+        checkAndResetNeedSaving(store, expDirty);
+    }
+
+    private void checkAndResetNeedSaving(ClientPropertiesPreferenceStore store, boolean expValue)
+    {
+        assertThat(store.needsSaving(), is(expValue));
+        store.resetDirty();
+    }
+
+    @Test
+    public void testIsDefault()
+    {
+        var store = new ClientPropertiesPreferenceStore(new Client());
+        store.setDefault("dfltbool", true);
+        store.setDefault("dfltint", 1);
+        store.setDefault("dfltlong", 2L);
+        store.setDefault("dfltfloat", 3.4f);
+        store.setDefault("dfltdouble", 5.6d);
+        store.setDefault("dfltstring", " some string ");
+
+        store.setValue("bool", true);
+        store.setValue("int", 7);
+        store.setValue("long", 8L);
+        store.setValue("float", 9.1f);
+        store.setValue("double", 10.2d);
+        store.setValue("string", " some non-default string ");
+
+        String[] defaultIdents = { "dfltbool", "dfltint", "dfltlong", "dfltfloat", "dfltdouble", "dfltstring" };
+        String[] nonDefaultIdents = { "bool", "int", "long", "float", "double", "string" };
+
+        Arrays.stream(defaultIdents) //
+                        .forEach(ident -> assertThat(ident, store.isDefault(ident), is(true)));
+        Arrays.stream(nonDefaultIdents) //
+                        .forEach(ident -> assertThat(ident, store.isDefault(ident), is(false)));
+        assertThat(store.isDefault("dummy"), is(false));
+
+        store.setValue("dfltbool", true);
+        store.setValue("dfltint", 2);
+        store.setValue("dfltlong", 3);
+        store.setValue("dfltfloat", 5.1);
+        store.setValue("dfltdouble", 6.2);
+        store.setValue("dfltstring", " some other non-default string ");
+
+        Arrays.stream(defaultIdents) //
+                        .forEach(ident -> {
+                            assertThat(ident, store.isDefault(ident), is(false));
+                            store.setToDefault(ident);
+                            assertThat(ident, store.isDefault(ident), is(true));
+                        });
+
+        store.setToDefault("dummy");
+        assertThat(store.isDefault("dummy"), is(false));
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/FormattingPreferencePage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/FormattingPreferencePage.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.jface.preference.ComboFieldEditor;
@@ -14,7 +15,7 @@ import org.eclipse.jface.preference.IntegerFieldEditor;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
 
-import com.google.common.base.Objects;
+import com.google.common.annotations.VisibleForTesting;
 
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ClientProperties;
@@ -104,7 +105,7 @@ class ClientPropertiesPreferenceStore implements IPreferenceStore
     public void setValue(String name, String value)
     {
         var oldValue = getString(name);
-        if (!Objects.equal(oldValue, value))
+        if (!Objects.equals(oldValue, value))
         {
             client.setProperty(name, value);
             isDirty = true;
@@ -115,8 +116,8 @@ class ClientPropertiesPreferenceStore implements IPreferenceStore
     @Override
     public void setValue(String name, long value)
     {
-        var oldValue = getString(name);
-        if (!Objects.equal(oldValue, value))
+        var oldValue = getLong(name);
+        if (!Objects.equals(oldValue, value))
         {
             client.setProperty(name, Long.toString(value));
             isDirty = true;
@@ -128,8 +129,8 @@ class ClientPropertiesPreferenceStore implements IPreferenceStore
     @Override
     public void setValue(String name, int value)
     {
-        var oldValue = getString(name);
-        if (!Objects.equal(oldValue, value))
+        var oldValue = getInt(name);
+        if (!Objects.equals(oldValue, value))
         {
             client.setProperty(name, Integer.toString(value));
             isDirty = true;
@@ -140,8 +141,8 @@ class ClientPropertiesPreferenceStore implements IPreferenceStore
     @Override
     public void setValue(String name, float value)
     {
-        var oldValue = getString(name);
-        if (!Objects.equal(oldValue, value))
+        var oldValue = getFloat(name);
+        if (!Objects.equals(oldValue, value))
         {
             client.setProperty(name, Float.toString(value));
             isDirty = true;
@@ -152,8 +153,8 @@ class ClientPropertiesPreferenceStore implements IPreferenceStore
     @Override
     public void setValue(String name, double value)
     {
-        var oldValue = getString(name);
-        if (!Objects.equal(oldValue, value))
+        var oldValue = getDouble(name);
+        if (!Objects.equals(oldValue, value))
         {
             client.setProperty(name, Double.toString(value));
             isDirty = true;
@@ -164,8 +165,8 @@ class ClientPropertiesPreferenceStore implements IPreferenceStore
     @Override
     public void setValue(String name, boolean value)
     {
-        var oldValue = getString(name);
-        if (!Objects.equal(oldValue, value))
+        var oldValue = getBoolean(name);
+        if (!Objects.equals(oldValue, value))
         {
             client.setProperty(name, Boolean.toString(value));
             isDirty = true;
@@ -226,6 +227,12 @@ class ClientPropertiesPreferenceStore implements IPreferenceStore
         return isDirty;
     }
 
+    @VisibleForTesting
+    void resetDirty()
+    {
+        isDirty = false;
+    }
+
     @Override
     public boolean isDefault(String name)
     {
@@ -247,25 +254,25 @@ class ClientPropertiesPreferenceStore implements IPreferenceStore
     @Override
     public int getInt(String name)
     {
-        return getInt(client.getProperty(name));
+        return asInt(client.getProperty(name));
     }
 
     @Override
     public float getFloat(String name)
     {
-        return getFloat(client.getProperty(name));
+        return asFloat(client.getProperty(name));
     }
 
     @Override
     public double getDouble(String name)
     {
-        return getDouble(client.getProperty(name));
+        return asDouble(client.getProperty(name));
     }
 
     @Override
     public boolean getBoolean(String name)
     {
-        return getBoolean(client.getProperty(name));
+        return asBoolean(client.getProperty(name));
     }
 
     @Override
@@ -310,18 +317,20 @@ class ClientPropertiesPreferenceStore implements IPreferenceStore
         return client.getProperty(name) != null;
     }
 
-    private String asString(String value)
+    @VisibleForTesting
+    String asString(String value)
     {
-        return value == null ? "" : value; //$NON-NLS-1$
+        return Objects.toString(value, ""); //$NON-NLS-1$
     }
 
-    private double asDouble(String value)
+    @VisibleForTesting
+    double asDouble(String value)
     {
         if (value == null)
             return 0;
         try
         {
-            return Double.parseDouble(value);
+            return Double.parseDouble(value.trim());
         }
         catch (NumberFormatException e)
         {
@@ -329,13 +338,14 @@ class ClientPropertiesPreferenceStore implements IPreferenceStore
         }
     }
 
-    private float asFloat(String value)
+    @VisibleForTesting
+    float asFloat(String value)
     {
         if (value == null)
             return 0;
         try
         {
-            return Float.parseFloat(value);
+            return Float.parseFloat(value.trim());
         }
         catch (NumberFormatException e)
         {
@@ -343,13 +353,14 @@ class ClientPropertiesPreferenceStore implements IPreferenceStore
         }
     }
 
-    private int asInt(String value)
+    @VisibleForTesting
+    int asInt(String value)
     {
         if (value == null)
             return 0;
         try
         {
-            return Integer.parseInt(value);
+            return Integer.parseInt(value.trim());
         }
         catch (NumberFormatException e)
         {
@@ -357,13 +368,14 @@ class ClientPropertiesPreferenceStore implements IPreferenceStore
         }
     }
 
-    private long asLong(String value)
+    @VisibleForTesting
+    long asLong(String value)
     {
         if (value == null)
             return 0;
         try
         {
-            return Long.parseLong(value);
+            return Long.parseLong(value.trim());
         }
         catch (NumberFormatException e)
         {
@@ -371,10 +383,11 @@ class ClientPropertiesPreferenceStore implements IPreferenceStore
         }
     }
 
-    private boolean asBoolean(String value)
+    @VisibleForTesting
+    boolean asBoolean(String value)
     {
         if (value == null)
             return false;
-        return Boolean.parseBoolean(value);
+        return Boolean.parseBoolean(value.trim());
     }
 }


### PR DESCRIPTION
Having checked the blocker-entries [reported by Sonar](https://sonarcloud.io/project/issues?open=AZJ_bIlzitd4gtZo2PMI&id=name.abuchen.portfolio%3Aportfolio-app), I came across FormattingPreferenceStore where the complaint actually is due to a bug leading to a non-terminating recursive call.

I took the liberty to fix that and created tests around the class. This brought up more things:

 - All non-String setValue-methods are calling `google.Objects.equal` passing a `String` and the non-String value which always returns `false` treating every value as a new one and the store as dirty.
 - Since `google.Objects.equal` simply calls `java.lang.Objects.equals` I've changed it to directly call it. Fun fact: Above problem show up as a warning that we're comparing different types when using `java.util.Objects`.
 - Most non-String getType-methods called `getType` instead of `asType` leading to the same recursion Sonar complained about in `getBoolean`.
 - Because `parseDouble` and `parseFloat` do an internal trim before parsing, I've added these trims to `asInt` and `asLong` to have the same behavior.
