### PR TITLE
Support multi-security selection in TransactionsPane

### DIFF
--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/panes/TransactionsPaneMultiSelectionTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/views/panes/TransactionsPaneMultiSelectionTest.java
@@ -1,0 +1,155 @@
+package name.abuchen.portfolio.ui.views.panes;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.junit.AccountBuilder;
+import name.abuchen.portfolio.junit.PortfolioBuilder;
+import name.abuchen.portfolio.junit.SecurityBuilder;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.ui.selection.SecuritySelection;
+
+@SuppressWarnings("nls")
+public class TransactionsPaneMultiSelectionTest
+{
+    @Test
+    public void testResolveMultipleSecuritiesCollectsAllTransactions()
+    {
+        var client = new Client();
+
+        var securityA = new SecurityBuilder()
+                        .addPrice("2024-01-01", Values.Quote.factorize(100))
+                        .addTo(client);
+
+        var securityB = new SecurityBuilder()
+                        .addPrice("2024-01-01", Values.Quote.factorize(50))
+                        .addTo(client);
+
+        new AccountBuilder()
+                        .dividend("2024-03-01", Values.Amount.factorize(10), securityA)
+                        .dividend("2024-06-01", Values.Amount.factorize(5), securityB)
+                        .addTo(client);
+
+        var account = client.getAccounts().get(0);
+
+        new PortfolioBuilder(account)
+                        .buy(securityA, "2024-01-15", Values.Share.factorize(10), Values.Amount.factorize(1000))
+                        .buy(securityB, "2024-02-01", Values.Share.factorize(20), Values.Amount.factorize(1000))
+                        .sell(securityA, "2024-04-01", Values.Share.factorize(5), Values.Amount.factorize(600))
+                        .addTo(client);
+
+        var selection = new SecuritySelection(client, Arrays.asList(securityA, securityB));
+        var resolved = TransactionPaneInput.resolve(selection, client);
+
+        assertThat(resolved.getTransactions(), hasSize(5)); // buyA + divA + sellA + buyB + divB
+        assertThat(resolved.getSource(), is(selection));
+    }
+
+    @Test
+    public void testResolveSingleSecuritySelection()
+    {
+        var client = new Client();
+
+        var securityA = new SecurityBuilder()
+                        .addPrice("2024-01-01", Values.Quote.factorize(100))
+                        .addTo(client);
+
+        var securityB = new SecurityBuilder()
+                        .addPrice("2024-01-01", Values.Quote.factorize(50))
+                        .addTo(client);
+
+        new AccountBuilder()
+                        .dividend("2024-03-01", Values.Amount.factorize(10), securityA)
+                        .dividend("2024-06-01", Values.Amount.factorize(5), securityB)
+                        .addTo(client);
+
+        var account = client.getAccounts().get(0);
+
+        new PortfolioBuilder(account)
+                        .buy(securityA, "2024-01-15", Values.Share.factorize(10), Values.Amount.factorize(1000))
+                        .addTo(client);
+
+        var selection = new SecuritySelection(client, securityA);
+        var resolved = TransactionPaneInput.resolve(selection, client);
+
+        assertThat(resolved.getTransactions(), hasSize(2)); // buy + dividend
+    }
+
+    @Test
+    public void testResolveEmptySelectionReturnsNoTransactions()
+    {
+        var client = new Client();
+
+        var selection = new SecuritySelection(client, List.of());
+        var resolved = TransactionPaneInput.resolve(selection, client);
+
+        assertThat(resolved.getTransactions(), hasSize(0));
+        assertThat(resolved.getExportLabel(), is(""));
+    }
+
+    @Test
+    public void testResolveBareSecurityInput()
+    {
+        var client = new Client();
+
+        var security = new SecurityBuilder()
+                        .addPrice("2024-01-01", Values.Quote.factorize(100))
+                        .addTo(client);
+
+        var account = new AccountBuilder()
+                        .dividend("2024-03-01", Values.Amount.factorize(10), security)
+                        .addTo(client);
+
+        new PortfolioBuilder(account)
+                        .buy(security, "2024-01-15", Values.Share.factorize(10), Values.Amount.factorize(1000))
+                        .addTo(client);
+
+        var resolved = TransactionPaneInput.resolve(security, client);
+
+        assertThat(resolved.getTransactions(), hasSize(2)); // buy + dividend
+        assertThat(resolved.getSource(), is(security));
+    }
+
+    @Test
+    public void testExportLabelForMultipleSecurities()
+    {
+        var client = new Client();
+        var securityA = new SecurityBuilder().addTo(client);
+        var securityB = new SecurityBuilder().addTo(client);
+
+        var selection = new SecuritySelection(client, Arrays.asList(securityA, securityB));
+        var resolved = TransactionPaneInput.resolve(selection, client);
+
+        assertThat(resolved.getExportLabel(), is("2 Securities"));
+    }
+
+    @Test
+    public void testExportLabelForSingleSecuritySelection()
+    {
+        var client = new Client();
+        var security = new SecurityBuilder().addTo(client);
+
+        var selection = new SecuritySelection(client, security);
+        var resolved = TransactionPaneInput.resolve(selection, client);
+
+        assertThat(resolved.getExportLabel(), is(security.getName()));
+    }
+
+    @Test
+    public void testExportLabelForBareSecurity()
+    {
+        var client = new Client();
+        var security = new SecurityBuilder().addTo(client);
+
+        var resolved = TransactionPaneInput.resolve(security, client);
+
+        assertThat(resolved.getExportLabel(), is(security.getName()));
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/TransactionPaneInput.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/TransactionPaneInput.java
@@ -1,0 +1,93 @@
+package name.abuchen.portfolio.ui.views.panes;
+
+import static name.abuchen.portfolio.util.CollectorsUtil.toMutableList;
+
+import java.util.Collections;
+import java.util.List;
+
+import name.abuchen.portfolio.model.Account;
+import name.abuchen.portfolio.model.Adaptor;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.InvestmentPlan;
+import name.abuchen.portfolio.model.Portfolio;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TransactionPair;
+import name.abuchen.portfolio.ui.selection.SecuritySelection;
+
+/* package */ class TransactionPaneInput
+{
+    private final Object source;
+    private final List<TransactionPair<?>> transactions;
+
+    private TransactionPaneInput(Object source, List<TransactionPair<?>> transactions)
+    {
+        this.source = source;
+        this.transactions = transactions;
+    }
+
+    public Object getSource()
+    {
+        return source;
+    }
+
+    public List<TransactionPair<?>> getTransactions()
+    {
+        return transactions;
+    }
+
+    public String getExportLabel()
+    {
+        return exportLabelFor(source);
+    }
+
+    public static String exportLabelFor(Object source)
+    {
+        if (source instanceof SecuritySelection sel)
+            return sel.size() == 1 ? sel.getSecurity().getName() : sel.size() + " Securities";
+        if (source instanceof Security sec)
+            return sec.getName();
+        if (source != null)
+            return source.toString();
+        return "";
+    }
+
+    public static TransactionPaneInput resolve(Object input, Client client)
+    {
+        var investmentPlan = Adaptor.adapt(InvestmentPlan.class, input);
+        if (investmentPlan != null)
+            return new TransactionPaneInput(investmentPlan, investmentPlan.getTransactions(client));
+
+        var securitySelection = Adaptor.adapt(SecuritySelection.class, input);
+        if (securitySelection != null && !securitySelection.isEmpty())
+        {
+            var allTransactions = securitySelection.getSecurities().stream()
+                            .flatMap(s -> s.getTransactions(client).stream())
+                            .collect(toMutableList());
+            return new TransactionPaneInput(securitySelection, allTransactions);
+        }
+
+        var security = Adaptor.adapt(Security.class, input);
+        if (security != null)
+            return new TransactionPaneInput(security, security.getTransactions(client));
+
+        var account = Adaptor.adapt(Account.class, input);
+        if (account != null)
+        {
+            List<TransactionPair<?>> txList = account.getTransactions().stream()
+                            .<TransactionPair<?>>map(t -> new TransactionPair<>(account, t))
+                            .collect(toMutableList());
+            return new TransactionPaneInput(account, txList);
+        }
+
+        var portfolio = Adaptor.adapt(Portfolio.class, input);
+        if (portfolio != null)
+        {
+            List<TransactionPair<?>> txList = portfolio.getTransactions().stream()
+                            .<TransactionPair<?>>map(t -> new TransactionPair<>(portfolio, t))
+                            .collect(toMutableList());
+            return new TransactionPaneInput(portfolio, txList);
+        }
+
+        return new TransactionPaneInput(null, Collections.emptyList());
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/TransactionsPane.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/panes/TransactionsPane.java
@@ -1,8 +1,5 @@
 package name.abuchen.portfolio.ui.views.panes;
 
-import static name.abuchen.portfolio.util.CollectorsUtil.toMutableList;
-
-import java.util.Collections;
 import java.util.List;
 
 import jakarta.inject.Inject;
@@ -16,12 +13,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
-import name.abuchen.portfolio.model.Account;
-import name.abuchen.portfolio.model.Adaptor;
 import name.abuchen.portfolio.model.Client;
-import name.abuchen.portfolio.model.InvestmentPlan;
-import name.abuchen.portfolio.model.Portfolio;
-import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.TransactionPair;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
@@ -96,7 +88,7 @@ public class TransactionsPane implements InformationPanePage
         toolBar.add(transactionFilter);
 
         toolBar.add(new SimpleAction(Messages.MenuExportData, Images.EXPORT,
-                        a -> new TableViewerCSVExporter(transactions.getTableViewer()).export(getLabel(), source)));
+                        a -> new TableViewerCSVExporter(transactions.getTableViewer()).export(getLabel(), getExportLabel())));
 
         toolBar.add(new DropDown(Messages.MenuShowHideColumns, Images.CONFIG, SWT.NONE,
                         manager -> transactions.getColumnSupport().menuAboutToShow(manager)));
@@ -105,46 +97,9 @@ public class TransactionsPane implements InformationPanePage
     @Override
     public void setInput(Object input)
     {
-        // first check for the investment plan, because a plan can also be
-        // adapted to a security (if it is a regular purchase) or an account (if
-        // it is a regular transfer)
-
-        InvestmentPlan investmentPlan = Adaptor.adapt(InvestmentPlan.class, input);
-        if (investmentPlan != null)
-        {
-            source = investmentPlan;
-            transactions.setInput(investmentPlan.getTransactions(client));
-            return;
-        }
-
-        Security security = Adaptor.adapt(Security.class, input);
-        if (security != null)
-        {
-            source = security;
-            transactions.setInput(security.getTransactions(client));
-            return;
-        }
-
-        Account account = Adaptor.adapt(Account.class, input);
-        if (account != null)
-        {
-            source = account;
-            transactions.setInput(account.getTransactions().stream().map(t -> new TransactionPair<>(account, t))
-                            .collect(toMutableList()));
-            return;
-        }
-
-        Portfolio portfolio = Adaptor.adapt(Portfolio.class, input);
-        if (portfolio != null)
-        {
-            source = portfolio;
-            transactions.setInput(portfolio.getTransactions().stream().map(t -> new TransactionPair<>(portfolio, t))
-                            .collect(toMutableList()));
-            return;
-        }
-
-        source = null;
-        transactions.setInput(Collections.emptyList());
+        var resolved = TransactionPaneInput.resolve(input, client);
+        source = resolved.getSource();
+        transactions.setInput(resolved.getTransactions());
     }
 
     @Override
@@ -152,6 +107,11 @@ public class TransactionsPane implements InformationPanePage
     {
         if (source != null)
             setInput(source);
+    }
+
+    private String getExportLabel()
+    {
+        return TransactionPaneInput.exportLabelFor(source);
     }
 
     public void notifyModelUpdated()


### PR DESCRIPTION
The Transactions tab in the "All Securities" view previously only showed transactions for the first selected security. When multiple securities are selected, transactions for all of them are now displayed and exported.