### PR TITLE
Add explicit cost method calculation APIs

### DIFF
--- a/name.abuchen.portfolio.tests/src/issues/Issue1498FifoCrossPortfolioTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue1498FifoCrossPortfolioTest.java
@@ -56,7 +56,7 @@ public class Issue1498FifoCrossPortfolioTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1150))));
 
         // pinned values previously verified via SecurityPerformanceSnapshotComparator
-        assertThat(record.getSharesHeld(), is(6000000000L));
+        assertThat(record.getSharesHeld(name.abuchen.portfolio.model.CostMethod.FIFO), is(6000000000L));
         assertThat(record.getMarketValue(), is(Money.of("EUR", 60000L))); //$NON-NLS-1$
         assertThat(record.getQuote(), is(Quote.of("EUR", 1000000000L))); //$NON-NLS-1$
         assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of("EUR", 99345L))); //$NON-NLS-1$
@@ -92,7 +92,7 @@ public class Issue1498FifoCrossPortfolioTest
         assertThat(record.getUnrealizedCapitalGains(CostMethod.MOVING_AVERAGE).getCapitalGains(),
                         is(Money.of("EUR", -39345L))); //$NON-NLS-1$
 
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, period);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, period, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         // losses:
         // purchase #1 10 shares à 15 -> 50 EUR loss

--- a/name.abuchen.portfolio.tests/src/issues/Issue1817CapitalGainsOnFilteredClientIfSecurityIsTransferredTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue1817CapitalGainsOnFilteredClientIfSecurityIsTransferredTest.java
@@ -37,7 +37,7 @@ public class Issue1817CapitalGainsOnFilteredClientIfSecurityIsTransferredTest
 
         Client filteredClient = filter.filter(client);
 
-        ClientPerformanceSnapshot clientSnapshot = new ClientPerformanceSnapshot(filteredClient, converter, period);
+        ClientPerformanceSnapshot clientSnapshot = new ClientPerformanceSnapshot(filteredClient, converter, period, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         ClientPerformanceSnapshotTest.assertThatCalculationWorksOut(clientSnapshot, converter);
     }

--- a/name.abuchen.portfolio.tests/src/issues/Issue1879DividendRateOfReturnPerYearWithSecurityInMultipleAccountsTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue1879DividendRateOfReturnPerYearWithSecurityInMultipleAccountsTest.java
@@ -43,14 +43,15 @@ public class Issue1879DividendRateOfReturnPerYearWithSecurityInMultipleAccountsT
 
         assertThat(record.getDividendEventCount(), is(2));
 
-        assertThat(record.getRateOfReturnPerYear(), is(IsCloseTo.closeTo(0.096466, 0.000001)));
+        assertThat(record.getRateOfReturnPerYear(name.abuchen.portfolio.model.CostMethod.MOVING_AVERAGE), is(IsCloseTo.closeTo(0.096466, 0.000001)));
 
         record.getLineItems().stream().filter(item -> item instanceof DividendPayment).map(DividendPayment.class::cast)
-                        .forEach(payment -> assertThat(payment.getPersonalDividendYieldMovingAverage(),
+                        .forEach(payment -> assertThat(
+                                        record.getPersonalDividendYield(payment, CostMethod.MOVING_AVERAGE),
                                         is(IsCloseTo.closeTo(0.096466, 0.000001))));
 
         // pinned values previously verified via SecurityPerformanceSnapshotComparator
-        assertThat(record.getSharesHeld(), is(20000000000L));
+        assertThat(record.getSharesHeld(name.abuchen.portfolio.model.CostMethod.FIFO), is(20000000000L));
         assertThat(record.getMarketValue(), is(Money.of("EUR", 80120L))); //$NON-NLS-1$
         assertThat(record.getQuote(), is(Quote.of("EUR", 400600000L))); //$NON-NLS-1$
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of("EUR", 82930L))); //$NON-NLS-1$

--- a/name.abuchen.portfolio.tests/src/issues/Issue1897AddFeesToDividendTransactionsTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue1897AddFeesToDividendTransactionsTest.java
@@ -63,7 +63,7 @@ public class Issue1897AddFeesToDividendTransactionsTest
 
         // test that taxes and fees are properly sorted
 
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, period);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, period, name.abuchen.portfolio.model.CostMethod.FIFO);
         ClientPerformanceSnapshot.Category feesCategory = snapshot.getCategoryByType(CategoryType.FEES);
 
         assertThat(feesCategory.getValuation(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10.0 + 5.0))));
@@ -81,7 +81,7 @@ public class Issue1897AddFeesToDividendTransactionsTest
 
         Client clientWithoutTaxes = new WithoutTaxesFilter().filter(client);
         ClientPerformanceSnapshot snapshotWithoutTaxes = new ClientPerformanceSnapshot(clientWithoutTaxes, converter,
-                        period);
+                        period, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertSnapshot(snapshotWithoutTaxes);
     }
@@ -115,7 +115,7 @@ public class Issue1897AddFeesToDividendTransactionsTest
 
         Client filteredClient = filter.filter(client);
 
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(filteredClient, converter, period);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(filteredClient, converter, period, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertSnapshot(snapshot);
     }
@@ -131,7 +131,7 @@ public class Issue1897AddFeesToDividendTransactionsTest
 
         Client filteredClient = filter.filter(client);
 
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(filteredClient, converter, period);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(filteredClient, converter, period, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertSnapshot(snapshot);
     }
@@ -144,7 +144,7 @@ public class Issue1897AddFeesToDividendTransactionsTest
 
         Client filteredClient = new ClientSecurityFilter(security).filter(client);
 
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(filteredClient, converter, period);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(filteredClient, converter, period, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertSnapshot(snapshot);
     }

--- a/name.abuchen.portfolio.tests/src/issues/Issue1909FIFOCalculationOfSecurityPositionTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue1909FIFOCalculationOfSecurityPositionTest.java
@@ -64,7 +64,7 @@ public class Issue1909FIFOCalculationOfSecurityPositionTest
         // TTWROR / drawdown / volatility / IRR are skipped because the interval
         // starts at LocalDate.MIN, which the lazy PerformanceIndex cannot build
         // (OOM) and which would produce a degenerate IRR anyway.
-        assertThat(record.getSharesHeld(), is(1000000000L));
+        assertThat(record.getSharesHeld(name.abuchen.portfolio.model.CostMethod.FIFO), is(1000000000L));
         assertThat(record.getMarketValue(), is(Money.of("EUR", 280500L))); //$NON-NLS-1$
         assertThat(record.getQuote(), is(Quote.of("EUR", 28050000000L))); //$NON-NLS-1$
         assertThat(record.getFees(), is(Money.of("EUR", 0L))); //$NON-NLS-1$

--- a/name.abuchen.portfolio.tests/src/issues/Issue371PurchaseValueWithTransfersTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue371PurchaseValueWithTransfersTest.java
@@ -20,8 +20,8 @@ import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.money.Quote;
+import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.ClientSnapshot;
 import name.abuchen.portfolio.snapshot.SecurityPosition;
 import name.abuchen.portfolio.snapshot.security.BaseSecurityPerformanceRecord;
@@ -60,7 +60,7 @@ public class Issue371PurchaseValueWithTransfersTest
         LazySecurityPerformanceRecord record = securitySnapshot.getRecords().get(0);
         assertThat(record.getSecurity(), is(adidas));
 
-        assertThat(securityPosition.getShares(), is(record.getSharesHeld()));
+        assertThat(securityPosition.getShares(), is(record.getSharesHeld(name.abuchen.portfolio.model.CostMethod.FIFO)));
         assertThat(securityPosition.calculateValue(), is(record.getMarketValue()));
 
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),

--- a/name.abuchen.portfolio.tests/src/issues/Issue4446FIFOMultipleTransfers.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue4446FIFOMultipleTransfers.java
@@ -44,7 +44,7 @@ public class Issue4446FIFOMultipleTransfers
         Trade t = trades.getFirst();
 
         assertThat(t.getLastTransaction().getTransaction().getNote(), is("buy-in should be 1000")); //$NON-NLS-1$
-        assertThat(t.getEntryValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
+        assertThat(t.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
     }
 
     @Test
@@ -68,7 +68,7 @@ public class Issue4446FIFOMultipleTransfers
         var trade = trades.stream().filter(t -> t.getEnd().isEmpty()).findFirst().orElseThrow();
 
         assertThat(trade.getEnd().isEmpty(), is(true));
-        assertThat(trade.getEntryValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3916.56))));
+        assertThat(trade.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3916.56))));
 
         // check FIFO via CostCalculation class
 

--- a/name.abuchen.portfolio.tests/src/issues/Issue672CapitalGainsIfSecurityIsTransferredTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/Issue672CapitalGainsIfSecurityIsTransferredTest.java
@@ -57,7 +57,7 @@ public class Issue672CapitalGainsIfSecurityIsTransferredTest
         // pinned values previously verified via SecurityPerformanceSnapshotComparator
         // IRR is omitted because the filtered client produces a degenerate
         // cash-flow series with an absurdly large IRR.
-        assertThat(record.getSharesHeld(), is(1000000000L));
+        assertThat(record.getSharesHeld(name.abuchen.portfolio.model.CostMethod.FIFO), is(1000000000L));
         assertThat(record.getQuote(), is(Quote.of("EUR", 9714100000L))); //$NON-NLS-1$
         assertThat(record.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of("EUR", 88310L))); //$NON-NLS-1$
         assertThat(record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),

--- a/name.abuchen.portfolio.tests/src/issues/IssueCurrencyGainsRoundingErrorTest.java
+++ b/name.abuchen.portfolio.tests/src/issues/IssueCurrencyGainsRoundingErrorTest.java
@@ -33,7 +33,7 @@ public class IssueCurrencyGainsRoundingErrorTest
 
         CurrencyConverter converter = new TestCurrencyConverter();
 
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, period);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, period, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         MutableMoney currencyGains = MutableMoney.of(converter.getTermCurrency());
         currencyGains.subtract(snapshot.getValue(CategoryType.INITIAL_VALUE));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SingleSecurityDebugClientFactoryTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/SingleSecurityDebugClientFactoryTest.java
@@ -28,7 +28,6 @@ public class SingleSecurityDebugClientFactoryTest
     private Security securityA;
     private Security securityB;
     private Account accountA;
-    private Account accountB;
     private Portfolio portfolio;
     private AttributeType attributeType;
 
@@ -67,7 +66,7 @@ public class SingleSecurityDebugClientFactoryTest
                         .addTo(client);
         accountA.setName("My Real Account");
 
-        accountB = new AccountBuilder(CurrencyUnit.EUR) //
+        new AccountBuilder(CurrencyUnit.EUR) //
                         .deposit_("2020-01-01", Values.Amount.factorize(5000)) //
                         .dividend("2020-04-01", Values.Amount.factorize(10), securityB) //
                         .addTo(client);
@@ -145,7 +144,7 @@ public class SingleSecurityDebugClientFactoryTest
     {
         Client copy = SingleSecurityDebugClientFactory.create(client, securityA);
 
-        // accountB was only used by securityB (plus a deposit) -> pruned
+        // the second account was only used by securityB (plus a deposit) -> pruned
         assertThat(copy.getAccounts(), hasSize(1));
         assertThat(copy.getPortfolios(), hasSize(1));
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshotTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshotTest.java
@@ -55,7 +55,7 @@ public class ClientPerformanceSnapshotTest
         client.addAccount(account);
 
         CurrencyConverter converter = new TestCurrencyConverter();
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate, name.abuchen.portfolio.model.CostMethod.FIFO);
         assertNotNull(snapshot);
 
         assertNotNull(snapshot.getStartClientSnapshot());
@@ -91,7 +91,7 @@ public class ClientPerformanceSnapshotTest
         client.addAccount(account);
 
         CurrencyConverter converter = new TestCurrencyConverter();
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertThat(snapshot.getValue(CategoryType.INITIAL_VALUE), is(Money.of(CurrencyUnit.EUR, 1050_00)));
         assertThat(snapshot.getValue(CategoryType.EARNINGS), is(Money.of(CurrencyUnit.EUR, 0)));
@@ -116,7 +116,7 @@ public class ClientPerformanceSnapshotTest
         client.addAccount(account);
 
         CurrencyConverter converter = new TestCurrencyConverter();
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertThat(snapshot.getValue(CategoryType.INITIAL_VALUE), is(Money.of(CurrencyUnit.EUR, 1000_00)));
         assertThat(snapshot.getValue(CategoryType.EARNINGS), is(Money.of(CurrencyUnit.EUR, 50_00)));
@@ -156,7 +156,7 @@ public class ClientPerformanceSnapshotTest
                         50_00, security, AccountTransaction.Type.DIVIDENDS));
 
         CurrencyConverter converter = new TestCurrencyConverter();
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertThat(snapshot.getValue(CategoryType.EARNINGS), is(Money.of(CurrencyUnit.EUR, 50_00)));
         assertThat(snapshot.getCategoryByType(CategoryType.EARNINGS).getPositions().size(), is(1));
@@ -185,7 +185,7 @@ public class ClientPerformanceSnapshotTest
         client.addPortfolio(portfolio);
 
         CurrencyConverter converter = new TestCurrencyConverter();
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertThat(snapshot.getValue(CategoryType.INITIAL_VALUE), is(Money.of(CurrencyUnit.EUR, 1000_00)));
         assertThat(snapshot.getValue(CategoryType.EARNINGS), is(Money.of(CurrencyUnit.EUR, 0)));
@@ -219,7 +219,7 @@ public class ClientPerformanceSnapshotTest
         client.addPortfolio(portfolio);
 
         CurrencyConverter converter = new TestCurrencyConverter();
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertThat(snapshot.getValue(CategoryType.INITIAL_VALUE), is(Money.of(CurrencyUnit.EUR, 1000_00)));
         assertThat(snapshot.getValue(CategoryType.EARNINGS), is(Money.of(CurrencyUnit.EUR, 0)));
@@ -254,7 +254,7 @@ public class ClientPerformanceSnapshotTest
                         .addTo(client);
 
         CurrencyConverter converter = new TestCurrencyConverter();
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertThat(snapshot.getValue(CategoryType.INITIAL_VALUE), is(Money.of(CurrencyUnit.EUR, 1000_00)));
         assertThat(snapshot.getValue(CategoryType.EARNINGS), is(Money.of(CurrencyUnit.EUR, 0)));
@@ -295,7 +295,7 @@ public class ClientPerformanceSnapshotTest
                         .addTo(client);
 
         CurrencyConverter converter = new TestCurrencyConverter();
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertThat(snapshot.getValue(CategoryType.CAPITAL_GAINS),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize((110.0 * 9) - (100.0 * 9)))));
@@ -325,7 +325,7 @@ public class ClientPerformanceSnapshotTest
 
         CurrencyConverter converter = new TestCurrencyConverter();
         ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, //
-                        LocalDate.parse("2015-01-02"), LocalDate.parse("2015-01-15"));
+                        LocalDate.parse("2015-01-02"), LocalDate.parse("2015-01-15"), name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertThat(snapshot.getValue(CategoryType.INITIAL_VALUE),
                         is(Money.of(CurrencyUnit.EUR, Math.round(1000_00 * (1 / 1.2043)))));
@@ -372,7 +372,7 @@ public class ClientPerformanceSnapshotTest
 
         CurrencyConverter converter = new TestCurrencyConverter();
         ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, //
-                        LocalDate.parse("2015-01-01"), LocalDate.parse("2015-01-15"));
+                        LocalDate.parse("2015-01-01"), LocalDate.parse("2015-01-15"), name.abuchen.portfolio.model.CostMethod.FIFO);
 
         MutableMoney currencyGains = MutableMoney.of(converter.getTermCurrency());
         currencyGains.subtract(snapshot.getValue(CategoryType.INITIAL_VALUE));
@@ -407,7 +407,7 @@ public class ClientPerformanceSnapshotTest
         account.addTransaction(dividend);
 
         CurrencyConverter converter = new TestCurrencyConverter();
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertThat(snapshot.getValue(CategoryType.EARNINGS), is(Money.of(CurrencyUnit.EUR, 110_00)));
         assertThat(snapshot.getValue(CategoryType.TAXES), is(Money.of(CurrencyUnit.EUR, 10_00)));
@@ -445,7 +445,7 @@ public class ClientPerformanceSnapshotTest
         portfolio.addTransaction(delivery);
 
         CurrencyConverter converter = new TestCurrencyConverter();
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertThat(snapshot.getValue(CategoryType.EARNINGS), is(Money.of(CurrencyUnit.EUR, 0)));
         assertThat(snapshot.getValue(CategoryType.FEES), is(Money.of(CurrencyUnit.EUR, 10_00)));
@@ -465,7 +465,7 @@ public class ClientPerformanceSnapshotTest
                         .addTo(client);
 
         CurrencyConverter converter = new TestCurrencyConverter();
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertThat(snapshot.getValue(CategoryType.EARNINGS),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(-100))));
@@ -495,7 +495,7 @@ public class ClientPerformanceSnapshotTest
                         .addTo(client);
 
         CurrencyConverter converter = new TestCurrencyConverter();
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter, startDate, endDate, name.abuchen.portfolio.model.CostMethod.FIFO);
 
         assertThat(snapshot.getValue(CategoryType.FEES), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(-100))));
 
@@ -516,7 +516,7 @@ public class ClientPerformanceSnapshotTest
         // code under test
 
         ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter,
-                        LocalDate.parse("2015-01-05"), LocalDate.parse("2016-01-01"));
+                        LocalDate.parse("2015-01-05"), LocalDate.parse("2016-01-01"), name.abuchen.portfolio.model.CostMethod.FIFO);
 
         // assertions - unrealized gains
 
@@ -600,7 +600,7 @@ public class ClientPerformanceSnapshotTest
         // code under test
 
         ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter,
-                        LocalDate.parse("2014-12-31"), LocalDate.parse("2016-01-01"));
+                        LocalDate.parse("2014-12-31"), LocalDate.parse("2016-01-01"), name.abuchen.portfolio.model.CostMethod.FIFO);
 
         // assertions - unrealized gains
 
@@ -697,7 +697,7 @@ public class ClientPerformanceSnapshotTest
         // code under test
 
         ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(client, converter,
-                        LocalDate.parse("2015-01-05"), LocalDate.parse("2016-01-01"));
+                        LocalDate.parse("2015-01-05"), LocalDate.parse("2016-01-01"), name.abuchen.portfolio.model.CostMethod.FIFO);
 
         // calculation does not work out b/c of the short sale!
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/PerformanceIndexTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/PerformanceIndexTest.java
@@ -3,6 +3,8 @@ package name.abuchen.portfolio.snapshot;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.IsCloseTo.closeTo;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -13,6 +15,7 @@ import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
@@ -107,5 +110,22 @@ public class PerformanceIndexTest
 
         assertThat(investedCapital[0], is(Values.Amount.factorize(1 + 10)));
 
+    }
+
+    @Test
+    public void testClientPerformanceSnapshotsAreCachedPerCostMethod()
+    {
+        LocalDate today = LocalDate.now();
+        PerformanceIndex index = new PerformanceIndexStub(new LocalDate[] { today }, new long[] { 0 },
+                        new double[] { 0 });
+
+        ClientPerformanceSnapshot fifo = index.getClientPerformanceSnapshot(CostMethod.FIFO).orElseThrow();
+        ClientPerformanceSnapshot movingAverage = index.getClientPerformanceSnapshot(CostMethod.MOVING_AVERAGE)
+                        .orElseThrow();
+
+        assertSame(fifo, index.getClientPerformanceSnapshot(CostMethod.FIFO).orElseThrow());
+        assertSame(movingAverage,
+                        index.getClientPerformanceSnapshot(CostMethod.MOVING_AVERAGE).orElseThrow());
+        assertNotSame(fifo, movingAverage);
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/filter/WithoutTaxesFilterTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/filter/WithoutTaxesFilterTest.java
@@ -224,8 +224,10 @@ public class WithoutTaxesFilterTest
                         LocalDate.of(2016, Month.MARCH, 31));
         CurrencyConverter converter = new TestCurrencyConverter();
 
-        ClientPerformanceSnapshot originalP = new ClientPerformanceSnapshot(client, converter, period);
-        ClientPerformanceSnapshot filteredP = new ClientPerformanceSnapshot(filtered, converter, period);
+        ClientPerformanceSnapshot originalP = new ClientPerformanceSnapshot(client, converter, period,
+                        name.abuchen.portfolio.model.CostMethod.FIFO);
+        ClientPerformanceSnapshot filteredP = new ClientPerformanceSnapshot(filtered, converter, period,
+                        name.abuchen.portfolio.model.CostMethod.FIFO);
 
         // taxes should be 0 with the filter applied, even though they were originally not
         assertThat(filteredP.getValue(CategoryType.TAXES).isZero(), is(true));

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/CostCalculationTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/CostCalculationTest.java
@@ -6,6 +6,9 @@ import static org.hamcrest.Matchers.is;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
@@ -31,6 +34,24 @@ import name.abuchen.portfolio.util.Interval;
 @SuppressWarnings("nls")
 public class CostCalculationTest
 {
+    private static CostCalculation calculate(CostMethod costMethod, List<CalculationLineItem> items)
+    {
+        Collections.sort(items, new CalculationLineItemComparator());
+
+        CostCalculation cost = new CostCalculation(costMethod);
+        cost.setTermCurrency(CurrencyUnit.EUR);
+        cost.visitAll(new TestCurrencyConverter(), items);
+        return cost;
+    }
+
+    private static List<CalculationLineItem> items(Portfolio... portfolios)
+    {
+        List<CalculationLineItem> items = new ArrayList<>();
+        for (Portfolio portfolio : portfolios)
+            portfolio.getTransactions().stream().map(t -> CalculationLineItem.of(portfolio, t)).forEach(items::add);
+        return items;
+    }
+
     @Test
     public void testFifoBuySellTransactions()
     {
@@ -46,25 +67,26 @@ public class CostCalculationTest
                         .buy(security, "2010-03-01", Values.Share.factorize(32), Values.Amount.factorize(959.30)) //
                         .addTo(client);
 
-        CostCalculation cost = new CostCalculation();
-        cost.setTermCurrency(CurrencyUnit.EUR);
-        cost.visitAll(new TestCurrencyConverter(), portfolio.getTransactions().stream()
-                        .map(t -> CalculationLineItem.of(portfolio, t)).collect(Collectors.toList()));
+        List<CalculationLineItem> lineItems = portfolio.getTransactions().stream()
+                        .map(t -> CalculationLineItem.of(portfolio, t)).collect(Collectors.toList());
+        CostCalculation fifo = calculate(CostMethod.FIFO, new ArrayList<>(lineItems));
 
         // expected:
         // 3149,20 - round(3149,20 * 15/109) + 1684,92 + 959,30 = 5360,04385
 
-        assertThat(cost.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+        assertThat(fifo.getCost(TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5360.04))));
 
-        assertThat(cost.getFifoCostTrail().getValue(), is(cost.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED)));
+        assertThat(fifo.getCostTrail().orElseThrow().getValue(), is(fifo.getCost(TaxesAndFees.INCLUDED)));
 
         // expected moving average is identical because it is only one buy
         // transaction
         // 3149,20 * 94/109 + 1684.92 + 959.30 = 5360,04385
 
-        assertThat(cost.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+        CostCalculation movingAverage = calculate(CostMethod.MOVING_AVERAGE, new ArrayList<>(lineItems));
+        assertThat(movingAverage.getCost(TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5360.04))));
+        assertThat(movingAverage.getCostTrail().isEmpty(), is(true));
     }
 
     @Test
@@ -81,24 +103,25 @@ public class CostCalculationTest
                         .sell(security, "2010-03-01", Values.Share.factorize(15), Values.Amount.factorize(531.50)) //
                         .addTo(client);
 
-        CostCalculation cost = new CostCalculation();
-        cost.setTermCurrency(CurrencyUnit.EUR);
-        cost.visitAll(new TestCurrencyConverter(), portfolio.getTransactions().stream()
-                        .map(t -> CalculationLineItem.of(portfolio, t)).collect(Collectors.toList()));
+        List<CalculationLineItem> lineItems = portfolio.getTransactions().stream()
+                        .map(t -> CalculationLineItem.of(portfolio, t)).collect(Collectors.toList());
+        CostCalculation fifo = calculate(CostMethod.FIFO, new ArrayList<>(lineItems));
 
         // expected:
         // 3149,20 + 1684,92 - round(3149,20 * 15/109) = 4400,743853211009174
 
-        assertThat(cost.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+        assertThat(fifo.getCost(TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4400.74))));
 
-        assertThat(cost.getFifoCostTrail().getValue(), is(cost.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED)));
+        assertThat(fifo.getCostTrail().orElseThrow().getValue(), is(fifo.getCost(TaxesAndFees.INCLUDED)));
 
         // transaction
         // (3149,20 + 1684.92) * 146/161 = 4383,736149068322981
 
-        assertThat(cost.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+        CostCalculation movingAverage = calculate(CostMethod.MOVING_AVERAGE, new ArrayList<>(lineItems));
+        assertThat(movingAverage.getCost(TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4383.74))));
+        assertThat(movingAverage.getCostTrail().isEmpty(), is(true));
     }
 
     @Test
@@ -146,7 +169,7 @@ public class CostCalculationTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize((1000 / 1.1588) + 1100))));
 
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
-                        is(record.explain(BaseSecurityPerformanceRecord.Trails.FIFO_COST)
+                        is(record.explain(BaseSecurityPerformanceRecord.Trails.COST, CostMethod.FIFO)
                                         .orElseThrow(IllegalArgumentException::new).getRecord().getValue()));
     }
 
@@ -165,14 +188,13 @@ public class CostCalculationTest
                         .sell(security, "2010-03-01", Values.Share.factorize(4), 1) //
                         .addTo(client);
 
-        CostCalculation cost = new CostCalculation();
-        cost.setTermCurrency(CurrencyUnit.EUR);
-        cost.visitAll(new TestCurrencyConverter(), portfolio.getTransactions().stream()
-                        .map(t -> CalculationLineItem.of(portfolio, t)).collect(Collectors.toList()));
+        CostCalculation fifo = calculate(CostMethod.FIFO, items(portfolio));
+        assertThat(fifo.getCost(TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0L)));
+        assertThat(fifo.getCostTrail().orElseThrow(), is(TrailRecord.empty()));
 
-        assertThat(cost.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0L)));
-        assertThat(cost.getFifoCostTrail(), is(TrailRecord.empty()));
-        assertThat(cost.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0L)));
+        CostCalculation movingAverage = calculate(CostMethod.MOVING_AVERAGE, items(portfolio));
+        assertThat(movingAverage.getCost(TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0L)));
+        assertThat(movingAverage.getCostTrail().isEmpty(), is(true));
     }
 
     @Test
@@ -190,14 +212,13 @@ public class CostCalculationTest
                         .sell(security, "2010-04-01", Values.Share.factorize(50), 53150) //
                         .addTo(client);
 
-        CostCalculation cost = new CostCalculation();
-        cost.setTermCurrency(CurrencyUnit.EUR);
-        cost.visitAll(new TestCurrencyConverter(), portfolio.getTransactions().stream()
-                        .map(t -> CalculationLineItem.of(portfolio, t)).collect(Collectors.toList()));
+        CostCalculation fifo = calculate(CostMethod.FIFO, items(portfolio));
+        assertThat(fifo.getCost(TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0L)));
+        assertThat(fifo.getCostTrail().orElseThrow(), is(TrailRecord.empty()));
 
-        assertThat(cost.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0L)));
-        assertThat(cost.getFifoCostTrail(), is(TrailRecord.empty()));
-        assertThat(cost.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0L)));
+        CostCalculation movingAverage = calculate(CostMethod.MOVING_AVERAGE, items(portfolio));
+        assertThat(movingAverage.getCost(TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0L)));
+        assertThat(movingAverage.getCostTrail().isEmpty(), is(true));
     }
 
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendCalculationTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendCalculationTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.PortfolioTransaction.Type;
@@ -64,7 +65,12 @@ public class DividendCalculationTest
 
         assertEquals(0, dc.getNumOfEvents());
         assertEquals(Periodicity.NONE, dc.getPeriodicity());
-        assertEquals(0.0, dc.getRateOfReturnPerYear(), 0.0);
+
+        DividendRateOfReturnCalculation rate = Calculation.perform(
+                        () -> new DividendRateOfReturnCalculation(payment -> {
+                            throw new AssertionError("Cost provider must not be accessed without payments");
+                        }), converter, security, transactions);
+        assertEquals(0.0, rate.getRateOfReturnPerYear(), 0.0);
     }
 
     @Test
@@ -190,11 +196,11 @@ public class DividendCalculationTest
         transactions.add(createDividendTransaction(LocalDateTime.of(2019, 01, 15, 12, 00)));
         transactions.add(createDividendTransaction(LocalDateTime.of(2020, 01, 15, 12, 00)));
 
-        // We need to calculate the costs, in order to get the average return
-        @SuppressWarnings("unused")
-        CostCalculation cost = Calculation.perform(CostCalculation.class, converter, security, transactions);
-        DividendCalculation dividends = Calculation.perform(DividendCalculation.class, converter, security,
-                        transactions);
+        CostCalculation cost = Calculation.perform(() -> new CostCalculation(CostMethod.MOVING_AVERAGE), converter,
+                        security, transactions);
+        DividendRateOfReturnCalculation dividends = Calculation.perform(
+                        () -> new DividendRateOfReturnCalculation(cost.getResult()::getDividendCost), converter,
+                        security, transactions);
 
         assertEquals(0.1, dividends.getRateOfReturnPerYear(), 0.0);
     }
@@ -242,10 +248,11 @@ public class DividendCalculationTest
 
         transactions.add(CalculationLineItem.of(new Account(), dividend));
 
-        @SuppressWarnings("unused")
-        CostCalculation cost = Calculation.perform(CostCalculation.class, converter, testSecurity, transactions);
-        DividendCalculation dividends = Calculation.perform(DividendCalculation.class, converter, testSecurity,
-                        transactions);
+        CostCalculation cost = Calculation.perform(() -> new CostCalculation(CostMethod.MOVING_AVERAGE), converter,
+                        testSecurity, transactions);
+        DividendRateOfReturnCalculation dividends = Calculation.perform(
+                        () -> new DividendRateOfReturnCalculation(cost.getResult()::getDividendCost), converter,
+                        testSecurity, transactions);
 
         // Expected: 50 USD / 1000 USD = 0.05 (5%)
         // After currency conversion to EUR: ~58.54 EUR / ~1170.8 EUR = 0.05

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendTransactionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DividendTransactionTest.java
@@ -42,10 +42,7 @@ public class DividendTransactionTest
         if (tax > 0)
             t.addUnit(new Unit(Unit.Type.TAX, Money.of(CurrencyUnit.EUR, tax * -1)));
 
-        CalculationLineItem.DividendPayment answer = (CalculationLineItem.DividendPayment) CalculationLineItem
-                        .of(account, t);
-        answer.setTotalShares(shares);
-        return answer;
+        return (CalculationLineItem.DividendPayment) CalculationLineItem.of(account, t);
     }
 
     @Test
@@ -97,29 +94,17 @@ public class DividendTransactionTest
     @Test
     public void testGetMovingAverageCost()
     {
-        CalculationLineItem.DividendPayment t1 = createDividendTransaction(100L, 10L, 1L,
-                        LocalDateTime.of(2019, 01, 15, 12, 00));
-        Money movingAverageCost = Money.of(CurrencyUnit.EUR, 1000L);
-        t1.setMovingAverageCost(movingAverageCost);
-
-        Money result = t1.getMovingAverageCost();
-        Money expected = Money.of(CurrencyUnit.EUR, 1000L);
-
-        assertEquals(expected, result);
+        CalculationLineItem.DividendPayment payment = createDividendTransaction(100L, 5L, 0L,
+                        LocalDateTime.of(2019, 1, 15, 12, 0));
+        assertEquals(0.1d, payment.getPersonalDividendYield(Money.of(CurrencyUnit.EUR, 2000L), 10L), 0d);
     }
 
     @Test
     public void testGetFifoCosts()
     {
-        CalculationLineItem.DividendPayment t1 = createDividendTransaction(100L, 10L, 0L,
-                        LocalDateTime.of(2019, 01, 15, 12, 00));
-        Money fifoCost = Money.of(CurrencyUnit.EUR, 2000L);
-        t1.setFifoCost(fifoCost);
-
-        Money result = t1.getFifoCost();
-        Money expected = Money.of(CurrencyUnit.EUR, 2000L);
-
-        assertEquals(expected, result);
+        CalculationLineItem.DividendPayment payment = createDividendTransaction(100L, 10L, 0L,
+                        LocalDateTime.of(2019, 1, 15, 12, 0));
+        assertEquals(0.05d, payment.getPersonalDividendYield(Money.of(CurrencyUnit.EUR, 2000L), 10L), 0d);
     }
 
     @Test
@@ -127,11 +112,7 @@ public class DividendTransactionTest
     {
         CalculationLineItem.DividendPayment t1 = createDividendTransaction(100L, 10L, 0L,
                         LocalDateTime.of(2019, 01, 15, 12, 00));
-        Money fifoCost = Money.of(CurrencyUnit.EUR, 2000L);
-        t1.setFifoCost(fifoCost);
-
-        //
-        double result = t1.getPersonalDividendYield(); // hence 5% yield
+        double result = t1.getPersonalDividendYield(Money.of(CurrencyUnit.EUR, 2000L), 10L); // hence 5% yield
 
         assertEquals(0.05d, result, 0.0d);
     }
@@ -141,9 +122,7 @@ public class DividendTransactionTest
     {
         CalculationLineItem.DividendPayment t1 = createDividendTransaction(100L, 10L, 0L,
                         LocalDateTime.of(2019, 01, 15, 12, 00));
-        // Transaction has no movingAverageCosts
-
-        double result = t1.getPersonalDividendYield();
+        double result = t1.getPersonalDividendYield(null, 10L);
 
         assertEquals(0.0, result, 0.001d);
     }
@@ -156,12 +135,7 @@ public class DividendTransactionTest
 
         CalculationLineItem.DividendPayment t1 = createDividendTransaction(100L, 0L, 0L,
                         LocalDateTime.of(2019, 01, 15, 12, 00));
-        Money fifoCost = Money.of(CurrencyUnit.EUR, 2000L); // we paid
-                                                            // originally 2000$
-        t1.setFifoCost(fifoCost);
-
-        //
-        double result = t1.getPersonalDividendYield(); // hence 5% yield
+        double result = t1.getPersonalDividendYield(Money.of(CurrencyUnit.EUR, 2000L), 0L); // hence 5% yield
 
         assertEquals(0.05d, result, 0.0d);
     }
@@ -171,15 +145,7 @@ public class DividendTransactionTest
     {
         CalculationLineItem.DividendPayment t1 = createDividendTransaction(100L, 10L, 0L,
                         LocalDateTime.of(2019, 01, 15, 12, 00));
-        Money movingAverageCost = Money.of(CurrencyUnit.EUR, 1800); // we paid
-                                                                    // originally
-                                                                    // around
-                                                                    // 1800
-        t1.setMovingAverageCost(movingAverageCost);
-
-        double result = t1.getPersonalDividendYieldMovingAverage(); // hence
-                                                                    // 5.5556%
-                                                                    // yield
+        double result = t1.getPersonalDividendYield(Money.of(CurrencyUnit.EUR, 1800), 10L); // hence 5.5556% yield
 
         assertEquals(0.0556d, result, 0.001d);
     }
@@ -189,9 +155,7 @@ public class DividendTransactionTest
     {
         CalculationLineItem.DividendPayment t1 = createDividendTransaction(100L, 10L, 0L,
                         LocalDateTime.of(2019, 01, 15, 12, 00));
-        // Transaction has no movingAverageCosts
-
-        double result = t1.getPersonalDividendYieldMovingAverage();
+        double result = t1.getPersonalDividendYield(Money.of(CurrencyUnit.EUR, 0L), 10L);
 
         assertEquals(0.0, result, 0.001d);
     }
@@ -204,15 +168,7 @@ public class DividendTransactionTest
 
         CalculationLineItem.DividendPayment t1 = createDividendTransaction(100L, 0L, 0L,
                         LocalDateTime.of(2019, 01, 15, 12, 00));
-        Money movingAverageCost = Money.of(CurrencyUnit.EUR, 1500); // we paid
-                                                                    // originally
-                                                                    // around
-                                                                    // 1800
-        t1.setMovingAverageCost(movingAverageCost);
-
-        double result = t1.getPersonalDividendYieldMovingAverage(); // hence
-                                                                    // 6.66666%
-                                                                    // yield
+        double result = t1.getPersonalDividendYield(Money.of(CurrencyUnit.EUR, 1500), 0L); // hence 6.66666% yield
 
         assertEquals(0.06666, result, 0.001d);
     }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshotTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/SecurityPerformanceSnapshotTest.java
@@ -26,7 +26,6 @@ import name.abuchen.portfolio.util.Interval;
 @SuppressWarnings("nls")
 public class SecurityPerformanceSnapshotTest
 {
-
     @Test
     public void testBigPurchases()
     {
@@ -48,7 +47,7 @@ public class SecurityPerformanceSnapshotTest
         LazySecurityPerformanceRecord record = snapshot.getRecords().get(0);
         assertThat(record.getSecurity(), is(security));
 
-        assertThat(record.getSharesHeld(), is(0L));
+        assertThat(record.getSharesHeld(name.abuchen.portfolio.model.CostMethod.FIFO), is(0L));
 
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0)));
         assertThat(record.getCostPerSharesHeld(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
@@ -80,7 +79,7 @@ public class SecurityPerformanceSnapshotTest
         LazySecurityPerformanceRecord record = snapshot.getRecords().get(0);
         assertThat(record.getSecurity(), is(security));
 
-        assertThat(record.getSharesHeld(), is(Values.Share.factorize(499999)));
+        assertThat(record.getSharesHeld(name.abuchen.portfolio.model.CostMethod.FIFO), is(Values.Share.factorize(499999)));
 
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(450000 - 0.9))));
@@ -95,7 +94,8 @@ public class SecurityPerformanceSnapshotTest
         SecurityPosition position = ClientSnapshot.create(client, new TestCurrencyConverter(), reportingPeriod.getEnd())
                         .getPositionsByVehicle().get(security).getPosition();
 
-        assertThat(position.getShares(), is(record.getSharesHeld()));
+        assertThat(position.getShares(), is(record.getSharesHeld(name.abuchen.portfolio.model.CostMethod.FIFO)));
         assertThat(position.calculateValue(), is(record.getMarketValue()));
     }
+
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/SharesHeldCalculationTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/SharesHeldCalculationTest.java
@@ -37,7 +37,7 @@ public class SharesHeldCalculationTest
 
         assertThat(snapshot.getRecords().size(), is(1));
 
-        assertThat(snapshot.getRecords().get(0).getSharesHeld(), is(Values.Share.factorize(2)));
+        assertThat(snapshot.getRecords().get(0).getSharesHeld(name.abuchen.portfolio.model.CostMethod.FIFO), is(Values.Share.factorize(2)));
     }
 
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCategoryTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCategoryTest.java
@@ -20,8 +20,10 @@ import name.abuchen.portfolio.math.IRR;
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Taxonomy;
 import name.abuchen.portfolio.model.TransactionPair;
 import name.abuchen.portfolio.money.CurrencyUnit;
@@ -70,16 +72,37 @@ public class TradeCategoryTest
 
         // verify aggregations
         assertThat(category.getTradeCount(), is(1L));
-        assertThat(category.getTotalEntryValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10000))));
+        assertThat(category.getTotalEntryValue(CostMethod.FIFO), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10000))));
         assertThat(category.getTotalExitValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11000))));
-        assertThat(category.getTotalProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
-        assertThat(category.getTotalProfitLossMovingAverage(),
+        assertThat(category.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
+        assertThat(category.getTotalProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
-        assertThat(category.getTotalProfitLossMovingAverageWithoutTaxesAndFees(),
+        assertThat(category.getTotalProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
-        assertThat(category.getWinningTradesCount(), is(1L));
-        assertThat(category.getLosingTradesCount(), is(0L));
-        assertThat(category.getAverageReturnMovingAverage(), is(closeTo(0.1, 1e-10)));
+        assertThat(category.getWinningTradesCount(CostMethod.FIFO), is(1L));
+        assertThat(category.getLosingTradesCount(CostMethod.FIFO), is(0L));
+        assertThat(category.getAverageReturn(CostMethod.MOVING_AVERAGE), is(closeTo(0.1, 1e-10)));
+
+        TradesGroupedByTaxonomy grouped = new TradesGroupedByTaxonomy(taxonomy, trades,
+                        new TestCurrencyConverter());
+        TradeTotals totals = new TradeTotals(grouped);
+        assertThat(totals.getTotalEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10000))));
+        assertThat(totals.getTotalEntryValue(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10000))));
+        assertThat(totals.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
+        assertThat(totals.getTotalProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
+        assertThat(totals.getAverageReturn(CostMethod.FIFO), is(closeTo(0.1, 1e-10)));
+        assertThat(totals.getAverageReturn(CostMethod.MOVING_AVERAGE), is(closeTo(0.1, 1e-10)));
+
+        // Adding another assignment invalidates both method-specific results.
+        category.addTrade(trades.get(0), 0.5);
+        assertThat(category.getTotalEntryValue(CostMethod.FIFO),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(15000))));
+        assertThat(category.getTotalEntryValue(CostMethod.MOVING_AVERAGE),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(15000))));
     }
 
     @Test
@@ -117,14 +140,14 @@ public class TradeCategoryTest
         category.addTrade(trades.get(0), 0.5);
 
         // verify weighted aggregations - profit should be 50% of 1000 = 500
-        assertThat(category.getTotalEntryValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5000))));
+        assertThat(category.getTotalEntryValue(CostMethod.FIFO), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5000))));
         assertThat(category.getTotalExitValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5500))));
-        assertThat(category.getTotalProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500))));
-        assertThat(category.getTotalProfitLossMovingAverage(),
+        assertThat(category.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500))));
+        assertThat(category.getTotalProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500))));
-        assertThat(category.getTotalProfitLossMovingAverageWithoutTaxesAndFees(),
+        assertThat(category.getTotalProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500))));
-        assertThat(category.getAverageReturnMovingAverage(), is(closeTo(0.1, 1e-10)));
+        assertThat(category.getAverageReturn(CostMethod.MOVING_AVERAGE), is(closeTo(0.1, 1e-10)));
 
         assertThat(category.getTradeAssignments().size(), is(1));
         TradeCategory.TradeAssignment assignment = category.getTradeAssignments().get(0);
@@ -164,8 +187,8 @@ public class TradeCategoryTest
         category.addTrade(trades.get(0), 0.4);
 
         assertThat(category.getTradeCount(), is(1L));
-        assertThat(category.getWinningTradesCount(), is(1L));
-        assertThat(category.getLosingTradesCount(), is(0L));
+        assertThat(category.getWinningTradesCount(CostMethod.FIFO), is(1L));
+        assertThat(category.getLosingTradesCount(CostMethod.FIFO), is(0L));
     }
 
     @Test
@@ -201,12 +224,12 @@ public class TradeCategoryTest
 
         Trade shortTrade = trades.get(0);
         assertThat(shortTrade.isLong(), is(false));
-        assertThat(shortTrade.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
+        assertThat(shortTrade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
 
         TradeCategory category = new TradeCategory(shorts, new TestCurrencyConverter());
         category.addTrade(shortTrade, 1.0);
 
-        assertThat(category.getAverageReturn(), is(closeTo(shortTrade.getReturn(), 1e-10)));
+        assertThat(category.getAverageReturn(CostMethod.FIFO), is(closeTo(shortTrade.getReturn(CostMethod.FIFO), 1e-10)));
     }
 
     @Test
@@ -358,4 +381,5 @@ public class TradeCategoryTest
 
         assertThat(category.getAverageIRR(), is(closeTo(expectedIrr, 1e-10)));
     }
+
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector2Test.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector2Test.java
@@ -98,9 +98,9 @@ public class TradeCollector2Test
                         Interval.of(LocalDate.MIN, LocalDate.now()));
         var securityRecord = snapshot.getRecord(att).get();
 
-        assertThat(secondTrade.getEntryValue(),
+        assertThat(secondTrade.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED),
                         is(securityRecord.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED)));
-        assertThat(secondTrade.getEntryValueMovingAverage(),
+        assertThat(secondTrade.getEntryValue(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
                         is(securityRecord.getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED)));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector3Test.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector3Test.java
@@ -13,7 +13,9 @@ import name.abuchen.portfolio.junit.SecurityBuilder;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
@@ -50,7 +52,7 @@ public class TradeCollector3Test
         assertThat(firstTrade.getEnd().orElseThrow(IllegalArgumentException::new),
                         is(LocalDateTime.parse("2022-01-01T00:00")));
         assertThat(firstTrade.getHoldingPeriod(), is(0L));
-        assertThat(firstTrade.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, 0L)));
+        assertThat(firstTrade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, 0L)));
     }
 
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector4Test.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector4Test.java
@@ -13,7 +13,9 @@ import org.junit.Test;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ClientFactory;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
@@ -59,7 +61,7 @@ public class TradeCollector4Test
         // because (sale − purchase A) / (owned − purchase A)
         // (0.00636567 − 0.001301 ) / (0.014125 − 0.001301 )
 
-        assertThat(firstTrade.getEntryValue(),
+        assertThat(firstTrade.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Money.factorize(10 + 39.49368372))));
 
         // moving average
@@ -67,7 +69,7 @@ public class TradeCollector4Test
         // 110 * (sale / owned)
         // 110 * (0.00636567 / 0.014125) = 49.573359292
 
-        assertThat(firstTrade.getEntryValueMovingAverage(),
+        assertThat(firstTrade.getEntryValue(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Money.factorize(49.573359292))));
 
         // Note: FIFO and moving average cost differ because each transaction as

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector5Test.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector5Test.java
@@ -13,7 +13,9 @@ import org.junit.Test;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ClientFactory;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 
@@ -48,7 +50,7 @@ public class TradeCollector5Test
 
         // In this case, FIFO and moving average result in the same entry value.
         // This test case tests other currencies than EUR.
-        assertThat(firstTrade.getEntryValue(), is(Money.of("CAD", Values.Money.factorize(9994.44))));
-        assertThat(firstTrade.getEntryValueMovingAverage(), is(firstTrade.getEntryValue()));
+        assertThat(firstTrade.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of("CAD", Values.Money.factorize(9994.44))));
+        assertThat(firstTrade.getEntryValue(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(firstTrade.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED)));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector6Test.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector6Test.java
@@ -14,7 +14,9 @@ import name.abuchen.portfolio.junit.SecurityBuilder;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
@@ -47,14 +49,14 @@ public class TradeCollector6Test
         assertThat(firstTrade.getEnd().isPresent(), is(false));
 
         // 200*15-520-1000 = 1480
-        assertThat(firstTrade.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1480.00))));
-        assertThat(firstTrade.getProfitLossMovingAverage(), is(firstTrade.getProfitLoss()));
+        assertThat(firstTrade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1480.00))));
+        assertThat(firstTrade.getProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), is(firstTrade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED)));
 
         // 200*15-520-10-10-1000 = 1500
-        assertThat(firstTrade.getProfitLossWithoutTaxesAndFees(),
+        assertThat(firstTrade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1500.00))));
-        assertThat(firstTrade.getProfitLossMovingAverageWithoutTaxesAndFees(),
-                        is(firstTrade.getProfitLossWithoutTaxesAndFees()));
+        assertThat(firstTrade.getProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
+                        is(firstTrade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED)));
     }
 
     @Test
@@ -85,42 +87,42 @@ public class TradeCollector6Test
         assertThat(firstTrade.getEnd().isPresent(), is(true));
 
         // 1480 - (520 + 1000*5/10) = 460
-        assertThat(firstTrade.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(460.00))));
+        assertThat(firstTrade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(460.00))));
         // 1480 - (520 + 1000)*10/15 = 466.67
-        assertThat(firstTrade.getProfitLossMovingAverage(),
+        assertThat(firstTrade.getProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(466.67))));
 
         // 1480+10+10 - (520-10-10 + 1000*5/10) = 500
-        assertThat(firstTrade.getProfitLossWithoutTaxesAndFees(),
+        assertThat(firstTrade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500.00))));
         // 1480+10+10 - (520-10-10 + 1000)*10/15 = 500
-        assertThat(firstTrade.getProfitLossMovingAverageWithoutTaxesAndFees(),
+        assertThat(firstTrade.getProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500.00))));
 
         // return : 1480/(520 + 1000*5/10)-1=0.45098
-        assertThat(firstTrade.getReturn(), closeTo(0.4510, 0.0001));
+        assertThat(firstTrade.getReturn(CostMethod.FIFO), closeTo(0.4510, 0.0001));
         // return : 1480/[(520 + 1000)*10/15]-1=0.46052
-        assertThat(firstTrade.getReturnMovingAverage(), closeTo(0.4605, 0.0001));
+        assertThat(firstTrade.getReturn(CostMethod.MOVING_AVERAGE), closeTo(0.4605, 0.0001));
 
         Trade secondTrade = trades.get(1);
         assertThat(secondTrade.getEnd().isPresent(), is(false));
         // 200*5 - (1000*5/10) = 500
-        assertThat(secondTrade.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500.00))));
+        assertThat(secondTrade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500.00))));
         // 200*5 - (520 + 1000)*5/15 = 493.33
-        assertThat(secondTrade.getProfitLossMovingAverage(),
+        assertThat(secondTrade.getProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(493.33))));
 
         // 200*5 - (500*5/10) = 500
-        assertThat(secondTrade.getProfitLossWithoutTaxesAndFees(),
+        assertThat(secondTrade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500.00))));
         // 200*5 - (520-10-10 + 1000)*5/15 = 500
-        assertThat(secondTrade.getProfitLossMovingAverageWithoutTaxesAndFees(),
+        assertThat(secondTrade.getProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500.00))));
 
         // return : 200*5 / (1000*5/10)-1 = 1
-        assertThat(secondTrade.getReturn(), closeTo(1.0000, 0.0001));
+        assertThat(secondTrade.getReturn(CostMethod.FIFO), closeTo(1.0000, 0.0001));
         // return : 200*5 / [(520 + 1000)*5/15]-1 = 0.97368
-        assertThat(secondTrade.getReturnMovingAverage(), closeTo(0.9737, 0.0001));
+        assertThat(secondTrade.getReturn(CostMethod.MOVING_AVERAGE), closeTo(0.9737, 0.0001));
     }
 
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollectorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollectorTest.java
@@ -14,7 +14,9 @@ import org.junit.Test;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ClientFactory;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
@@ -48,7 +50,7 @@ public class TradeCollectorTest
         assertThat(firstTrade.getEnd().orElseThrow(IllegalArgumentException::new),
                         is(LocalDateTime.parse("2012-01-13T00:00")));
         assertThat(firstTrade.getHoldingPeriod(), is(11L));
-        assertThat(firstTrade.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1605 - 737.81))));
+        assertThat(firstTrade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1605 - 737.81))));
 
         Trade secondTrade = trades.get(1);
 
@@ -74,7 +76,7 @@ public class TradeCollectorTest
         assertThat(firstTrade.getEnd().orElseThrow(IllegalArgumentException::new),
                         is(LocalDateTime.parse("2012-01-10T00:00")));
         assertThat(firstTrade.getHoldingPeriod(), is(9L));
-        assertThat(firstTrade.getProfitLoss(),
+        assertThat(firstTrade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(688.36 - 1019.80))));
     }
 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeTest.java
@@ -6,6 +6,7 @@ import static name.abuchen.portfolio.junit.PortfolioBuilder.sharesOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,7 +17,9 @@ import name.abuchen.portfolio.junit.PortfolioBuilder;
 import name.abuchen.portfolio.junit.SecurityBuilder;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 
@@ -49,12 +52,22 @@ public class TradeTest
         assertThat(trade1.isLong(), is(true));
         assertThat(trade1.getShares(), is(sharesOf(5)));
         assertThat(trade1.getStart(), is(LocalDateTime.parse("2024-01-01T00:00")));
-        assertThat(trade1.getEntryValue(), is(Money.of(CurrencyUnit.EUR, amountOf(100) * 5)));
+        assertThat(trade1.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, amountOf(100) * 5)));
         assertThat(trade1.getEnd().get(), is(LocalDateTime.parse("2024-12-31T00:00")));
         assertThat(trade1.getExitValue(), is(Money.of(CurrencyUnit.EUR, amountOf(180) * 5)));
-        assertThat(trade1.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, amountOf(180 - 100) * 5)));
-        assertThat(trade1.getReturn(), is(0.8));
+        assertThat(trade1.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, amountOf(180 - 100) * 5)));
+        assertThat(trade1.getReturn(CostMethod.FIFO), is(0.8));
         assertEquals(trade1.getIRR(), 0.8, 0.0001);
+
+        assertThat(trade1.isLoss(CostMethod.FIFO),
+                        is(trade1.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED).isNegative()));
+        assertThat(trade1.isGrossLoss(CostMethod.FIFO),
+                        is(trade1.getProfitLoss(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED).isNegative()));
+        assertThat(trade1.isLoss(CostMethod.MOVING_AVERAGE),
+                        is(trade1.getProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED).isNegative()));
+        assertThat(trade1.isGrossLoss(CostMethod.MOVING_AVERAGE),
+                        is(trade1.getProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED).isNegative()));
+        assertThat(trade1.getCurrencyCode(), is(trade1.getExitValue().getCurrencyCode()));
     }
 
     @Test
@@ -78,11 +91,11 @@ public class TradeTest
         assertThat(trade1.isLong(), is(true));
         assertThat(trade1.getShares(), is(sharesOf(3)));
         assertThat(trade1.getStart(), is(LocalDateTime.parse("2024-01-01T00:00")));
-        assertThat(trade1.getEntryValue(), is(Money.of(CurrencyUnit.EUR, amountOf(100) * 3)));
+        assertThat(trade1.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, amountOf(100) * 3)));
         assertThat(trade1.getEnd().get(), is(LocalDateTime.parse("2024-12-31T00:00")));
         assertThat(trade1.getExitValue(), is(Money.of(CurrencyUnit.EUR, amountOf(180) * 3)));
-        assertThat(trade1.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, amountOf(180 - 100) * 3)));
-        assertThat(trade1.getReturn(), is(0.8));
+        assertThat(trade1.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, amountOf(180 - 100) * 3)));
+        assertThat(trade1.getReturn(CostMethod.FIFO), is(0.8));
         assertEquals(trade1.getIRR(), 0.8, 0.0001);
 
         Trade trade2 = trades.get(1);
@@ -90,11 +103,11 @@ public class TradeTest
         assertThat(trade2.isLong(), is(true));
         assertThat(trade2.getShares(), is(sharesOf(2)));
         assertThat(trade1.getStart(), is(LocalDateTime.parse("2024-01-01T00:00")));
-        assertThat(trade2.getEntryValue(), is(Money.of(CurrencyUnit.EUR, amountOf(100) * 2)));
+        assertThat(trade2.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, amountOf(100) * 2)));
         assertThat(trade2.getEnd().isPresent(), is(false));
         assertThat(trade2.getExitValue(), is(Money.of(CurrencyUnit.EUR, amountOf(210) * 2)));
-        assertThat(trade2.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, amountOf(210 - 100) * 2)));
-        assertThat(trade2.getReturn(), is((210 - 100) / 100.0));
+        assertThat(trade2.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, amountOf(210 - 100) * 2)));
+        assertThat(trade2.getReturn(CostMethod.FIFO), is((210 - 100) / 100.0));
     }
 
     @Test
@@ -118,12 +131,18 @@ public class TradeTest
         assertThat(trade1.isLong(), is(false));
         assertThat(trade1.getShares(), is(sharesOf(3)));
         assertThat(trade1.getStart(), is(LocalDateTime.parse("2024-01-01T00:00")));
-        assertThat(trade1.getEntryValue(), is(Money.of(CurrencyUnit.EUR, amountOf(20) * 3)));
+        assertThat(trade1.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, amountOf(20) * 3)));
         assertThat(trade1.getEnd().get(), is(LocalDateTime.parse("2024-12-31T00:00")));
         assertThat(trade1.getExitValue(), is(Money.of(CurrencyUnit.EUR, amountOf(5) * 3)));
-        assertThat(trade1.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, amountOf(20 - 5) * 3)));
-        assertThat(trade1.getReturn(), is(0.75));
+        assertThat(trade1.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, amountOf(20 - 5) * 3)));
+        assertThat(trade1.getReturn(CostMethod.FIFO), is(0.75));
         assertEquals(trade1.getIRR(), 0.75, 0.0001);
+
+        assertThat(trade1.getEntryValue(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, 0L)));
+        assertThat(trade1.getProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+                        is(Money.of(CurrencyUnit.EUR, amountOf(5) * 3)));
+        assertThat(trade1.getReturn(CostMethod.MOVING_AVERAGE), is(Double.POSITIVE_INFINITY));
     }
 
     @Test
@@ -141,9 +160,30 @@ public class TradeTest
         List<Trade> trades = collector.collect(securityShort);
         Trade trade = trades.get(0);
 
-        Money movingAverageEntryValue = trade.getEntryValueMovingAverage();
+        Money movingAverageEntryValue = trade.getEntryValue(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED);
 
         assertThat(movingAverageEntryValue, is(Money.of(CurrencyUnit.EUR, 0L)));
+    }
+
+    @Test
+    public void testExplicitCostMethodRejectsNullParameters() throws TradeCollectorException
+    {
+        Client client = new Client();
+        TradeCollector collector = new TradeCollector(client, new TestCurrencyConverter());
+        var portfolio = new PortfolioBuilder();
+        portfolio.addTo(client);
+
+        Security security = new SecurityBuilder().addTo(client);
+        portfolio.buyPrice(security, "2024-01-01", 1.0, 10.0).sellPrice(security, "2024-12-31", 1.0, 12.0);
+        Trade trade = collector.collect(security).get(0);
+
+        assertThrows(NullPointerException.class, () -> trade.getEntryValue(null, TaxesAndFees.INCLUDED));
+        assertThrows(NullPointerException.class, () -> trade.getEntryValue(CostMethod.FIFO, null));
+        assertThrows(NullPointerException.class, () -> trade.getProfitLoss(null, TaxesAndFees.INCLUDED));
+        assertThrows(NullPointerException.class, () -> trade.getProfitLoss(CostMethod.FIFO, null));
+        assertThrows(NullPointerException.class, () -> trade.getReturn(null));
+        assertThrows(NullPointerException.class, () -> trade.isLoss(null));
+        assertThrows(NullPointerException.class, () -> trade.isGrossLoss(null));
     }
 
     @Test
@@ -169,8 +209,8 @@ public class TradeTest
         assertThat(trade1.getShares(), is(sharesOf(18)));
         var entryAmount = 12 * 10 + 5 * 12 + 1 * 30;
         var exitAmount = 18 * 20;
-        assertThat(trade1.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, amountOf(exitAmount - entryAmount))));
-        assertEquals(trade1.getReturn(), (double) (exitAmount - entryAmount) / entryAmount, 0.00000001);
+        assertThat(trade1.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, amountOf(exitAmount - entryAmount))));
+        assertEquals(trade1.getReturn(CostMethod.FIFO), (double) (exitAmount - entryAmount) / entryAmount, 0.00000001);
         assertEquals(trade1.getIRR(), 0.76018, 0.0001);
 
         Trade trade2 = trades.get(1);
@@ -178,7 +218,7 @@ public class TradeTest
         assertThat(trade2.isLong(), is(true));
         assertThat(trade2.getShares(), is(sharesOf(2)));
         assertThat(trade2.getEnd().isPresent(), is(false));
-        assertThat(trade2.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, amountOf(2 * 2 - 2 * 30))));
+        assertThat(trade2.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, amountOf(2 * 2 - 2 * 30))));
     }
 
     @Test
@@ -205,10 +245,10 @@ public class TradeTest
         assertThat(trade1.getShares(), is(sharesOf(4)));
         var entryAmount = 2 * 100 + 2 * 120;
         var exitAmount = 4 * 20;
-        assertThat(trade1.getEntryValue(), is(Money.of(CurrencyUnit.EUR, amountOf(entryAmount))));
+        assertThat(trade1.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, amountOf(entryAmount))));
         assertThat(trade1.getExitValue(), is(Money.of(CurrencyUnit.EUR, amountOf(exitAmount))));
-        assertThat(trade1.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, amountOf(entryAmount - exitAmount))));
-        assertThat(trade1.getReturn(), is(1.0 - (double) exitAmount / entryAmount));
+        assertThat(trade1.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, amountOf(entryAmount - exitAmount))));
+        assertThat(trade1.getReturn(CostMethod.FIFO), is(1.0 - (double) exitAmount / entryAmount));
         assertEquals(0.8710, trade1.getIRR(), 0.0001);
 
         Trade trade2 = trades.get(1);
@@ -216,7 +256,7 @@ public class TradeTest
         assertThat(trade2.isLong(), is(false));
         assertThat(trade2.getShares(), is(sharesOf(3)));
         assertThat(trade2.getEnd().isPresent(), is(false));
-        assertThat(trade2.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, amountOf(1 * 120 + 2 * 50 - 0))));
-        assertThat(trade2.getReturn(), is(1.0));
+        assertThat(trade2.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, amountOf(1 * 120 + 2 * 50 - 0))));
+        assertThat(trade2.getReturn(CostMethod.FIFO), is(1.0));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradesGroupedByTaxonomyTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradesGroupedByTaxonomyTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertThrows;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -18,7 +19,9 @@ import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Taxonomy;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
@@ -82,15 +85,15 @@ public class TradesGroupedByTaxonomyTest
         TradeCategory stocksCategory = grouped.byClassification(stocks);
         assertThat(stocksCategory, notNullValue());
         assertThat(stocksCategory.getTradeCount(), is(1L));
-        assertThat(stocksCategory.getTotalProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
+        assertThat(stocksCategory.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
 
         TradeCategory bondsCategory = grouped.byClassification(bonds);
         assertThat(bondsCategory, notNullValue());
         assertThat(bondsCategory.getTradeCount(), is(1L));
-        assertThat(bondsCategory.getTotalProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500))));
+        assertThat(bondsCategory.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500))));
 
         // verify total
-        assertThat(grouped.getTotalProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1500))));
+        assertThat(grouped.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1500))));
     }
 
     @Test
@@ -140,14 +143,14 @@ public class TradesGroupedByTaxonomyTest
 
         TradeCategory equitiesCategory = grouped.byClassification(equities);
         assertThat(equitiesCategory, notNullValue());
-        assertThat(equitiesCategory.getTotalProfitLoss(),
+        assertThat(equitiesCategory.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
 
         TradeCategory growthCategory = grouped.byClassification(growth);
         assertThat(growthCategory, notNullValue());
-        assertThat(growthCategory.getTotalProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(400))));
+        assertThat(growthCategory.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(400))));
 
-        assertThat(grouped.getTotalProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1400))));
+        assertThat(grouped.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1400))));
     }
 
     @Test
@@ -188,26 +191,26 @@ public class TradesGroupedByTaxonomyTest
 
         // verify both categories have half the profit
         TradeCategory techCategory = grouped.byClassification(tech);
-        assertThat(techCategory.getTotalProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500))));
+        assertThat(techCategory.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500))));
 
         TradeCategory healthcareCategory = grouped.byClassification(healthcare);
-        assertThat(healthcareCategory.getTotalProfitLoss(),
+        assertThat(healthcareCategory.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500))));
 
-        String techCurrency = techCategory.getTotalProfitLoss().getCurrencyCode();
+        String techCurrency = techCategory.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED).getCurrencyCode();
         Money techContribution = techCategory.getTradeAssignments().stream() //
-                        .map(a -> a.getTrade().getProfitLoss().multiplyAndRound(a.getWeight())) //
+                        .map(a -> a.getTrade().getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED).multiplyAndRound(a.getWeight())) //
                         .collect(MoneyCollectors.sum(techCurrency));
-        assertThat(techContribution, is(techCategory.getTotalProfitLoss()));
+        assertThat(techContribution, is(techCategory.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED)));
 
-        String healthcareCurrency = healthcareCategory.getTotalProfitLoss().getCurrencyCode();
+        String healthcareCurrency = healthcareCategory.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED).getCurrencyCode();
         Money healthcareContribution = healthcareCategory.getTradeAssignments().stream() //
-                        .map(a -> a.getTrade().getProfitLoss().multiplyAndRound(a.getWeight())) //
+                        .map(a -> a.getTrade().getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED).multiplyAndRound(a.getWeight())) //
                         .collect(MoneyCollectors.sum(healthcareCurrency));
-        assertThat(healthcareContribution, is(healthcareCategory.getTotalProfitLoss()));
+        assertThat(healthcareContribution, is(healthcareCategory.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED)));
 
         // total should still be 1000
-        assertThat(grouped.getTotalProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
+        assertThat(grouped.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
     }
 
     @Test
@@ -247,18 +250,18 @@ public class TradesGroupedByTaxonomyTest
 
         TradeCategory techCategory = grouped.byClassification(tech);
         assertThat(techCategory, notNullValue());
-        assertThat(techCategory.getTotalProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(250))));
+        assertThat(techCategory.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(250))));
 
         TradeCategory unassignedCategory = grouped.asList().stream() //
                         .filter(c -> Classification.UNASSIGNED_ID.equals(c.getClassification().getId())) //
                         .findFirst().orElse(null);
 
         assertThat(unassignedCategory, notNullValue());
-        assertThat(unassignedCategory.getTotalProfitLoss(),
+        assertThat(unassignedCategory.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(750))));
 
         // total should still be 1000
-        assertThat(grouped.getTotalProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
+        assertThat(grouped.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
     }
 
     @Test
@@ -311,7 +314,7 @@ public class TradesGroupedByTaxonomyTest
             totals.addTrade(trade, 1.0);
         }
 
-        assertThat(totals.getTotalProfitLoss().getAmount(), greaterThan(0L));
+        assertThat(totals.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED).getAmount(), greaterThan(0L));
         assertThat(totals.getAverageIRR(), greaterThan(0.0));
     }
 
@@ -354,8 +357,9 @@ public class TradesGroupedByTaxonomyTest
         assertThat(equitiesCategory.getCurrencyKey(), is(CurrencyUnit.USD));
 
         Trade usdTrade = trades.get(0);
-        assertThat(usdTrade.getProfitLoss().getCurrencyCode(), is(CurrencyUnit.USD));
-        assertThat(equitiesCategory.getTotalProfitLoss(), is(usdTrade.getProfitLoss()));
+        assertThat(usdTrade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED).getCurrencyCode(), is(CurrencyUnit.USD));
+        assertThat(usdTrade.getCurrencyCode(), is(CurrencyUnit.USD));
+        assertThat(equitiesCategory.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(usdTrade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED)));
         assertThat(grouped.asList().size(), is(1));
     }
 
@@ -408,20 +412,47 @@ public class TradesGroupedByTaxonomyTest
         Money expectedTotal = trades.stream() //
                         .map(trade -> {
                             LocalDate date = trade.getEnd().map(LocalDate::from).orElse(LocalDate.now());
-                            return trade.getProfitLoss().with(converter.at(date));
+                            return trade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED).with(converter.at(date));
                         }) //
                         .collect(MoneyCollectors.sum(converter.getTermCurrency()));
 
-        assertThat(grouped.getTotalProfitLoss(), is(expectedTotal));
+        assertThat(grouped.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(expectedTotal));
+        assertThat(grouped.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(expectedTotal));
 
         Money expectedWithout = trades.stream() //
                         .map(trade -> {
                             LocalDate date = trade.getEnd().map(LocalDate::from).orElse(LocalDate.now());
-                            return trade.getProfitLossWithoutTaxesAndFees().with(converter.at(date));
+                            return trade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED).with(converter.at(date));
                         }) //
                         .collect(MoneyCollectors.sum(converter.getTermCurrency()));
 
-        assertThat(grouped.getTotalProfitLossWithoutTaxesAndFees(), is(expectedWithout));
+        assertThat(grouped.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED), is(expectedWithout));
+        assertThat(grouped.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED), is(expectedWithout));
+
+        Money expectedMovingAverage = trades.stream() //
+                        .map(trade -> {
+                            LocalDate date = trade.getEnd().map(LocalDate::from).orElse(LocalDate.now());
+                            return trade.getProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED)
+                                            .with(converter.at(date));
+                        }) //
+                        .collect(MoneyCollectors.sum(converter.getTermCurrency()));
+        Money expectedMovingAverageWithout = trades.stream() //
+                        .map(trade -> {
+                            LocalDate date = trade.getEnd().map(LocalDate::from).orElse(LocalDate.now());
+                            return trade.getProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED)
+                                            .with(converter.at(date));
+                        }) //
+                        .collect(MoneyCollectors.sum(converter.getTermCurrency()));
+
+        assertThat(grouped.getTotalProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+                        is(expectedMovingAverage));
+        assertThat(grouped.getTotalProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
+                        is(expectedMovingAverageWithout));
+        assertThat(expectedMovingAverage.getCurrencyCode(), is(expectedTotal.getCurrencyCode()));
+        assertThrows(NullPointerException.class,
+                        () -> grouped.getTotalProfitLoss(null, TaxesAndFees.INCLUDED));
+        assertThrows(NullPointerException.class,
+                        () -> grouped.getTotalProfitLoss(CostMethod.FIFO, null));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/scenarios/ClientPerformanceSnapshotTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/ClientPerformanceSnapshotTestCase.java
@@ -38,7 +38,7 @@ public class ClientPerformanceSnapshotTestCase
         ReportingPeriod period = new ReportingPeriod.FromXtoY(LocalDate.parse("2015-01-02"),
                         LocalDate.parse("2015-01-14"));
         ClientPerformanceSnapshot performance = new ClientPerformanceSnapshot(client, converter,
-                        period.toInterval(LocalDate.now()));
+                        period.toInterval(LocalDate.now()), name.abuchen.portfolio.model.CostMethod.FIFO);
 
         // calculating the totals is tested with #testClientSnapshot
         assertThat(performance.getValue(CategoryType.INITIAL_VALUE),

--- a/name.abuchen.portfolio.tests/src/scenarios/CurrencyTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/CurrencyTestCase.java
@@ -178,7 +178,7 @@ public class CurrencyTestCase
         ReportingPeriod period = new ReportingPeriod.FromXtoY(LocalDate.parse("2015-01-02"),
                         LocalDate.parse("2015-01-14"));
         ClientPerformanceSnapshot performance = new ClientPerformanceSnapshot(client, converter,
-                        period.toInterval(LocalDate.now()));
+                        period.toInterval(LocalDate.now()), name.abuchen.portfolio.model.CostMethod.FIFO);
 
         // calculating the totals is tested with #testClientSnapshot
         assertThat(performance.getValue(CategoryType.INITIAL_VALUE), is(Money.of(CurrencyUnit.EUR, 4131_99)));
@@ -235,7 +235,7 @@ public class CurrencyTestCase
         LazySecurityPerformanceRecord record = performance.getRecords().stream()
                         .filter(r -> r.getSecurity() == securityUSD).findAny()
                         .orElseThrow(IllegalArgumentException::new);
-        assertThat(record.getSharesHeld(), is(Values.Share.factorize(15)));
+        assertThat(record.getSharesHeld(name.abuchen.portfolio.model.CostMethod.FIFO), is(Values.Share.factorize(15)));
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
                         is(Money.of(CurrencyUnit.EUR, 454_60L + 471_05 + 498_45)));
 

--- a/name.abuchen.portfolio.tests/src/scenarios/SecurityPerformanceTaxRefundTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/SecurityPerformanceTaxRefundTestCase.java
@@ -22,13 +22,13 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.ClientFactory;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
-import name.abuchen.portfolio.model.CostMethod;
-import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
@@ -113,7 +113,7 @@ public class SecurityPerformanceTaxRefundTestCase
         assertThat(accountIndex.getFinalAccumulatedPercentage(), is(0d));
 
         // pinned values previously verified via SecurityPerformanceSnapshotComparator
-        assertThat(record.getSharesHeld(), is(10000000000L));
+        assertThat(record.getSharesHeld(name.abuchen.portfolio.model.CostMethod.FIFO), is(10000000000L));
         assertThat(record.getMarketValue(), is(Money.of("EUR", 743000L)));
         assertThat(record.getQuote(), is(Quote.of("EUR", 7430000000L)));
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of("EUR", 765800L)));
@@ -165,7 +165,7 @@ public class SecurityPerformanceTaxRefundTestCase
         LazySecurityPerformanceRecord record = snapshot.getRecords().get(0);
 
         assertThat(record.getSecurity().getName(), is("Basf SE"));
-        assertThat(record.getSharesHeld(), is(0L));
+        assertThat(record.getSharesHeld(name.abuchen.portfolio.model.CostMethod.FIFO), is(0L));
 
         // no changes in holdings, ttwror must (without taxes and tax refunds):
         double startValue = (double) delivery.getAmount() - delivery.getUnitSum(Unit.Type.TAX).getAmount();

--- a/name.abuchen.portfolio.tests/src/scenarios/SecurityTaxAndFeeAccountTransactionsTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/SecurityTaxAndFeeAccountTransactionsTestCase.java
@@ -138,7 +138,7 @@ public class SecurityTaxAndFeeAccountTransactionsTestCase
         checkFilteredClientAdidas(filteredClient, 0.5);
 
         // pinned values previously verified via SecurityPerformanceSnapshotComparator
-        assertThat(record.getSharesHeld(), is(1000000000L));
+        assertThat(record.getSharesHeld(name.abuchen.portfolio.model.CostMethod.FIFO), is(1000000000L));
         assertThat(record.getMarketValue(), is(Money.of("EUR", 145650L)));
         assertThat(record.getQuote(), is(Quote.of("EUR", 14565000000L)));
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of("EUR", 153300L)));

--- a/name.abuchen.portfolio.tests/src/scenarios/SecurityTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/SecurityTestCase.java
@@ -59,7 +59,7 @@ public class SecurityTestCase
         assertThat(record.getIrr(), closeTo(-0.0643, 0.0001));
 
         // pinned values previously verified via SecurityPerformanceSnapshotComparator
-        assertThat(record.getSharesHeld(), is(10000000000L));
+        assertThat(record.getSharesHeld(name.abuchen.portfolio.model.CostMethod.FIFO), is(10000000000L));
         assertThat(record.getMarketValue(), is(Money.of("EUR", 728800L)));
         assertThat(record.getQuote(), is(Quote.of("EUR", 7288000000L)));
         assertThat(record.getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED), is(Money.of("EUR", 774800L)));

--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/PerformanceViewTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/PerformanceViewTest.java
@@ -1,0 +1,81 @@
+package name.abuchen.portfolio.ui.views;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.eclipse.jface.preference.PreferenceStore;
+import org.junit.Test;
+
+import name.abuchen.portfolio.model.CostMethod;
+
+@SuppressWarnings("nls")
+public class PerformanceViewTest
+{
+    private static final String PREFERENCE_KEY = "PerformanceView-CAPITAL_GAIN_USE_FIFO";
+
+    @Test
+    public void legacyTrueIsReadAsFifoAndNormalized()
+    {
+        var preferences = new PreferenceStore();
+        preferences.setValue(PREFERENCE_KEY, "true");
+
+        assertThat(PerformanceView.readCapitalGainCostMethod(preferences), is(CostMethod.FIFO));
+        assertThat(preferences.getString(PREFERENCE_KEY), is(CostMethod.FIFO.name()));
+    }
+
+    @Test
+    public void legacyFalseIsReadAsMovingAverageAndNormalized()
+    {
+        var preferences = new PreferenceStore();
+        preferences.setValue(PREFERENCE_KEY, "false");
+
+        assertThat(PerformanceView.readCapitalGainCostMethod(preferences), is(CostMethod.MOVING_AVERAGE));
+        assertThat(preferences.getString(PREFERENCE_KEY), is(CostMethod.MOVING_AVERAGE.name()));
+    }
+
+    @Test
+    public void canonicalValuesAreReadWithoutBeingRewritten()
+    {
+        var preferences = new PreferenceStore();
+
+        preferences.setValue(PREFERENCE_KEY, CostMethod.FIFO.name());
+        assertThat(PerformanceView.readCapitalGainCostMethod(preferences), is(CostMethod.FIFO));
+        assertThat(preferences.getString(PREFERENCE_KEY), is(CostMethod.FIFO.name()));
+
+        preferences.setValue(PREFERENCE_KEY, CostMethod.MOVING_AVERAGE.name());
+        assertThat(PerformanceView.readCapitalGainCostMethod(preferences), is(CostMethod.MOVING_AVERAGE));
+        assertThat(preferences.getString(PREFERENCE_KEY), is(CostMethod.MOVING_AVERAGE.name()));
+    }
+
+    @Test
+    public void emptyAndUnknownValuesUseFifo()
+    {
+        var preferences = new PreferenceStore();
+
+        assertThat(PerformanceView.readCapitalGainCostMethod(preferences), is(CostMethod.FIFO));
+
+        preferences.setValue(PREFERENCE_KEY, "unknown");
+        assertThat(PerformanceView.readCapitalGainCostMethod(preferences), is(CostMethod.FIFO));
+        assertThat(preferences.getString(PREFERENCE_KEY), is("unknown"));
+    }
+
+    @Test
+    public void fifoSelectionWritesCanonicalValue()
+    {
+        var preferences = new PreferenceStore();
+
+        PerformanceView.writeCapitalGainCostMethod(preferences, CostMethod.FIFO);
+
+        assertThat(preferences.getString(PREFERENCE_KEY), is("FIFO"));
+    }
+
+    @Test
+    public void movingAverageSelectionWritesCanonicalValue()
+    {
+        var preferences = new PreferenceStore();
+
+        PerformanceView.writeCapitalGainCostMethod(preferences, CostMethod.MOVING_AVERAGE);
+
+        assertThat(preferences.getString(PREFERENCE_KEY), is("MOVING_AVERAGE"));
+    }
+}

--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/TradesTableViewerTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/TradesTableViewerTest.java
@@ -21,8 +21,10 @@ import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Taxonomy;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.trades.Trade;
@@ -63,11 +65,11 @@ public class TradesTableViewerTest
         Trade trade = trades.get(0);
         TradeElement element = new TradeElement(trade, 0, 0.5);
 
-        double expected = trade.getReturn();
+        double expected = trade.getReturn(CostMethod.FIFO);
 
         assertThat(expected, closeTo(0.1, 0.0000001));
-        assertThat(TradesTableViewer.getReturnValue(element), closeTo(expected, 0.0000001));
-        assertThat(TradesTableViewer.getReturnValue(trade), closeTo(expected, 0.0000001));
+        assertThat(TradesTableViewer.getReturnValue(element, CostMethod.FIFO), closeTo(expected, 0.0000001));
+        assertThat(TradesTableViewer.getReturnValue(trade, CostMethod.FIFO), closeTo(expected, 0.0000001));
     }
 
     @Test
@@ -155,9 +157,9 @@ public class TradesTableViewerTest
             if (element instanceof TradeElement te)
             {
                 if (te.isTrade())
-                    return te.getTrade().getProfitLoss();
+                    return te.getTrade().getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED);
                 if (te.isCategory())
-                    return te.getCategory().getTotalProfitLoss();
+                    return te.getCategory().getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED);
             }
             return null;
         }, client);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceView.java
@@ -14,6 +14,7 @@ import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.action.ToolBarManager;
 import org.eclipse.jface.layout.TableColumnLayout;
 import org.eclipse.jface.layout.TreeColumnLayout;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.resource.FontDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.viewers.ArrayContentProvider;
@@ -88,7 +89,7 @@ import name.abuchen.portfolio.util.Interval;
 
 public class PerformanceView extends AbstractHistoricView
 {
-    private static final String CAPITAL_GAIN_USE_FIFO = PerformanceView.class.getSimpleName()
+    private static final String CAPITAL_GAIN_COST_METHOD = PerformanceView.class.getSimpleName()
                     + "-CAPITAL_GAIN_USE_FIFO"; //$NON-NLS-1$
 
     @Inject
@@ -103,7 +104,7 @@ public class PerformanceView extends AbstractHistoricView
     private ClientFilterDropDown clientFilter;
 
     private boolean preTax = false;
-    private boolean useFifo = true;
+    private CostMethod costMethod = CostMethod.FIFO;
 
     private TreeViewer calculation;
     private StatementOfAssetsViewer snapshotStart;
@@ -147,19 +148,19 @@ public class PerformanceView extends AbstractHistoricView
             manager.add(new LabelOnly(Messages.LabelCapitalGainsMethod));
 
             SimpleAction useFifoAction = new SimpleAction(CostMethod.FIFO.getLabel(), a -> {
-                this.useFifo = true;
-                getPreferenceStore().setValue(CAPITAL_GAIN_USE_FIFO, String.valueOf(useFifo));
+                this.costMethod = CostMethod.FIFO;
+                writeCapitalGainCostMethod(getPreferenceStore(), this.costMethod);
                 reportingPeriodUpdated();
             });
-            useFifoAction.setChecked(this.useFifo);
+            useFifoAction.setChecked(this.costMethod == CostMethod.FIFO);
             manager.add(useFifoAction);
 
             SimpleAction movingAverageMethod = new SimpleAction(CostMethod.MOVING_AVERAGE.getLabel(), a -> {
-                this.useFifo = false;
-                getPreferenceStore().setValue(CAPITAL_GAIN_USE_FIFO, String.valueOf(useFifo));
+                this.costMethod = CostMethod.MOVING_AVERAGE;
+                writeCapitalGainCostMethod(getPreferenceStore(), this.costMethod);
                 reportingPeriodUpdated();
             });
-            movingAverageMethod.setChecked(!this.useFifo);
+            movingAverageMethod.setChecked(this.costMethod == CostMethod.MOVING_AVERAGE);
             manager.add(movingAverageMethod);
         }));
     }
@@ -176,7 +177,8 @@ public class PerformanceView extends AbstractHistoricView
 
         setToContext(UIConstants.Context.FILTERED_CLIENT, filteredClient);
 
-        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(filteredClient, converter, period, useFifo);
+        ClientPerformanceSnapshot snapshot = new ClientPerformanceSnapshot(filteredClient, converter, period,
+                        costMethod);
 
         try
         {
@@ -230,24 +232,43 @@ public class PerformanceView extends AbstractHistoricView
         fees = createTransactionViewer(folder, Messages.PerformanceTabFees);
 
         folder.setSelection(0);
-        String capitalGainMethod = getPreferenceStore().getString(CAPITAL_GAIN_USE_FIFO);
-        if (capitalGainMethod != null && !capitalGainMethod.isEmpty())
-        {
-            try
-            {
-                this.useFifo = Boolean.valueOf(capitalGainMethod);
-            }
-            catch (IllegalArgumentException e)
-            {
-                // unknown capital gain method type; continue to use the default
-                // one
-            }
-        }
+        this.costMethod = readCapitalGainCostMethod(getPreferenceStore());
 
         reportingPeriodUpdated();
         updateTitle(getDefaultTitle());
 
         return folder;
+    }
+
+    static CostMethod readCapitalGainCostMethod(IPreferenceStore preferences)
+    {
+        String value = preferences.getString(CAPITAL_GAIN_COST_METHOD);
+
+        if (Boolean.TRUE.toString().equalsIgnoreCase(value))
+        {
+            writeCapitalGainCostMethod(preferences, CostMethod.FIFO);
+            return CostMethod.FIFO;
+        }
+
+        if (Boolean.FALSE.toString().equalsIgnoreCase(value))
+        {
+            writeCapitalGainCostMethod(preferences, CostMethod.MOVING_AVERAGE);
+            return CostMethod.MOVING_AVERAGE;
+        }
+
+        try
+        {
+            return CostMethod.valueOf(value);
+        }
+        catch (IllegalArgumentException e)
+        {
+            return CostMethod.FIFO;
+        }
+    }
+
+    static void writeCapitalGainCostMethod(IPreferenceStore preferences, CostMethod costMethod)
+    {
+        preferences.setValue(CAPITAL_GAIN_COST_METHOD, costMethod.name());
     }
 
     private StatementOfAssetsViewer createStatementOfAssetsItem(CTabFolder folder, String title)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -391,7 +391,7 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         {
             if (performanceRecord == null)
                 return Optional.empty();
-            return performanceRecord.explain(key);
+            return performanceRecord.explain(key, CostMethod.FIFO);
         }
 
         private Security getSecurity()
@@ -606,8 +606,8 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
 
     private class FilterDropDown extends DropDown implements IMenuListener
     {
-        private final Predicate<LazySecurityPerformanceRecord> sharesNotZero = r -> r.getSharesHeld() != 0;
-        private final Predicate<LazySecurityPerformanceRecord> sharesEqualZero = r -> r.getSharesHeld() == 0;
+        private final Predicate<LazySecurityPerformanceRecord> sharesNotZero = r -> r.getSharesHeld(CostMethod.FIFO) != 0;
+        private final Predicate<LazySecurityPerformanceRecord> sharesEqualZero = r -> r.getSharesHeld(CostMethod.FIFO) == 0;
 
         public FilterDropDown(IPreferenceStore preferenceStore)
         {
@@ -948,10 +948,11 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
             public Long getValue(Object e)
             {
                 var row = (RowElement) e;
-                return row.performanceRecord != null ? row.performanceRecord.getSharesHeld() : null;
+                return row.performanceRecord != null ? row.performanceRecord.getSharesHeld(CostMethod.FIFO) : null;
             }
         });
-        column.setSorter(ColumnViewerSorter.create(e -> ((LazySecurityPerformanceRecord) e).getSharesHeld()));
+        column.setSorter(ColumnViewerSorter
+                        .create(e -> ((LazySecurityPerformanceRecord) e).getSharesHeld(CostMethod.FIFO)));
         recordColumns.addColumn(column);
 
         // security name
@@ -1144,7 +1145,7 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                                                                                         TaxesAndFees.INCLUDED)),
                                                         getClient().getBaseCurrency())));
         column.setToolTipProvider(
-                        element -> ((RowElement) element).explain(LazySecurityPerformanceRecord.Trails.FIFO_COST));
+                        element -> ((RowElement) element).explain(LazySecurityPerformanceRecord.Trails.COST));
         column.setSorter(ColumnViewerSorter.create(
                         e -> ((LazySecurityPerformanceRecord) e).getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED)));
         recordColumns.addColumn(column);
@@ -1638,8 +1639,10 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setDescription(Messages.ColumnDividendRateOfReturnPerYear_Description);
         column.setVisible(false);
         column.setLabelProvider(
-                        new RowElementLabelProvider(r -> Values.Percent2.formatNonZero(r.getRateOfReturnPerYear())));
-        column.setSorter(ColumnViewerSorter.create(e -> ((LazySecurityPerformanceRecord) e).getRateOfReturnPerYear()));
+                        new RowElementLabelProvider(r -> Values.Percent2
+                                        .formatNonZero(r.getRateOfReturnPerYear(CostMethod.MOVING_AVERAGE))));
+        column.setSorter(ColumnViewerSorter.create(
+                        e -> ((LazySecurityPerformanceRecord) e).getRateOfReturnPerYear(CostMethod.MOVING_AVERAGE)));
         recordColumns.addColumn(column);
 
         // Anzahl der Dividendenereignisse
@@ -1788,14 +1791,15 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
         column.setOptions(new ClientFilterColumnOptions(Messages.ColumnSharesOwned + suffix,
                         new ClientFilterMenu(getClient(), getPreferenceStore())));
         column.setGroupLabel(Messages.LabelClientFilterMenu);
-        column.setLabelProvider(new RowElementOptionLabelProvider(r -> Values.Share.formatNonZero(r.getSharesHeld())));
+        column.setLabelProvider(new RowElementOptionLabelProvider(
+                        r -> Values.Share.formatNonZero(r.getSharesHeld(CostMethod.FIFO))));
         column.setSorter(ColumnViewerSorter.createWithOption((element, option) -> {
             // important: because we wrap all sorters centrally, we only have
             // the unwrapped record here -> use the model to resolve the correct
             // record
             var dataRecord = model.getRecord(((LazySecurityPerformanceRecord) element).getSecurity(),
                             (ClientFilterMenu.Item) option);
-            return dataRecord == null ? null : dataRecord.getSharesHeld();
+            return dataRecord == null ? null : dataRecord.getSharesHeld(CostMethod.FIFO);
         }));
 
         column.setVisible(false);
@@ -1823,7 +1827,8 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
             if (!row.isRecord())
                 return null;
             var dataRecord = row.model.getRecord(row.performanceRecord.getSecurity(), (ClientFilterMenu.Item) option);
-            return dataRecord == null ? "" : dataRecord.explain(LazySecurityPerformanceRecord.Trails.FIFO_COST); //$NON-NLS-1$
+            return dataRecord == null ? ""
+                            : dataRecord.explain(LazySecurityPerformanceRecord.Trails.COST, CostMethod.FIFO); //$NON-NLS-1$
         });
         column.setSorter(ColumnViewerSorter.createWithOption((element, option) -> {
             var dataRecord = model.getRecord(((LazySecurityPerformanceRecord) element).getSecurity(),

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
@@ -26,6 +26,7 @@ import org.eclipse.swt.widgets.Event;
 
 import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Named;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.model.TransactionPair;
 import name.abuchen.portfolio.money.Money;
@@ -180,32 +181,18 @@ public class TradesTableViewer
             return null;
     }
 
-    static Double getReturnValue(Object element)
+    static Double getReturnValue(Object element, CostMethod costMethod)
     {
         Trade trade = asTrade(element);
         if (trade != null)
-            return trade.getReturn();
+            return trade.getReturn(costMethod);
 
         TradeTotals totals = asTotals(element);
         if (totals != null)
-            return totals.getAverageReturn();
+            return totals.getAverageReturn(costMethod);
 
         TradeCategory category = asCategory(element);
-        return category != null ? category.getAverageReturn() : null;
-    }
-
-    static Double getReturnMovingAverageValue(Object element)
-    {
-        Trade trade = asTrade(element);
-        if (trade != null)
-            return trade.getReturnMovingAverage();
-
-        TradeTotals totals = asTotals(element);
-        if (totals != null)
-            return totals.getAverageReturnMovingAverage();
-
-        TradeCategory category = asCategory(element);
-        return category != null ? category.getAverageReturnMovingAverage() : null;
+        return category != null ? category.getAverageReturn(costMethod) : null;
     }
 
     /**
@@ -453,8 +440,11 @@ public class TradesTableViewer
         column.setGroupLabel(Messages.ColumnEntryValue);
         column.setMenuLabel(Messages.ColumnEntryValue + " (" + CostMethod.FIFO.getLabel() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
         var entryValue = tradeAggregateValue(
-                        (trade, element) -> applyWeight(trade.getEntryValue(), getTradeWeight(element)),
-                        TradeCategory::getTotalEntryValue, TradeTotals::getTotalEntryValue);
+                        (trade, element) -> applyWeight(
+                                        trade.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                                        getTradeWeight(element)),
+                        category -> category.getTotalEntryValue(CostMethod.FIFO),
+                        totals -> totals.getTotalEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED));
         column.setLabelProvider(withBoldFont(new ColumnLabelProvider()
         {
             @Override
@@ -472,8 +462,11 @@ public class TradesTableViewer
         column.setGroupLabel(Messages.ColumnEntryValue);
         column.setMenuLabel(Messages.ColumnEntryValue + " (" + CostMethod.MOVING_AVERAGE.getLabel() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
         var entryValueMovingAverage = tradeAggregateValue(
-                        (trade, element) -> applyWeight(trade.getEntryValueMovingAverage(), getTradeWeight(element)),
-                        TradeCategory::getTotalEntryValueMovingAverage, TradeTotals::getTotalEntryValueMovingAverage);
+                        (trade, element) -> applyWeight(
+                                        trade.getEntryValue(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+                                        getTradeWeight(element)),
+                        category -> category.getTotalEntryValue(CostMethod.MOVING_AVERAGE),
+                        totals -> totals.getTotalEntryValue(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED));
         column.setLabelProvider(withBoldFont(new ColumnLabelProvider()
         {
             @Override
@@ -489,7 +482,7 @@ public class TradesTableViewer
         Function<Trade, Money> averagePurchasePrice = t -> {
             if (t.getShares() == 0)
                 return null;
-            Money tradeEntryValue = t.getEntryValue();
+            Money tradeEntryValue = t.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED);
             return Money.of(tradeEntryValue.getCurrencyCode(),
                             Math.round(tradeEntryValue.getAmount() / (double) t.getShares() * Values.Share.factor()));
         };
@@ -515,7 +508,7 @@ public class TradesTableViewer
         Function<Trade, Money> averagePurchasePriceMovingAverage = t -> {
             if (t.getShares() == 0)
                 return null;
-            Money movingAverageEntry = t.getEntryValueMovingAverage();
+            Money movingAverageEntry = t.getEntryValue(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED);
             if (movingAverageEntry == null)
                 return null;
             return Money.of(movingAverageEntry.getCurrencyCode(), Math
@@ -586,8 +579,11 @@ public class TradesTableViewer
         column.setGroupLabel(Messages.ColumnProfitLoss);
         column.setMenuLabel(Messages.ColumnProfitLoss + " (" + CostMethod.FIFO.getLabel() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
         var profitLoss = tradeAggregateValue(
-                        (trade, element) -> applyWeight(trade.getProfitLoss(), getTradeWeight(element)),
-                        TradeCategory::getTotalProfitLoss, TradeTotals::getTotalProfitLoss);
+                        (trade, element) -> applyWeight(
+                                        trade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                                        getTradeWeight(element)),
+                        category -> category.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED),
+                        totals -> totals.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED));
         column.setLabelProvider(withBoldFont(new MoneyColorLabelProvider(profitLoss, view.getClient())));
         column.setSorter(ColumnViewerSorter.create(toComparable(profitLoss)));
         support.addColumn(column);
@@ -596,10 +592,11 @@ public class TradesTableViewer
         column.setGroupLabel(Messages.ColumnProfitLoss);
         column.setMenuLabel(Messages.ColumnGrossProfitLoss + " (" + CostMethod.FIFO.getLabel() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
         var grossProfitLoss = tradeAggregateValue(
-                        (trade, element) -> applyWeight(trade.getProfitLossWithoutTaxesAndFees(),
+                        (trade, element) -> applyWeight(
+                                        trade.getProfitLoss(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
                                         getTradeWeight(element)),
-                        TradeCategory::getTotalProfitLossWithoutTaxesAndFees,
-                        TradeTotals::getTotalProfitLossWithoutTaxesAndFees);
+                        category -> category.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
+                        totals -> totals.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED));
         column.setLabelProvider(withBoldFont(new MoneyColorLabelProvider(grossProfitLoss, view.getClient())));
         column.setSorter(ColumnViewerSorter.create(toComparable(grossProfitLoss)));
         column.setVisible(false);
@@ -611,8 +608,11 @@ public class TradesTableViewer
         column.setGroupLabel(Messages.ColumnProfitLoss);
         column.setMenuLabel(Messages.ColumnProfitLoss + " (" + CostMethod.MOVING_AVERAGE.getLabel() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
         var profitLossMovingAverage = tradeAggregateValue(
-                        (trade, element) -> applyWeight(trade.getProfitLossMovingAverage(), getTradeWeight(element)),
-                        TradeCategory::getTotalProfitLossMovingAverage, TradeTotals::getTotalProfitLossMovingAverage);
+                        (trade, element) -> applyWeight(
+                                        trade.getProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+                                        getTradeWeight(element)),
+                        category -> category.getTotalProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
+                        totals -> totals.getTotalProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED));
         column.setLabelProvider(withBoldFont(new MoneyColorLabelProvider(profitLossMovingAverage, view.getClient())));
         column.setSorter(ColumnViewerSorter.create(toComparable(profitLossMovingAverage)));
         column.setVisible(false);
@@ -624,10 +624,12 @@ public class TradesTableViewer
         column.setGroupLabel(Messages.ColumnProfitLoss);
         column.setMenuLabel(Messages.ColumnGrossProfitLoss + " (" + CostMethod.MOVING_AVERAGE.getLabel() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
         var grossProfitLossMovingAverage = tradeAggregateValue(
-                        (trade, element) -> applyWeight(trade.getProfitLossMovingAverageWithoutTaxesAndFees(),
+                        (trade, element) -> applyWeight(
+                                        trade.getProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
                                         getTradeWeight(element)),
-                        TradeCategory::getTotalProfitLossMovingAverageWithoutTaxesAndFees,
-                        TradeTotals::getTotalProfitLossMovingAverageWithoutTaxesAndFees);
+                        category -> category.getTotalProfitLoss(CostMethod.MOVING_AVERAGE,
+                                        TaxesAndFees.NOT_INCLUDED),
+                        totals -> totals.getTotalProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED));
         column.setLabelProvider(
                         withBoldFont(new MoneyColorLabelProvider(grossProfitLossMovingAverage, view.getClient())));
         column.setSorter(ColumnViewerSorter.create(toComparable(grossProfitLossMovingAverage)));
@@ -666,7 +668,7 @@ public class TradesTableViewer
         column = new Column("return", Messages.ColumnReturn, SWT.RIGHT, 80); //$NON-NLS-1$
         column.setGroupLabel(Messages.ColumnReturn);
         column.setMenuLabel(Messages.ColumnReturn + " (" + CostMethod.FIFO.getLabel() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
-        Function<Object, Double> returnValue = TradesTableViewer::getReturnValue;
+        Function<Object, Double> returnValue = element -> getReturnValue(element, CostMethod.FIFO);
         column.setLabelProvider(withBoldFont(new NumberColorLabelProvider<>(Values.Percent2, returnValue::apply)));
         column.setSorter(ColumnViewerSorter.create(toComparable(returnValue)));
         column.setVisible(false);
@@ -677,7 +679,8 @@ public class TradesTableViewer
                         SWT.RIGHT, 80);
         column.setGroupLabel(Messages.ColumnReturn);
         column.setMenuLabel(Messages.ColumnReturn + " (" + CostMethod.MOVING_AVERAGE.getLabel() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
-        Function<Object, Double> returnMovingAverage = TradesTableViewer::getReturnMovingAverageValue;
+        Function<Object, Double> returnMovingAverage = element -> getReturnValue(element,
+                        CostMethod.MOVING_AVERAGE);
         column.setLabelProvider(
                         withBoldFont(new NumberColorLabelProvider<>(Values.Percent2, returnMovingAverage::apply)));
         column.setSorter(ColumnViewerSorter.create(toComparable(returnMovingAverage)));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PerformanceCalculationWidget.java
@@ -276,8 +276,8 @@ public class PerformanceCalculationWidget extends WidgetDelegate<ClientPerforman
         return () -> {
             PerformanceIndex index = getDashboardData().calculate(get(DataSeriesConfig.class).getDataSeries(),
                             get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now()));
-            boolean useFifo = get(CostMethodConfig.class).getValue().useFifo();
-            return index.getClientPerformanceSnapshot(useFifo).orElseThrow(IllegalArgumentException::new);
+            var costMethod = get(CostMethodConfig.class).getValue();
+            return index.getClientPerformanceSnapshot(costMethod).orElseThrow(IllegalArgumentException::new);
         };
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PortfolioTaxOrFeeRateWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/PortfolioTaxOrFeeRateWidget.java
@@ -7,6 +7,7 @@ import java.util.function.Supplier;
 import org.eclipse.swt.widgets.Composite;
 
 import name.abuchen.portfolio.model.Dashboard.Widget;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.ClientPerformanceSnapshot;
@@ -52,7 +53,7 @@ public class PortfolioTaxOrFeeRateWidget extends AbstractIndicatorWidget<Object>
             PerformanceIndex index = getDashboardData().calculate(get(DataSeriesConfig.class).getDataSeries(),
                             get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now()));
 
-            ClientPerformanceSnapshot snapshot = index.getClientPerformanceSnapshot()
+            ClientPerformanceSnapshot snapshot = index.getClientPerformanceSnapshot(CostMethod.FIFO)
                             .orElseThrow(IllegalArgumentException::new);
 
             return valueProvider.apply(snapshot);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TopContributorsReturnWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TopContributorsReturnWidget.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import name.abuchen.portfolio.model.Dashboard.Widget;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.security.LazySecurityPerformanceRecord;
 import name.abuchen.portfolio.snapshot.security.LazySecurityPerformanceSnapshot;
@@ -30,7 +31,8 @@ public class TopContributorsReturnWidget extends AbstractTopContributorsWidget<L
 
             var index = getDashboardData().calculate(get(DataSeriesConfig.class).getDataSeries(), interval);
 
-            var snapshot = index.getClientPerformanceSnapshot().orElseThrow(IllegalArgumentException::new);
+            var snapshot = index.getClientPerformanceSnapshot(CostMethod.FIFO)
+                            .orElseThrow(IllegalArgumentException::new);
             var client = snapshot.getClient();
             var converter = getDashboardData().getCurrencyConverter();
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TopContributorsWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TopContributorsWidget.java
@@ -10,6 +10,7 @@ import java.util.function.Supplier;
 
 import name.abuchen.portfolio.model.Dashboard;
 import name.abuchen.portfolio.model.Dashboard.Widget;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
@@ -69,7 +70,7 @@ public class TopContributorsWidget extends AbstractTopContributorsWidget<ClientP
         return () -> {
             PerformanceIndex index = getDashboardData().calculate(get(DataSeriesConfig.class).getDataSeries(),
                             get(ReportingPeriodConfig.class).getReportingPeriod().toInterval(LocalDate.now()));
-            return index.getClientPerformanceSnapshot(true).orElseThrow(IllegalArgumentException::new);
+            return index.getClientPerformanceSnapshot(CostMethod.FIFO).orElseThrow(IllegalArgumentException::new);
         };
     }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TradesAverageHoldingPeriodWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TradesAverageHoldingPeriodWidget.java
@@ -9,6 +9,8 @@ import java.util.function.Predicate;
 
 import name.abuchen.portfolio.model.Dashboard;
 import name.abuchen.portfolio.model.Dashboard.Widget;
+import name.abuchen.portfolio.model.CostMethod;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.MoneyCollectors;
 import name.abuchen.portfolio.snapshot.trades.Trade;
 import name.abuchen.portfolio.ui.Messages;
@@ -70,12 +72,15 @@ public class TradesAverageHoldingPeriodWidget extends AbstractTradesWidget
 
         List<Trade> trades = input.getTrades();
 
-        double totalPurchasePrice = trades.stream().map(Trade::getEntryValue)
+        double totalPurchasePrice = trades.stream()
+                        .map(t -> t.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED))
                         .collect(MoneyCollectors.sum(getDashboardData().getCurrencyConverter().getTermCurrency()))
                         .getAmount();
 
         double averageHoldingDays = trades.stream()
-                        .mapToDouble(t -> t.getHoldingPeriod() * t.getEntryValue().getAmount() / totalPurchasePrice)
+                        .mapToDouble(t -> t.getHoldingPeriod()
+                                        * t.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED).getAmount()
+                                        / totalPurchasePrice)
                         .sum();
 
         this.indicator.setText(get(MetricConfig.class).getValue().format(averageHoldingDays));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TradesProfitLossWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TradesProfitLossWidget.java
@@ -4,6 +4,7 @@ import java.text.MessageFormat;
 import java.util.List;
 
 import name.abuchen.portfolio.model.Dashboard.Widget;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MoneyCollectors;
 import name.abuchen.portfolio.money.Values;
@@ -25,13 +26,10 @@ public class TradesProfitLossWidget extends AbstractTradesWidget
         this.title.setText(TextUtil.tooltip(getWidget().getLabel()));
 
         List<Trade> trades = input.getTrades();
-        boolean useFifo = get(CostMethodConfig.class).getValue().useFifo();
+        var costMethod = get(CostMethodConfig.class).getValue();
 
-        Money profitLoss = useFifo
-                        ? trades.stream().map(Trade::getProfitLoss)
-                                        .collect(MoneyCollectors.sum(
-                                                        getDashboardData().getCurrencyConverter().getTermCurrency()))
-                        : trades.stream().map(Trade::getProfitLossMovingAverage)
+        Money profitLoss = trades.stream()
+                        .map(trade -> trade.getProfitLoss(costMethod, TaxesAndFees.INCLUDED))
                         .collect(MoneyCollectors.sum(getDashboardData().getCurrencyConverter().getTermCurrency()));
 
         this.indicator.setText(

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TradesWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/TradesWidget.java
@@ -7,6 +7,8 @@ import org.eclipse.jface.action.IMenuManager;
 
 import name.abuchen.portfolio.model.Dashboard;
 import name.abuchen.portfolio.model.Dashboard.Widget;
+import name.abuchen.portfolio.model.CostMethod;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.snapshot.trades.Trade;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.SimpleAction;
@@ -77,7 +79,8 @@ public class TradesWidget extends AbstractTradesWidget
         this.title.setText(TextUtil.tooltip(getWidget().getLabel()));
 
         List<Trade> trades = input.getTrades();
-        long positive = trades.stream().filter(t -> t.getProfitLoss().isPositive()).count();
+        long positive = trades.stream()
+                        .filter(t -> t.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED).isPositive()).count();
         String text = MessageFormat.format("{0} <positive>↑{1}</positive> <negative>↓{2}</negative>", //$NON-NLS-1$
                         trades.size(), positive, trades.size() - positive);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/CalculationLineItemPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/CalculationLineItemPane.java
@@ -19,6 +19,7 @@ import org.eclipse.swt.widgets.Control;
 
 import name.abuchen.portfolio.model.Adaptor;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.model.TransactionOwner;
@@ -26,6 +27,7 @@ import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.SecurityPosition;
 import name.abuchen.portfolio.snapshot.security.BaseSecurityPerformanceRecord;
 import name.abuchen.portfolio.snapshot.security.CalculationLineItem;
+import name.abuchen.portfolio.snapshot.security.LazySecurityPerformanceRecord;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.DropDown;
@@ -178,8 +180,10 @@ public class CalculationLineItemPane implements InformationPanePage
             public String getText(Object e)
             {
                 CalculationLineItem item = (CalculationLineItem) e;
-                if (item instanceof CalculationLineItem.DividendPayment dividend)
-                    return Values.Percent2.formatNonZero(dividend.getPersonalDividendYield());
+                if (item instanceof CalculationLineItem.DividendPayment dividend
+                                && record instanceof LazySecurityPerformanceRecord lazyRecord)
+                    return Values.Percent2
+                                    .formatNonZero(lazyRecord.getPersonalDividendYield(dividend, CostMethod.FIFO));
                 else
                     return null;
             }
@@ -195,8 +199,10 @@ public class CalculationLineItemPane implements InformationPanePage
             public String getText(Object e)
             {
                 CalculationLineItem item = (CalculationLineItem) e;
-                if (item instanceof CalculationLineItem.DividendPayment dividend)
-                    return Values.Percent2.formatNonZero(dividend.getPersonalDividendYieldMovingAverage());
+                if (item instanceof CalculationLineItem.DividendPayment dividend
+                                && record instanceof LazySecurityPerformanceRecord lazyRecord)
+                    return Values.Percent2.formatNonZero(
+                                    lazyRecord.getPersonalDividendYield(dividend, CostMethod.MOVING_AVERAGE));
                 else
                     return null;
             }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsView.java
@@ -202,12 +202,12 @@ public class PaymentsView extends AbstractFinanceView
 
                 var action = new SimpleAction(CostMethod.FIFO.getLabel(), //
                                 a -> model.setCostMethod(CostMethod.FIFO));
-                action.setChecked(model.getCostMethod().useFifo());
+                action.setChecked(model.getCostMethod() == CostMethod.FIFO);
                 costMethodMenu.add(action);
 
                 action = new SimpleAction(CostMethod.MOVING_AVERAGE.getLabel(),
                                 a -> model.setCostMethod(CostMethod.MOVING_AVERAGE));
-                action.setChecked(!model.getCostMethod().useFifo());
+                action.setChecked(model.getCostMethod() == CostMethod.MOVING_AVERAGE);
                 costMethodMenu.add(action);
             }
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsViewModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsViewModel.java
@@ -23,6 +23,7 @@ import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.InvestmentVehicle;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.model.TransactionPair;
@@ -360,9 +361,7 @@ public class PaymentsViewModel
                     continue;
 
                 long value = 0;
-                value = costMethod.useFifo()
-                                ? trade.getProfitLossWithoutTaxesAndFees().getAmount()
-                                : trade.getProfitLossMovingAverageWithoutTaxesAndFees().getAmount();
+                value = trade.getProfitLoss(costMethod, TaxesAndFees.NOT_INCLUDED).getAmount();
 
                 if (value != 0)
                 {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeDetailsView.java
@@ -34,6 +34,8 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Text;
 
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Taxonomy;
 import name.abuchen.portfolio.money.CurrencyConverter;
@@ -235,9 +237,10 @@ public final class TradeDetailsView extends AbstractFinanceView
                 if (onlyOpen)
                     filteredTrades = filteredTrades.filter(t -> !t.isClosed());
                 if (onlyLossMaking)
-                    filteredTrades = filteredTrades.filter(Trade::isLoss);
+                    filteredTrades = filteredTrades.filter(t -> t.isLoss(CostMethod.FIFO));
                 if (onlyProfitable)
-                    filteredTrades = filteredTrades.filter(t -> t.getProfitLoss().isPositive());
+                    filteredTrades = filteredTrades
+                                    .filter(t -> t.getProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED).isPositive());
                 if (jobFilterPattern != null)
                     filteredTrades = filteredTrades.filter(t -> matchesFilter(t, jobFilterPattern));
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/exporter/VINISExporter.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/csv/exporter/VINISExporter.java
@@ -50,11 +50,11 @@ public class VINISExporter
                         firstYear.with(TemporalAdjusters.firstDayOfYear()), LocalDate.now());
 
         var performanceAllYears = new ClientPerformanceSnapshot(client, converter,
-                        periodAllYears.toInterval(LocalDate.now()));
+                        periodAllYears.toInterval(LocalDate.now()), CostMethod.FIFO);
         var performanceCurrentYear = new ClientPerformanceSnapshot(client, converter,
-                        periodCurrentYear.toInterval(LocalDate.now()));
+                        periodCurrentYear.toInterval(LocalDate.now()), CostMethod.FIFO);
         var performanceLastYear = new ClientPerformanceSnapshot(client, converter,
-                        periodLastYear.toInterval(LocalDate.now()));
+                        periodLastYear.toInterval(LocalDate.now()), CostMethod.FIFO);
 
         var earningsCurrentYear = performanceCurrentYear.getValue(CategoryType.EARNINGS);
         var earningsLastYear = performanceLastYear.getValue(CategoryType.EARNINGS);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/CostMethod.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/CostMethod.java
@@ -31,9 +31,4 @@ public enum CostMethod
     {
         return abbreviation;
     }
-
-    public boolean useFifo()
-    {
-        return this == FIFO;
-    }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/DivvyDiaryUploader.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/DivvyDiaryUploader.java
@@ -92,7 +92,7 @@ public class DivvyDiaryUploader
             item.put("isin", security.getIsin());
 
             // fill in current holdings
-            item.put("quantity", performanceRecord.getSharesHeld() / Values.Share.divider());
+            item.put("quantity", performanceRecord.getSharesHeld(CostMethod.FIFO) / Values.Share.divider());
 
             // Add the "buyin" (the FIFO cost). Used if no transactions are
             // transmitted. Add for backward compatibility in case transactions

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshot.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshot.java
@@ -7,6 +7,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -18,6 +19,7 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Adaptable;
 import name.abuchen.portfolio.model.Adaptor;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
@@ -29,7 +31,6 @@ import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MoneyCollectors;
 import name.abuchen.portfolio.money.MutableMoney;
 import name.abuchen.portfolio.money.Values;
-import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.snapshot.security.CapitalGainsRecord;
 import name.abuchen.portfolio.snapshot.security.LazySecurityPerformanceRecord;
 import name.abuchen.portfolio.snapshot.security.LazySecurityPerformanceSnapshot;
@@ -168,7 +169,7 @@ public class ClientPerformanceSnapshot
     private final Interval period;
     private ClientSnapshot snapshotStart;
     private ClientSnapshot snapshotEnd;
-    private boolean useFifo = true;
+    private final CostMethod costMethod;
 
     private final EnumMap<CategoryType, Category> categories = new EnumMap<>(CategoryType.class);
     private final List<TransactionPair<?>> earnings = new ArrayList<>();
@@ -176,19 +177,16 @@ public class ClientPerformanceSnapshot
     private final List<TransactionPair<?>> taxes = new ArrayList<>();
     private double irr;
 
-    public ClientPerformanceSnapshot(Client client, CurrencyConverter converter, LocalDate startDate, LocalDate endDate)
+    public ClientPerformanceSnapshot(Client client, CurrencyConverter converter, LocalDate startDate, LocalDate endDate,
+                    CostMethod costMethod)
     {
-        this(client, converter, Interval.of(startDate, endDate), true);
+        this(client, converter, Interval.of(startDate, endDate), costMethod);
     }
 
-    public ClientPerformanceSnapshot(Client client, CurrencyConverter converter, Interval period)
+    public ClientPerformanceSnapshot(Client client, CurrencyConverter converter, Interval period,
+                    CostMethod costMethod)
     {
-        this(client, converter, period, true);
-    }
-
-    public ClientPerformanceSnapshot(Client client, CurrencyConverter converter, Interval period, boolean useFifo)
-    {
-        this.useFifo = useFifo;
+        this.costMethod = Objects.requireNonNull(costMethod);
         this.client = client;
         this.converter = converter;
         this.period = period;
@@ -352,56 +350,30 @@ public class ClientPerformanceSnapshot
 
         irr = ClientIRRYield.create(client, snapshotStart, snapshotEnd).getIrr();
 
-        if (useFifo)
-            addCapitalGainsFifo();
-        else
-            addCapitalGainsMovingAverage();
+        addCapitalGains(costMethod);
 
         addEarnings();
         addCurrencyGains();
     }
 
     /**
-     * Calculates realized and unrealized capital gains using the FIFO method.
-     * If the security is traded in forex then additionally the currency gains
-     * are calculated, i.e. the change in value if the investment would have
-     * been in cash in the foreign currency.
+     * Calculates realized and unrealized capital gains using the selected cost
+     * method. If the security is traded in forex, the corresponding currency
+     * gains are calculated as well.
      */
-    private void addCapitalGainsFifo()
+    private void addCapitalGains(CostMethod costMethod)
     {
         LazySecurityPerformanceSnapshot securityPerformance = LazySecurityPerformanceSnapshot.create(client, converter,
                         period, snapshotStart, snapshotEnd);
 
         Category realizedCapitalGains = categories.get(CategoryType.REALIZED_CAPITAL_GAINS);
         addCapitalGains(realizedCapitalGains, securityPerformance,
-                        record -> record.getRealizedCapitalGains(CostMethod.FIFO));
+                        record -> record.getRealizedCapitalGains(costMethod));
 
         // create position for unrealized capital gains
 
         Category capitalGains = categories.get(CategoryType.CAPITAL_GAINS);
-        addCapitalGains(capitalGains, securityPerformance, record -> record.getUnrealizedCapitalGains(CostMethod.FIFO));
-    }
-
-    /**
-     * Calculates realized and unrealized capital gains using the Moving Average
-     * method. If the security is traded in forex then additionally the currency
-     * gains are calculated, i.e. the change in value if the investment would
-     * have been in cash in the foreign currency.
-     */
-    private void addCapitalGainsMovingAverage()
-    {
-        LazySecurityPerformanceSnapshot securityPerformance = LazySecurityPerformanceSnapshot.create(client, converter,
-                        period, snapshotStart, snapshotEnd);
-
-        Category realizedCapitalGains = categories.get(CategoryType.REALIZED_CAPITAL_GAINS);
-        addCapitalGains(realizedCapitalGains, securityPerformance,
-                        record -> record.getRealizedCapitalGains(CostMethod.MOVING_AVERAGE));
-
-        // create position for unrealized capital gains
-
-        Category capitalGains = categories.get(CategoryType.CAPITAL_GAINS);
-        addCapitalGains(capitalGains, securityPerformance,
-                        record -> record.getUnrealizedCapitalGains(CostMethod.MOVING_AVERAGE));
+        addCapitalGains(capitalGains, securityPerformance, record -> record.getUnrealizedCapitalGains(costMethod));
     }
 
     private void addCapitalGains(Category category, LazySecurityPerformanceSnapshot securityPerformance,

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.IntPredicate;
 import java.util.function.ToLongBiFunction;
@@ -25,6 +26,7 @@ import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
@@ -35,6 +37,7 @@ import name.abuchen.portfolio.snapshot.filter.ClientClassificationFilter;
 import name.abuchen.portfolio.snapshot.filter.ClientSecurityFilter;
 import name.abuchen.portfolio.snapshot.filter.PortfolioClientFilter;
 import name.abuchen.portfolio.util.Interval;
+import name.abuchen.portfolio.util.LazyValue;
 import name.abuchen.portfolio.util.TradeCalendar;
 import name.abuchen.portfolio.util.TradeCalendarManager;
 
@@ -60,8 +63,9 @@ public class PerformanceIndex
 
     private Drawdown drawdown;
     private Volatility volatility;
-    private ClientPerformanceSnapshot performanceSnapshotFifo;
-    private ClientPerformanceSnapshot performanceSnapshotMovingAverage;
+    private ClientPerformanceSnapshot fifoPerformanceSnapshot;
+    private ClientPerformanceSnapshot movingAveragePerformanceSnapshot;
+    private final LazyValue<Double> performanceIRR = new LazyValue<>(this::calculatePerformanceIRR);
 
     /* package */ PerformanceIndex(Client client, CurrencyConverter converter, Interval reportInterval)
     {
@@ -277,41 +281,52 @@ public class PerformanceIndex
     }
 
     /**
-     * Returns the ClientPerformanceSnapshot if available. The snapshot is not
-     * available for benchmarks and the consumer price indices.
+     * Returns the ClientPerformanceSnapshot for the selected cost method if
+     * available. The snapshot is not available for benchmarks and the consumer
+     * price indices.
      */
-    public Optional<ClientPerformanceSnapshot> getClientPerformanceSnapshot()
+    public Optional<ClientPerformanceSnapshot> getClientPerformanceSnapshot(CostMethod costMethod)
     {
-        return getClientPerformanceSnapshot(true);
+        ClientPerformanceSnapshot snapshot = switch (Objects.requireNonNull(costMethod))
+        {
+            case FIFO -> getOrCreateFifoPerformanceSnapshot();
+            case MOVING_AVERAGE -> getOrCreateMovingAveragePerformanceSnapshot();
+        };
+
+        return Optional.of(snapshot);
     }
 
-    /**
-     * Returns the ClientPerformanceSnapshot if available with a choice between
-     * FIFO (useFifo true) or Moving Average (useFifo = false) CapitalGains. The
-     * snapshot is not available for benchmarks and the consumer price indices.
-     */
-    public Optional<ClientPerformanceSnapshot> getClientPerformanceSnapshot(boolean useFifo)
+    private ClientPerformanceSnapshot getOrCreateFifoPerformanceSnapshot()
     {
-        if (useFifo)
+        if (fifoPerformanceSnapshot == null)
         {
-            if (performanceSnapshotFifo == null)
-                performanceSnapshotFifo = new ClientPerformanceSnapshot(client, converter, reportInterval, true);
+            fifoPerformanceSnapshot = new ClientPerformanceSnapshot(client, converter, reportInterval, CostMethod.FIFO);
+        }
 
-            return Optional.of(performanceSnapshotFifo);
-        }
-        else
+        return fifoPerformanceSnapshot;
+    }
+
+    private ClientPerformanceSnapshot getOrCreateMovingAveragePerformanceSnapshot()
+    {
+        if (movingAveragePerformanceSnapshot == null)
         {
-            if (performanceSnapshotMovingAverage == null)
-                performanceSnapshotMovingAverage = new ClientPerformanceSnapshot(client, converter, reportInterval,
-                                false);
-            return Optional.of(performanceSnapshotMovingAverage);
+            movingAveragePerformanceSnapshot = new ClientPerformanceSnapshot(client, converter, reportInterval,
+                            CostMethod.MOVING_AVERAGE);
         }
+
+        return movingAveragePerformanceSnapshot;
     }
 
     public double getPerformanceIRR()
     {
-        return getClientPerformanceSnapshot().map(ClientPerformanceSnapshot::getPerformanceIRR)
-                        .orElseThrow(IllegalArgumentException::new);
+        return performanceIRR.get();
+    }
+
+    private double calculatePerformanceIRR()
+    {
+        ClientSnapshot snapshotStart = ClientSnapshot.create(client, converter, reportInterval.getStart());
+        ClientSnapshot snapshotEnd = ClientSnapshot.create(client, converter, reportInterval.getEnd());
+        return ClientIRRYield.create(client, snapshotStart, snapshotEnd).getIrr();
     }
 
     public long[] getTaxes()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/BaseSecurityPerformanceRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/BaseSecurityPerformanceRecord.java
@@ -27,7 +27,7 @@ public class BaseSecurityPerformanceRecord
 
     public interface Trails // NOSONAR
     {
-        String FIFO_COST = "fifoCost"; //$NON-NLS-1$
+        String COST = "cost"; //$NON-NLS-1$
         String REALIZED_CAPITAL_GAINS = "realizedCapitalGains"; //$NON-NLS-1$
         String REALIZED_CAPITAL_GAINS_FOREX = "realizedCapitalGainsForex"; //$NON-NLS-1$
         String UNREALIZED_CAPITAL_GAINS = "unrealizedCapitalGains"; //$NON-NLS-1$

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/Calculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/Calculation.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.snapshot.security;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.PortfolioTransaction;
@@ -108,17 +109,35 @@ import name.abuchen.portfolio.money.CurrencyConverter;
     {
         try
         {
-            T thing = type.getDeclaredConstructor().newInstance();
-            thing.setSecurity(security);
-            thing.setTermCurrency(converter.getTermCurrency());
-            thing.prepare();
-            thing.visitAll(converter, lineItems);
-            thing.finish(converter, lineItems);
-            return thing;
+            return execute(type.getDeclaredConstructor().newInstance(), converter, security, lineItems);
         }
         catch (Exception e)
         {
             throw new UnsupportedOperationException(e);
         }
+    }
+
+    static <T extends Calculation> T perform(Supplier<T> factory, CurrencyConverter converter,
+                    Security security, List<CalculationLineItem> lineItems)
+    {
+        try
+        {
+            return execute(factory.get(), converter, security, lineItems);
+        }
+        catch (Exception e)
+        {
+            throw new UnsupportedOperationException(e);
+        }
+    }
+
+    private static <T extends Calculation> T execute(T calculation, CurrencyConverter converter, Security security,
+                    List<CalculationLineItem> lineItems)
+    {
+        calculation.setSecurity(security);
+        calculation.setTermCurrency(converter.getTermCurrency());
+        calculation.prepare();
+        calculation.visitAll(converter, lineItems);
+        calculation.finish(converter, lineItems);
+        return calculation;
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CalculationLineItem.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CalculationLineItem.java
@@ -81,10 +81,6 @@ public interface CalculationLineItem
 
     public static class DividendPayment extends TransactionItem
     {
-        private long totalShares;
-        private Money fifoCost;
-        private Money movingAverageCost;
-
         private DividendPayment(TransactionPair<?> transaction)
         {
             super(transaction);
@@ -95,65 +91,19 @@ public interface CalculationLineItem
             return amountFractionPerShare(getGrossValueAmount(), tx().getShares());
         }
 
-        /**
-         * Returns the FIFO costs. It is the cost of the total position of the
-         * given security. However, a dividend payment may only be about partial
-         * holdings, for example if the security is held in multiple securities
-         * accounts.
-         */
-        /* package */ Money getFifoCost()
+        public double getPersonalDividendYield(Money positionCost, long totalShares)
         {
-            return fifoCost;
-        }
-
-        /* package */ void setFifoCost(Money fifoCost)
-        {
-            this.fifoCost = fifoCost;
-        }
-
-        /**
-         * Returns the costs based on moving average. It is the cost of the
-         * total position of the given security. However, a dividend payment may
-         * only be about partial holdings, for example if the security is held
-         * in multiple securities accounts.
-         */
-        /* package */ Money getMovingAverageCost()
-        {
-            return movingAverageCost;
-        }
-
-        /* package */ void setMovingAverageCost(Money movingAverageCost)
-        {
-            this.movingAverageCost = movingAverageCost;
-        }
-
-        /* package */ void setTotalShares(long totalShares)
-        {
-            this.totalShares = totalShares;
-        }
-
-        public double getPersonalDividendYield()
-        {
-            if ((fifoCost == null) || (fifoCost.getAmount() <= 0))
+            if ((positionCost == null) || (positionCost.getAmount() <= 0))
                 return 0;
 
-            double cost = fifoCost.getAmount();
+            double cost = positionCost.getAmount();
 
             if (tx().getShares() > 0)
-                cost = fifoCost.getAmount() * (tx().getShares() / (double) totalShares);
-
-            return getGrossValueAmount() / cost;
-        }
-
-        public double getPersonalDividendYieldMovingAverage()
-        {
-            if ((movingAverageCost == null) || (movingAverageCost.getAmount() <= 0))
-                return 0;
-
-            double cost = movingAverageCost.getAmount();
-
-            if (tx().getShares() > 0)
-                cost = movingAverageCost.getAmount() * (tx().getShares() / (double) totalShares);
+            {
+                if (totalShares == 0)
+                    return 0;
+                cost = positionCost.getAmount() * (tx().getShares() / (double) totalShares);
+            }
 
             return getGrossValueAmount() / cost;
         }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationFifo.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationFifo.java
@@ -20,7 +20,7 @@ import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.SecurityPosition;
 import name.abuchen.portfolio.snapshot.trail.TrailRecord;
 
-/* package */class CapitalGainsCalculation extends AbstractCapitalGainsCalculation
+/* package */class CapitalGainsCalculationFifo extends AbstractCapitalGainsCalculation
 {
     private static class LineItem
     {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CostCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CostCalculation.java
@@ -2,16 +2,19 @@ package name.abuchen.portfolio.snapshot.security;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.PortfolioLog;
-import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.TaxesAndFees;
-import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.model.TransactionOwner;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.Money;
@@ -21,289 +24,400 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
 
 /* package */class CostCalculation extends Calculation
 {
-    public record CostCalculationResult(long sharesHeld, Money fifoCost, TrailRecord fifoCostTrail, Money netFifoCost,
-                    Money movingAverageCost, Money netMovingAverageCost, Money fees, Money taxes)
+    public record DividendCostContext(Money cost, long totalShares)
     {
     }
 
-    private static class LineItem
+    public record CostCalculationResult(Money cost, Money netCost, long sharesHeld, Optional<TrailRecord> trail,
+                    Map<CalculationLineItem.DividendPayment, DividendCostContext> dividendCosts)
     {
-        private TransactionOwner<?> owner;
-        private long shares;
-        private long grossAmount;
-        private long netAmount;
-
-        private final TrailRecord trail;
-
-        /**
-         * Holds the original number of shares (of the transaction). The
-         * original shares are needed to calculate fractions if the transaction
-         * is split up multiple times
-         */
-        private final long originalShares;
-
-        public LineItem(TransactionOwner<?> owner, long shares, long grossAmount, long netAmount, TrailRecord trail)
+        public CostCalculationResult
         {
-            this.owner = owner;
-            this.shares = shares;
-            this.grossAmount = grossAmount;
-            this.netAmount = netAmount;
-            this.trail = trail;
-            this.originalShares = shares;
+            // Calculation and consumers share the same line-item instances;
+            // identity therefore uniquely identifies each dividend event.
+            dividendCosts = Collections.unmodifiableMap(new IdentityHashMap<>(dividendCosts));
+        }
+
+        public Optional<DividendCostContext> getDividendCost(CalculationLineItem.DividendPayment payment)
+        {
+            return Optional.ofNullable(dividendCosts.get(payment));
         }
     }
 
-    private List<LineItem> fifo = new ArrayList<>();
+    private interface CostState
+    {
+        void visit(CurrencyConverter converter, CalculationLineItem.ValuationAtStart item, String termCurrency);
 
-    private long movingRelativeCost = 0;
-    private long movingRelativeNetCost = 0;
-    private long heldShares = 0;
+        void visit(CurrencyConverter converter, CalculationLineItem.TransactionItem item, PortfolioTransaction t,
+                        String termCurrency);
 
-    private long fees;
-    private long taxes;
+        long getCost(TaxesAndFees taxesAndFees);
+
+        long getSharesHeld();
+
+        Optional<TrailRecord> getTrail(String termCurrency);
+    }
+
+    private static final class FifoCostState implements CostState
+    {
+        private static class LineItem
+        {
+            private TransactionOwner<?> owner;
+            private long shares;
+            private long grossAmount;
+            private long netAmount;
+
+            private final TrailRecord trail;
+
+            /**
+             * Holds the original number of shares (of the transaction). The
+             * original shares are needed to calculate fractions if the transaction
+             * is split up multiple times
+             */
+            private final long originalShares;
+
+            public LineItem(TransactionOwner<?> owner, long shares, long grossAmount, long netAmount,
+                            TrailRecord trail)
+            {
+                this.owner = owner;
+                this.shares = shares;
+                this.grossAmount = grossAmount;
+                this.netAmount = netAmount;
+                this.trail = trail;
+                this.originalShares = shares;
+            }
+        }
+
+        private final List<LineItem> fifo = new ArrayList<>();
+
+        @Override
+        public void visit(CurrencyConverter converter, CalculationLineItem.ValuationAtStart item,
+                        String termCurrency)
+        {
+            Money valuation = item.getValue();
+            SecurityPosition position = item.getSecurityPosition().orElseThrow(IllegalArgumentException::new);
+            long amount = converter.convert(item.getDateTime(), valuation).getAmount();
+
+            add(converter, item, position, valuation, amount, termCurrency);
+        }
+
+        public void add(CurrencyConverter converter, CalculationLineItem.ValuationAtStart item,
+                        SecurityPosition position, Money valuation, long amount, String termCurrency)
+        {
+            TrailRecord trail = TrailRecord.ofPosition(item.getDateTime().toLocalDate(), (Portfolio) item.getOwner(),
+                            position);
+
+            if (!termCurrency.equals(valuation.getCurrencyCode()))
+                trail = trail.convert(Money.of(termCurrency, amount),
+                                converter.getRate(item.getDateTime(), valuation.getCurrencyCode()));
+
+            fifo.add(new LineItem(item.getOwner(), position.getShares(), amount, amount, trail));
+        }
+
+        public void add(CurrencyConverter converter, CalculationLineItem.TransactionItem item, PortfolioTransaction t,
+                        long grossAmount, long netAmount, String termCurrency)
+        {
+            TrailRecord trail = TrailRecord.ofTransaction(t);
+            if (!termCurrency.equals(t.getCurrencyCode()))
+                trail = trail.convert(Money.of(termCurrency, grossAmount),
+                                converter.getRate(t.getDateTime(), t.getCurrencyCode()));
+
+            fifo.add(new LineItem(item.getOwner(), t.getShares(), grossAmount, netAmount, trail));
+        }
+
+        @Override
+        public void visit(CurrencyConverter converter, CalculationLineItem.TransactionItem item,
+                        PortfolioTransaction t, String termCurrency)
+        {
+            switch (t.getType())
+            {
+                case BUY:
+                case DELIVERY_INBOUND:
+                    add(converter, item, t, t.getMonetaryAmount(converter).getAmount(),
+                                    t.getGrossValue(converter).getAmount(), termCurrency);
+                    break;
+                case SELL:
+                case DELIVERY_OUTBOUND:
+                    remove(item, t);
+                    break;
+                case TRANSFER_IN:
+                    transfer(item, t, termCurrency);
+                    break;
+                case TRANSFER_OUT:
+                    // ignore -> handled via TRANSFER_IN
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+
+        public void remove(CalculationLineItem.TransactionItem item, PortfolioTransaction t)
+        {
+            long sold = t.getShares();
+
+            for (LineItem entry : fifo)
+            {
+                if (sold <= 0)
+                    break;
+
+                if (!entry.owner.equals(item.getOwner()))
+                    continue;
+
+                if (entry.shares == 0)
+                    continue;
+
+                long n = Math.min(sold, entry.shares);
+
+                entry.grossAmount -= Math.round(n / (double) entry.shares * entry.grossAmount);
+                entry.netAmount -= Math.round(n / (double) entry.shares * entry.netAmount);
+                entry.shares -= n;
+
+                sold -= n;
+            }
+
+            if (sold > 0)
+            {
+                // FIXME Oops. More sold than bought.
+                PortfolioLog.warning(MessageFormat.format(Messages.MsgNegativeHoldingsDuringFIFOCostCalculation,
+                                Values.Share.format(sold), t.getSecurity().getName(),
+                                Values.DateTime.format(t.getDateTime())));
+            }
+        }
+
+        public void transfer(CalculationLineItem.TransactionItem item, PortfolioTransaction t, String termCurrency)
+        {
+            long moved = t.getShares();
+
+            TransactionOwner<?> source = t.getCrossEntry().getCrossOwner(t);
+
+            // iterate on copy b/c underlying list can be changed
+            for (LineItem entry : new ArrayList<>(fifo))
+            {
+                if (moved <= 0)
+                    break;
+
+                if (!entry.owner.equals(source))
+                    continue;
+
+                if (entry.shares == 0)
+                    continue;
+
+                long n = Math.min(moved, entry.shares);
+
+                if (n == entry.shares)
+                {
+                    // if all shares are moved, simply re-assign owner of
+                    // the shares
+                    entry.owner = item.getOwner();
+                }
+                else
+                {
+                    long transferredGrossAmount = Math.round(n / (double) entry.shares * entry.grossAmount);
+                    long transferredNetAmount = Math.round(n / (double) entry.shares * entry.netAmount);
+
+                    LineItem transfer = new LineItem(item.getOwner(), //
+                                    n, //
+                                    transferredGrossAmount, //
+                                    transferredNetAmount, //
+                                    entry.trail.fraction(Money.of(termCurrency, transferredGrossAmount), n,
+                                                    entry.originalShares) //
+                                                    .transfer(item.getDateTime().toLocalDate(), entry.owner,
+                                                                    item.getOwner()));
+
+                    entry.grossAmount -= transferredGrossAmount;
+                    entry.netAmount -= transferredNetAmount;
+                    entry.shares -= n;
+
+                    fifo.add(fifo.indexOf(entry) + 1, transfer);
+                }
+
+                moved -= n;
+            }
+
+            if (moved > 0)
+            {
+                // FIXME Oops. More moved than available.
+                PortfolioLog.warning(MessageFormat.format(Messages.MsgNegativeHoldingsDuringFIFOCostCalculation,
+                                Values.Share.format(moved), t.getSecurity().getName(),
+                                Values.DateTime.format(t.getDateTime())));
+            }
+        }
+
+        @Override
+        public long getCost(TaxesAndFees taxesAndFees)
+        {
+            long cost = 0;
+            for (LineItem entry : fifo)
+                cost += taxesAndFees.isIncluded() ? entry.grossAmount : entry.netAmount;
+            return cost;
+        }
+
+        @Override
+        public Optional<TrailRecord> getTrail(String termCurrency)
+        {
+            return Optional.of(TrailRecord.of(fifo.stream().filter(entry -> entry.grossAmount > 0) //
+                            .map(entry -> entry.trail.fraction(Money.of(termCurrency, entry.grossAmount), entry.shares,
+                                            entry.originalShares))
+                            .toList()));
+        }
+
+        @Override
+        public long getSharesHeld()
+        {
+            long shares = 0;
+            for (LineItem entry : fifo)
+                shares += entry.shares;
+            return shares;
+        }
+    }
+
+    private static final class MovingAverageCostState implements CostState
+    {
+        private long movingRelativeCost;
+        private long movingRelativeNetCost;
+        private long heldShares;
+
+        @Override
+        public void visit(CurrencyConverter converter, CalculationLineItem.ValuationAtStart item,
+                        String termCurrency)
+        {
+            Money valuation = item.getValue();
+            SecurityPosition position = item.getSecurityPosition().orElseThrow(IllegalArgumentException::new);
+            long amount = converter.convert(item.getDateTime(), valuation).getAmount();
+
+            add(amount, position.getShares());
+        }
+
+        public void add(long amount, long shares)
+        {
+            movingRelativeCost += amount;
+            movingRelativeNetCost += amount;
+            heldShares += shares;
+        }
+
+        public void add(long grossAmount, long netAmount, long shares)
+        {
+            movingRelativeCost += grossAmount;
+            movingRelativeNetCost += netAmount;
+            heldShares += shares;
+        }
+
+        public void remove(long soldShares)
+        {
+            long remaining = heldShares - soldShares;
+            if (remaining <= 0)
+            {
+                movingRelativeCost = 0;
+                movingRelativeNetCost = 0;
+                heldShares = 0;
+            }
+            else
+            {
+                movingRelativeCost = Math.round(movingRelativeCost / (double) heldShares * remaining);
+                movingRelativeNetCost = Math.round(movingRelativeNetCost / (double) heldShares * remaining);
+                heldShares = remaining;
+            }
+        }
+
+        public void transfer()
+        {
+            // client-wide costs and shares do not change on portfolio transfers
+        }
+
+        @Override
+        public void visit(CurrencyConverter converter, CalculationLineItem.TransactionItem item,
+                        PortfolioTransaction t, String termCurrency)
+        {
+            switch (t.getType())
+            {
+                case BUY:
+                case DELIVERY_INBOUND:
+                    add(t.getMonetaryAmount(converter).getAmount(), t.getGrossValue(converter).getAmount(),
+                                    t.getShares());
+                    break;
+                case SELL:
+                case DELIVERY_OUTBOUND:
+                    remove(t.getShares());
+                    break;
+                case TRANSFER_IN:
+                case TRANSFER_OUT:
+                    transfer();
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+
+        @Override
+        public long getCost(TaxesAndFees taxesAndFees)
+        {
+            return taxesAndFees.isIncluded() ? movingRelativeCost : movingRelativeNetCost;
+        }
+
+        @Override
+        public long getSharesHeld()
+        {
+            return heldShares;
+        }
+
+        @Override
+        public Optional<TrailRecord> getTrail(String termCurrency)
+        {
+            return Optional.empty();
+        }
+    }
+
+    private final CostMethod costMethod;
+    private final CostState state;
+
+    private final Map<CalculationLineItem.DividendPayment, DividendCostContext> dividendCosts = new IdentityHashMap<>();
+
+    public CostCalculation(CostMethod costMethod)
+    {
+        this.costMethod = Objects.requireNonNull(costMethod);
+        this.state = createState(costMethod);
+    }
+
+    private static CostState createState(CostMethod costMethod)
+    {
+        return switch (costMethod)
+        {
+            case FIFO -> new FifoCostState();
+            case MOVING_AVERAGE -> new MovingAverageCostState();
+        };
+    }
 
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.ValuationAtStart item)
     {
-        Money valuation = item.getValue();
-        SecurityPosition position = item.getSecurityPosition().orElseThrow(IllegalArgumentException::new);
-
-        long amount = converter.convert(item.getDateTime(), valuation).getAmount();
-
-        TrailRecord trail = TrailRecord.ofPosition(item.getDateTime().toLocalDate(), (Portfolio) item.getOwner(),
-                        position);
-
-        if (!getTermCurrency().equals(valuation.getCurrencyCode()))
-            trail = trail.convert(Money.of(getTermCurrency(), amount),
-                            converter.getRate(item.getDateTime(), valuation.getCurrencyCode()));
-
-        fifo.add(new LineItem(item.getOwner(), position.getShares(), amount, amount, trail));
-        movingRelativeCost += amount;
-        movingRelativeNetCost += amount;
-        heldShares += position.getShares();
+        state.visit(converter, item, getTermCurrency());
     }
 
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.TransactionItem item, PortfolioTransaction t)
     {
-        long fee = t.getUnitSum(Unit.Type.FEE, converter).getAmount();
-        long tax = t.getUnitSum(Unit.Type.TAX, converter).getAmount();
-        fees += fee;
-        taxes += tax;
-
-        switch (t.getType())
-        {
-            case BUY:
-            case DELIVERY_INBOUND:
-                long grossAmount = t.getMonetaryAmount(converter).getAmount();
-                long netAmount = t.getGrossValue(converter).getAmount();
-
-                TrailRecord trail = TrailRecord.ofTransaction(t);
-                if (!getTermCurrency().equals(t.getCurrencyCode()))
-                    trail = trail.convert(Money.of(getTermCurrency(), grossAmount),
-                                    converter.getRate(t.getDateTime(), t.getCurrencyCode()));
-
-                fifo.add(new LineItem(item.getOwner(), t.getShares(), grossAmount, netAmount, trail));
-                movingRelativeCost += grossAmount;
-                movingRelativeNetCost += netAmount;
-                heldShares += t.getShares();
-                break;
-
-            case SELL:
-            case DELIVERY_OUTBOUND:
-                long sold = t.getShares();
-
-                long remaining = heldShares - sold;
-                if (remaining <= 0)
-                {
-                    movingRelativeCost = 0;
-                    movingRelativeNetCost = 0;
-                    heldShares = 0;
-                }
-                else
-                {
-                    movingRelativeCost = Math.round(movingRelativeCost / (double) heldShares * remaining);
-                    movingRelativeNetCost = Math.round(movingRelativeNetCost / (double) heldShares * remaining);
-                    heldShares = remaining;
-                }
-
-                for (LineItem entry : fifo)
-                {
-                    if (sold <= 0)
-                        break;
-
-                    if (!entry.owner.equals(item.getOwner()))
-                        continue;
-
-                    if (entry.shares == 0)
-                        continue;
-
-                    long n = Math.min(sold, entry.shares);
-
-                    entry.grossAmount -= Math.round(n / (double) entry.shares * entry.grossAmount);
-                    entry.netAmount -= Math.round(n / (double) entry.shares * entry.netAmount);
-                    entry.shares -= n;
-
-                    sold -= n;
-                }
-
-                if (sold > 0)
-                {
-                    // FIXME Oops. More sold than bought.
-                    PortfolioLog.warning(MessageFormat.format(Messages.MsgNegativeHoldingsDuringFIFOCostCalculation,
-                                    Values.Share.format(sold), t.getSecurity().getName(),
-                                    Values.DateTime.format(t.getDateTime())));
-                }
-
-                break;
-
-            case TRANSFER_IN:
-                long moved = t.getShares();
-
-                TransactionOwner<?> source = t.getCrossEntry().getCrossOwner(t);
-
-                // iterate on copy b/c underlying list can be changed
-                for (LineItem entry : new ArrayList<>(fifo))
-                {
-                    if (moved <= 0)
-                        break;
-
-                    if (!entry.owner.equals(source))
-                        continue;
-
-                    if (entry.shares == 0)
-                        continue;
-
-                    long n = Math.min(moved, entry.shares);
-
-                    if (n == entry.shares)
-                    {
-                        // if all shares are moved, simply re-assign owner of
-                        // the shares
-                        entry.owner = item.getOwner();
-                    }
-                    else
-                    {
-                        long transferredGrossAmount = Math.round(n / (double) entry.shares * entry.grossAmount);
-                        long transferredNetAmount = Math.round(n / (double) entry.shares * entry.netAmount);
-
-                        LineItem transfer = new LineItem(item.getOwner(), //
-                                        n, //
-                                        transferredGrossAmount, //
-                                        transferredNetAmount, //
-                                        entry.trail.fraction(Money.of(getTermCurrency(), transferredGrossAmount), n,
-                                                        entry.originalShares) //
-                                                        .transfer(item.getDateTime().toLocalDate(), entry.owner,
-                                                                        item.getOwner()));
-
-                        entry.grossAmount -= transferredGrossAmount;
-                        entry.netAmount -= transferredNetAmount;
-                        entry.shares -= n;
-
-                        fifo.add(fifo.indexOf(entry) + 1, transfer);
-                    }
-
-                    moved -= n;
-                }
-
-                if (moved > 0)
-                {
-                    // FIXME Oops. More moved than available.
-                    PortfolioLog.warning(MessageFormat.format(Messages.MsgNegativeHoldingsDuringFIFOCostCalculation,
-                                    Values.Share.format(moved), t.getSecurity().getName(),
-                                    Values.DateTime.format(t.getDateTime())));
-                }
-
-                break;
-
-            case TRANSFER_OUT:
-                // ignore -> handled via TRANSFER_IN
-                break;
-            default:
-                throw new UnsupportedOperationException();
-        }
-    }
-
-    @Override
-    public void visit(CurrencyConverter converter, CalculationLineItem.TransactionItem item, AccountTransaction t)
-    {
-        switch (t.getType())
-        {
-            case TAXES:
-                taxes += converter.convert(t.getDateTime(), t.getMonetaryAmount()).getAmount();
-                break;
-            case TAX_REFUND:
-                taxes -= converter.convert(t.getDateTime(), t.getMonetaryAmount()).getAmount();
-                break;
-            case FEES:
-                fees += converter.convert(t.getDateTime(), t.getMonetaryAmount()).getAmount();
-                break;
-            case FEES_REFUND:
-                fees -= converter.convert(t.getDateTime(), t.getMonetaryAmount()).getAmount();
-                break;
-            default:
-        }
+        state.visit(converter, item, t, getTermCurrency());
     }
 
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.DividendPayment t)
     {
-        taxes += t.getTransaction().orElseThrow(IllegalArgumentException::new).getUnitSum(Unit.Type.TAX, converter)
-                        .getAmount();
-
-        t.setFifoCost(getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED));
-        t.setMovingAverageCost(getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED));
-        t.setTotalShares(getSharesHeld());
+        dividendCosts.put(t, new DividendCostContext(getCost(TaxesAndFees.INCLUDED), state.getSharesHeld()));
     }
 
     public CostCalculationResult getResult()
     {
-        return new CostCalculationResult(getSharesHeld(), getCost(CostMethod.FIFO, TaxesAndFees.INCLUDED),
-                        getFifoCostTrail(), getCost(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED),
-                        getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
-                        getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED), getFees(), getTaxes());
+        return new CostCalculationResult(getCost(TaxesAndFees.INCLUDED), getCost(TaxesAndFees.NOT_INCLUDED),
+                        state.getSharesHeld(), state.getTrail(getTermCurrency()), dividendCosts);
     }
 
-    public TrailRecord getFifoCostTrail()
+    public Optional<TrailRecord> getCostTrail()
     {
-        return TrailRecord.of(fifo.stream().filter(entry -> entry.grossAmount > 0) //
-                        .map(entry -> entry.trail.fraction(Money.of(getTermCurrency(), entry.grossAmount), entry.shares,
-                                        entry.originalShares))
-                        .toList());
+        return state.getTrail(getTermCurrency());
     }
 
-    private long getSharesHeld()
+    public Money getCost(TaxesAndFees taxesAndFees)
     {
-        long shares = 0;
-        for (LineItem entry : fifo)
-            shares += entry.shares;
-        return shares;
-    }
-
-    public Money getFees()
-    {
-        return Money.of(getTermCurrency(), fees);
-    }
-
-    public Money getTaxes()
-    {
-        return Money.of(getTermCurrency(), taxes);
-    }
-
-    public Money getCost(CostMethod method, TaxesAndFees taxesAndFees)
-    {
-        return Money.of(getTermCurrency(), switch (method)
-        {
-            case FIFO -> sumFifo(taxesAndFees);
-            case MOVING_AVERAGE -> taxesAndFees.isIncluded() ? movingRelativeCost : movingRelativeNetCost;
-        });
-    }
-
-    private long sumFifo(TaxesAndFees taxesAndFees)
-    {
-        long cost = 0;
-        for (LineItem entry : fifo)
-            cost += taxesAndFees.isIncluded() ? entry.grossAmount : entry.netAmount;
-        return cost;
+        return Money.of(getTermCurrency(), state.getCost(taxesAndFees));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
@@ -5,6 +5,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
 
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.SecurityPrice;
@@ -13,12 +15,13 @@ import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MutableMoney;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.security.BaseSecurityPerformanceRecord.Periodicity;
+import name.abuchen.portfolio.snapshot.security.CostCalculation.DividendCostContext;
 import name.abuchen.portfolio.util.Dates;
 
 /* package */class DividendCalculation extends Calculation
 {
     public record DividendCalculationResult(Money sum, LocalDate lastDividendPayment, int numOfEvents,
-                    Periodicity periodicity, double rateOfReturnPerYear)
+                    Periodicity periodicity)
     {
     }
 
@@ -40,70 +43,25 @@ import name.abuchen.portfolio.util.Dates;
          */
         public final int year;
         /**
-         * Rate of return for this payment.
-         */
-        public final double rateOfReturn;
-
-        /**
          * Constructs an instance.
          *
          * @param converter
          *            currency converter
          * @param t
          *            {@link DividendTransaction}
-         * @param security
-         *            {@link Security}
          */
-        public Payment(CurrencyConverter converter, CalculationLineItem.DividendPayment t, Security security)
+        public Payment(CurrencyConverter converter, CalculationLineItem.DividendPayment t)
         {
             this.amount = t.getGrossValue().with(converter.at(t.getDateTime()));
             LocalDateTime time = t.getDateTime();
             this.year = time.getYear();
             this.date = time.toLocalDate();
-
-            // try to set rate of return, default is NaN
-            double rr = Double.NaN;
-            if (security != null)
-            {
-                // calculate the rate of return, but do NOT use the method on
-                // the DividendPayment class. Why? The DividendPayment looks
-                // only at the payment, but the payment might only be for a
-                // partial position (for example if the security is held in
-                // multiple accounts). The moving average cost is always the
-                // total costs.
-
-                Money movingAverageCost = t.getMovingAverageCost();
-                if (movingAverageCost != null && !movingAverageCost.isZero())
-                {
-                    // Use converted amount (in term currency) instead of raw amount (in transaction currency)
-                    // to ensure both values are in the same currency for correct calculation
-                    rr = this.amount.getAmount() / (double) movingAverageCost.getAmount();
-                }
-
-                // check if it is valid (non 0)
-                if (rr == 0)
-                {
-                    // else use the security price at that date
-                    SecurityPrice p = security.getSecurityPrice(date);
-                    // getSecurityPrice may return an empty price value, so
-                    // check that
-                    long pValue = p.getValue();
-                    if (pValue != 0)
-                    {
-                        double sharePriceAmount = ((double) pValue) / Values.Quote.factor()
-                                        * Values.AmountFraction.factor();
-                        rr = t.getDividendPerShare() / sharePriceAmount;
-                    }
-                }
-            }
-            this.rateOfReturn = rr;
         }
     }
 
     private final List<Payment> payments = new ArrayList<>();
     private Periodicity periodicity;
     private MutableMoney sum;
-    private double rateOfReturnPerYear;
 
     @Override
     public void finish(CurrencyConverter converter, List<CalculationLineItem> lineItems)
@@ -127,22 +85,17 @@ import name.abuchen.portfolio.util.Dates;
 
         int significantCount = 0;
         int insignificantYears = 0;
-        double sumRateOfReturn = 0;
 
         // first calc total sum of all payments
         for (Payment p : payments)
         {
             // add to total sum
             sum.add(p.amount);
-            sumRateOfReturn += p.rateOfReturn;
         }
-
-        int years = 0;
 
         // now walk through individual years
         for (int year = firstPayment.getYear(); year <= lastPayment.getYear(); year++)
         {
-            years++;
             int countPerYear = 0;
             long sumPerYear = 0;
             LocalDate lastDate = null;
@@ -190,8 +143,6 @@ import name.abuchen.portfolio.util.Dates;
             }
         }
 
-        this.rateOfReturnPerYear = sumRateOfReturn / years;
-
         // determine periodicity?
         if (significantCount > 0)
         {
@@ -224,8 +175,7 @@ import name.abuchen.portfolio.util.Dates;
 
     public DividendCalculationResult getResult()
     {
-        return new DividendCalculationResult(sum.toMoney(), getLastDividendPayment(), payments.size(), periodicity,
-                        rateOfReturnPerYear);
+        return new DividendCalculationResult(sum.toMoney(), getLastDividendPayment(), payments.size(), periodicity);
     }
 
     public LocalDate getLastDividendPayment()
@@ -248,11 +198,6 @@ import name.abuchen.portfolio.util.Dates;
         return periodicity;
     }
 
-    public double getRateOfReturnPerYear()
-    {
-        return rateOfReturnPerYear;
-    }
-
     public Money getSum()
     {
         return sum.toMoney();
@@ -269,6 +214,78 @@ import name.abuchen.portfolio.util.Dates;
     public void visit(CurrencyConverter converter, CalculationLineItem.DividendPayment t)
     {
         // construct new payment and add it to the list
-        payments.add(new Payment(converter, t, getSecurity()));
+        payments.add(new Payment(converter, t));
+    }
+}
+
+/* package */class DividendRateOfReturnCalculation extends Calculation
+{
+    private static final class Payment
+    {
+        private final LocalDate date;
+        private final double rateOfReturn;
+
+        private Payment(CurrencyConverter converter, CalculationLineItem.DividendPayment payment, Security security,
+                        Optional<DividendCostContext> context)
+        {
+            Money amount = payment.getGrossValue().with(converter.at(payment.getDateTime()));
+            this.date = payment.getDateTime().toLocalDate();
+
+            // Keep the existing fallback and NaN behavior unchanged.
+            double rr = Double.NaN;
+            if (security != null)
+            {
+                if (context.isPresent() && !context.get().cost().isZero())
+                    rr = amount.getAmount() / (double) context.get().cost().getAmount();
+
+                if (rr == 0)
+                {
+                    SecurityPrice price = security.getSecurityPrice(date);
+                    long priceValue = price.getValue();
+                    if (priceValue != 0)
+                    {
+                        double sharePriceAmount = ((double) priceValue) / Values.Quote.factor()
+                                        * Values.AmountFraction.factor();
+                        rr = payment.getDividendPerShare() / sharePriceAmount;
+                    }
+                }
+            }
+            this.rateOfReturn = rr;
+        }
+    }
+
+    private final Function<CalculationLineItem.DividendPayment, Optional<DividendCostContext>> costProvider;
+    private final List<Payment> payments = new ArrayList<>();
+    private double rateOfReturnPerYear;
+
+    public DividendRateOfReturnCalculation(
+                    Function<CalculationLineItem.DividendPayment, Optional<DividendCostContext>> costProvider)
+    {
+        this.costProvider = costProvider;
+    }
+
+    @Override
+    public void visit(CurrencyConverter converter, CalculationLineItem.DividendPayment payment)
+    {
+        payments.add(new Payment(converter, payment, getSecurity(), costProvider.apply(payment)));
+    }
+
+    @Override
+    public void finish(CurrencyConverter converter, List<CalculationLineItem> lineItems)
+    {
+        if (payments.isEmpty())
+            return;
+
+        Collections.sort(payments, (r, l) -> r.date.compareTo(l.date));
+        int firstYear = payments.get(0).date.getYear();
+        int lastYear = payments.get(payments.size() - 1).date.getYear();
+        int years = lastYear - firstYear + 1;
+
+        rateOfReturnPerYear = payments.stream().mapToDouble(payment -> payment.rateOfReturn).sum() / years;
+    }
+
+    public double getRateOfReturnPerYear()
+    {
+        return rateOfReturnPerYear;
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/FeesAndTaxesCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/FeesAndTaxesCalculation.java
@@ -1,0 +1,50 @@
+package name.abuchen.portfolio.snapshot.security;
+
+import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.Transaction.Unit;
+import name.abuchen.portfolio.money.CurrencyConverter;
+import name.abuchen.portfolio.money.Money;
+
+/* package */final class FeesAndTaxesCalculation extends Calculation
+{
+    public record FeesAndTaxesResult(Money fees, Money taxes)
+    {
+    }
+
+    private long fees;
+    private long taxes;
+
+    @Override
+    public void visit(CurrencyConverter converter, CalculationLineItem.TransactionItem item, PortfolioTransaction t)
+    {
+        fees += t.getUnitSum(Unit.Type.FEE, converter).getAmount();
+        taxes += t.getUnitSum(Unit.Type.TAX, converter).getAmount();
+    }
+
+    @Override
+    public void visit(CurrencyConverter converter, CalculationLineItem.TransactionItem item, AccountTransaction t)
+    {
+        switch (t.getType())
+        {
+            case TAXES -> taxes += converter.convert(t.getDateTime(), t.getMonetaryAmount()).getAmount();
+            case TAX_REFUND -> taxes -= converter.convert(t.getDateTime(), t.getMonetaryAmount()).getAmount();
+            case FEES -> fees += converter.convert(t.getDateTime(), t.getMonetaryAmount()).getAmount();
+            case FEES_REFUND -> fees -= converter.convert(t.getDateTime(), t.getMonetaryAmount()).getAmount();
+            default -> {
+            }
+        }
+    }
+
+    @Override
+    public void visit(CurrencyConverter converter, CalculationLineItem.DividendPayment payment)
+    {
+        taxes += payment.getTransaction().orElseThrow(IllegalArgumentException::new)
+                        .getUnitSum(Unit.Type.TAX, converter).getAmount();
+    }
+
+    public FeesAndTaxesResult getResult()
+    {
+        return new FeesAndTaxesResult(Money.of(getTermCurrency(), fees), Money.of(getTermCurrency(), taxes));
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.snapshot.security;
 import java.lang.ref.WeakReference;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -27,13 +28,13 @@ import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.PerformanceIndex;
 import name.abuchen.portfolio.snapshot.security.CostCalculation.CostCalculationResult;
 import name.abuchen.portfolio.snapshot.security.DividendCalculation.DividendCalculationResult;
+import name.abuchen.portfolio.snapshot.security.FeesAndTaxesCalculation.FeesAndTaxesResult;
 import name.abuchen.portfolio.snapshot.trail.Trail;
-import name.abuchen.portfolio.snapshot.trail.TrailProvider;
 import name.abuchen.portfolio.util.Interval;
 import name.abuchen.portfolio.util.LazyValue;
 
 public final class LazySecurityPerformanceRecord extends BaseSecurityPerformanceRecord
-                implements Adaptable, TrailProvider
+                implements Adaptable
 {
     /**
      * The lazy weak value computes the value only when needed but also keeps
@@ -145,35 +146,24 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
         return converter.convert(price.getDate(), Quote.of(security.getCurrencyCode(), price.getValue()));
     });
 
-    private final LazyValue<CostCalculationResult> costCalculation = new LazyValue<>(
-                    () -> Calculation.perform(CostCalculation.class, converter, security, lineItems).getResult());
+    private final LazyValue<FeesAndTaxesResult> feesAndTaxes = new LazyValue<>(
+                    () -> Calculation.perform(FeesAndTaxesCalculation.class, converter, security, lineItems)
+                                    .getResult());
 
-    /**
-     * cost of shares held
-     */
-    private Money getCostMoney(CostMethod costMethod, TaxesAndFees taxesAndFees)
-    {
-        return switch (costMethod)
-        {
-            case FIFO -> taxesAndFees.isIncluded() ? costCalculation.get().fifoCost()
-                            : costCalculation.get().netFifoCost();
+    private final LazyValue<DividendCalculationResult> dividendCalculation = new LazyValue<>(
+                    () -> Calculation.perform(DividendCalculation.class, converter, security, lineItems).getResult());
 
-            case MOVING_AVERAGE -> taxesAndFees.isIncluded() ? costCalculation.get().movingAverageCost()
-                            : costCalculation.get().netMovingAverageCost();
-        };
-    }
-
-    private final LazyValue<DividendCalculationResult> dividendCalculation = new LazyValue<>(() -> {
-        // ensure cost calculation is done (and has calculated
-        // moving averages)
-        costCalculation.get();
-        return Calculation.perform(DividendCalculation.class, converter, security, lineItems).getResult();
-    });
-
-    private final LazyValue<CapitalGainsCalculation> capitalGains = new LazyValue<>(
-                    () -> Calculation.perform(CapitalGainsCalculation.class, converter, security, lineItems));
-
-    private final LazyValue<CapitalGainsCalculationMovingAverage> capitalGainsMovingAvg = new LazyValue<>(
+    private final LazyValue<CostCalculationResult> fifoCosts = new LazyValue<>(
+                    () -> calculateCosts(CostMethod.FIFO));
+    private final LazyValue<CostCalculationResult> movingAverageCosts = new LazyValue<>(
+                    () -> calculateCosts(CostMethod.MOVING_AVERAGE));
+    private final LazyValue<Double> fifoDividendRateOfReturn = new LazyValue<>(
+                    () -> calculateDividendRateOfReturn(CostMethod.FIFO));
+    private final LazyValue<Double> movingAverageDividendRateOfReturn = new LazyValue<>(
+                    () -> calculateDividendRateOfReturn(CostMethod.MOVING_AVERAGE));
+    private final LazyValue<CapitalGainsCalculationFifo> fifoCapitalGains = new LazyValue<>(
+                    () -> Calculation.perform(CapitalGainsCalculationFifo.class, converter, security, lineItems));
+    private final LazyValue<CapitalGainsCalculationMovingAverage> movingAverageCapitalGains = new LazyValue<>(
                     () -> Calculation.perform(CapitalGainsCalculationMovingAverage.class, converter, security,
                                     lineItems));
 
@@ -181,6 +171,37 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
                     Interval interval)
     {
         super(client, security, converter, interval);
+    }
+
+    private CostCalculationResult calculateCosts(CostMethod costMethod)
+    {
+        return Calculation.perform(() -> new CostCalculation(costMethod), converter, security, lineItems).getResult();
+    }
+
+    private CostCalculationResult getCosts(CostMethod costMethod)
+    {
+        return switch (Objects.requireNonNull(costMethod))
+        {
+            case FIFO -> fifoCosts.get();
+            case MOVING_AVERAGE -> movingAverageCosts.get();
+        };
+    }
+
+    private Double calculateDividendRateOfReturn(CostMethod costMethod)
+    {
+        CostCalculationResult result = getCosts(costMethod);
+
+        return Calculation.perform(() -> new DividendRateOfReturnCalculation(result::getDividendCost), converter,
+                        security, lineItems).getRateOfReturnPerYear();
+    }
+
+    private Double getDividendRateOfReturn(CostMethod costMethod)
+    {
+        return switch (Objects.requireNonNull(costMethod))
+        {
+            case FIFO -> fifoDividendRateOfReturn.get();
+            case MOVING_AVERAGE -> movingAverageDividendRateOfReturn.get();
+        };
     }
 
     public Double getIrr()
@@ -243,46 +264,47 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
      */
     public Money getCost(CostMethod costMethod, TaxesAndFees taxesAndFees)
     {
-        return getCostMoney(costMethod, taxesAndFees);
+        CostCalculationResult result = getCosts(costMethod);
+        return taxesAndFees.isIncluded() ? result.cost() : result.netCost();
     }
 
     public Money getCapitalGainsOnHoldings(CostMethod costMethod)
     {
-        return marketValue.get().subtract(getCostMoney(costMethod, TaxesAndFees.INCLUDED));
+        return marketValue.get().subtract(getCost(costMethod, TaxesAndFees.INCLUDED));
     }
 
     public Double getCapitalGainsOnHoldingsPercent(CostMethod costMethod)
     {
-        var mv = marketValue.get();
-        var cost = getCostMoney(costMethod, TaxesAndFees.INCLUDED);
+        Money value = marketValue.get();
+        Money cost = getCost(costMethod, TaxesAndFees.INCLUDED);
 
-        if (mv.getAmount() == 0L && cost.getAmount() == 0L)
+        if (value.getAmount() == 0L && cost.getAmount() == 0L)
             return 0d;
-        else
-            return ((double) mv.getAmount() / (double) cost.getAmount()) - 1;
+
+        return value.getAmount() / (double) cost.getAmount() - 1;
     }
 
     public Money getFees()
     {
-        return costCalculation.get().fees();
+        return feesAndTaxes.get().fees();
     }
 
     public Money getTaxes()
     {
-        return costCalculation.get().taxes();
+        return feesAndTaxes.get().taxes();
     }
 
-    public Long getSharesHeld()
+    public Long getSharesHeld(CostMethod costMethod)
     {
-        return costCalculation.get().sharesHeld();
+        return getCosts(costMethod).sharesHeld();
     }
 
     public Quote getCostPerSharesHeld(CostMethod costMethod, TaxesAndFees taxesAndFees)
     {
-        var sharesHeld = getSharesHeld();
-        Money cost = getCostMoney(costMethod, taxesAndFees);
+        long shares = getCosts(costMethod).sharesHeld();
+        Money cost = getCost(costMethod, taxesAndFees);
 
-        return Quote.of(cost.getCurrencyCode(), Math.round(cost.getAmount() / (double) sharesHeld
+        return Quote.of(cost.getCurrencyCode(), Math.round(cost.getAmount() / (double) shares
                         * Values.Share.factor() * Values.Quote.factorToMoney()));
     }
 
@@ -312,35 +334,43 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
      *
      * @return rate of return per year on success, else 0
      */
-    public Double getRateOfReturnPerYear()
+    public Double getRateOfReturnPerYear(CostMethod costMethod)
     {
-        return dividendCalculation.get().rateOfReturnPerYear();
+        return getDividendRateOfReturn(costMethod);
+    }
+
+    public double getPersonalDividendYield(CalculationLineItem.DividendPayment payment, CostMethod costMethod)
+    {
+        CostCalculation.DividendCostContext context = getCosts(costMethod).getDividendCost(payment)
+                        .orElseThrow(() -> new IllegalArgumentException("Missing dividend cost context")); //$NON-NLS-1$
+
+        return payment.getPersonalDividendYield(context.cost(), context.totalShares());
     }
 
     public Double getTotalRateOfReturnDiv(CostMethod costMethod)
     {
-        var costs = costCalculation.get();
-        var cost = getCostMoney(costMethod, TaxesAndFees.INCLUDED);
+        CostCalculationResult result = getCosts(costMethod);
+        Money cost = getCost(costMethod, TaxesAndFees.INCLUDED);
 
-        return costs.sharesHeld() > 0 ? (double) dividendCalculation.get().sum().getAmount() / (double) cost.getAmount()
+        return result.sharesHeld() > 0 ? dividendCalculation.get().sum().getAmount() / (double) cost.getAmount()
                         : 0;
     }
 
     public CapitalGainsRecord getRealizedCapitalGains(CostMethod costMethod)
     {
-        return switch (costMethod)
+        return switch (Objects.requireNonNull(costMethod))
         {
-            case FIFO -> capitalGains.get().getRealizedCapitalGains();
-            case MOVING_AVERAGE -> capitalGainsMovingAvg.get().getRealizedCapitalGains();
+            case FIFO -> fifoCapitalGains.get().getRealizedCapitalGains();
+            case MOVING_AVERAGE -> movingAverageCapitalGains.get().getRealizedCapitalGains();
         };
     }
 
     public CapitalGainsRecord getUnrealizedCapitalGains(CostMethod costMethod)
     {
-        return switch (costMethod)
+        return switch (Objects.requireNonNull(costMethod))
         {
-            case FIFO -> capitalGains.get().getUnrealizedCapitalGains();
-            case MOVING_AVERAGE -> capitalGainsMovingAvg.get().getUnrealizedCapitalGains();
+            case FIFO -> fifoCapitalGains.get().getUnrealizedCapitalGains();
+            case MOVING_AVERAGE -> movingAverageCapitalGains.get().getUnrealizedCapitalGains();
         };
     }
 
@@ -361,26 +391,22 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
             return null;
     }
 
-    @Override
-    public Optional<Trail> explain(String key)
+    public Optional<Trail> explain(String key, CostMethod costMethod)
     {
-        switch (key)
+        return switch (key)
         {
-            case Trails.FIFO_COST:
-                return Trail.of(getSecurityName(), costCalculation.get().fifoCostTrail());
-            case Trails.REALIZED_CAPITAL_GAINS:
-                return Trail.of(getSecurityName(), getRealizedCapitalGains(CostMethod.FIFO).getCapitalGainsTrail());
-            case Trails.REALIZED_CAPITAL_GAINS_FOREX:
-                return Trail.of(getSecurityName(),
-                                getRealizedCapitalGains(CostMethod.FIFO).getForexCapitalGainsTrail());
-            case Trails.UNREALIZED_CAPITAL_GAINS:
-                return Trail.of(getSecurityName(), getUnrealizedCapitalGains(CostMethod.FIFO).getCapitalGainsTrail());
-            case Trails.UNREALIZED_CAPITAL_GAINS_FOREX:
-                return Trail.of(getSecurityName(),
-                                getUnrealizedCapitalGains(CostMethod.FIFO).getForexCapitalGainsTrail());
-            default:
-                return Optional.empty();
-        }
+            case Trails.COST -> getCosts(costMethod).trail()
+                            .flatMap(trail -> Trail.of(getSecurityName(), trail));
+            case Trails.REALIZED_CAPITAL_GAINS -> Trail.of(getSecurityName(),
+                            getRealizedCapitalGains(costMethod).getCapitalGainsTrail());
+            case Trails.REALIZED_CAPITAL_GAINS_FOREX -> Trail.of(getSecurityName(),
+                            getRealizedCapitalGains(costMethod).getForexCapitalGainsTrail());
+            case Trails.UNREALIZED_CAPITAL_GAINS -> Trail.of(getSecurityName(),
+                            getUnrealizedCapitalGains(costMethod).getCapitalGainsTrail());
+            case Trails.UNREALIZED_CAPITAL_GAINS_FOREX -> Trail.of(getSecurityName(),
+                            getUnrealizedCapitalGains(costMethod).getForexCapitalGainsTrail());
+            default -> Optional.empty();
+        };
     }
 
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import name.abuchen.portfolio.math.IRR;
@@ -34,6 +35,10 @@ import name.abuchen.portfolio.util.LazyValue;
 
 public class Trade implements Adaptable
 {
+    private record TradeCostResult(Money entryValue, Money entryValueWithoutTaxesAndFees)
+    {
+    }
+
     private static final class CollateralLot
     {
         private long shares;
@@ -54,15 +59,16 @@ public class Trade implements Adaptable
 
     private List<TransactionPair<PortfolioTransaction>> transactions = new ArrayList<>();
 
-    private Money entryValue;
-    private Money entryValueWithoutTaxesAndFees;
     private Money exitValue;
     private Money exitValueWithoutTaxesAndFees;
     private long holdingPeriod;
     private double irr;
 
-    private LazyValue<Money> entryValueMovingAverage;
-    private LazyValue<Money> entryValueMovingAverageWithoutTaxesAndFees;
+    private final LazyValue<TradeCostResult> fifoCostResult = new LazyValue<>(this::calculateFifoCostResult);
+    private final LazyValue<TradeCostResult> movingAverageCostResult = new LazyValue<>(
+                    this::calculateMovingAverageCostResult);
+    private Client client;
+    private CurrencyConverter converter;
 
     public Trade(Security security, Portfolio portfolio, long shares)
     {
@@ -79,22 +85,8 @@ public class Trade implements Adaptable
     /* package */ void calculate(Client client, CurrencyConverter converter)
     {
         boolean isLong = this.isLong();
-
-        // for purchases, getMonetaryAmount() returns the value including taxes
-        // and fees paid
-        this.entryValue = transactions.stream() //
-                        .filter(t -> t.getTransaction().getType().isPurchase() == isLong)
-                        .map(t -> t.getTransaction().getMonetaryAmount()
-                                        .with(converter.at(t.getTransaction().getDateTime())))
-                        .collect(MoneyCollectors.sum(converter.getTermCurrency()));
-
-        // for purchases, getGrossValue() returns the value without taxes and
-        // fees paid
-        this.entryValueWithoutTaxesAndFees = transactions.stream() //
-                        .filter(t -> t.getTransaction().getType().isPurchase() == isLong)
-                        .map(t -> t.getTransaction().getGrossValue()
-                                        .with(converter.at(t.getTransaction().getDateTime())))
-                        .collect(MoneyCollectors.sum(converter.getTermCurrency()));
+        this.client = client;
+        this.converter = converter;
 
         if (end != null)
         {
@@ -149,10 +141,15 @@ public class Trade implements Adaptable
 
         calculateIRR(converter);
 
-        this.entryValueMovingAverage = new LazyValue<>(
-                        () -> getMovingAverageCost(client, converter, TaxesAndFees.INCLUDED));
-        this.entryValueMovingAverageWithoutTaxesAndFees = new LazyValue<>(
-                        () -> getMovingAverageCost(client, converter, TaxesAndFees.NOT_INCLUDED));
+    }
+
+    private TradeCostResult getCostResult(CostMethod costMethod)
+    {
+        return switch (Objects.requireNonNull(costMethod))
+        {
+            case FIFO -> fifoCostResult.get();
+            case MOVING_AVERAGE -> movingAverageCostResult.get();
+        };
     }
 
     private void calculateIRR(CurrencyConverter converter)
@@ -307,14 +304,12 @@ public class Trade implements Adaptable
         return isClosed() ? Optional.of(transactions.get(transactions.size() - 1)) : Optional.empty();
     }
 
-    public Money getEntryValue()
+    public Money getEntryValue(CostMethod costMethod, TaxesAndFees taxesAndFees)
     {
-        return entryValue;
-    }
+        Objects.requireNonNull(taxesAndFees);
 
-    public Money getEntryValueMovingAverage()
-    {
-        return entryValueMovingAverage.get();
+        TradeCostResult result = getCostResult(costMethod);
+        return taxesAndFees == TaxesAndFees.INCLUDED ? result.entryValue() : result.entryValueWithoutTaxesAndFees();
     }
 
     public Money getExitValue()
@@ -322,30 +317,27 @@ public class Trade implements Adaptable
         return exitValue;
     }
 
-    public Money getProfitLoss()
+    /**
+     * Returns the reporting currency of this calculated trade.
+     */
+    public String getCurrencyCode()
     {
-        if (isLong())
-            return exitValue.subtract(entryValue);
-        else
-            return entryValue.subtract(exitValue);
+        return getExitValue().getCurrencyCode();
     }
 
-    public Money getProfitLossMovingAverage()
+    public Money getProfitLoss(CostMethod costMethod, TaxesAndFees taxesAndFees)
     {
-        return exitValue.subtract(entryValueMovingAverage.get());
-    }
+        Objects.requireNonNull(taxesAndFees);
 
-    public Money getProfitLossWithoutTaxesAndFees()
-    {
-        if (isLong())
-            return exitValueWithoutTaxesAndFees.subtract(entryValueWithoutTaxesAndFees);
-        else
-            return entryValueWithoutTaxesAndFees.subtract(exitValueWithoutTaxesAndFees);
-    }
+        CostMethod method = Objects.requireNonNull(costMethod);
+        Money entry = getEntryValue(method, taxesAndFees);
+        Money exit = taxesAndFees == TaxesAndFees.INCLUDED ? exitValue : exitValueWithoutTaxesAndFees;
 
-    public Money getProfitLossMovingAverageWithoutTaxesAndFees()
-    {
-        return exitValueWithoutTaxesAndFees.subtract(entryValueMovingAverageWithoutTaxesAndFees.get());
+        return switch (method)
+        {
+            case FIFO -> isLong() ? exit.subtract(entry) : entry.subtract(exit);
+            case MOVING_AVERAGE -> exit.subtract(entry);
+        };
     }
 
     public long getHoldingPeriod()
@@ -358,17 +350,17 @@ public class Trade implements Adaptable
         return irr;
     }
 
-    public double getReturn()
+    public double getReturn(CostMethod costMethod)
     {
-        if (isLong())
-            return (exitValue.getAmount() / (double) entryValue.getAmount()) - 1;
-        else
-            return 1 - (exitValue.getAmount() / (double) entryValue.getAmount());
-    }
+        CostMethod method = Objects.requireNonNull(costMethod);
+        long entryAmount = getEntryValue(method, TaxesAndFees.INCLUDED).getAmount();
 
-    public double getReturnMovingAverage()
-    {
-        return (exitValue.getAmount() / (double) entryValueMovingAverage.get().getAmount()) - 1;
+        return switch (method)
+        {
+            case FIFO -> isLong() ? (exitValue.getAmount() / (double) entryAmount) - 1
+                            : 1 - (exitValue.getAmount() / (double) entryAmount);
+            case MOVING_AVERAGE -> (exitValue.getAmount() / (double) entryAmount) - 1;
+        };
     }
 
     /**
@@ -384,18 +376,18 @@ public class Trade implements Adaptable
      * @brief Checks if the trade made a net loss
      * @return True if the trade resulted in a net loss
      */
-    public boolean isLoss()
+    public boolean isLoss(CostMethod costMethod)
     {
-        return this.getProfitLoss().isNegative();
+        return getProfitLoss(Objects.requireNonNull(costMethod), TaxesAndFees.INCLUDED).isNegative();
     }
 
     /**
      * @brief Check if the trade made a gross gross
      * @return True if the trade result in a gross loss
      */
-    public boolean isGrossLoss()
+    public boolean isGrossLoss(CostMethod costMethod)
     {
-        return this.getProfitLossWithoutTaxesAndFees().isNegative();
+        return getProfitLoss(Objects.requireNonNull(costMethod), TaxesAndFees.NOT_INCLUDED).isNegative();
     }
 
     @Override
@@ -410,11 +402,30 @@ public class Trade implements Adaptable
     @Override
     public String toString()
     {
-        return String.format("<Trade sh=%s %s %s -> %s %s>", //$NON-NLS-1$
-                        shares, start, entryValue, end, exitValue);
+        return String.format("<Trade sh=%s %s -> %s %s>", //$NON-NLS-1$
+                        shares, start, end, exitValue);
     }
 
-    private Money getMovingAverageCost(Client client, CurrencyConverter converter, TaxesAndFees taxesAndFees)
+    private TradeCostResult calculateFifoCostResult()
+    {
+        boolean isLong = isLong();
+
+        Money entryValue = transactions.stream() //
+                        .filter(t -> t.getTransaction().getType().isPurchase() == isLong)
+                        .map(t -> t.getTransaction().getMonetaryAmount()
+                                        .with(converter.at(t.getTransaction().getDateTime())))
+                        .collect(MoneyCollectors.sum(converter.getTermCurrency()));
+
+        Money entryValueWithoutTaxesAndFees = transactions.stream() //
+                        .filter(t -> t.getTransaction().getType().isPurchase() == isLong)
+                        .map(t -> t.getTransaction().getGrossValue()
+                                        .with(converter.at(t.getTransaction().getDateTime())))
+                        .collect(MoneyCollectors.sum(converter.getTermCurrency()));
+
+        return new TradeCostResult(entryValue, entryValueWithoutTaxesAndFees);
+    }
+
+    private TradeCostResult calculateMovingAverageCostResult()
     {
         var closingTransaction = transactions.stream() //
                         .filter(t -> t.getTransaction().getType().isLiquidation()) //
@@ -437,22 +448,30 @@ public class Trade implements Adaptable
                                                         : LocalDate.now()));
         var r = snapshot.getRecord(security);
         if (r.isEmpty())
-            return null;
+            return new TradeCostResult(null, null);
 
         // the trade might be a partial liquidation, so we have to calculate
         // the moving average purchase value based on the number of shares
         // sold
 
-        Money totalCosts = r.get().getCost(CostMethod.MOVING_AVERAGE, taxesAndFees);
-        var totalShares = r.get().getSharesHeld();
+        Money totalCosts = r.get().getCost(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED);
+        Money totalCostsWithoutTaxesAndFees = r.get().getCost(CostMethod.MOVING_AVERAGE,
+                        TaxesAndFees.NOT_INCLUDED);
+        var totalShares = r.get().getSharesHeld(CostMethod.MOVING_AVERAGE);
 
         if (totalShares <= 0)
-            return Money.of(totalCosts.getCurrencyCode(), 0);
+            return new TradeCostResult(Money.of(totalCosts.getCurrencyCode(), 0),
+                            Money.of(totalCostsWithoutTaxesAndFees.getCurrencyCode(), 0));
 
-        var cost = BigDecimal.valueOf(shares / (double) totalShares) //
+        BigDecimal shareRatio = BigDecimal.valueOf(shares / (double) totalShares);
+        var cost = shareRatio //
                         .multiply(BigDecimal.valueOf(totalCosts.getAmount())) //
                         .setScale(0, RoundingMode.HALF_DOWN).longValue();
+        var costWithoutTaxesAndFees = shareRatio //
+                        .multiply(BigDecimal.valueOf(totalCostsWithoutTaxesAndFees.getAmount())) //
+                        .setScale(0, RoundingMode.HALF_DOWN).longValue();
 
-        return Money.of(totalCosts.getCurrencyCode(), cost);
+        return new TradeCostResult(Money.of(totalCosts.getCurrencyCode(), cost),
+                        Money.of(totalCostsWithoutTaxesAndFees.getCurrencyCode(), costWithoutTaxesAndFees));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeCategory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeCategory.java
@@ -7,11 +7,14 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import name.abuchen.portfolio.math.IRR;
 import name.abuchen.portfolio.model.Classification;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.TransactionPair;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.Money;
@@ -21,6 +24,15 @@ import name.abuchen.portfolio.util.TextUtil;
 
 public class TradeCategory
 {
+    private record TradeCategoryCostResult(Money totalEntryValue, Money totalProfitLoss,
+                    Money totalProfitLossWithoutTaxesAndFees, double averageReturn, double winRate)
+    {
+    }
+
+    private record TradeCategoryCommonResult(Money totalExitValue, double averageIRR, long averageHoldingPeriod)
+    {
+    }
+
     public static final class ByDescription implements Comparator<TradeCategory>
     {
         @Override
@@ -131,20 +143,9 @@ public class TradeCategory
     private final String currencyKey;
     private final List<WeightedTrade> weightedTrades = new ArrayList<>();
 
-    // lazy calculations
-    private Money totalEntryValue;
-    private Money totalEntryValueMovingAverage;
-    private Money totalExitValue;
-    private Money totalProfitLoss;
-    private Money totalProfitLossWithoutTaxesAndFees;
-    private Money totalProfitLossMovingAverage;
-    private Money totalProfitLossMovingAverageWithoutTaxesAndFees;
-    private double averageReturn;
-    private double averageReturnMovingAverage;
-    private double averageIRR;
-    private long averageHoldingPeriod;
-    private double winRate;
-    private boolean calculated = false;
+    private TradeCategoryCostResult fifoResult;
+    private TradeCategoryCostResult movingAverageResult;
+    private TradeCategoryCommonResult commonResult;
 
     /* package */ TradeCategory(Classification classification, CurrencyConverter converter)
     {
@@ -196,7 +197,9 @@ public class TradeCategory
     /* package */ void addTrade(Trade trade, double weight)
     {
         this.weightedTrades.add(new WeightedTrade(trade, weight));
-        this.calculated = false;
+        this.fifoResult = null;
+        this.movingAverageResult = null;
+        this.commonResult = null;
     }
 
     public List<Trade> getTrades()
@@ -213,7 +216,6 @@ public class TradeCategory
 
     public long getTradeCount()
     {
-        ensureCalculated();
         return weightedTrades.stream().map(wt -> wt.trade).distinct().count();
     }
 
@@ -222,88 +224,57 @@ public class TradeCategory
         return weightedTrades.stream().mapToDouble(wt -> wt.weight).sum();
     }
 
-    public Money getTotalProfitLoss()
+    public Money getTotalEntryValue(CostMethod costMethod)
     {
-        ensureCalculated();
-        return totalProfitLoss;
-    }
-
-    public Money getTotalEntryValue()
-    {
-        ensureCalculated();
-        return totalEntryValue;
-    }
-
-    public Money getTotalEntryValueMovingAverage()
-    {
-        ensureCalculated();
-        return totalEntryValueMovingAverage;
+        return getCostResult(costMethod).totalEntryValue();
     }
 
     public Money getTotalExitValue()
     {
-        ensureCalculated();
-        return totalExitValue;
+        return getCommonResult().totalExitValue();
     }
 
-    public Money getTotalProfitLossWithoutTaxesAndFees()
+    public Money getTotalProfitLoss(CostMethod costMethod, TaxesAndFees taxesAndFees)
     {
-        ensureCalculated();
-        return totalProfitLossWithoutTaxesAndFees;
+        Objects.requireNonNull(taxesAndFees);
+
+        TradeCategoryCostResult result = getCostResult(costMethod);
+        return taxesAndFees == TaxesAndFees.INCLUDED ? result.totalProfitLoss()
+                        : result.totalProfitLossWithoutTaxesAndFees();
     }
 
-    public Money getTotalProfitLossMovingAverage()
+    public double getAverageReturn(CostMethod costMethod)
     {
-        ensureCalculated();
-        return totalProfitLossMovingAverage;
-    }
-
-    public Money getTotalProfitLossMovingAverageWithoutTaxesAndFees()
-    {
-        ensureCalculated();
-        return totalProfitLossMovingAverageWithoutTaxesAndFees;
-    }
-
-    public double getAverageReturn()
-    {
-        ensureCalculated();
-        return averageReturn;
-    }
-
-    public double getAverageReturnMovingAverage()
-    {
-        ensureCalculated();
-        return averageReturnMovingAverage;
+        return getCostResult(costMethod).averageReturn();
     }
 
     public double getAverageIRR()
     {
-        ensureCalculated();
-        return averageIRR;
+        return getCommonResult().averageIRR();
     }
 
     public long getAverageHoldingPeriod()
     {
-        ensureCalculated();
-        return averageHoldingPeriod;
+        return getCommonResult().averageHoldingPeriod();
     }
 
-    public double getWinRate()
+    public double getWinRate(CostMethod costMethod)
     {
-        ensureCalculated();
-        return winRate;
+        return getCostResult(costMethod).winRate();
     }
 
-    public long getWinningTradesCount()
+    public long getWinningTradesCount(CostMethod costMethod)
     {
-        ensureCalculated();
-        return weightedTrades.stream().filter(wt -> !wt.trade.isLoss()).map(wt -> wt.trade).distinct().count();
+        Objects.requireNonNull(costMethod);
+        return weightedTrades.stream().filter(wt -> !wt.trade.isLoss(costMethod)).map(wt -> wt.trade).distinct()
+                        .count();
     }
 
-    public long getLosingTradesCount()
+    public long getLosingTradesCount(CostMethod costMethod)
     {
-        ensureCalculated();
-        return weightedTrades.stream().filter(wt -> wt.trade.isLoss()).map(wt -> wt.trade).distinct().count();
+        Objects.requireNonNull(costMethod);
+        return weightedTrades.stream().filter(wt -> wt.trade.isLoss(costMethod)).map(wt -> wt.trade).distinct()
+                        .count();
     }
 
     /**
@@ -405,126 +376,94 @@ public class TradeCategory
         return Double.isFinite(irr) ? irr : 0;
     }
 
-    private void ensureCalculated()
+    private TradeCategoryCostResult getCostResult(CostMethod costMethod)
     {
-        if (calculated)
-            return;
+        return switch (Objects.requireNonNull(costMethod))
+        {
+            case FIFO -> {
+                if (fifoResult == null)
+                    fifoResult = calculateCostResult(CostMethod.FIFO);
+                yield fifoResult;
+            }
+            case MOVING_AVERAGE -> {
+                if (movingAverageResult == null)
+                    movingAverageResult = calculateCostResult(CostMethod.MOVING_AVERAGE);
+                yield movingAverageResult;
+            }
+        };
+    }
 
+    private TradeCategoryCostResult calculateCostResult(CostMethod costMethod)
+    {
         double totalWeight = getTotalWeight();
-
         if (totalWeight == 0)
         {
-            this.totalEntryValue = Money.of(converter.getTermCurrency(), 0);
-            this.totalEntryValueMovingAverage = Money.of(converter.getTermCurrency(), 0);
-            this.totalExitValue = Money.of(converter.getTermCurrency(), 0);
-            this.totalProfitLoss = Money.of(converter.getTermCurrency(), 0);
-            this.totalProfitLossWithoutTaxesAndFees = Money.of(converter.getTermCurrency(), 0);
-            this.totalProfitLossMovingAverage = Money.of(converter.getTermCurrency(), 0);
-            this.totalProfitLossMovingAverageWithoutTaxesAndFees = Money.of(converter.getTermCurrency(), 0);
-            this.averageReturn = 0;
-            this.averageReturnMovingAverage = 0;
-            this.averageIRR = 0;
-            this.averageHoldingPeriod = 0;
-            this.winRate = 0;
-        }
-        else
-        {
-            this.totalEntryValue = weightedTrades.stream() //
-                            .map(wt -> {
-                                Money value = wt.trade.getEntryValue();
-                                if (value == null)
-                                    return Money.of(converter.getTermCurrency(), 0);
-                                LocalDate date = wt.trade.getStart().toLocalDate();
-                                return value.with(converter.at(date)).multiplyAndRound(wt.weight);
-                            }) //
-                            .collect(MoneyCollectors.sum(converter.getTermCurrency()));
-
-            this.totalEntryValueMovingAverage = weightedTrades.stream() //
-                            .map(wt -> {
-                                Money value = wt.trade.getEntryValueMovingAverage();
-                                if (value == null)
-                                    return Money.of(converter.getTermCurrency(), 0);
-                                LocalDate date = wt.trade.getStart().toLocalDate();
-                                return value.with(converter.at(date)).multiplyAndRound(wt.weight);
-                            }) //
-                            .collect(MoneyCollectors.sum(converter.getTermCurrency()));
-
-            this.totalExitValue = weightedTrades.stream() //
-                            .map(wt -> {
-                                Money value = wt.trade.getExitValue();
-                                if (value == null)
-                                    return Money.of(converter.getTermCurrency(), 0);
-                                LocalDate date = wt.trade.getEnd().map(LocalDate::from).orElse(LocalDate.now());
-                                return value.with(converter.at(date)).multiplyAndRound(wt.weight);
-                            }) //
-                            .collect(MoneyCollectors.sum(converter.getTermCurrency()));
-
-            this.totalProfitLoss = weightedTrades.stream() //
-                            .map(wt -> {
-                                Money pnl = wt.trade.getProfitLoss();
-                                LocalDate date = wt.trade.getEnd().map(LocalDate::from).orElse(LocalDate.now());
-                                return pnl.with(converter.at(date)).multiplyAndRound(wt.weight);
-                            }) //
-                            .collect(MoneyCollectors.sum(converter.getTermCurrency()));
-
-            this.totalProfitLossWithoutTaxesAndFees = weightedTrades.stream() //
-                            .map(wt -> {
-                                Money pnl = wt.trade.getProfitLossWithoutTaxesAndFees();
-                                LocalDate date = wt.trade.getEnd().map(LocalDate::from).orElse(LocalDate.now());
-                                return pnl.with(converter.at(date)).multiplyAndRound(wt.weight);
-                            }) //
-                            .collect(MoneyCollectors.sum(converter.getTermCurrency()));
-
-            this.totalProfitLossMovingAverage = weightedTrades.stream() //
-                            .map(wt -> {
-                                Money pnl = wt.trade.getProfitLossMovingAverage();
-                                LocalDate date = wt.trade.getEnd().map(LocalDate::from).orElse(LocalDate.now());
-                                return pnl.with(converter.at(date)).multiplyAndRound(wt.weight);
-                            }) //
-                            .collect(MoneyCollectors.sum(converter.getTermCurrency()));
-
-            this.totalProfitLossMovingAverageWithoutTaxesAndFees = weightedTrades.stream() //
-                            .map(wt -> {
-                                Money pnl = wt.trade.getProfitLossMovingAverageWithoutTaxesAndFees();
-                                LocalDate date = wt.trade.getEnd().map(LocalDate::from).orElse(LocalDate.now());
-                                return pnl.with(converter.at(date)).multiplyAndRound(wt.weight);
-                            }) //
-                            .collect(MoneyCollectors.sum(converter.getTermCurrency()));
-
-            // Calculate category-level IRR by combining all cash flows
-            this.averageIRR = calculateCategoryIRR();
-
-            // Calculate category-level return from aggregate P&L and entry
-            // value
-            if (totalEntryValue.getAmount() != 0)
-            {
-                this.averageReturn = totalProfitLoss.getAmount() / (double) totalEntryValue.getAmount();
-            }
-            else
-            {
-                this.averageReturn = 0;
-            }
-
-            if (totalEntryValueMovingAverage.getAmount() != 0)
-            {
-                this.averageReturnMovingAverage = totalProfitLossMovingAverage.getAmount()
-                                / (double) totalEntryValueMovingAverage.getAmount();
-            }
-            else
-            {
-                this.averageReturnMovingAverage = 0;
-            }
-
-            this.averageHoldingPeriod = Math.round(
-                            weightedTrades.stream().mapToDouble(wt -> wt.trade.getHoldingPeriod() * wt.weight).sum()
-                                            / totalWeight);
-
-            double winningWeight = weightedTrades.stream().filter(wt -> !wt.trade.isLoss()).mapToDouble(wt -> wt.weight)
-                            .sum();
-            this.winRate = winningWeight / totalWeight;
+            Money zero = Money.of(converter.getTermCurrency(), 0);
+            return new TradeCategoryCostResult(zero, zero, zero, 0, 0);
         }
 
-        this.calculated = true;
+        Money totalEntryValue = weightedTrades.stream() //
+                        .map(wt -> {
+                            Money value = wt.trade.getEntryValue(costMethod, TaxesAndFees.INCLUDED);
+                            if (value == null)
+                                return Money.of(converter.getTermCurrency(), 0);
+                            LocalDate date = wt.trade.getStart().toLocalDate();
+                            return value.with(converter.at(date)).multiplyAndRound(wt.weight);
+                        }) //
+                        .collect(MoneyCollectors.sum(converter.getTermCurrency()));
+
+        Money totalProfitLoss = calculateTotalProfitLoss(costMethod, TaxesAndFees.INCLUDED);
+        Money totalProfitLossWithoutTaxesAndFees = calculateTotalProfitLoss(costMethod,
+                        TaxesAndFees.NOT_INCLUDED);
+        double averageReturn = totalEntryValue.getAmount() != 0
+                        ? totalProfitLoss.getAmount() / (double) totalEntryValue.getAmount()
+                        : 0;
+        double winningWeight = weightedTrades.stream().filter(wt -> !wt.trade.isLoss(costMethod))
+                        .mapToDouble(wt -> wt.weight).sum();
+
+        return new TradeCategoryCostResult(totalEntryValue, totalProfitLoss, totalProfitLossWithoutTaxesAndFees,
+                        averageReturn, winningWeight / totalWeight);
+    }
+
+    private Money calculateTotalProfitLoss(CostMethod costMethod, TaxesAndFees taxesAndFees)
+    {
+        return weightedTrades.stream() //
+                        .map(wt -> {
+                            Money pnl = wt.trade.getProfitLoss(costMethod, taxesAndFees);
+                            LocalDate date = wt.trade.getEnd().map(LocalDate::from).orElse(LocalDate.now());
+                            return pnl.with(converter.at(date)).multiplyAndRound(wt.weight);
+                        }) //
+                        .collect(MoneyCollectors.sum(converter.getTermCurrency()));
+    }
+
+    private TradeCategoryCommonResult getCommonResult()
+    {
+        if (commonResult == null)
+            commonResult = calculateCommonResult();
+        return commonResult;
+    }
+
+    private TradeCategoryCommonResult calculateCommonResult()
+    {
+        double totalWeight = getTotalWeight();
+        if (totalWeight == 0)
+            return new TradeCategoryCommonResult(Money.of(converter.getTermCurrency(), 0), 0, 0);
+
+        Money totalExitValue = weightedTrades.stream() //
+                        .map(wt -> {
+                            Money value = wt.trade.getExitValue();
+                            if (value == null)
+                                return Money.of(converter.getTermCurrency(), 0);
+                            LocalDate date = wt.trade.getEnd().map(LocalDate::from).orElse(LocalDate.now());
+                            return value.with(converter.at(date)).multiplyAndRound(wt.weight);
+                        }) //
+                        .collect(MoneyCollectors.sum(converter.getTermCurrency()));
+
+        long averageHoldingPeriod = Math.round(
+                        weightedTrades.stream().mapToDouble(wt -> wt.trade.getHoldingPeriod() * wt.weight).sum()
+                                        / totalWeight);
+
+        return new TradeCategoryCommonResult(totalExitValue, calculateCategoryIRR(), averageHoldingPeriod);
     }
 
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeTotals.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeTotals.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import name.abuchen.portfolio.model.Classification;
+import name.abuchen.portfolio.model.CostMethod;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MoneyCollectors;
@@ -13,16 +15,20 @@ import name.abuchen.portfolio.money.Values;
 
 public class TradeTotals
 {
+    private record TradeTotalsCostResult(Money totalEntryValue, Money totalEntryValueWithoutTaxesAndFees,
+                    Money totalProfitLoss,
+                    Money totalProfitLossWithoutTaxesAndFees, double averageReturn)
+    {
+    }
+
     private final CurrencyConverter converter;
     private final List<Trade> trades;
     private final TradeCategory aggregate;
 
-    private final Money totalEntryValue;
-    private final Money totalEntryValueMovingAverage;
     private final Money totalExitValue;
-    private final Money totalProfitLossMovingAverage;
-    private final Money totalProfitLossMovingAverageWithoutTaxesAndFees;
     private final long totalShares;
+    private TradeTotalsCostResult fifoResult;
+    private TradeTotalsCostResult movingAverageResult;
 
     public TradeTotals(TradesGroupedByTaxonomy groupedTrades)
     {
@@ -34,14 +40,64 @@ public class TradeTotals
         this.trades.stream().distinct().forEach(trade -> aggregate.addTrade(trade, 1.0));
 
         this.totalShares = trades.stream().mapToLong(Trade::getShares).sum();
-        this.totalEntryValue = sumMoney(Trade::getEntryValue, Trade::getStart);
-        this.totalEntryValueMovingAverage = sumMoney(Trade::getEntryValueMovingAverage, Trade::getStart);
         this.totalExitValue = sumMoney(Trade::getExitValue, trade -> trade.getEnd().orElse(LocalDateTime.now()));
-        this.totalProfitLossMovingAverage = sumMoney(Trade::getProfitLossMovingAverage,
+    }
+
+    private TradeTotalsCostResult getCostResult(CostMethod costMethod)
+    {
+        return switch (Objects.requireNonNull(costMethod))
+        {
+            case FIFO -> getOrCalculateFifoResult();
+            case MOVING_AVERAGE -> getOrCalculateMovingAverageResult();
+        };
+    }
+
+    private TradeTotalsCostResult getOrCalculateFifoResult()
+    {
+        if (fifoResult == null)
+            fifoResult = calculateFifoResult();
+
+        return fifoResult;
+    }
+
+    private TradeTotalsCostResult getOrCalculateMovingAverageResult()
+    {
+        if (movingAverageResult == null)
+            movingAverageResult = calculateMovingAverageResult();
+
+        return movingAverageResult;
+    }
+
+    private TradeTotalsCostResult calculateFifoResult()
+    {
+        Money totalEntryValue = sumMoney(
+                        trade -> trade.getEntryValue(CostMethod.FIFO, TaxesAndFees.INCLUDED), Trade::getStart);
+        Money totalEntryValueWithoutTaxesAndFees = sumMoney(
+                        trade -> trade.getEntryValue(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED), Trade::getStart);
+        Money totalProfitLoss = aggregate.getTotalProfitLoss(CostMethod.FIFO, TaxesAndFees.INCLUDED);
+        Money totalProfitLossWithoutTaxesAndFees = aggregate.getTotalProfitLoss(CostMethod.FIFO,
+                        TaxesAndFees.NOT_INCLUDED);
+        return new TradeTotalsCostResult(totalEntryValue, totalEntryValueWithoutTaxesAndFees, totalProfitLoss,
+                        totalProfitLossWithoutTaxesAndFees, aggregate.getAverageReturn(CostMethod.FIFO));
+    }
+
+    private TradeTotalsCostResult calculateMovingAverageResult()
+    {
+        Money totalEntryValue = sumMoney(
+                        trade -> trade.getEntryValue(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED), Trade::getStart);
+        Money totalEntryValueWithoutTaxesAndFees = sumMoney(
+                        trade -> trade.getEntryValue(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
+                        Trade::getStart);
+        Money totalProfitLoss = sumMoney(
+                        trade -> trade.getProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED),
                         trade -> trade.getEnd().orElse(LocalDateTime.now()));
-        this.totalProfitLossMovingAverageWithoutTaxesAndFees = sumMoney(
-                        Trade::getProfitLossMovingAverageWithoutTaxesAndFees,
+        Money totalProfitLossWithoutTaxesAndFees = sumMoney(
+                        trade -> trade.getProfitLoss(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED),
                         trade -> trade.getEnd().orElse(LocalDateTime.now()));
+        double averageReturn = totalEntryValue.isZero() ? 0
+                        : totalProfitLoss.getAmount() / (double) totalEntryValue.getAmount();
+        return new TradeTotalsCostResult(totalEntryValue, totalEntryValueWithoutTaxesAndFees, totalProfitLoss,
+                        totalProfitLossWithoutTaxesAndFees, averageReturn);
     }
 
     private Money sumMoney(Function<Trade, Money> extractor, Function<Trade, LocalDateTime> dateExtractor)
@@ -71,14 +127,12 @@ public class TradeTotals
         return totalShares;
     }
 
-    public Money getTotalEntryValue()
+    public Money getTotalEntryValue(CostMethod costMethod, TaxesAndFees taxesAndFees)
     {
-        return totalEntryValue;
-    }
-
-    public Money getTotalEntryValueMovingAverage()
-    {
-        return totalEntryValueMovingAverage;
+        Objects.requireNonNull(taxesAndFees);
+        TradeTotalsCostResult result = getCostResult(Objects.requireNonNull(costMethod));
+        return taxesAndFees == TaxesAndFees.INCLUDED ? result.totalEntryValue()
+                        : result.totalEntryValueWithoutTaxesAndFees();
     }
 
     public Money getTotalExitValue()
@@ -86,24 +140,13 @@ public class TradeTotals
         return totalExitValue;
     }
 
-    public Money getTotalProfitLoss()
+    public Money getTotalProfitLoss(CostMethod costMethod, TaxesAndFees taxesAndFees)
     {
-        return aggregate.getTotalProfitLoss();
-    }
-
-    public Money getTotalProfitLossWithoutTaxesAndFees()
-    {
-        return aggregate.getTotalProfitLossWithoutTaxesAndFees();
-    }
-
-    public Money getTotalProfitLossMovingAverage()
-    {
-        return totalProfitLossMovingAverage;
-    }
-
-    public Money getTotalProfitLossMovingAverageWithoutTaxesAndFees()
-    {
-        return totalProfitLossMovingAverageWithoutTaxesAndFees;
+        Objects.requireNonNull(costMethod);
+        Objects.requireNonNull(taxesAndFees);
+        TradeTotalsCostResult result = getCostResult(costMethod);
+        return taxesAndFees == TaxesAndFees.INCLUDED ? result.totalProfitLoss()
+                        : result.totalProfitLossWithoutTaxesAndFees();
     }
 
     public long getAverageHoldingPeriod()
@@ -116,33 +159,18 @@ public class TradeTotals
         return aggregate.getAverageIRR();
     }
 
-    public double getAverageReturn()
+    public double getAverageReturn(CostMethod costMethod)
     {
-        return aggregate.getAverageReturn();
+        return getCostResult(Objects.requireNonNull(costMethod)).averageReturn();
     }
 
-    public double getAverageReturnMovingAverage()
-    {
-        if (totalEntryValueMovingAverage.isZero())
-            return 0;
-        return totalProfitLossMovingAverage.getAmount() / (double) totalEntryValueMovingAverage.getAmount();
-    }
-
-    public Money getAverageEntryPrice()
+    public Money getAverageEntryPrice(CostMethod costMethod, TaxesAndFees taxesAndFees)
     {
         if (totalShares == 0)
             return null;
+        Money totalEntryValue = getTotalEntryValue(costMethod, taxesAndFees);
         long amount = Math.round(totalEntryValue.getAmount() / (double) totalShares * Values.Share.factor());
         return Money.of(totalEntryValue.getCurrencyCode(), amount);
-    }
-
-    public Money getAverageEntryPriceMovingAverage()
-    {
-        if (totalShares == 0)
-            return null;
-        long amount = Math
-                        .round(totalEntryValueMovingAverage.getAmount() / (double) totalShares * Values.Share.factor());
-        return Money.of(totalEntryValueMovingAverage.getCurrencyCode(), amount);
     }
 
     public Money getAverageExitPrice()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradesGroupedByTaxonomy.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradesGroupedByTaxonomy.java
@@ -15,8 +15,10 @@ import java.util.stream.Collectors;
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.model.Classification.Assignment;
+import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.InvestmentVehicle;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Taxonomy;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.Money;
@@ -44,7 +46,7 @@ public class TradesGroupedByTaxonomy
             return;
 
         Set<String> distinctCurrencies = allTrades.stream()
-                        .map(t -> t.getProfitLoss() != null ? t.getProfitLoss().getCurrencyCode() : null)
+                        .map(Trade::getCurrencyCode)
                         .filter(Objects::nonNull).collect(Collectors.toSet());
 
         final boolean multiCurrencyMode = distinctCurrencies.size() > 1
@@ -84,10 +86,9 @@ public class TradesGroupedByTaxonomy
                 {
                     if (trade.getSecurity().equals(security))
                     {
-                        if (trade.getProfitLoss() == null || trade.getProfitLoss().getCurrencyCode() == null)
+                        String currencyCode = trade.getCurrencyCode();
+                        if (currencyCode == null)
                             continue;
-
-                        String currencyCode = trade.getProfitLoss().getCurrencyCode();
 
                         Object key = multiCurrencyMode
                                         ? new AbstractMap.SimpleImmutableEntry<>(classification, currencyCode)
@@ -135,10 +136,9 @@ public class TradesGroupedByTaxonomy
 
             if (assignedWeight < Classification.ONE_HUNDRED_PERCENT)
             {
-                if (trade.getProfitLoss() == null || trade.getProfitLoss().getCurrencyCode() == null)
+                String currencyCode = trade.getCurrencyCode();
+                if (currencyCode == null)
                     continue;
-
-                String currencyCode = trade.getProfitLoss().getCurrencyCode();
 
                 TradeCategory unassignedCategory = unassignedCategories.computeIfAbsent(currencyCode,
                                 cc -> multiCurrencyMode ? new TradeCategory(unassignedClassification, converter, cc)
@@ -177,22 +177,13 @@ public class TradesGroupedByTaxonomy
         return Collections.unmodifiableList(allTrades);
     }
 
-    public Money getTotalProfitLoss()
+    public Money getTotalProfitLoss(CostMethod costMethod, TaxesAndFees taxesAndFees)
     {
-        return allTrades.stream().map(trade -> {
-            Money pnl = trade.getProfitLoss();
-            if (pnl == null)
-                return Money.of(converter.getTermCurrency(), 0);
+        Objects.requireNonNull(costMethod);
+        Objects.requireNonNull(taxesAndFees);
 
-            LocalDate date = trade.getEnd().map(LocalDate::from).orElse(LocalDate.now());
-            return pnl.with(converter.at(date));
-        }).collect(MoneyCollectors.sum(converter.getTermCurrency()));
-    }
-
-    public Money getTotalProfitLossWithoutTaxesAndFees()
-    {
         return allTrades.stream().map(trade -> {
-            Money pnl = trade.getProfitLossWithoutTaxesAndFees();
+            Money pnl = trade.getProfitLoss(costMethod, taxesAndFees);
             if (pnl == null)
                 return Money.of(converter.getTermCurrency(), 0);
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit FIFO and Moving Average cost-method handling across performance, capital gains, trade, dividend, and portfolio calculations.
  * Performance and payment views now consistently display values based on the selected cost method.
  * Trade tables and dashboards now clearly account for taxes and fees in profit, loss, return, and entry-value calculations.
  * Added preference compatibility for legacy cost-method settings, with automatic normalization to the new format.

* **Bug Fixes**
  * Improved consistency of share counts, transferred positions, dividend yields, and capital gains across reports and filtered views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

As proposed at #5880, PR scope is to make the API border to CostMethod more transparent, prior UX adjustment.

@buchen @mierin12 

Scope clarification

This PR is a behavior-preserving API and calculation-state refactoring.

It makes CostMethod explicit, separates FIFO and moving-average execution, and
removes boolean and method-specific compatibility APIs. It intentionally does
not change existing formulas or edge-case behavior.

In particular, this PR does not change benchmark snapshot availability, FIFO
transfer-trail semantics, dividend fallback or fee aggregation, nullable
moving-average trade results, or the tax-and-fee dimensions of category entry
values. Those topics require separate behavioral decisions and regression
tests.