### PR TITLE
UmweltBank: support Kontoauszug account statements

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/umweltbankag/Kontoauszug01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/umweltbankag/Kontoauszug01.txt
@@ -1,0 +1,65 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.83.2
+System: macosx | aarch64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+UmweltFlexkonto
+EUR-Konto Kontonummer 0050413
+UmweltBank AG
+Laufertorgraben 6 * 90489 Nürnberg K o n to a u s z u g Nr.  4/2026
+erstellt am 30.04.2026 22:26 Blatt  1 von 1
+IBAN: iW61 3898 5430 6126 3320 43 BIC: UMWEDE7NXXX
+Frau
+Tg. mCKEyz TaYzbfdB VtPgbU Ihr Berater: Service UmweltBank
+tw rgRiXFbtOIn 9
+12373 mVvcqZ
+Bu-Tag Wert Vorgang
+alter Kontostand vom 31.03.2026  5.268,24 H
+10.04. 10.04. Dauerauftragsgutschr 200,00 H
+ ZeeWke NSCcip
+ für Anleihe-Sparplan zum 15. monatlich
+17.04. 17.04. Effekten  200,00 S
+ UmweltBank AG
+ WERTPAPIERABRECHNUNG
+ KAUF WKN A41CHM / LU3093383670
+ UMWELTBA-GR.SO.BD EO PEOD DEPOTNR.: 64666451
+ HANDELSTAG 15.04.2026 MENGE 20,0224
+ KURS 9,98880000 AUFTRAGSNR. 9028797680
+                                    ──────────────────────────────────────────────────────
+ neuer Kontostand vom 30.04.2026 5.268,24 H
+                                    ──────────────────────────────────────────────────────
+ Bleiben Sie informiert: umweltbank.de/newsletter
+0112
+403
+H27515774
+5M Bitte beachten S ie die Hinweise auf der Rückseite oder am Ende des Dokuments
+Sehr geehrte Kundin, sehr geehrter Kunde,
+Sie haben eine B ankmitteilung erhalten, z. B . einen Kontoauszug, einen Sparkontoauszug oder eine Dividendenabrechnung. B itte
+prüfen Sie diese genau: Ist alles korrekt?  Falls  nicht, sprechen Sie uns bitte an. Damit S ie immer gut informiert s ind und wissen, wie
+S ie Ihre B ankmitteilung "richtig lesen", haben wir diese nützlichen Hinweise für S ie zusammengestellt:
+Falls  in diesem Dokument B ankdienstleistungen aufgeführt s ind, s ind diese umsatzsteuerfrei - sofern nichts Abweichendes angegeben
+ist. Der im Kontoauszug ausgewiesene B etrag muss nicht dem tatsächlichen Kontoguthaben entsprechen, weil z. B . die Wertstellung
+einzelner B uchungen nicht berücksichtigt wurde oder noch Zinsen für eine Kontoüberziehung bei einer Verfügung anfallen können.
+Rechnungsabschlüsse
+Ihr Kontoauszug ist mit dem Hinweis "Rechnungsabschluss" versehen?
+Dann haben wir für Ihr Konto einen Rechnungsabschluss durchgeführt, einschließlich Zinsen und Entgelte. Alle weiteren, nach dem
+Erstellungsdatum dieser Mitteilung anfallenden Umsätze und Kontoauszüge werden erst in der folgenden Abrechnung
+berücksichtigt - auch wenn sie s ich auf den Abrechnungssaldo des abgelaufenen Abrechnungszeitraumes auswirken.
+Korrekturen werden gekennzeichnet. Den Rechnungsabschluss können Sie beim Finanzamt vorlegen.
+Einwendungen
+Sie haben Einwendungen gegen den Rechnungsabschluss Ihres Kontokorrentkontos oder den Inhalt des Sparkontoauszugs? Dann
+haben Sie nach Erhalt sechs Wochen Zeit, uns zu informieren. Sonst gilt der Rechnungsabschluss zum Kontokorrentkonto oder der
+Sparkontoauszug als  genehmigt. Wenn Sie ihre Einwendungen in Textform geltend machen, z. B . per E-Mail oder B rief, so genügt die
+Absendung innerhalb von sechs Wochen nach Erhalt.
+Einzugsaufträge
+Einzugspapiere wie z. B . Schecks und Lastschriften werden unter dem Vorbehalt des Eingangs gutgeschrieben, und zwar auch
+dann, wenn diese Papiere bei uns selbst zahlbar s ind.
+Schecks und Lastschriften sind erst eingelöst, wenn die B elastungsbuchung nicht spätestens am zweiten B ankarbeitstag - bei
+Lastschriften im SEPA-Firmen-Lastschriftverfahren nicht spätestens am dritten B ankarbeitstag - nach ihrer Vornahme rückgängig
+gemacht wird. B arschecks s ind bereits  mit Zahlung an den Scheckvorleger eingelöst. Schecks s ind auch schon dann eingelöst,
+wenn wir im Einzelfall eine B ezahltmeldung absenden.
+Guthaben
+Guthaben sind als  Einlagen nach Maßgabe des Einlagensicherungsgesetzes entschädigungsfähig. Nähere Informationen können dem
+"Informationsbogen für den Einleger" entnommen werden.
+Sie haben noch Fragen? Dann kontaktieren Sie uns bitte. Wir s ind gern für S ie da.
+Mit freundlichen Grüßen
+Ihre B ank

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/umweltbankag/UmweltbankAGPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/umweltbankag/UmweltbankAGPDFExtractorTest.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf.umweltbankag;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
@@ -105,5 +106,43 @@ public class UmweltbankAGPDFExtractorTest
                         hasNote("Auftragsnummer 653140/64.00"), //
                         hasAmount("EUR", 13040.15 - 380.70), hasGrossValue("EUR", 13040.15 - 380.70 - 247.76), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 247.76))));
+    }
+
+    @Test
+    public void testKontoauszug01()
+    {
+        var extractor = new UmweltbankAGPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kontoauszug01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("LU3093383670"), hasWkn("A41CHM"), hasTicker(null), //
+                        hasName("UMWELTBA-GR.SO.BD EO PEOD"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-04-15"), hasShares(20.0224), //
+                        hasSource("Kontoauszug01.txt"), //
+                        hasNote("Auftragsnummer 9028797680"), //
+                        hasAmount("EUR", 200.00), hasGrossValue("EUR", 200.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check deposit transaction
+        assertThat(results, hasItem(deposit(hasDate("2026-04-10"), hasAmount("EUR", 200.00), //
+                        hasSource("Kontoauszug01.txt"), hasNote("Dauerauftragsgutschrift"))));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UmweltbankAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/UmweltbankAGPDFExtractor.java
@@ -6,6 +6,7 @@ import static name.abuchen.portfolio.util.TextUtil.trim;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
+import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
@@ -36,6 +37,7 @@ public class UmweltbankAGPDFExtractor extends AbstractPDFExtractor
         addBankIdentifier("UmweltBank AG");
 
         addBuySellTransaction();
+        addAccountStatementTransaction();
     }
 
     @Override
@@ -135,6 +137,113 @@ public class UmweltbankAGPDFExtractor extends AbstractPDFExtractor
                         .wrap(BuySellEntryItem::new);
 
         addFeesSectionsTransaction(pdfTransaction, type);
+    }
+
+    private void addAccountStatementTransaction()
+    {
+        final var type = new DocumentType("[A-Z]{3}\\-Konto Kontonummer", //
+                        documentContext -> documentContext //
+                                        // @formatter:off
+                                        // EUR-Konto Kontonummer 0050413
+                                        // @formatter:on
+                                        .section("currency") //
+                                        .match("^(?<currency>[A-Z]{3})\\-Konto Kontonummer.*$") //
+                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency"))))
+
+                                        // @formatter:off
+                                        // Laufertorgraben 6 * 90489 Nürnberg K o n to a u s z u g Nr.  4/2026
+                                        // @formatter:on
+                                        .section("year") //
+                                        .match("^.* Nr\\.[\\s]{1,}[\\d]{1,2}\\/(?<year>[\\d]{4})$") //
+                                        .assign((ctx, v) -> ctx.put("year", v.get("year"))));
+        this.addDocumentTyp(type);
+
+        // @formatter:off
+        // 10.04. 10.04. Dauerauftragsgutschr 200,00 H
+        //  ZeeWke NSCcip
+        //  für Anleihe-Sparplan zum 15. monatlich
+        // @formatter:on
+        var depositRemovalBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. Dauerauftragsgutschr[\\s]{1,}[\\.,\\d]+ [S|H]$");
+        type.addBlock(depositRemovalBlock);
+        depositRemovalBlock.set(new Transaction<AccountTransaction>()
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
+
+                        .section("date", "amount", "type") //
+                        .documentContext("currency", "year") //
+                        .match("^(?<date>[\\d]{2}\\.[\\d]{2}\\.) [\\d]{2}\\.[\\d]{2}\\. Dauerauftragsgutschr[\\s]{1,}(?<amount>[\\.,\\d]+) (?<type>[S|H])$") //
+                        .assign((t, v) -> {
+                            // @formatter:off
+                            // Is type --> "S" change from DEPOSIT to REMOVAL
+                            // @formatter:on
+                            if ("S".equals(v.get("type")))
+                                t.setType(AccountTransaction.Type.REMOVAL);
+
+                            t.setDateTime(asDate(v.get("date") + v.get("year")));
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setCurrencyCode(v.get("currency"));
+                            t.setNote("Dauerauftragsgutschrift");
+                        })
+
+                        .wrap(TransactionItem::new));
+
+        // @formatter:off
+        // 17.04. 17.04. Effekten  200,00 S
+        //  UmweltBank AG
+        //  WERTPAPIERABRECHNUNG
+        //  KAUF WKN A41CHM / LU3093383670
+        //  UMWELTBA-GR.SO.BD EO PEOD DEPOTNR.: 64666451
+        //  HANDELSTAG 15.04.2026 MENGE 20,0224
+        //  KURS 9,98880000 AUFTRAGSNR. 9028797680
+        // @formatter:on
+        var buyBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. Effekten[\\s]{1,}[\\.,\\d]+ S$");
+        type.addBlock(buyBlock);
+        buyBlock.set(new Transaction<BuySellEntry>()
+
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
+
+                        // @formatter:off
+                        // KAUF WKN A41CHM / LU3093383670
+                        // UMWELTBA-GR.SO.BD EO PEOD DEPOTNR.: 64666451
+                        // @formatter:on
+                        .section("wkn", "isin", "name") //
+                        .documentContext("currency") //
+                        .match("^([\\s]+)?KAUF[\\s]{1,}WKN (?<wkn>[A-Z0-9]{6}) \\/ (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                        .match("^([\\s]+)?(?<name>.*)[\\s]{1,}DEPOTNR\\.:[\\s]{1,}[\\d]+$") //
+                        .assign((t, v) -> {
+                            v.put("name", trim(v.get("name")));
+                            t.setSecurity(getOrCreateSecurity(v));
+                        })
+
+                        // @formatter:off
+                        // HANDELSTAG 15.04.2026 MENGE 20,0224
+                        // @formatter:on
+                        .section("date", "shares") //
+                        .match("^([\\s]+)?HANDELSTAG (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})[\\s]{1,}MENGE[\\s]{1,}(?<shares>[\\.,\\d]+)$") //
+                        .assign((t, v) -> {
+                            t.setDate(asDate(v.get("date")));
+                            t.setShares(asShares(v.get("shares")));
+                        })
+
+                        // @formatter:off
+                        // 17.04. 17.04. Effekten  200,00 S
+                        // @formatter:on
+                        .section("amount") //
+                        .documentContext("currency") //
+                        .match("^[\\d]{2}\\.[\\d]{2}\\. [\\d]{2}\\.[\\d]{2}\\. Effekten[\\s]{1,}(?<amount>[\\.,\\d]+) S$") //
+                        .assign((t, v) -> {
+                            t.setCurrencyCode(v.get("currency"));
+                            t.setAmount(asAmount(v.get("amount")));
+                        })
+
+                        // @formatter:off
+                        // KURS 9,98880000 AUFTRAGSNR. 9028797680
+                        // @formatter:on
+                        .section("note").optional() //
+                        .match("^([\\s]+)?KURS [\\.,\\d]+[\\s]{1,}AUFTRAGSNR\\.[\\s]{1,}(?<note>.*)$") //
+                        .assign((t, v) -> t.setNote("Auftragsnummer " + trim(v.get("note"))))
+
+                        .wrap(BuySellEntryItem::new));
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)


### PR DESCRIPTION
Adds support for UmweltBank AG settlement-account statements (UmweltFlexkonto Kontoauszug), which previously could not be read.

- Deposits: `Dauerauftragsgutschr` bookings
- Securities purchases: `Effekten` bookings, using the embedded WERTPAPIERABRECHNUNG details (WKN/ISIN, security name, shares from MENGE, trade date from HANDELSTAG)

New test fixture and test case included (statement text taken from the issue report).

Closes #5695