### PR TITLE
Wrap column headers onto two lines when the column is too narrow

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -1304,6 +1304,7 @@ public class Messages extends NLS
     public static String PrefMsgConfigureUpdates;
     public static String PrefMsgLanguageConfig;
     public static String PrefMyDividends24APIKey;
+    public static String PrefNoteExperimentsRestartRequired;
     public static String PrefNoteIndirectQuotation;
     public static String PrefNoteStoreSettingsNextToFile;
     public static String PrefPortfolioReportAPIKey;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -2602,6 +2602,8 @@ PrefMsgLanguageConfig = To change the language, a restart is required.
 
 PrefMyDividends24APIKey = myDividends24 API Key
 
+PrefNoteExperimentsRestartRequired = A change takes effect for views opened afterwards. Quit and relaunch the application to apply it everywhere.
+
 PrefNoteIndirectQuotation = Quotes using a country's home currency as the price currency (for example, EUR 0.9009 = USD 1.00 in the Eurozone) are known as direct quotation or price quotation (from that country's perspective) and are used by most countries.\n\nQuotes using a country's home currency as the unit currency (for example, USD 1.11 = EUR 1.00 in the Eurozone) are known as indirect quotation or quantity quotation and are used in British newspapers and are also common in Australia, New Zealand and the Eurozone.\n\nSource: https://en.wikipedia.org/wiki/Exchange_rate\n\n\nExamples:\n\nIndirect (Quantity) Quotation: EUR/USD 1.1232\n"For one Euro one gets 1.1232 USD."\n\nDirect (Price) Quotation: USD/EUR 0.89\n"One USD costs 0.89 EUR."
 
 PrefNoteStoreSettingsNextToFile = The GUI settings contain configurations such as the start page, the width of some columns and window areas, the expanded nodes of the classification view, and more.\n\nBy default, the GUI settings are stored hidden in the 'workspace' folder. It is also possible to store them in a '.settings' file next to the Portfolio Performance file itself. This facilitates synchronizing the settings across multiple PCs.\n\nAttention: the GUI settings are not migrated. To keep the current settings, do the following: open a Portfolio Performance file -> then change the checkbox here -> then save the file under a new name.

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/Experiments.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/Experiments.java
@@ -12,7 +12,7 @@ public class Experiments
 {
     public enum Feature
     {
-        JULY26_PREVENT_UPDATE_WHILE_EDITING_CELLS
+        JULY26_PREVENT_UPDATE_WHILE_EDITING_CELLS, JULY26_WRAP_COLUMN_HEADERS
     }
 
     public boolean isEnabled(Feature feature)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/ExperimentsPreferencePage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/ExperimentsPreferencePage.java
@@ -43,6 +43,9 @@ public class ExperimentsPreferencePage extends FieldEditorPreferencePage
         addField(new CheckboxGroupFieldEditor(UIConstants.Preferences.EXPERIMENTS,
                         Messages.PrefLabelEnableExperimentalFeatures, features, getFieldEditorParent()));
 
+        PreferenceDialogUtil.createNoteComposite(getFieldEditorParent().getFont(), getFieldEditorParent(),
+                        Messages.PrefLabelNote, Messages.PrefNoteExperimentsRestartRequired);
+
         var os = Platform.getOS();
         var showMonitorSpecificScaling = Platform.OS_WIN32.equals(os) || Platform.OS_LINUX.equals(os);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/ThemePreferencePage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/ThemePreferencePage.java
@@ -1,22 +1,16 @@
 package name.abuchen.portfolio.ui.preferences;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.e4.ui.css.swt.theme.ITheme;
 import org.eclipse.e4.ui.css.swt.theme.IThemeEngine;
@@ -262,29 +256,12 @@ public final class ThemePreferencePage extends PreferencePage
 
     private Path getPathToCustomCSS() throws IOException, URISyntaxException
     {
-        URL url = FileLocator.resolve(new URI("platform:/meta/name.abuchen.portfolio.ui/custom.css").toURL()); //$NON-NLS-1$ //NOSONAR
-        return new File(url.getFile()).toPath();
+        return ThemePreferences.getPathToCustomCSS();
     }
 
     private int readFontSizeFromCSS()
     {
-        try
-        {
-            String customCSS = Files.readString(getPathToCustomCSS());
-
-            Pattern p = Pattern.compile("font-size: (\\d+)px;"); //$NON-NLS-1$
-            Matcher m = p.matcher(customCSS);
-
-            if (!m.find())
-                return -1;
-
-            return Integer.parseInt(m.group(1));
-        }
-        catch (IOException | URISyntaxException | NumberFormatException e)
-        {
-            PortfolioPlugin.log(e);
-            return -1;
-        }
+        return ThemePreferences.getConfiguredFontSize();
     }
 
     private void setThemeToAutomatic()
@@ -319,6 +296,10 @@ public final class ThemePreferencePage extends PreferencePage
             }
 
             Files.writeString(getPathToCustomCSS(), css, StandardOpenOption.TRUNCATE_EXISTING);
+
+            // the running application keeps rendering with the previous size
+            // until it is restarted, so the size in effect is now unknown
+            ThemePreferences.invalidateSessionFontSize();
         }
         catch (IOException | URISyntaxException e)
         {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ThemePreferences.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/theme/ThemePreferences.java
@@ -1,7 +1,16 @@
 package name.abuchen.portfolio.ui.theme;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.regex.Pattern;
 
+import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.e4.ui.css.swt.internal.theme.ThemeEngine;
 import org.osgi.framework.FrameworkUtil;
@@ -18,6 +27,10 @@ import name.abuchen.portfolio.ui.PortfolioPlugin;
 public class ThemePreferences
 {
     private static final String THEMEID_KEY = "themeid"; //$NON-NLS-1$
+    private static final String PATH_TO_CUSTOM_CSS = "platform:/meta/name.abuchen.portfolio.ui/custom.css"; //$NON-NLS-1$
+    private static final Pattern FONT_SIZE_PATTERN = Pattern.compile("font-size:\\s*(\\d+)px"); //$NON-NLS-1$
+
+    private static OptionalInt sessionFontSize;
 
     private ThemePreferences()
     {
@@ -27,6 +40,82 @@ public class ThemePreferences
     {
         var preferences = InstanceScope.INSTANCE.getNode(FrameworkUtil.getBundle(ThemeEngine.class).getSymbolicName());
         return Optional.ofNullable(preferences != null ? preferences.get(THEMEID_KEY, null) : null);
+    }
+
+    /**
+     * Returns the font size configured on the theme preference page, or -1 if the
+     * default font size is used. Returns an empty result if the style sheet cannot
+     * be read or does not parse, which callers must distinguish from the default
+     * whenever they rely on knowing the size. The size is stored in the custom
+     * style sheet written by the preference page; there is no public API to read
+     * it.
+     */
+    /**
+     * Returns the path to the custom style sheet that holds the configured font
+     * size. The file is created on start up because the theme style sheets require
+     * it to exist.
+     */
+    public static Path getPathToCustomCSS() throws IOException, URISyntaxException
+    {
+        var url = FileLocator.resolve(new URI(PATH_TO_CUSTOM_CSS).toURL()); // NOSONAR
+        return new File(url.getFile()).toPath();
+    }
+
+    public static OptionalInt readConfiguredFontSize()
+    {
+        try
+        {
+            var customCSS = Files.readString(getPathToCustomCSS());
+
+            // the file is created empty on start up and the preference page
+            // writes it empty again for the default font size
+            if (customCSS.isBlank())
+                return OptionalInt.of(-1);
+
+            var matcher = FONT_SIZE_PATTERN.matcher(customCSS);
+            if (matcher.find())
+                return OptionalInt.of(Integer.parseInt(matcher.group(1)));
+
+            // content that was not written by the preference page: the size in
+            // effect is unknown rather than the default
+            return OptionalInt.empty();
+        }
+        catch (IOException | URISyntaxException | NumberFormatException e)
+        {
+            PortfolioPlugin.log(e);
+            return OptionalInt.empty();
+        }
+    }
+
+    /**
+     * Returns the font size configured when this session started, or an empty
+     * result if it is unknown - including after the size has been changed during
+     * this session, because such a change only takes full effect after a restart.
+     */
+    public static synchronized OptionalInt getSessionFontSize()
+    {
+        if (sessionFontSize == null)
+            sessionFontSize = readConfiguredFontSize();
+        return sessionFontSize;
+    }
+
+    /**
+     * Marks the font size in effect for this session as unknown. Called when the
+     * configured size is changed, because the running application keeps rendering
+     * with the previous size until it is restarted.
+     */
+    public static synchronized void invalidateSessionFontSize()
+    {
+        sessionFontSize = OptionalInt.empty();
+    }
+
+    /**
+     * Returns the font size configured on the theme preference page, or -1 if the
+     * default font size is used or the style sheet cannot be read.
+     */
+    public static int getConfiguredFontSize()
+    {
+        return readConfiguredFontSize().orElse(-1);
     }
 
     public static void clearConfiguredThemeId()

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TableViewerCSVExporter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TableViewerCSVExporter.java
@@ -21,6 +21,7 @@ import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.util.viewers.DateLabelProvider;
 import name.abuchen.portfolio.ui.util.viewers.DateTimeLabelProvider;
 import name.abuchen.portfolio.ui.util.viewers.SharesLabelProvider;
+import name.abuchen.portfolio.ui.util.viewers.ShowHideColumnHelper;
 import name.abuchen.portfolio.util.TextUtil;
 
 public class TableViewerCSVExporter extends AbstractCSVExporter
@@ -58,7 +59,7 @@ public class TableViewerCSVExporter extends AbstractCSVExporter
 
             // write header
             for (TableColumn column : viewer.getTable().getColumns())
-                printer.print(column.getText());
+                printer.print(ShowHideColumnHelper.getColumnLabel(column));
             printer.println();
 
             // check for "special" label provider

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TreeViewerCSVExporter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/TreeViewerCSVExporter.java
@@ -17,6 +17,7 @@ import org.eclipse.swt.widgets.Shell;
 
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.util.viewers.SharesLabelProvider;
+import name.abuchen.portfolio.ui.util.viewers.ShowHideColumnHelper;
 import name.abuchen.portfolio.util.TextUtil;
 
 public class TreeViewerCSVExporter extends AbstractCSVExporter
@@ -49,11 +50,11 @@ public class TreeViewerCSVExporter extends AbstractCSVExporter
             extractLabelProvider(labels);
 
             // write header
-            String label = viewer.getTree().getColumn(0).getText();
+            var label = ShowHideColumnHelper.getColumnLabel(viewer.getTree().getColumn(0));
             for (int ii = 0; ii < depth; ii++)
                 printer.print(label + " " + (ii + 1)); //$NON-NLS-1$
             for (int ii = 1; ii < columnCount; ii++)
-                printer.print(viewer.getTree().getColumn(ii).getText());
+                printer.print(ShowHideColumnHelper.getColumnLabel(viewer.getTree().getColumn(ii)));
             printer.println();
 
             // write body

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ShowHideColumnHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/viewers/ShowHideColumnHelper.java
@@ -1,11 +1,14 @@
 package name.abuchen.portfolio.ui.util.viewers;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Consumer;
+import java.util.function.IntSupplier;
 import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.Platform;
@@ -28,6 +31,8 @@ import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.TreeViewerColumn;
 import org.eclipse.jface.viewers.ViewerColumn;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ControlListener;
+import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Composite;
@@ -44,6 +49,8 @@ import org.eclipse.swt.widgets.Widget;
 
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.preferences.Experiments;
+import name.abuchen.portfolio.ui.theme.ThemePreferences;
 import name.abuchen.portfolio.ui.util.ConfigurationStore;
 import name.abuchen.portfolio.ui.util.ConfigurationStore.ConfigurationStoreOwner;
 import name.abuchen.portfolio.ui.util.ContextMenu;
@@ -157,6 +164,160 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
             // labels, but not Windows
             return Platform.OS_WIN32.equals(Platform.getOS()) ? TextUtil.wordwrap(text) : text;
         }
+    }
+
+    /**
+     * Returns the logical label of a column, i.e. the label without any line break
+     * inserted for the two-line header display. Use this instead of
+     * {@link Item#getText()} wherever the label is consumed as data - for example
+     * when exporting to CSV - so that a wrapped header never leaks a line break
+     * into the output.
+     */
+    public static String getColumnLabel(Item column)
+    {
+        var label = (String) column.getData(WRAP_LABEL_KEY);
+        return label != null ? label : column.getText();
+    }
+
+    /**
+     * Re-applies the two-line header wrap after the label of a column has been
+     * changed. Does nothing unless the wrap is active for this column, so callers
+     * do not need to know whether the feature is enabled.
+     */
+    private static void reflowHeader(Item column)
+    {
+        if (column.getData(REFLOW_KEY) instanceof Runnable reflow)
+            reflow.run();
+    }
+
+    /**
+     * Answers whether the header is drawn small enough for a second line to fit.
+     * A size that cannot be determined counts as too large: wrapping a header that
+     * then does not fit is worse than not wrapping one that would.
+     */
+    private static boolean isFontSizeSmallEnoughToWrap()
+    {
+        return ThemePreferences.getSessionFontSize().orElse(Integer.MAX_VALUE) <= MAX_FONT_SIZE_FOR_WRAP;
+    }
+
+    /**
+     * Wraps a column header label onto a second line only when the full label does
+     * not fit the column's current width; snaps back to a single line once it does.
+     * Re-evaluated on every column resize, so it stays correct as the user drags.
+     * The label to wrap is tracked via {@link #WRAP_LABEL_KEY} rather than closed
+     * over at attach time, so a later rename or restored custom label is wrapped
+     * instead of being silently overwritten by the original label on next resize.
+     */
+    private static void attachDynamicHeaderWrap(Item column, IntSupplier widthSupplier, Consumer<String> textSetter,
+                    Control measureControl, String fullLabel)
+    {
+        if (!new Experiments().isEnabled(Experiments.Feature.JULY26_WRAP_COLUMN_HEADERS))
+            return;
+
+        // native header text renders single-line only on Windows (win32
+        // header custom-draw uses DT_SINGLELINE) and is unverified on Linux;
+        // an embedded "\n" only produces a real two-line header on macOS
+        if (!Platform.OS_MACOSX.equals(Platform.getOS()))
+            return;
+
+        // the header row has a fixed height that does not grow with the font
+        // size. Two lines only fit while the header is drawn in the small
+        // system font; as soon as a larger font size is configured, the style
+        // sheet sets that font on the table, the header cell inherits it, and
+        // the second line would be cut off. Keep the single line in that case.
+        if (!isFontSizeSmallEnoughToWrap())
+            return;
+
+        column.setData(WRAP_LABEL_KEY, fullLabel);
+
+        Consumer<String> setIfChanged = text -> {
+            if (!text.equals(column.getText()))
+                textSetter.accept(text);
+        };
+
+        Runnable reflow = () -> {
+            var label = (String) column.getData(WRAP_LABEL_KEY);
+            if (label == null)
+                label = fullLabel;
+
+            if (!label.contains(" ")) //$NON-NLS-1$
+            {
+                setIfChanged.accept(label);
+                return;
+            }
+
+            var gc = new GC(measureControl);
+            try
+            {
+                // this GC inherits the table's 13pt body font, but on macOS
+                // the header itself always renders in Cocoa's 11pt small
+                // system font (both fixed AppKit constants) -- SWT exposes no
+                // API for the header's real font or its usable width, so this
+                // ~15% overestimate is used deliberately in place of an
+                // explicit margin: it approximates the space actually
+                // reserved by native chrome SWT doesn't expose (sort-arrow
+                // icon, cell padding). Do not "fix" this by measuring with
+                // the true 11pt font unless an explicit margin is added back
+                // for that reserved space -- doing one without the other
+                // causes real clipping on sorted columns
+                var available = widthSupplier.getAsInt();
+                if (available <= 0)
+                    return;
+
+                // hysteresis: wrap as soon as it no longer fits, but only
+                // unwrap once there is a bit of extra headroom -- otherwise a
+                // live drag hovering right at the boundary flips the header
+                // between one and two lines on every pixel of movement
+                var wasWrapped = column.getText().indexOf('\n') >= 0;
+                var fitThreshold = wasWrapped ? available - UNWRAP_HYSTERESIS_PX : available;
+
+                if (gc.textExtent(label).x <= fitThreshold)
+                {
+                    setIfChanged.accept(label);
+                    return;
+                }
+
+                var words = label.split(" "); //$NON-NLS-1$
+                var fillTo = 1;
+                for (int i = 2; i <= words.length; i++)
+                {
+                    var candidate = String.join(" ", Arrays.copyOfRange(words, 0, i)); //$NON-NLS-1$
+                    if (gc.textExtent(candidate).x > fitThreshold)
+                        break;
+                    fillTo = i;
+                }
+                var line2 = String.join(" ", Arrays.copyOfRange(words, fillTo, words.length)); //$NON-NLS-1$
+                if (line2.isEmpty())
+                {
+                    setIfChanged.accept(label);
+                    return;
+                }
+                var line1 = String.join(" ", Arrays.copyOfRange(words, 0, fillTo)); //$NON-NLS-1$
+                setIfChanged.accept(line1 + "\n" + line2); //$NON-NLS-1$
+            }
+            finally
+            {
+                gc.dispose();
+            }
+        };
+
+        column.setData(REFLOW_KEY, reflow);
+
+        if (column instanceof TableColumn tc)
+            tc.addControlListener(ControlListener.controlResizedAdapter(e -> reflow.run()));
+        else if (column instanceof TreeColumn tc)
+            tc.addControlListener(ControlListener.controlResizedAdapter(e -> reflow.run()));
+
+        reflow.run();
+
+        // the theme engine applies fonts only after the columns have been
+        // created and a font change fires no resize event, so the measurement
+        // above can still be based on the pre-theme font; recompute once the
+        // UI has settled so that a view already wraps when it is first opened
+        measureControl.getDisplay().asyncExec(() -> {
+            if (!column.isDisposed() && !measureControl.isDisposed())
+                reflow.run();
+        });
     }
 
     private static class TableViewerPolicy extends ViewerPolicy
@@ -283,6 +444,8 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
                 tableColumn.setText(column.getLabel());
                 tableColumn.setToolTipText(
                                 createToolTip(column.getLabel(), column.getDescription(), column.getMenuLabel()));
+                attachDynamicHeaderWrap(tableColumn, tableColumn::getWidth, tableColumn::setText, table.getTable(),
+                                column.getLabel());
             }
             else
             {
@@ -292,6 +455,8 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
                 tableColumn.setToolTipText(createToolTip(text, description, column.getMenuLabel()));
 
                 tableColumn.setData(OPTIONS_KEY, option);
+                attachDynamicHeaderWrap(tableColumn, tableColumn::getWidth, tableColumn::setText, table.getTable(),
+                                text);
             }
 
             CellLabelProvider labelProvider = column.getLabelProvider().get();
@@ -454,6 +619,8 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
                 treeColumn.setText(column.getLabel());
                 treeColumn.setToolTipText(
                                 createToolTip(column.getLabel(), column.getDescription(), column.getMenuLabel()));
+                attachDynamicHeaderWrap(treeColumn, treeColumn::getWidth, treeColumn::setText, tree.getTree(),
+                                column.getLabel());
             }
             else
             {
@@ -462,6 +629,7 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
                 String description = column.getOptions().getDescription(option);
                 treeColumn.setToolTipText(createToolTip(text, description, column.getMenuLabel()));
                 treeColumn.setData(OPTIONS_KEY, option);
+                attachDynamicHeaderWrap(treeColumn, treeColumn::getWidth, treeColumn::setText, tree.getTree(), text);
             }
 
             CellLabelProvider labelProvider = column.getLabelProvider().get();
@@ -501,6 +669,10 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
 
     /* package */static final String OPTIONS_KEY = Column.class.getName() + "_OPTION"; //$NON-NLS-1$
     private static final String ORIGINAL_LABEL_KEY = "$original_label$"; //$NON-NLS-1$
+    private static final String WRAP_LABEL_KEY = "$wrap_label$"; //$NON-NLS-1$
+    private static final String REFLOW_KEY = "$wrap_reflow$"; //$NON-NLS-1$
+    private static final int UNWRAP_HYSTERESIS_PX = 8;
+    private static final int MAX_FONT_SIZE_FOR_WRAP = 11;
     private static final int NO_COLUMN_SELECTED = -1;
 
     private final String identifier;
@@ -924,8 +1096,12 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
 
                 if (item.getLabel() != null)
                 {
-                    viewerColumn.setData(ORIGINAL_LABEL_KEY, viewerColumn.getText());
+                    var cleanDefault = viewerColumn.getData(WRAP_LABEL_KEY);
+                    viewerColumn.setData(ORIGINAL_LABEL_KEY,
+                                    cleanDefault != null ? cleanDefault : viewerColumn.getText());
                     viewerColumn.setText(item.getLabel());
+                    viewerColumn.setData(WRAP_LABEL_KEY, item.getLabel());
+                    reflowHeader(viewerColumn);
                 }
             });
 
@@ -993,7 +1169,10 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
 
             String originalLabel = (String) col.getData(ORIGINAL_LABEL_KEY);
             if (originalLabel != null)
-                item.setLabel(col.getText());
+            {
+                var wrapLabel = (String) col.getData(WRAP_LABEL_KEY);
+                item.setLabel(wrapLabel != null ? wrapLabel : col.getText());
+            }
 
             configuration.addItem(item);
         }
@@ -1034,12 +1213,14 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
             return;
 
         String originalLabel = (String) widget.getData(ORIGINAL_LABEL_KEY);
+        var wrapLabel = (String) widget.getData(WRAP_LABEL_KEY);
+        var currentLabel = wrapLabel != null ? wrapLabel : widget.getText();
 
-        manager.add(new LabelOnly(originalLabel != null ? originalLabel : widget.getText()));
+        manager.add(new LabelOnly(originalLabel != null ? originalLabel : currentLabel));
 
         manager.add(new SimpleAction(Messages.MenuRenameColumn, a -> {
 
-            String oldLabel = widget.getText();
+            var oldLabel = currentLabel;
 
             InputDialog dlg = new InputDialog(Display.getCurrent().getActiveShell(), Messages.ColumnName,
                             Messages.ColumnName, oldLabel,
@@ -1049,6 +1230,8 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
 
             String newLabel = dlg.getValue();
             widget.setText(newLabel);
+            widget.setData(WRAP_LABEL_KEY, newLabel);
+            reflowHeader(widget);
 
             if (originalLabel == null)
                 widget.setData(ORIGINAL_LABEL_KEY, oldLabel);
@@ -1059,6 +1242,8 @@ public class ShowHideColumnHelper implements IMenuListener, ConfigurationStoreOw
             manager.add(new SimpleAction(Messages.MenuResetColumnName, a -> {
                 widget.setData(ORIGINAL_LABEL_KEY, null);
                 widget.setText(originalLabel);
+                widget.setData(WRAP_LABEL_KEY, originalLabel);
+                reflowHeader(widget);
             }));
         }
 


### PR DESCRIPTION
Long column headers (e.g. "Capital Gains (FIFO) 1 year") are currently truncated when the column is narrower than the label, leaving the header unreadable even when a two-line header would fit comfortably.

With this change, a column header wraps onto a second line when the full label does not fit the current column width, and snaps back to a single line as soon as the column is wide enough. The break point is chosen dynamically by measuring the actual rendered text width (greedy fill of the first line), not hardcoded into the label strings — so translations and renamed columns work without any per-language changes.

Headers wrapped when columns narrow
<img width="425" height="143" alt="PP_feature_header-wrap" src="https://github.com/user-attachments/assets/b8329ef9-99e1-4c52-b681-953948cfc1ce" />

Header unwraps again when a column gets wider
<img width="475" height="148" alt="PP_feature_header-unwrap" src="https://github.com/user-attachments/assets/9e966784-9103-43d5-9013-445375cd7a30" />

Implementation notes:
- Lives in `ShowHideColumnHelper`, so it applies uniformly to every table and tree in the application; no per-view changes and no message-string changes.
- The logical (unwrapped) label is tracked in widget data: column rename, "reset column name", and saved column configurations all persist the clean label — a rendered line break never leaks into saved state.
- Tested on macOS. Windows (Header32) and Linux (GTK) rendering of multi-line native headers is not verified.