### PR TITLE
Union Investment: support new Abrechnung format

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dzbankgruppe/DZBankGruppePDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dzbankgruppe/DZBankGruppePDFExtractorTest.java
@@ -14,6 +14,8 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
@@ -3020,5 +3022,47 @@ public class DZBankGruppePDFExtractorTest
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
         assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
                         is(Money.of("EUR", Values.Amount.factorize(0.00))));
+    }
+
+    @Test
+    public void testUmsatzuebersicht13()
+    {
+        var extractor = new DZBankGruppePDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Umsatzuebersicht13.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(2L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("DE000A1W2CK8"), hasWkn(null), hasTicker(null), //
+                        hasName("GLS Bank Aktienfonds Inhaber-Anteil"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check sale transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-01-06T00:00"), hasShares(2.560), //
+                        hasSource("Umsatzuebersicht13.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 198.99), hasGrossValue("EUR", 200.00), //
+                        hasTaxes("EUR", 1.01), hasFees("EUR", 0.00))));
+
+        // check purchase transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-27T00:00"), hasShares(2.541), //
+                        hasSource("Umsatzuebersicht13.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 200.00), hasGrossValue("EUR", 200.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dzbankgruppe/Umsatzuebersicht13.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dzbankgruppe/Umsatzuebersicht13.txt
@@ -1,0 +1,91 @@
+PDFBox Version: 1.8.16
+-----------------------------------------
+Gern berät Sie:
+GLS Gemeinschaftsbank eG
+Union Investment - Kundenservice
+Telefon: 069 58998-6000
+E-Mail: service@union-investment.de
+Herrn
+Max Mustermann UnionDepot: 11111111
+Musterstr. 12 Depotinhaber: 
+11111 Musterstadt Max Mustermann
+28. Januar 2026
+Abrechnung Nr. 63
+Unterdepot-Nr.: 1111111101
+Fonds: GLS Bank Aktienfonds Inhaber-Anteil ISIN: DE000A1W2CK8
+Buchungs-/ Umsatzart Betrag/EUR Ausgabe- Preis/EUR Anteile
+Preisdatum aufschlag %
+Vortrag vom 02.01.2026 2,819
+07.01.2026
+06.01.2026 Verkauf *1 200,00 78,11 -2,560
+Kapitalertragsteuer -1,01
+inklusive Solidaritätszuschlag
+Auszahlung 198,99
+zu Gunsten IBAN DE86 XXXX XXXX XXXX XXXX XX
+28.01.2026
+27.01.2026 Kauf 200,00
+ Anlage 200,00 0,00 78,70 2,541
+Bestand am 28.01.2026 2,800
+*1 Die steuerpflichtigen Erträge betragen 3,83 Euro.
+Steuerübersicht per 28.01.2026
+Es liegt kein Freistellungsauftrag vor.
+Verlustverrechnungstopf für Kapitalerträge in EUR: 0,00
+gezahlte Kapitalertragsteuer in EUR: 0,96
+gezahlte Kirchensteuer in EUR: 0,00
+gezahlter Solidaritätszuschlag in EUR: 0,05
+Fortsetzung auf Seite 2
+Union Investment Service Bank AG · 60621 Frankfurt am Main
+Tel.: 069 58998-0 · E-Mail: service@union-investment.de · Internet: www.union-investment.de · Registergericht: Amtsgericht Frankfurt am Main HRB 54979
+Vorstand: Christoph Pöhlsen, Bettina Tews · Aufsichtsratsvorsitzende: Sonja Albers · Gläubiger-ID: DE81USB00000002100  
+Einzahlungen: DZ BANK AG Deutsche Zentral-Genossenschaftsbank, Frankfurt am Main, IBAN: DE34 5006 0400 0000 0006 86 (BIC: GENODEFFXXX)
+Seite 2 von 2 Datenschutzfeld
+zum Schreiben vom 28. Januar 2026 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+UnionDepot: 11111111 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Depotinhaber: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Max Mustermann XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+Depotübersicht zum 28.01.2026
+Unterdepot- Fondsname/Produktname/Wertpapiername Anteil- Rücknahme-/ Depotwert
+Nr. ISIN/Ertragsverwendung bestand Verkaufspreis Währung
+Verwahrart/Lagerland Währung
+1111111101 GLS Bank Aktienfonds Inhaber-Anteil 2,800 78,70 EUR 220,36 EUR
+DE000A1W2CK8/ausschüttend
+Wertpapierrechnung/CBL - Luxemburg
+Gesamt-Depotwert 220,36 EUR
+Die Bewertung von Fonds (mit Ausnahme von börsengehandelten Investmentfonds, wie "Exchange-Traded-Funds" bzw. "ETC") erfolgt zum 
+jeweils letzten verfügbaren Rücknahmepreis. Bei börsengehandelten Wertpapieren wird auf den jeweiligen zuletzt verfügbaren Börsenpreis 
+abgestellt. In der Depotübersicht sind alle Anteile, bzw. Stücke enthalten, die am Tag der Erstellung dieser Abrechnung in Ihrem Depotbestand 
+sind.
+In manchen Fällen weichen die Werte der Depotübersicht von der Abrechnungsübersicht ab. Das kann dann vorkommen, wenn zum Beispiel 
+Fonds betroffen sind, die nicht taggleich abgerechnet werden. Das ist bei den meisten Drittfonds oder Finanzportfolioverwaltungen der Fall. 
+Hier können Transaktionen zwar bereits für einen der betroffenen Fonds gebucht und abgerechnet sein, für den anderen betroffenen Fonds 
+aber noch nicht. In Ihrer nächsten Depotübersicht ist die ausstehende Buchung berücksichtigt.
+Bitte überprüfen Sie, ob wir Ihre Aufträge weisungsgemäß ausgeführt haben. Bei Differenzen informieren Sie uns bitte schriftlich unverzüglich 
+unter Angabe Ihrer jeweiligen 10-stelligen Unterdepot-Nummer und der Abrechnungsnummer, die Sie auf der ersten Seite der Abrechnung 
+finden. Die Verkaufsunterlagen nach § 297 Abs. 5 KAGB und aktuelle Fondsinformationen erhalten Sie kostenlos bei Ihrer Bank oder im 
+Internet unter www.union-investment.de.
+Ihr Beraterteam vor Ort 
+Auf Wunsch steht Ihnen Ihre Beraterin oder Ihr Berater bei der GLS Gemeinschaftsbank eG für ein Beratungsgespräch gerne zur Verfügung. 
+B ei Fragen sind wir gern für Sie da. Rufen Sie uns einfach an! Sie erreichen uns montags bis freitags zwischen 08:00 und 18:00 Uhr.
+Nutzen Sie jetzt das elektronische Postfach und profitieren Sie 
+von vielen Vorteilen! Sprechen Sie gern Ihren Berater an oder 
+wenden Sie sich direkt an unseren Kundenservice.

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankGruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DZBankGruppePDFExtractor.java
@@ -368,7 +368,7 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
         final DocumentType type = new DocumentType("Abrechnung Nr\\. [\\d]+", (context, lines) -> {
             Pattern pAccountingNumber = Pattern.compile("^(?<accountingNumber>Abrechnung Nr\\. [\\d]+)$");
             Pattern pBaseCurrency = Pattern.compile("^.* Preis\\/(?<baseCurrency>[\\w]{3}) .*$");
-            Pattern pNameIsin = Pattern.compile("^(Fonds: )?(?<name>((?!MusterFonds).)*) ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) .*$");
+            Pattern pNameIsin = Pattern.compile("^(Fonds: )?(?<name>((?!MusterFonds).)*) ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])( .*)?$");
 
             // Set end of line of the securities transaction block
             int endOfLineOfSecurityTransactionBlock = lines.length;
@@ -403,6 +403,9 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                     //
                     // Example:
                     // Fonds: PrivatFonds: Kontrolliert pro ISIN: DE000A0RPAN3 Verwaltungsvergütung: 1,55 % p. a.
+                    // Buchungs-/ Umsatzart Betrag/EUR Ausgabe- Preis/EUR Anteile
+                    //
+                    // Fonds: GLS Bank Aktienfonds Inhaber-Anteil ISIN: DE000A1W2CK8
                     // Buchungs-/ Umsatzart Betrag/EUR Ausgabe- Preis/EUR Anteile
                     //
                     // Fonds: UniGlobal ISIN: DE0008491051 Verwaltungsvergütung: 1,20 % p. a.
@@ -509,7 +512,17 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
         // 17.07.2017 Kauf 2.125,00
         // Anlage 2.125,00 0,00 148,75 14,286
         //
+        // 28.01.2026
+        // 27.01.2026 Kauf 200,00
+        //  Anlage 200,00 0,00 78,70 2,541
+        //
         // 19.11.2020 Verkauf *1 18.103,67 63,38 -285,637
+        //
+        // 07.01.2026
+        // 06.01.2026 Verkauf *1 200,00 78,11 -2,560
+        // Kapitalertragsteuer -1,01
+        // inklusive Solidaritätszuschlag
+        // Auszahlung 198,99
         //
         // 27.11.2017
         // 2 4.11.2017 Wiederanlage 94,78 0,00 142,61 0,665
@@ -528,9 +541,35 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                             section -> section
                                     .attributes("date", "amount", "shares")
                                     .match("^(?<date>[\\s\\d]{2,3}\\.[\\d]{2}\\.[\\d]{4}) Kauf (?<amount>[\\.,\\d]+)$")
-                                    .match("^Anlage [\\.,\\d]+ [\\.,\\d]+ [\\.,\\d]+ (?<shares>[\\.,\\d]+)$")
+                                    .match("^([\\s]+)?Anlage [\\.,\\d]+ [\\.,\\d]+ [\\.,\\d]+ (?<shares>[\\.,\\d]+)$")
                                     .assign((t, v) -> {
                                         Map<String, String> context = type.getCurrentContext();
+
+                                        Security securityData = getSecurity(context, v.getStartLineNumber());
+                                        if (securityData != null)
+                                        {
+                                            v.put("name", securityData.getName());
+                                            v.put("isin", securityData.getIsin());
+                                            v.put("currency", asCurrencyCode(securityData.getCurrency()));
+                                        }
+                                        t.setSecurity(getOrCreateSecurity(v));
+
+                                        t.setDate(asDate(stripBlanks(v.get("date"))));
+                                        t.setShares(asShares(v.get("shares")));
+                                        t.setCurrencyCode(asCurrencyCode(context.get("baseCurrency")));
+                                        t.setAmount(asAmount(v.get("amount")));
+                                    })
+                            ,
+                            section -> section
+                                    .attributes("date", "shares", "amount")
+                                    .match("^(?<date>[\\s\\d]{2,3}\\.[\\d]{2}\\.[\\d]{4}) Verkauf \\*[\\d]+ [\\.,\\d]+ [\\.,\\d]+ \\-(?<shares>[\\.,\\d]+)$")
+                                    .match("^Kapitalertragsteuer \\-[\\.,\\d]+$")
+                                    .match("^Auszahlung (?<amount>[\\.,\\d]+)$")
+                                    .assign((t, v) -> {
+                                        Map<String, String> context = type.getCurrentContext();
+
+                                        // We switch to SELL
+                                        t.setType(PortfolioTransaction.Type.SELL);
 
                                         Security securityData = getSecurity(context, v.getStartLineNumber());
                                         if (securityData != null)
@@ -1095,6 +1134,19 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type))
 
                         // @formatter:off
+                        // Kapitalertragsteuer -1,01
+                        // inklusive Solidaritätszuschlag
+                        // @formatter:on
+                        .section("tax").optional() //
+                        .match("^Kapitalertragsteuer \\-(?<tax>[\\.,\\d]+)$") //
+                        .assign((t, v) -> {
+                            Map<String, String> context = type.getCurrentContext();
+
+                            v.put("currency", asCurrencyCode(context.get("baseCurrency")));
+                            processTaxEntries(t, v, type);
+                        })
+
+                        // @formatter:off
                         // abgeführte Kapitalertragsteuer 0,00
                         // @formatter:on
                         .section("tax").optional() //
@@ -1160,9 +1212,10 @@ public class DZBankGruppePDFExtractor extends AbstractPDFExtractor
 
                         // @formatter:off
                         // Anlage 2.125,00 2,00 113,45 18,730
+                        //  Anlage 200,00 0,00 78,70 2,541
                         // @formatter:on
                         .section("amount", "percentageFee").optional() //
-                        .match("^Anlage (?<amount>[\\.,\\d]+) (?<percentageFee>[\\.,\\d]+) [\\.,\\d]+ [\\.,\\d]+") //
+                        .match("^([\\s]+)?Anlage (?<amount>[\\.,\\d]+) (?<percentageFee>[\\.,\\d]+) [\\.,\\d]+ [\\.,\\d]+$") //
                         .assign((t, v) -> {
                             Map<String, String> context = type.getCurrentContext();
                             v.put("currency", asCurrencyCode(context.get("baseCurrency")));


### PR DESCRIPTION
New Union Investment "Abrechnung" documents (here issued via GLS Bank) changed the depot statement format in three ways, so the import failed completely:

- the fund line no longer carries a suffix after the ISIN (`Fonds: GLS Bank Aktienfonds Inhaber-Anteil ISIN: DE000A1W2CK8`), so no security was collected
- the `Anlage` detail line of a purchase is indented with a leading space
- a sale can now carry withheld tax (`Kapitalertragsteuer -1,01`, incl. Solidaritätszuschlag) followed by the net payout (`Auszahlung 198,99`)

Changes:

- relax `pNameIsin` to also accept fund lines ending at the ISIN
- tolerate leading whitespace on the `Anlage` detail line (buy section and percentage fee section)
- new `oneOf` alternative for sales with withheld tax: the amount is taken from the `Auszahlung` line, the tax is added as a tax unit
- new fixture `Umsatzuebersicht13.txt` and test based on the document from the issue

Closes #5415