### PR TITLE
DekaBank importer: migrate to ctx.markAsFailure

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DekaBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DekaBankPDFExtractor.java
@@ -1056,7 +1056,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                 {
                     if (t.getPortfolioTransaction().getShares() != 0)
                     {
-                        item.setFailureMessage(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                        ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
                         return item;
                     }
                     return new SkippedItem(item, Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
@@ -1254,7 +1254,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                     {
                         if (t.getShares() != 0)
                         {
-                            item.setFailureMessage(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                            ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
                             return item;
                         }
                         return new SkippedItem(item, Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
@@ -1427,7 +1427,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                     {
                         if (t.getShares() != 0)
                         {
-                            item.setFailureMessage(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                            ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
                             return item;
                         }
                         return new SkippedItem(item, Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
@@ -1606,7 +1606,7 @@ public class DekaBankPDFExtractor extends AbstractPDFExtractor
                     {
                         if (t.getShares() != 0)
                         {
-                            item.setFailureMessage(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                            ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
                             return item;
                         }
                         return new SkippedItem(item, Messages.MsgErrorTransactionTypeNotSupportedOrRequired);


### PR DESCRIPTION
Closes #5521

Replaces the last remaining `item.setFailureMessage(Messages.MsgErrorTransactionTypeNotSupportedOrRequired)` calls — all four in `DekaBankPDFExtractor` — with `ctx.markAsFailure(...)`. Behavior is unchanged: `PDFParser` propagates the context failure reason to the item after the wrap callback. The skip case (zero amount, zero shares) already returned a `SkippedItem` and is untouched.

Verified with `DekaBankPDFExtractorTest` (54 tests, all green).

### Checklist status in #5521

The issue checklist is stale — against current `master`, nothing matching the old pattern remains outside DekaBank:

- **Checked and done:** BaaderBank, Comdirect, Commerzbank
- **Unchecked but already migrated** (via earlier commits, mostly to `return new SkippedItem(...)` or `ctx.markAsFailure`): DeutscheBank, Direkt1822, DKB, DZ Bank Gruppe, EasyBank, FinTechGroup, ING-DiBa, MerkurPrivatBank, ModenaEstonia, OldenburgischeLandesbank, Onvista, RaiffeisenBankgruppe, RaisinBank, SBroker (all 8 sites), ScalableCapital, Sunrise, Targobank, TradeRepublic, WirBank
- **Not on the checklist but already in the new style:** Consorsbank, DebitumInvestments, TradegateAG
- **DekaBank** (this PR): the three listed sites plus a fourth one; the shares != 0 → failure / shares == 0 → skip differentiation from the issue discussion was already in place, only the failure branch still used `setFailureMessage`.

With this change no PDF extractor calls `Item.setFailureMessage` directly anymore.