### PR TITLE
Show column menu on table header right-click

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ShowHideColumnHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ShowHideColumnHelper.java
@@ -858,31 +858,37 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
                             .forEach(c -> policy.create(c, null, c.getDefaultSortDirection(), c.getDefaultWidth()));
         }
 
-        if (isEditable)
-        {
-            ContextMenu headerMenu = new ContextMenu(policy.getViewer().getControl(), this::headerMenuAboutToShow);
+        var headerMenu = new ContextMenu(policy.getViewer().getControl(), manager -> {
+            if (isEditable)
+            {
+                headerMenuAboutToShow(manager);
+                if (manager.getItems().length > 0)
+                    manager.add(new Separator());
+            }
+            menuAboutToShow(manager);
+        });
 
-            policy.getViewer().getControl().addListener(SWT.MenuDetect, event -> {
-                Control control = policy.getViewer().getControl();
-                Menu tableMenu = (Menu) control.getData(ContextMenu.DEFAULT_MENU);
-                Point pt = event.display.map(null, control, new Point(event.x, event.y));
-                Rectangle clientArea = ((Composite) control).getClientArea();
-                boolean isHeader = clientArea.y <= pt.y && pt.y < (clientArea.y + policy.getHeaderHeight());
+        policy.getViewer().getControl().addListener(SWT.MenuDetect, event -> {
+            Control control = policy.getViewer().getControl();
+            Menu tableMenu = (Menu) control.getData(ContextMenu.DEFAULT_MENU);
+            Point pt = event.display.map(null, control, new Point(event.x, event.y));
+            Rectangle clientArea = ((Composite) control).getClientArea();
+            boolean isHeader = clientArea.y <= pt.y && pt.y < (clientArea.y + policy.getHeaderHeight());
 
-                if (isHeader)
-                {
-                    // remember the current column in selectedColumnIndex for
-                    // later use in the context menu
+            if (isHeader)
+            {
+                // remember the current column in selectedColumnIndex for
+                // later use in the context menu (only relevant when
+                // isEditable, but harmless otherwise)
 
-                    selectedColumnIndex = policy.getColumnIndex(pt);
-                    control.setMenu(headerMenu.getMenu());
-                }
-                else
-                {
-                    control.setMenu(tableMenu);
-                }
-            });
-        }
+                selectedColumnIndex = policy.getColumnIndex(pt);
+                control.setMenu(headerMenu.getMenu());
+            }
+            else
+            {
+                control.setMenu(tableMenu);
+            }
+        });
     }
 
     private void createFromColumnConfig(String config)


### PR DESCRIPTION
Today the show/hide-columns menu is only reachable via the small gear icon in each view's toolbar, and only some views additionally offer a per-column rename/hide menu when right-clicking a column header. Right-click is the more common convention for this in most desktop applications.

This combines both into a single header right-click menu: for views that already support column renaming, the rename/reset-name/hide-this-column items appear first, followed by the full show/hide-columns list; for views that don't support renaming, right-click now shows the show/hide-columns list directly (previously nothing useful happened there).

<img width="1210" height="690" alt="PP_feature_right-click-columns" src="https://github.com/user-attachments/assets/c5172a0e-0ea0-4fe5-a123-75b780a42356" />

No behavior change for the toolbar gear icon or for column renaming itself — this only adds a second, more discoverable way to reach the same functionality.
