### PR TITLE
Findependent AG: support FX surcharge and sell with forex

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/findependentag/FindependentAGPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/findependentag/FindependentAGPDFExtractorTest.java
@@ -666,6 +666,80 @@ public class FindependentAGPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierKauf12()
+    {
+        var extractor = new FindependentAGPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf12.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00BFNM3G45"), hasWkn(null), hasTicker(null), //
+                        hasName("iShares MSCI USA Screened ETF"), //
+                        hasCurrencyCode("USD"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-03-19T00:00"), hasShares(142), //
+                        hasSource("Kauf12.txt"), //
+                        hasNote(null), //
+                        hasAmount("CHF", 1536.76), hasGrossValue("CHF", 1527.81), //
+                        hasForexGrossValue("USD", 1920.69), //
+                        hasTaxes("CHF", 2.29), hasFees("CHF", 6.42 + 0.24))));
+    }
+
+    @Test
+    public void testWertpapierKauf12WithSecurityInCHF()
+    {
+        var security = new Security("iShares MSCI USA Screened ETF", "CHF");
+        security.setIsin("IE00BFNM3G45");
+
+        var client = new Client();
+        client.addSecurity(security);
+
+        var extractor = new FindependentAGPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf12.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "CHF");
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-03-19T00:00"), hasShares(142), //
+                        hasSource("Kauf12.txt"), //
+                        hasNote(null), //
+                        hasAmount("CHF", 1536.76), hasGrossValue("CHF", 1527.81), //
+                        hasTaxes("CHF", 2.29), hasFees("CHF", 6.42 + 0.24), //
+                        check(tx -> {
+                            var c = new CheckCurrenciesAction();
+                            var s = c.process((PortfolioTransaction) tx, new Portfolio());
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
+    }
+
+    @Test
     public void testWertpapierVerkauf01()
     {
         var extractor = new FindependentAGPDFExtractor(new Client());
@@ -697,6 +771,154 @@ public class FindependentAGPDFExtractorTest
                         hasNote(null), //
                         hasAmount("CHF", 700.02), hasGrossValue("CHF", 701.12), //
                         hasTaxes("CHF", 1.05), hasFees("CHF", 0.05))));
+    }
+
+    @Test
+    public void testWertpapierVerkauf02()
+    {
+        var extractor = new FindependentAGPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00BFNM3G45"), hasWkn(null), hasTicker(null), //
+                        hasName("iShares MSCI USA Screened ETF"), //
+                        hasCurrencyCode("USD"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-04-02T00:00"), hasShares(96), //
+                        hasSource("Verkauf02.txt"), //
+                        hasNote(null), //
+                        hasAmount("CHF", 1016.83), hasGrossValue("CHF", 1022.81), //
+                        hasForexGrossValue("USD", 1278.91), //
+                        hasTaxes("CHF", 1.53), hasFees("CHF", 4.30 + 0.15))));
+    }
+
+    @Test
+    public void testWertpapierVerkauf02WithSecurityInCHF()
+    {
+        var security = new Security("iShares MSCI USA Screened ETF", "CHF");
+        security.setIsin("IE00BFNM3G45");
+
+        var client = new Client();
+        client.addSecurity(security);
+
+        var extractor = new FindependentAGPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "CHF");
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-04-02T00:00"), hasShares(96), //
+                        hasSource("Verkauf02.txt"), //
+                        hasNote(null), //
+                        hasAmount("CHF", 1016.83), hasGrossValue("CHF", 1022.81), //
+                        hasTaxes("CHF", 1.53), hasFees("CHF", 4.30 + 0.15), //
+                        check(tx -> {
+                            var c = new CheckCurrenciesAction();
+                            var s = c.process((PortfolioTransaction) tx, new Portfolio());
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
+    }
+
+    @Test
+    public void testWertpapierVerkauf03()
+    {
+        var extractor = new FindependentAGPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00BFNM3D14"), hasWkn(null), hasTicker(null), //
+                        hasName("iShares MSCI Europe Screened ETF"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-04-02T00:00"), hasShares(2), //
+                        hasSource("Verkauf03.txt"), //
+                        hasNote(null), //
+                        hasAmount("CHF", 18.08), hasGrossValue("CHF", 18.19), //
+                        hasForexGrossValue("EUR", 19.73), //
+                        hasTaxes("CHF", 0.03), hasFees("CHF", 0.08 + 0.00))));
+    }
+
+    @Test
+    public void testWertpapierVerkauf03WithSecurityInCHF()
+    {
+        var security = new Security("iShares MSCI Europe Screened ETF", "CHF");
+        security.setIsin("IE00BFNM3D14");
+
+        var client = new Client();
+        client.addSecurity(security);
+
+        var extractor = new FindependentAGPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "CHF");
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-04-02T00:00"), hasShares(2), //
+                        hasSource("Verkauf03.txt"), //
+                        hasNote(null), //
+                        hasAmount("CHF", 18.08), hasGrossValue("CHF", 18.19), //
+                        hasTaxes("CHF", 0.03), hasFees("CHF", 0.08 + 0.00), //
+                        check(tx -> {
+                            var c = new CheckCurrenciesAction();
+                            var s = c.process((PortfolioTransaction) tx, new Portfolio());
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/findependentag/Kauf12.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/findependentag/Kauf12.txt
@@ -1,0 +1,30 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.83.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Findependent AG
+Kasernenstrasse 26
+5000 Aarau
+www.findependent.ch
+service@findependent.ch
+Max Muster Kundennr. 123456
+Strasse 1 Portfolio-Nr. 123456789
+1234 Stadt Zielname Vermögensaufbau
+Aarau, 19.03.2026
+ETF-Kauf
+Für deine Anlagelösung wurde folgende ETF-Transaktion getätigt:
+ETF-Name iShares MSCI USA Screened ETF
+ISIN IE00BFNM3G45
+Valuta 19.03.2026
+Anzahl Anteile 142
+Preis pro Anteil USD 13.5260
+Kaufpreis total USD 1'920.69
+Wechselkurs CHF/USD 0.795450
+Kaufpreis CHF CHF 1'527.81
+Wechselkursaufschlag CHF 6.42
+Börsenabgaben CHF 0.24
+Stempelabgaben CHF 2.29
+Verrechneter Betrag CHF 1'536.76
+Dein findependent Team
+Anzeige ohne Unterschrift.
+Erstellt am: 1. Mai 2026 3 von 6

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/findependentag/Verkauf02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/findependentag/Verkauf02.txt
@@ -1,0 +1,30 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.83.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Findependent AG
+Kasernenstrasse 26
+5000 Aarau
+www.findependent.ch
+service@findependent.ch
+Max Muster Kundennr. 123456
+Strasse 1 Portfolio-Nr. 123456789
+1234 Stadt Zielname Vermögensaufbau
+Aarau, 02.04.2026
+ETF-Verkauf
+Für deine Anlagelösung wurde folgende ETF-Transaktion getätigt:
+ETF-Name iShares MSCI USA Screened ETF
+ISIN IE00BFNM3G45
+Valuta 02.04.2026
+Anzahl Anteile 96
+Preis pro Anteil USD 13.3220
+Verkaufspreis total USD 1'278.91
+Wechselkurs CHF/USD 0.799750
+Verkaufspreis CHF CHF 1'022.81
+Wechselkursaufschlag CHF -4.30
+Börsenabgaben CHF -0.15
+Stempelabgaben CHF -1.53
+Gutgeschriebener Betrag CHF 1'016.83
+Dein findependent Team
+Anzeige ohne Unterschrift.
+Erstellt am: 1. Mai 2026 6 von 6

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/findependentag/Verkauf03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/findependentag/Verkauf03.txt
@@ -1,0 +1,30 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.83.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Findependent AG
+Kasernenstrasse 26
+5000 Aarau
+www.findependent.ch
+service@findependent.ch
+Max Muster Kundennr. 123456
+Strasse 1 Portfolio-Nr. 123456789
+1234 Stadt Zielname Vermögensaufbau
+Aarau, 02.04.2026
+ETF-Verkauf
+Für deine Anlagelösung wurde folgende ETF-Transaktion getätigt:
+ETF-Name iShares MSCI Europe Screened ETF
+ISIN IE00BFNM3D14
+Valuta 02.04.2026
+Anzahl Anteile 2
+Preis pro Anteil EUR 9.8640
+Verkaufspreis total EUR 19.73
+Wechselkurs CHF/EUR 0.922180
+Verkaufspreis CHF CHF 18.19
+Wechselkursaufschlag CHF -0.08
+Börsenabgaben CHF -0.00
+Stempelabgaben CHF -0.03
+Gutgeschriebener Betrag CHF 18.08
+Dein findependent Team
+Anzeige ohne Unterschrift.
+Erstellt am: 1. Mai 2026 1 von 6

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FindependentAGPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FindependentAGPDFExtractor.java
@@ -101,11 +101,15 @@ public class FindependentAGPDFExtractor extends AbstractPDFExtractor
                         // Kaufpreis total USD 912.50
                         // Wechselkurs CHF/USD 0.87555
                         // Kaufpreis CHF CHF 798.94
+                        //
+                        // Verkaufspreis total USD 1'278.91
+                        // Wechselkurs CHF/USD 0.799750
+                        // Verkaufspreis CHF CHF 1'022.81
                         // @formatter:on
                         .section("fxGross", "baseCurrency", "termCurrency", "exchangeRate", "gross").optional() //
-                        .match("^Kaufpreis total [\\w]{3} (?<fxGross>[\\.'\\d]+)$") //
+                        .match("^(Kaufpreis|Verkaufspreis) total [\\w]{3} (?<fxGross>[\\.'\\d]+)$") //
                         .match("^Wechselkurs (?<termCurrency>[\\w]{3})\\/(?<baseCurrency>[\\w]{3}) (?<exchangeRate>[\\.'\\d]+)$") //
-                        .match("^Kaufpreis [\\w]{3} [\\w]{3} (?<gross>[\\.'\\d]+)$") //
+                        .match("^(Kaufpreis|Verkaufspreis) [\\w]{3} [\\w]{3} (?<gross>[\\.'\\d]+)$") //
                         .assign((t, v) -> {
                             ExtrExchangeRate rate = asExchangeRate(v);
                             type.getCurrentContext().putType(rate);
@@ -290,6 +294,14 @@ public class FindependentAGPDFExtractor extends AbstractPDFExtractor
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
     {
         transaction //
+
+                        // @formatter:off
+                        // Wechselkursaufschlag CHF 6.42
+                        // Wechselkursaufschlag CHF -4.30
+                        // @formatter:on
+                        .section("currency", "fee").optional() //
+                        .match("^Wechselkursaufschlag (?<currency>[\\w]{3}) (\\-)?(?<fee>[\\.'\\d]+)$") //
+                        .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // Börsenabgaben CHF 0.05


### PR DESCRIPTION
Findependent changed its transaction note format: the FX surcharge, previously baked into the exchange rate (footnote "Wechselkursaufschlag von max. 0.5%"), is now an itemized line, and that broke imports in two ways:

1. **FX buys** failed the gross value check ("Importierter Bruttowert und berechneter Bruttowert stimmen nicht überein") because the itemized `Wechselkursaufschlag CHF x.xx` line was not captured as a fee.
2. **FX sells** failed with "Wechselkurs des Bruttowertes fehlt": the forex section only matched `Kaufpreis total` / `Kaufpreis CHF CHF`, while sell documents use `Verkaufspreis total` / `Verkaufspreis CHF CHF`, so no gross value unit was attached.

Changes:
- Add a `Wechselkursaufschlag` fee section (sign-tolerant; sells list it negative) to the shared fees block.
- Widen the forex section to `(Kaufpreis|Verkaufspreis)`.

New fixtures from the issue: FX buy in USD (Kauf12), FX sell in USD (Verkauf02), FX sell in EUR incl. the `Börsenabgaben CHF -0.00` edge case (Verkauf03), each with a `WithSecurityInCHF` test variant. The CAD buy from the issue report shares the Kauf12 code path, so no separate fixture was added. The old-format fixtures are unaffected: the footnote line cannot match the new fee pattern, and CHF-only sells lack the `Verkaufspreis total` line required by the forex section.

Closes #5664