### PR TITLE
Add Trading 212 PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/trading212/Aktivitaetsauszug01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/trading212/Aktivitaetsauszug01.txt
@@ -1,0 +1,171 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.1
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+Aktivitätsauszug
+Erstellt von FXFlat Bank GmbH am 7. Januar 2026, über von 05.01.2026 22:00 (UTC) bis 06.01.2026 21:59 (UTC).
+Übersicht
+Trading 212 Invest Trading 212 CFD
+Konto-ID: 12345678 Konto-ID: 12345678
+Einzahlungen €0.00 Einzahlungen €0.00
+Auszahlungen €0.00 Auszahlungen €0.00
+Realisierte Rendite €-0.26 FX Gebühr €0.00
+Unrealisierte Rendite €2.39 Dividendenanpassungen €0.00
+Unrealisierte Renditeänderung €2.39 Overnight-Zinsen €0.00
+Dividenden €0.00 Geschlossenes Ergebnis €0.00
+Verzinsung von Geld €1.83 Offenes Ergebnis €0.00
+FX Gebühr €0.00 Offene Ergebnisänderung €0.00
+Gebühren von Dritten €0.00 Margin-Anforderung €0.00
+Steuern €-0.44 Freie Margin €0.00
+Kontowert €12,005.74 Kontowert €0.00
+1/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+Invest-Konto - ausgeführte Aufträge
+GEBÜHREN DER
+HANDELSPLATT
+INSTRUMENT AUSFÜHRUNGS TRANSAKTIONS FORM &
+AUSFÜHRUNGSZEITPUNKT WERTPAPIER ISIN WÄHRUNG AUFTRAGS-ID-NR. ANWEISUNG ANZAHL AUSFÜHRUNGSKURS WERT AUFTRAGSTYP PLATZES SITZUNG DEVISENKURS WÄHRUNG FX GEBÜHR STEUERN RENDITE WERT STEUERN
+2026-01-06 08:04:56 VWCE IE00BK5BQT80 EUR 44501427897 Kaufen 0.03398586 147.12 5 Market OTC Reguläre Zeiten 1 EUR - - - 5 -
+2026-01-06 08:05:14 EUNL IE00B4L5Y983 EUR 44501429617 Kaufen 0.04437147 112.685 5 Market OTC Reguläre Zeiten 1 EUR - - - 5 -
+2026-01-06 08:08:12 EUNL IE00B4L5Y983 EUR 44501431724 Kaufen 1 112.67 112.67 Market OTC Reguläre Zeiten 1 EUR - - - 112.67 -
+2026-01-06 08:08:38 EUNL IE00B4L5Y983 EUR 44501432006 Kaufen 1 112.67 112.67 Market OTC Reguläre Zeiten 1 EUR - - - 112.67 -
+2026-01-06 08:11:08 EUNL IE00B4L5Y983 EUR 44501433363 Kaufen 2.21906621 112.66 250 Market OTC Reguläre Zeiten 1 EUR - - - 250 -
+2026-01-06 08:11:10 VWCE IE00BK5BQT80 EUR 44501433415 Kaufen 1.6999864 147.06 250 Market OTC Reguläre Zeiten 1 EUR - - - 250 -
+2026-01-06 08:12:29 VWCE IE00BK5BQT80 EUR 44466988302 Verkaufen 1.73397226 147.02 254.9286 Market OTC Reguläre Zeiten 1 EUR - - -0.07 254.93 0.01
+2026-01-06 08:12:29 EUNL IE00B4L5Y983 EUR 44466988303 Verkaufen 2.26343768 112.62 254.9084 Market OTC Reguläre Zeiten 1 EUR - - -0.11 254.91 0.02
+2026-01-06 08:12:56 EUNL IE00B4L5Y983 EUR 44501435029 Verkaufen 2 112.62 225.24 Market OTC Reguläre Zeiten 1 EUR - - -0.08 225.24 0.01
+2026-01-06 08:22:26 EUNL IE00B4L5Y983 EUR 44501443398 Kaufen 2 112.565 225.13 Market OTC Reguläre Zeiten 1 EUR - - - 225.13 -
+2026-01-06 08:23:06 EUNL IE00B4L5Y983 EUR 44501443474 Kaufen 1.11076553 112.535 125 Market OTC Reguläre Zeiten 1 EUR - - - 125 -
+2026-01-06 08:23:08 VWCE IE00BK5BQT80 EUR 44501443481 Kaufen 0.85068735 146.94 125 Market OTC Reguläre Zeiten 1 EUR - - - 125 -
+Die FXFlat Bank GmbH empfängt und übermittelt deine Aufträge, die anschließend, einschließlich eventueller Währungsumrechnungen, von Trading 212 Markets Ltd. ausgeführt werden. 2/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+Invest-Konto - Zusammenfassung offener Positionen
+Offene Aufträge
+WERTPAPIER ISIN INSTRUMENT WÄHRUNG AUFTRAGS-ID-NR. ART ANWEISUNG ABLAUF ANZAHL LIMIT-PREIS STOP-KURS WERT
+Keine Daten verfügbar
+Offene Positionen
+DURCHSCHNITTLICHER
+WERTPAPIER ISIN INSTRUMENT WÄHRUNG ANZAHL PREIS KURS RENDITE WERT DEVISENKURS RENDITE WERT
+EUNL IE00B4L5Y983 EUR 3.11076553 112.5542882 113.115 1.74 351.8742 1 €1.74 €351.87
+VWCE IE00BK5BQT80 EUR 0.85068735 146.94000093 147.7 0.65 125.6465 1 €0.65 €125.65
+Dein Bargeld ist jederzeit geschützt und deine Aufträge werden von der FXFlat Bank GmbH (Firmennummer 101710/Lizenznummer 10109603) empfangen und übermittelt. Deine Aufträge und etwaige Währungsumrechnungen werden von Trading 212 Markets Ltd (Firmennummer: HE 409763 / CySEC-Lizenznummer: 398/21) ausgeführt und dein Vermögen wird gesichert. 3/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+Invest-Konto - Transaktionen und Dividenden
+Transaktionen
+ZEIT ART WÄHRUNG BRUTTOBETRAG STEUERN STEUERN NETTOBETRAG
+2026-01-06 02:10:08 Verzinsung von Geld EUR 1.83 -0.48 €-0.48 1.35
+Dividenden
+WERTPAPIER ISIN INSTRUMENT WÄHRUNG AUSGABELAND ZULÄSSIGE BESTÄNDE ZAHLUNGSDATUM BETRAG PRO AKTIE GESAMTBETRAG QST-TARIFE WHT DEVISENKURS KONTOWÄHRUNG NETTOBETRAG
+Keine Daten verfügbar
+4/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+CFD-Konto - ausgeführte Aufträge
+AUSFÜHRUNGSZEITPUNKT WERTPAPIER INSTRUMENT WÄHRUNG AUFTRAGS-ID-NR. AUFTRAGSTYP ANWEISUNG ERÖFFNUNGSKURS ANZAHL AUSFÜHRUNGSKURS WERT SPREAD FX GEBÜHR DEVISENKURS AUSFÜHRUNGSPLATZES ERZIELTER G/V (EUR)
+Keine Daten verfügbar
+5/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+CFD-Konto - Zusammenfassung offener Positionen
+Offene Aufträge
+WERTPAPIER INSTRUMENT WÄHRUNG AUFTRAGS-ID-NR. ART ABLAUF ANWEISUNG ANZAHL KURS WERT (EUR)
+Keine Daten verfügbar
+Offene Positionen
+PREISÄNDERUNGEN IM
+WERTPAPIER INSTRUMENT WÄHRUNG ANWEISUNG ANZAHL ERÖFFNUNGSKURS KURS NICHT REALISIERTER G/V WERT NICHT REALISIERTER G/V (EUR) ZEITRAUM MARGIN
+Keine Daten verfügbar
+Dein Bargeld ist jederzeit geschützt und deine Aufträge werden von der FXFlat Bank GmbH ausgeführt. 6/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+CFD-Konto - Barmittelübersicht
+CFDs werden unverzüglich abgerechnet, somit sind alle freien Barmittel abgerechnete Barmittel. Erfahre mehr über abgerechnete Barmittelsaldo hier.
+Gesamte freie Barmittel
+WERT
+EUR barmittel 0
+Gesamte freie Barmittel bei Banken
+WERT
+EUR barmittel 0
+7/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+CFD-Konto - Transaktionen, Dividenden und Haltegebühr über Nacht
+Transaktionen
+ZEIT ART WÄHRUNG BETRAG
+Keine Daten verfügbar
+Dividendenanpassungen
+ZULÄSSIGE
+WERTPAPIER INSTRUMENT WÄHRUNG ANWEISUNG BESTÄNDE ZAHLUNGSDATUM BETRAG PRO AKTIE GESAMTBETRAG DEVISENKURS NETTOBETRAG (EUR)
+Keine Daten verfügbar
+Overnight-Zinsen
+TRANSAKTIONSZEITPUNKT WERTPAPIER ANWEISUNG ANZAHL BETRAG (EUR)
+Keine Daten verfügbar
+8/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+Glossar
+Wert Devisenkurs
+Der gesamte Wert des Trades/der Position, wobei die Quantität mit dem Preis multipliziert wird. • Ausgeführte Trades: Der zum Zeitpunkt der Trade-Ausführung geltende Wechselkurs.
+• Zusammenfassung offener Positionen: Der Bloomberg-Zinssatz zum Monatsende dient ausschließlich zur Orientierung.
+Ergebnis geschlossener Positionen/Realisierte Rendite
+Das Gesamtergebnis/die Gesamtrendite aus geschlossenen Positionen während des Zeitraums. Transaktions währung
+Die Währung, in der die Transaktion ausgeführt wird. Dabei kann es sich um die Hauptwährung des Kontos oder um die Währung der Wallet bei Konten
+Offenes Ergebnis/Rendite mit mehreren Währungen handeln.
+Das gesamte schwebende Ergebnis/Rendite deiner offenen Positionen, berechnet seit ihrer Eröffnung.
+WHT (Quellensteuer)
+Offene Ergebnis/Renditeänderung Eine an der Quelle einbehaltene Steuer, oft auf an Gebietsfremde gezahlte Zinsen oder Dividenden. Der Quellensteuersatz ist der Prozentsatz, der auf
+Die Veränderung des schwebenden Ergebnisses/Rendite deiner Positionen zwischen dem Beginn und dem Ende des Abrechnungszeitraums. diese Zahlungen angewendet wird.
+Kontowert Sitzung
+Die Summe der offenen Positionen und der Geldmittel auf dem Konto am Ende des ausgewählten Zeitraums. Die Sitzung, in der der Handel ausgeführt wurde, so dass Kunden zwischen Aufträgen während der Hauptzeiten, der verlängerten (vor- und
+nachbörslichen) und der Über-Nacht-Handelszeiten unterscheiden können.
+Instrument Währung
+Die Währung, in der das Instrument denominiert ist und gehandelt wird. Bonus
+Transaktionen, bei denen ein zusätzlicher Wert zugewiesen wird, wie z. B. Gratisaktien, Barauszahlungen oder Bezugsrechte.
+Auftrags-ID-Nr.
+Eine eindeutige Kennung für einen Auftrag. Ein Auftrag kann mehrere Ausführungen haben. Sonstiges
+Umfasst alle Transaktionen, die nicht unter die Hauptkategorien fallen, wie z. B. Anpassungen und Aktiensplits.
+Steuern
+Der Gesamtbetrag der auf Ihr Konto anfallenden Steuern, einschließlich Abgeltungssteuer, Solidaritätszuschlag und ggf. Kirchensteuer. Gebühren von Dritten
+Die Übersicht zeigt die Summe der Börsen- und Regierungsgebühren sowie der ADR-Gebühren.
+Ablauf
+Zeigt an, wann eine ausstehende Order ablaufen würde. Gebühren der Handelsplattform & Steuern
+Alle von den Behörden auferlegten obligatorischen Gebühren , darunter Stempelgebühren, Finanztransaktionssteuern, PTM-Abgaben, FINRA-Gebühren,
+Dividendenanpassungen SEC-Gebühren und Quellensteuern.
+Eine Geldgutschrift oder -abbuchung, die deinem Konto gutgeschrieben oder belastet wird, um die Dividendenzahlung des Basiswerts abzubilden. Bei
+einer Long-Position erhältst du eine Gutschrift, bei einer Short-Position wird dir eine Lastschrift berechnet. ADR-Gebühr
+Eine Verwaltungsgebühr für das Halten von American Depositary Receipts (ADRs). Diese geringe Gebühr wird von der Depotbank erhoben, die die
+Dividenden Aktien verwaltet. Wir geben sie in der Regel in Höhe von 0,01 bis 0,05 US-Dollar pro Aktie direkt an dich weiter.
+Bezieht sich auf den Teil des Gewinns eines Unternehmens, der an die Aktionäre ausgeschüttet wird. Der Betrag wird in der Regel auf der Grundlage
+der Anzahl der von jedem Aktionär gehaltenen Aktien ausgeschüttet. Overnight-Zinsen
+Eine vom Kunden für das Aufrechterhalten von CFD-Position über Nacht bezahlte oder erhaltene Zinszahlung.
+9/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+Offenlegungen
+Die Übersicht wird in der Hauptwährung des Kontos dargestellt. Bei Transaktionen in mehreren Währungen werden die Beträge anhand der zum Zeitpunkt der Transaktion geltenden
+Interbanken-Wechselkurse umgerechnet.
+Die Bargeld-Aufschlüsselung zeigt den Wert jeder Geldbörse in der jeweiligen Währung und in der Hauptwährung deines Kontos an. Der in der Währung des Hauptkontos angezeigte Wert
+wird zum aktuellen Wechselkurs am letzten Tag des Monats, für den dieser Auszug erstellt wurde, umgerechnet.
+Die Ausführungszeiten aller Transaktionen sind UTC.
+Die an einer Börse getätigten Anlagegeschäfte folgen dem Standardabwicklungszyklus für Aktien: Abschlusstag plus zwei Tage (T+2), auch wenn dieser Zeitraum aus betrieblichen Gründen
+gelegentlich verlängert werden kann. Wie in unseren AGB beschrieben, wird eine Transaktion, die nicht abgewickelt werden kann, storniert und dein Konto wird auf den Stand vor der
+Transaktion zurückgesetzt. Auf deinem Kontoauszug, den du bei der Transaktion bekommst, siehst du, ob die Transaktion an einer Börse ausgeführt wurde.
+Wurde ein Depotübertrag durchgeführt, ist der Ausführungspreis für die Übertragung in der Regel der Preis, zu dem eine Anlage gekauft wurde, wie vom Kunden während der Übertragung
+angegeben. Dessen Richtigkeit liegt in der alleinigen Verantwortung des Kunden. Bei einer Übertragung wäre der Ausführungskurs der Kurs, zu dem die Anlage gekauft wurde.
+Der Auszug umfasst auch die schwebenden Aufträge zum Zeitpunkt der Erstellung. Alle Aufträge, die danach aufgegeben oder storniert werden, werden nicht angezeigt. Es wird empfohlen,
+die Kontobewegungen auf der Online-Plattform regelmäßig zu überprüfen, um über alle Änderungen auf dem Laufenden zu bleiben.
+Bitte beachte, dass du für die Überprüfung deiner Auszüge verantwortlich bist und dafür, uns innerhalb von 24 Stunden nach Erhalt über Abweichungen zu informieren. Nach Ablauf dieser
+Frist gelten alle Geschäfte als von dir bestätigt. Diese Nachricht und alle Anhänge wurden vertraulich nur zu Händen des Adressaten versandt. Solltest du diese irrtümlich erhalten haben,
+teile uns das bitte mit, indem du uns unter info@trading212.com kontaktierst.
+Beim Investieren ist dein Kapital Risiken ausgesetzt und möglicherweise erhältst du weniger zurück als du ursprünglich investiert hast. Historische Entwicklungen sind keine Garantie für
+zukünftige Ergebnisse. Trading 212 ist ein Handelsname von FXFlat Bank GmbH. FXFlat Bank GmbH ist in Deutschland registriert (Firmennummer 101710). Eingetragene Adresse: Bahnstraße
+47, 40878 Ratingen, Deutschland. FXFlat Bank GmbH ist von der BaFin autorisiert und reguliert (Lizenznummer 10109603).
+Trading 212 Markets Ltd. ist in Zypern registriert (Firmennummer: 409763), autorisiert und reguliert durch die Cyprus Securities and Exchange Commission, CySEC (Register number 398/21).
+Dieser Auszug dient nur zu Informationszwecken und enthält keine Anlageberatung, Empfehlung oder Aufforderung zum Kauf oder Verkauf von Finanzinstrumenten.
+Trading 212 handelt bei allen Geschäften als Auftraggeber oder Vermittler und auf reiner Ausführungsbasis. Die Veröffentlichung dieses Auszugs ist gesetzlich vorgeschrieben und du kannst
+sie nicht abbestellen.
+10/10

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/trading212/Aktivitaetsauszug02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/trading212/Aktivitaetsauszug02.txt
@@ -1,0 +1,166 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.1
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+Aktivitätsauszug
+Erstellt von FXFlat Bank GmbH am 8. Januar 2026, über von 06.01.2026 22:00 (UTC) bis 07.01.2026 21:59 (UTC).
+Übersicht
+Trading 212 Invest Trading 212 CFD
+Konto-ID: 12345678 Konto-ID: 12345678
+Einzahlungen €22.33 Einzahlungen €0.00
+Auszahlungen €-257.25 Auszahlungen €0.00
+Realisierte Rendite €0.82 FX Gebühr €0.00
+Unrealisierte Rendite €2.90 Dividendenanpassungen €0.00
+Unrealisierte Renditeänderung €0.51 Overnight-Zinsen €0.00
+Dividenden €0.00 Geschlossenes Ergebnis €0.00
+Verzinsung von Geld €1.79 Offenes Ergebnis €0.00
+FX Gebühr €0.00 Offene Ergebnisänderung €0.00
+Gebühren von Dritten €0.00 Margin-Anforderung €0.00
+Steuern €-0.61 Freie Margin €0.00
+Kontowert €11,773.33 Kontowert €0.00
+1/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+Invest-Konto - ausgeführte Aufträge
+GEBÜHREN DER
+HANDELSPLATT
+INSTRUMENT AUSFÜHRUNGS TRANSAKTIONS FORM &
+AUSFÜHRUNGSZEITPUNKT WERTPAPIER ISIN WÄHRUNG AUFTRAGS-ID-NR. ANWEISUNG ANZAHL AUSFÜHRUNGSKURS WERT AUFTRAGSTYP PLATZES SITZUNG DEVISENKURS WÄHRUNG FX GEBÜHR STEUERN RENDITE WERT STEUERN
+2026-01-07 08:05:03 VWCE IE00BK5BQT80 EUR 44514761133 Kaufen 0.03377465 148.04 5 Market OTC Reguläre Zeiten 1 EUR - - - 5 -
+2026-01-07 08:05:24 EUNL IE00B4L5Y983 EUR 44514762366 Kaufen 0.04406062 113.48 5 Market OTC Reguläre Zeiten 1 EUR - - - 5 -
+2026-01-07 11:34:48 EUNL IE00B4L5Y983 EUR 44551706884 Verkaufen 1.00035279 113.38 113.42 Market OTC Reguläre Zeiten 1 EUR - - 0.82 113.42 -0.14
+2026-01-07 11:34:49 VWCE IE00BK5BQT80 EUR 44551706892 Kaufen 0.76659456 147.94 113.41 Market OTC Reguläre Zeiten 1 EUR - - - 113.41 -
+Die FXFlat Bank GmbH empfängt und übermittelt deine Aufträge, die anschließend, einschließlich eventueller Währungsumrechnungen, von Trading 212 Markets Ltd. ausgeführt werden. 2/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+Invest-Konto - Zusammenfassung offener Positionen
+Offene Aufträge
+WERTPAPIER ISIN INSTRUMENT WÄHRUNG AUFTRAGS-ID-NR. ART ANWEISUNG ABLAUF ANZAHL LIMIT-PREIS STOP-KURS WERT
+Keine Daten verfügbar
+Offene Positionen
+DURCHSCHNITTLICHER
+WERTPAPIER ISIN INSTRUMENT WÄHRUNG ANZAHL PREIS KURS RENDITE WERT DEVISENKURS RENDITE WERT
+EUNL IE00B4L5Y983 EUR 2.15447336 112.57043345 113.475 1.95 244.4789 1 €1.95 €244.48
+VWCE IE00BK5BQT80 EUR 1.65105656 147.42680893 148 0.95 244.3564 1 €0.95 €244.36
+Dein Bargeld ist jederzeit geschützt und deine Aufträge werden von der FXFlat Bank GmbH (Firmennummer 101710/Lizenznummer 10109603) empfangen und übermittelt. Deine Aufträge und etwaige Währungsumrechnungen werden von Trading 212 Markets Ltd (Firmennummer: HE 409763 / CySEC-Lizenznummer: 398/21) ausgeführt und dein Vermögen wird gesichert. 3/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+Invest-Konto - Transaktionen und Dividenden
+Transaktionen
+ZEIT ART WÄHRUNG BRUTTOBETRAG STEUERN STEUERN NETTOBETRAG
+2026-01-07 01:32:07 Kartenkauf EUR -57.35 - - -57.35
+2026-01-07 01:32:07 Kartenkauf EUR -199.9 - - -199.9
+2026-01-07 02:10:10 Verzinsung von Geld EUR 1.79 -0.47 €-0.47 1.32
+2026-01-07 11:30:16 JP Morgan Bankeinzahlung EUR 22.33 - - 22.33
+Dividenden
+WERTPAPIER ISIN INSTRUMENT WÄHRUNG AUSGABELAND ZULÄSSIGE BESTÄNDE ZAHLUNGSDATUM BETRAG PRO AKTIE GESAMTBETRAG QST-TARIFE WHT DEVISENKURS KONTOWÄHRUNG NETTOBETRAG
+Keine Daten verfügbar
+4/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+CFD-Konto - ausgeführte Aufträge
+AUSFÜHRUNGSZEITPUNKT WERTPAPIER INSTRUMENT WÄHRUNG AUFTRAGS-ID-NR. AUFTRAGSTYP ANWEISUNG ERÖFFNUNGSKURS ANZAHL AUSFÜHRUNGSKURS WERT SPREAD FX GEBÜHR DEVISENKURS AUSFÜHRUNGSPLATZES ERZIELTER G/V (EUR)
+Keine Daten verfügbar
+5/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+CFD-Konto - Zusammenfassung offener Positionen
+Offene Aufträge
+WERTPAPIER INSTRUMENT WÄHRUNG AUFTRAGS-ID-NR. ART ABLAUF ANWEISUNG ANZAHL KURS WERT (EUR)
+Keine Daten verfügbar
+Offene Positionen
+PREISÄNDERUNGEN IM
+WERTPAPIER INSTRUMENT WÄHRUNG ANWEISUNG ANZAHL ERÖFFNUNGSKURS KURS NICHT REALISIERTER G/V WERT NICHT REALISIERTER G/V (EUR) ZEITRAUM MARGIN
+Keine Daten verfügbar
+Dein Bargeld ist jederzeit geschützt und deine Aufträge werden von der FXFlat Bank GmbH ausgeführt. 6/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+CFD-Konto - Barmittelübersicht
+CFDs werden unverzüglich abgerechnet, somit sind alle freien Barmittel abgerechnete Barmittel. Erfahre mehr über abgerechnete Barmittelsaldo hier.
+Gesamte freie Barmittel
+WERT
+EUR barmittel 0
+Gesamte freie Barmittel bei Banken
+WERT
+EUR barmittel 0
+7/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+CFD-Konto - Transaktionen, Dividenden und Haltegebühr über Nacht
+Transaktionen
+ZEIT ART WÄHRUNG BETRAG
+Keine Daten verfügbar
+Dividendenanpassungen
+ZULÄSSIGE
+WERTPAPIER INSTRUMENT WÄHRUNG ANWEISUNG BESTÄNDE ZAHLUNGSDATUM BETRAG PRO AKTIE GESAMTBETRAG DEVISENKURS NETTOBETRAG (EUR)
+Keine Daten verfügbar
+Overnight-Zinsen
+TRANSAKTIONSZEITPUNKT WERTPAPIER ANWEISUNG ANZAHL BETRAG (EUR)
+Keine Daten verfügbar
+8/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+Glossar
+Wert Devisenkurs
+Der gesamte Wert des Trades/der Position, wobei die Quantität mit dem Preis multipliziert wird. • Ausgeführte Trades: Der zum Zeitpunkt der Trade-Ausführung geltende Wechselkurs.
+• Zusammenfassung offener Positionen: Der Bloomberg-Zinssatz zum Monatsende dient ausschließlich zur Orientierung.
+Ergebnis geschlossener Positionen/Realisierte Rendite
+Das Gesamtergebnis/die Gesamtrendite aus geschlossenen Positionen während des Zeitraums. Transaktions währung
+Die Währung, in der die Transaktion ausgeführt wird. Dabei kann es sich um die Hauptwährung des Kontos oder um die Währung der Wallet bei Konten
+Offenes Ergebnis/Rendite mit mehreren Währungen handeln.
+Das gesamte schwebende Ergebnis/Rendite deiner offenen Positionen, berechnet seit ihrer Eröffnung.
+WHT (Quellensteuer)
+Offene Ergebnis/Renditeänderung Eine an der Quelle einbehaltene Steuer, oft auf an Gebietsfremde gezahlte Zinsen oder Dividenden. Der Quellensteuersatz ist der Prozentsatz, der auf
+Die Veränderung des schwebenden Ergebnisses/Rendite deiner Positionen zwischen dem Beginn und dem Ende des Abrechnungszeitraums. diese Zahlungen angewendet wird.
+Kontowert Sitzung
+Die Summe der offenen Positionen und der Geldmittel auf dem Konto am Ende des ausgewählten Zeitraums. Die Sitzung, in der der Handel ausgeführt wurde, so dass Kunden zwischen Aufträgen während der Hauptzeiten, der verlängerten (vor- und
+nachbörslichen) und der Über-Nacht-Handelszeiten unterscheiden können.
+Instrument Währung
+Die Währung, in der das Instrument denominiert ist und gehandelt wird. Bonus
+Transaktionen, bei denen ein zusätzlicher Wert zugewiesen wird, wie z. B. Gratisaktien, Barauszahlungen oder Bezugsrechte.
+Auftrags-ID-Nr.
+Eine eindeutige Kennung für einen Auftrag. Ein Auftrag kann mehrere Ausführungen haben. Sonstiges
+Umfasst alle Transaktionen, die nicht unter die Hauptkategorien fallen, wie z. B. Anpassungen und Aktiensplits.
+Steuern
+Der Gesamtbetrag der auf Ihr Konto anfallenden Steuern, einschließlich Abgeltungssteuer, Solidaritätszuschlag und ggf. Kirchensteuer. Gebühren von Dritten
+Die Übersicht zeigt die Summe der Börsen- und Regierungsgebühren sowie der ADR-Gebühren.
+Ablauf
+Zeigt an, wann eine ausstehende Order ablaufen würde. Gebühren der Handelsplattform & Steuern
+Alle von den Behörden auferlegten obligatorischen Gebühren , darunter Stempelgebühren, Finanztransaktionssteuern, PTM-Abgaben, FINRA-Gebühren,
+Dividendenanpassungen SEC-Gebühren und Quellensteuern.
+Eine Geldgutschrift oder -abbuchung, die deinem Konto gutgeschrieben oder belastet wird, um die Dividendenzahlung des Basiswerts abzubilden. Bei
+einer Long-Position erhältst du eine Gutschrift, bei einer Short-Position wird dir eine Lastschrift berechnet. ADR-Gebühr
+Eine Verwaltungsgebühr für das Halten von American Depositary Receipts (ADRs). Diese geringe Gebühr wird von der Depotbank erhoben, die die
+Dividenden Aktien verwaltet. Wir geben sie in der Regel in Höhe von 0,01 bis 0,05 US-Dollar pro Aktie direkt an dich weiter.
+Bezieht sich auf den Teil des Gewinns eines Unternehmens, der an die Aktionäre ausgeschüttet wird. Der Betrag wird in der Regel auf der Grundlage
+der Anzahl der von jedem Aktionär gehaltenen Aktien ausgeschüttet. Overnight-Zinsen
+Eine vom Kunden für das Aufrechterhalten von CFD-Position über Nacht bezahlte oder erhaltene Zinszahlung.
+9/10
+KUNDEN-ID NAME DES KUNDEN
+12345678 Max Mustermann
+Offenlegungen
+Die Übersicht wird in der Hauptwährung des Kontos dargestellt. Bei Transaktionen in mehreren Währungen werden die Beträge anhand der zum Zeitpunkt der Transaktion geltenden
+Interbanken-Wechselkurse umgerechnet.
+Die Bargeld-Aufschlüsselung zeigt den Wert jeder Geldbörse in der jeweiligen Währung und in der Hauptwährung deines Kontos an. Der in der Währung des Hauptkontos angezeigte Wert
+wird zum aktuellen Wechselkurs am letzten Tag des Monats, für den dieser Auszug erstellt wurde, umgerechnet.
+Die Ausführungszeiten aller Transaktionen sind UTC.
+Die an einer Börse getätigten Anlagegeschäfte folgen dem Standardabwicklungszyklus für Aktien: Abschlusstag plus zwei Tage (T+2), auch wenn dieser Zeitraum aus betrieblichen Gründen
+gelegentlich verlängert werden kann. Wie in unseren AGB beschrieben, wird eine Transaktion, die nicht abgewickelt werden kann, storniert und dein Konto wird auf den Stand vor der
+Transaktion zurückgesetzt. Auf deinem Kontoauszug, den du bei der Transaktion bekommst, siehst du, ob die Transaktion an einer Börse ausgeführt wurde.
+Wurde ein Depotübertrag durchgeführt, ist der Ausführungspreis für die Übertragung in der Regel der Preis, zu dem eine Anlage gekauft wurde, wie vom Kunden während der Übertragung
+angegeben. Dessen Richtigkeit liegt in der alleinigen Verantwortung des Kunden. Bei einer Übertragung wäre der Ausführungskurs der Kurs, zu dem die Anlage gekauft wurde.
+Der Auszug umfasst auch die schwebenden Aufträge zum Zeitpunkt der Erstellung. Alle Aufträge, die danach aufgegeben oder storniert werden, werden nicht angezeigt. Es wird empfohlen,
+die Kontobewegungen auf der Online-Plattform regelmäßig zu überprüfen, um über alle Änderungen auf dem Laufenden zu bleiben.
+Bitte beachte, dass du für die Überprüfung deiner Auszüge verantwortlich bist und dafür, uns innerhalb von 24 Stunden nach Erhalt über Abweichungen zu informieren. Nach Ablauf dieser
+Frist gelten alle Geschäfte als von dir bestätigt. Diese Nachricht und alle Anhänge wurden vertraulich nur zu Händen des Adressaten versandt. Solltest du diese irrtümlich erhalten haben,
+teile uns das bitte mit, indem du uns unter info@trading212.com kontaktierst.
+Beim Investieren ist dein Kapital Risiken ausgesetzt und möglicherweise erhältst du weniger zurück als du ursprünglich investiert hast. Historische Entwicklungen sind keine Garantie für
+zukünftige Ergebnisse. Trading 212 ist ein Handelsname von FXFlat Bank GmbH. FXFlat Bank GmbH ist in Deutschland registriert (Firmennummer 101710). Eingetragene Adresse: Bahnstraße
+47, 40878 Ratingen, Deutschland. FXFlat Bank GmbH ist von der BaFin autorisiert und reguliert (Lizenznummer 10109603).
+Trading 212 Markets Ltd. ist in Zypern registriert (Firmennummer: 409763), autorisiert und reguliert durch die Cyprus Securities and Exchange Commission, CySEC (Register number 398/21).
+Dieser Auszug dient nur zu Informationszwecken und enthält keine Anlageberatung, Empfehlung oder Aufforderung zum Kauf oder Verkauf von Finanzinstrumenten.
+Trading 212 handelt bei allen Geschäften als Auftraggeber oder Vermittler und auf reiner Ausführungsbasis. Die Veröffentlichung dieses Auszugs ist gesetzlich vorgeschrieben und du kannst
+sie nicht abbestellen.
+10/10

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/trading212/Aktivitaetsauszug03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/trading212/Aktivitaetsauszug03.txt
@@ -1,0 +1,178 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.1
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+KUNDEN-ID NAME DES KUNDEN
+12462350 bAtaN HvbOoe
+Aktivitätsauszug
+Erstellt von FXFlat Bank GmbH am 14. Januar 2026, über von 12.01.2026 22:00 (UTC) bis 13.01.2026 21:59 (UTC).
+Übersicht
+Trading 212 Invest
+Konto-ID: 13673009
+Einzahlungen €20.55
+Auszahlungen €0.00
+Realisierte Rendite €0.00
+Unrealisierte Rendite €0.01
+Unrealisierte Renditeänderung €0.01
+Dividenden €0.00
+Verzinsung von Geld €0.00
+FX Gebühr €0.00
+Gebühren von Dritten €0.00
+Kontowert €25.54
+1/8
+KUNDEN-ID NAME DES KUNDEN
+70194194 gDFVv ZrgSes
+Invest-Konto - ausgeführte Aufträge
+GEBÜHREN DER
+INSTRUMENT AUSFÜHRUNGSP HANDELSPLATTF
+AUSFÜHRUNGSZEITPUNKT WERTPAPIER ISIN WÄHRUNG AUFTRAGS-ID-NR. ANWEISUNG ANZAHL AUSFÜHRUNGSKURS WERT AUFTRAGSTYP LATZES SITZUNG DEVISENKURS TRANSAKTIONS WÄHRUNG FX GEBÜHR ORM & STEUERN RENDITE WERT
+2026-01-13 13:45:41 CTP2 US20030N1019 EUR 44853850736 Kaufen 0.04070231 25.06 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:41 ASML NL0010273215 EUR 44853850742 Kaufen 0.00092744 1099.8 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:42 NKE US6541061031 EUR 44853850750 Kaufen 0.01810436 56.34 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:43 VFEM IE00B3VVMM84 EUR 44853850758 Kaufen 0.01522388 67 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:43 PRG US7427181091 EUR 44853850764 Kaufen 0.00827653 123.24 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:44 4OQ1 US00123Q1040 EUR 44853850770 Kaufen 0.10393315 9.814 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:44 CCC3 US1912161007 EUR 44853850777 Kaufen 0.01696042 60.14 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:44 UWS US94106L1098 EUR 44853850783 Kaufen 0.00543304 187.74 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:44 MSF US5949181045 EUR 44853850791 Kaufen 0.00249694 408.5 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:45 PHM7 US02209S1033 EUR 44853850797 Kaufen 0.02034303 50.14 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:46 LIN IE000S9YS762 EUR 44853850811 Kaufen 0.00268562 379.8 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:47 VHYL IE00B8GKDB10 EUR 44853850817 Kaufen 0.03549851 71.834 2.55 Market OTC Reguläre Zeiten 1 EUR - - - 2.55
+2026-01-13 13:45:47 SHELL GB00BP6MXD84 EUR 44853850823 Kaufen 0.03286082 31.04 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:47 RY6 US7561091049 EUR 44853850829 Kaufen 0.02020602 50.48 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:48 VERX IE00BKX55S42 EUR 44853850839 Kaufen 0.02148499 47.475 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:48 NOV DK0062498333 EUR 44853850845 Kaufen 0.01969111 51.8 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+Die FXFlat Bank GmbH empfängt und übermittelt deine Aufträge, die anschließend, einschließlich eventueller Währungsumrechnungen, von Trading 212 Markets Ltd. ausgeführt werden. 2/8
+KUNDEN-ID NAME DES KUNDEN
+92354426 uABMp qEdgSD
+GEBÜHREN DER
+INSTRUMENT AUSFÜHRUNGSP HANDELSPLATTF
+AUSFÜHRUNGSZEITPUNKT WERTPAPIER ISIN WÄHRUNG AUFTRAGS-ID-NR. ANWEISUNG ANZAHL AUSFÜHRUNGSKURS WERT AUFTRAGSTYP LATZES SITZUNG DEVISENKURS TRANSAKTIONS WÄHRUNG FX GEBÜHR ORM & STEUERN RENDITE WERT
+2026-01-13 13:45:49 RIO1 GB0007188757 EUR 44853850851 Kaufen 0.01424779 71.59 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:49 MDO US5801351017 EUR 44853850857 Kaufen 0.00387832 263 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:45:50 FTWD IE0000QLH0G6 EUR 44853850864 Kaufen 0.35971223 7.089 2.55 Market OTC Reguläre Zeiten 1 EUR - - - 2.55
+2026-01-13 13:46:00 AWC US0304201033 EUR 44853851006 Kaufen 0.00906666 112.5 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:46:02 EN3 CA29250N1050 EUR 44853851023 Kaufen 0.02579013 39.55 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+2026-01-13 13:47:23 CAT1 US1491231015 EUR 44853851247 Kaufen 0.00186813 546 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+Die FXFlat Bank GmbH empfängt und übermittelt deine Aufträge, die anschließend, einschließlich eventueller Währungsumrechnungen, von Trading 212 Markets Ltd. ausgeführt werden. 3/8
+KUNDEN-ID NAME DES KUNDEN
+70021066 WczjT IwlEkW
+Invest-Konto - Zusammenfassung offener Positionen
+Offene Aufträge
+WERTPAPIER ISIN INSTRUMENT WÄHRUNG AUFTRAGS-ID-NR. ART ANWEISUNG ABLAUF ANZAHL LIMIT-PREIS STOP-KURS WERT
+Keine Daten verfügbar
+Offene Positionen
+DURCHSCHNITTLICHER
+WERTPAPIER ISIN INSTRUMENT WÄHRUNG ANZAHL PREIS KURS RENDITE WERT DEVISENKURS RENDITE WERT
+4OQ1 US00123Q1040 EUR 0.10393315 9.81400063 9.698 -0.01 1.0079 1 €-0.01 €1.01
+ASML NL0010273215 EUR 0.00092744 1099.80160442 1102.6 0 1.0226 1 €0.00 €1.02
+AWC US0304201033 EUR 0.00906666 112.50008272 110.85 -0.01 1.005 1 €-0.01 €1.01
+CAT1 US1491231015 EUR 0.00186813 546.000546 551 0.01 1.0293 1 €0.01 €1.03
+CCC3 US1912161007 EUR 0.01696042 60.14002012 60.61 0.01 1.028 1 €0.01 €1.03
+CTP2 US20030N1019 EUR 0.04070231 25.06000274 24.69 -0.02 1.0049 1 €-0.02 €1.00
+EN3 CA29250N1050 EUR 0.02579013 39.5500139 39.792 0.01 1.0262 1 €0.01 €1.03
+FTWD IE0000QLH0G6 EUR 0.35971223 7.089 7.078 0 2.546 1 €0.00 €2.55
+LIN IE000S9YS762 EUR 0.00268562 379.80056747 378.6 0 1.0168 1 €0.00 €1.02
+MDO US5801351017 EUR 0.00387832 263.00047443 263.7 0 1.0227 1 €0.00 €1.02
+MSF US5949181045 EUR 0.00249694 408.500004 403.4 -0.01 1.0073 1 €-0.01 €1.01
+NKE US6541061031 EUR 0.01810436 56.34001975 56.85 0.01 1.0292 1 €0.01 €1.03
+NOV DK0062498333 EUR 0.01969111 51.80002549 51.5 -0.01 1.0141 1 €-0.01 €1.01
+PHM7 US02209S1033 EUR 0.02034303 50.14002339 50.92 0.02 1.0359 1 €0.02 €1.04
+PRG US7427181091 EUR 0.00827653 123.2400535 123.32 0 1.0207 1 €0.00 €1.02
+RIO1 GB0007188757 EUR 0.01424779 71.59005011 71.91 0 1.0246 1 €0.00 €1.02
+RY6 US7561091049 EUR 0.02020602 50.48000546 50.818 0.01 1.0268 1 €0.01 €1.03
+SHELL GB00BP6MXD84 EUR 0.03286082 31.04000448 31.455 0.01 1.0336 1 €0.01 €1.03
+UWS US94106L1098 EUR 0.00543304 187.74019702 185.22 -0.01 1.0063 1 €-0.01 €1.01
+VERX IE00BKX55S42 EUR 0.02148499 47.47500464 47.46 0 1.0197 1 €0.00 €1.02
+VFEM IE00B3VVMM84 EUR 0.01522388 67.00000263 67.11 0 1.0217 1 €0.00 €1.02
+VHYL IE00B8GKDB10 EUR 0.03549851 71.83400092 71.747 0 2.5469 1 €0.00 €2.55
+Dein Bargeld ist jederzeit geschützt und deine Aufträge werden von der FXFlat Bank GmbH (Firmennummer 101710/Lizenznummer 10109603) empfangen und übermittelt. Deine Aufträge und etwaige Währungsumrechnungen werden von Trading 212 Markets Ltd (Firmennummer: HE 409763 / CySEC-Lizenznummer: 398/21) ausgeführt und dein Vermögen wird gesichert. 4/8
+KUNDEN-ID NAME DES KUNDEN
+77072707 DhBTZ rJnPGo
+Invest-Konto - Barmittelübersicht
+Gesamtes Geldvermögen
+WERT WERT (EUR)
+EUR barmittel 0.04 0.04
+USD barmittel 0 0
+Dein Bargeld ist jederzeit durch die FXFlat Bank GmbH geschützt. Dein Gesamtbetrag an Barmitteln kann abgerechnete und nicht abgerechnete Geldmittel umfassen. Nur abgerechnete Barmittel können in QMMFs gehalten werden, so dass in der Regel eine Differenz zwischen deinen gesamten Barmitteln und dem in QMMFs gehaltenen Betrag besteht. Erfahre mehr über die
+Bargeldabwicklung hier. 5/8
+KUNDEN-ID NAME DES KUNDEN
+54547947 TRhmZ KJDGEE
+Invest-Konto - Transaktionen und Dividenden
+Transaktionen
+ZEIT ART WÄHRUNG BETRAG BETRAG
+2026-01-12 22:15:23 JP Morgan Bankeinzahlung EUR 0.39 €0.39
+2026-01-12 22:17:23 Währungsumtausch EUR -0.2 €-0.20
+2026-01-12 22:17:23 Währungsumtausch USD 0.23 €0.20
+2026-01-12 22:17:23 Währungsumtauschgebühr USD 0 €0.00
+2026-01-13 11:37:21 Währungsumtausch USD -0.23 €-0.20
+2026-01-13 11:37:21 Währungsumtausch EUR 0.19 €0.20
+2026-01-13 11:37:21 Währungsumtauschgebühr EUR 0 €0.00
+2026-01-13 12:30:09 JP Morgan Bankeinzahlung EUR 5.16 €5.16
+2026-01-13 12:30:09 JP Morgan Bankeinzahlung EUR 10 €10.00
+2026-01-13 13:45:09 JP Morgan Bankeinzahlung EUR 5 €5.00
+Dividenden
+WERTPAPIER ISIN INSTRUMENT WÄHRUNG AUSGABELAND ZULÄSSIGE BESTÄNDE ZAHLUNGSDATUM BETRAG PRO AKTIE GESAMTBETRAG QST-TARIFE WHT DEVISENKURS KONTOWÄHRUNG NETTOBETRAG
+Keine Daten verfügbar
+6/8
+KUNDEN-ID NAME DES KUNDEN
+98834264 DIMow CqfTjU
+Glossar
+Wert Devisenkurs
+Der gesamte Wert des Trades/der Position, wobei die Quantität mit dem Preis multipliziert wird. • Ausgeführte Trades: Der zum Zeitpunkt der Trade-Ausführung geltende Wechselkurs.
+• Zusammenfassung offener Positionen: Der Bloomberg-Zinssatz zum Monatsende dient ausschließlich zur Orientierung.
+Ergebnis geschlossener Positionen/Realisierte Rendite
+Das Gesamtergebnis/die Gesamtrendite aus geschlossenen Positionen während des Zeitraums. Transaktions währung
+Die Währung, in der die Transaktion ausgeführt wird. Dabei kann es sich um die Hauptwährung des Kontos oder um die Währung der Wallet bei Konten
+Offenes Ergebnis/Rendite mit mehreren Währungen handeln.
+Das gesamte schwebende Ergebnis/Rendite deiner offenen Positionen, berechnet seit ihrer Eröffnung.
+WHT (Quellensteuer)
+Offene Ergebnis/Renditeänderung Eine an der Quelle einbehaltene Steuer, oft auf an Gebietsfremde gezahlte Zinsen oder Dividenden. Der Quellensteuersatz ist der Prozentsatz, der auf
+Die Veränderung des schwebenden Ergebnisses/Rendite deiner Positionen zwischen dem Beginn und dem Ende des Abrechnungszeitraums. diese Zahlungen angewendet wird.
+Kontowert Sitzung
+Die Summe der offenen Positionen und der Geldmittel auf dem Konto am Ende des ausgewählten Zeitraums. Die Sitzung, in der der Handel ausgeführt wurde, so dass Kunden zwischen Aufträgen während der Hauptzeiten, der verlängerten (vor- und
+nachbörslichen) und der Über-Nacht-Handelszeiten unterscheiden können.
+Instrument Währung
+Die Währung, in der das Instrument denominiert ist und gehandelt wird. Bonus
+Transaktionen, bei denen ein zusätzlicher Wert zugewiesen wird, wie z. B. Gratisaktien, Barauszahlungen oder Bezugsrechte.
+Auftrags-ID-Nr.
+Eine eindeutige Kennung für einen Auftrag. Ein Auftrag kann mehrere Ausführungen haben. Sonstiges
+Umfasst alle Transaktionen, die nicht unter die Hauptkategorien fallen, wie z. B. Anpassungen und Aktiensplits.
+Steuern
+Der Gesamtbetrag der auf Ihr Konto anfallenden Steuern, einschließlich Abgeltungssteuer, Solidaritätszuschlag und ggf. Kirchensteuer. Gebühren von Dritten
+Die Übersicht zeigt die Summe der Börsen- und Regierungsgebühren sowie der ADR-Gebühren.
+Ablauf
+Zeigt an, wann eine ausstehende Order ablaufen würde. Gebühren der Handelsplattform & Steuern
+Alle von den Behörden auferlegten obligatorischen Gebühren , darunter Stempelgebühren, Finanztransaktionssteuern, PTM-Abgaben, FINRA-Gebühren,
+Dividenden SEC-Gebühren und Quellensteuern.
+Bezieht sich auf den Teil des Gewinns eines Unternehmens, der an die Aktionäre ausgeschüttet wird. Der Betrag wird in der Regel auf der Grundlage
+der Anzahl der von jedem Aktionär gehaltenen Aktien ausgeschüttet. ADR-Gebühr
+Eine Verwaltungsgebühr für das Halten von American Depositary Receipts (ADRs). Diese geringe Gebühr wird von der Depotbank erhoben, die die
+Aktien verwaltet. Wir geben sie in der Regel in Höhe von 0,01 bis 0,05 US-Dollar pro Aktie direkt an dich weiter.
+7/8
+KUNDEN-ID NAME DES KUNDEN
+10629962 NidVm KpyrQS
+Offenlegungen
+Die Übersicht wird in der Hauptwährung des Kontos dargestellt. Bei Transaktionen in mehreren Währungen werden die Beträge anhand der zum Zeitpunkt der Transaktion geltenden
+Interbanken-Wechselkurse umgerechnet.
+Die Bargeld-Aufschlüsselung zeigt den Wert jeder Geldbörse in der jeweiligen Währung und in der Hauptwährung deines Kontos an. Der in der Währung des Hauptkontos angezeigte Wert
+wird zum aktuellen Wechselkurs am letzten Tag des Monats, für den dieser Auszug erstellt wurde, umgerechnet.
+Die Ausführungszeiten aller Transaktionen sind UTC.
+Die an einer Börse getätigten Anlagegeschäfte folgen dem Standardabwicklungszyklus für Aktien: Abschlusstag plus zwei Tage (T+2), auch wenn dieser Zeitraum aus betrieblichen Gründen
+gelegentlich verlängert werden kann. Wie in unseren AGB beschrieben, wird eine Transaktion, die nicht abgewickelt werden kann, storniert und dein Konto wird auf den Stand vor der
+Transaktion zurückgesetzt. Auf deinem Kontoauszug, den du bei der Transaktion bekommst, siehst du, ob die Transaktion an einer Börse ausgeführt wurde.
+Wurde ein Depotübertrag durchgeführt, ist der Ausführungspreis für die Übertragung in der Regel der Preis, zu dem eine Anlage gekauft wurde, wie vom Kunden während der Übertragung
+angegeben. Dessen Richtigkeit liegt in der alleinigen Verantwortung des Kunden. Bei einer Übertragung wäre der Ausführungskurs der Kurs, zu dem die Anlage gekauft wurde.
+Der Auszug umfasst auch die schwebenden Aufträge zum Zeitpunkt der Erstellung. Alle Aufträge, die danach aufgegeben oder storniert werden, werden nicht angezeigt. Es wird empfohlen,
+die Kontobewegungen auf der Online-Plattform regelmäßig zu überprüfen, um über alle Änderungen auf dem Laufenden zu bleiben.
+Bitte beachte, dass du für die Überprüfung deiner Auszüge verantwortlich bist und dafür, uns innerhalb von 24 Stunden nach Erhalt über Abweichungen zu informieren. Nach Ablauf dieser
+Frist gelten alle Geschäfte als von dir bestätigt. Diese Nachricht und alle Anhänge wurden vertraulich nur zu Händen des Adressaten versandt. Solltest du diese irrtümlich erhalten haben,
+teile uns das bitte mit, indem du uns unter info@trading212.com kontaktierst.
+Beim Investieren ist dein Kapital Risiken ausgesetzt und möglicherweise erhältst du weniger zurück als du ursprünglich investiert hast. Historische Entwicklungen sind keine Garantie für
+zukünftige Ergebnisse. Trading 212 ist ein Handelsname von FXFlat Bank GmbH. FXFlat Bank GmbH ist in Deutschland registriert (Firmennummer 101710). Eingetragene Adresse: Bahnstraße
+47, 40878 Ratingen, Deutschland. FXFlat Bank GmbH ist von der BaFin autorisiert und reguliert (Lizenznummer 10109603).
+Trading 212 Markets Ltd. ist in Zypern registriert (Firmennummer: 409763), autorisiert und reguliert durch die Cyprus Securities and Exchange Commission, CySEC (Register number 398/21).
+Dieser Auszug dient nur zu Informationszwecken und enthält keine Anlageberatung, Empfehlung oder Aufforderung zum Kauf oder Verkauf von Finanzinstrumenten.
+Trading 212 handelt bei allen Geschäften als Auftraggeber oder Vermittler und auf reiner Ausführungsbasis. Die Veröffentlichung dieses Auszugs ist gesetzlich vorgeschrieben und du kannst
+sie nicht abbestellen.
+8/8

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/trading212/Trading212PDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/trading212/Trading212PDFExtractorTest.java
@@ -1,0 +1,570 @@
+package name.abuchen.portfolio.datatransfer.pdf.trading212;
+
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasIsin;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasName;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interest;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxRefund;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countItemsWithFailureMessage;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSkippedItems;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
+import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
+import name.abuchen.portfolio.datatransfer.pdf.Trading212PDFExtractor;
+import name.abuchen.portfolio.model.Client;
+
+@SuppressWarnings("nls")
+public class Trading212PDFExtractorTest
+{
+    @Test
+    public void testAktivitaetsauszug01()
+    {
+        var extractor = new Trading212PDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Aktivitaetsauszug01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(2L));
+        assertThat(countBuySell(results), is(12L));
+        assertThat(countAccountTransactions(results), is(4L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(18));
+        new AssertImportActions().check(results, "EUR");
+
+        // check securities
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00BK5BQT80"), hasWkn(null), hasTicker("VWCE"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00B4L5Y983"), hasWkn(null), hasTicker("EUNL"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transactions
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-06T08:04:56"), hasShares(0.03398586), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44501427897"), //
+                        hasAmount("EUR", 5.00), hasGrossValue("EUR", 5.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-06T08:05:14"), hasShares(0.04437147), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44501429617"), //
+                        hasAmount("EUR", 5.00), hasGrossValue("EUR", 5.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-06T08:08:12"), hasShares(1.00), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44501431724"), //
+                        hasAmount("EUR", 112.67), hasGrossValue("EUR", 112.67), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-06T08:08:38"), hasShares(1.00), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44501432006"), //
+                        hasAmount("EUR", 112.67), hasGrossValue("EUR", 112.67), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-06T08:11:08"), hasShares(2.21906621), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44501433363"), //
+                        hasAmount("EUR", 250.00), hasGrossValue("EUR", 250.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-06T08:11:10"), hasShares(1.6999864), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44501433415"), //
+                        hasAmount("EUR", 250.00), hasGrossValue("EUR", 250.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-01-06T08:12:29"), hasShares(1.73397226), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44466988302"), //
+                        hasAmount("EUR", 254.93), hasGrossValue("EUR", 254.93), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-01-06T08:12:29"), hasShares(2.26343768), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44466988303"), //
+                        hasAmount("EUR", 254.91), hasGrossValue("EUR", 254.91), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-01-06T08:12:56"), hasShares(2.00), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44501435029"), //
+                        hasAmount("EUR", 225.24), hasGrossValue("EUR", 225.24), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-06T08:22:26"), hasShares(2.00), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44501443398"), //
+                        hasAmount("EUR", 225.13), hasGrossValue("EUR", 225.13), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-06T08:23:06"), hasShares(1.11076553), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44501443474"), //
+                        hasAmount("EUR", 125.00), hasGrossValue("EUR", 125.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-06T08:23:08"), hasShares(0.85068735), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44501443481"), //
+                        hasAmount("EUR", 125.00), hasGrossValue("EUR", 125.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check tax refund transactions
+        assertThat(results, hasItem(taxRefund( //
+                        hasDate("2026-01-06T08:12:29"), hasShares(0.00), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44466988302"), //
+                        hasAmount("EUR", 0.01), hasGrossValue("EUR", 0.01), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(taxRefund( //
+                        hasDate("2026-01-06T08:12:29"), hasShares(0.00), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44466988303"), //
+                        hasAmount("EUR", 0.02), hasGrossValue("EUR", 0.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(taxRefund( //
+                        hasDate("2026-01-06T08:12:56"), hasShares(0.00), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44501435029"), //
+                        hasAmount("EUR", 0.01), hasGrossValue("EUR", 0.01), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check interest transaction
+        assertThat(results, hasItem(interest( //
+                        hasDate("2026-01-06T02:10:08"), //
+                        hasSource("Aktivitaetsauszug01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 1.35), hasGrossValue("EUR", 1.83), //
+                        hasTaxes("EUR", 0.48), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testAktivitaetsauszug02()
+    {
+        var extractor = new Trading212PDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Aktivitaetsauszug02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(2L));
+        assertThat(countBuySell(results), is(4L));
+        assertThat(countAccountTransactions(results), is(4L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(10));
+        new AssertImportActions().check(results, "EUR");
+
+        // check securities
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00BK5BQT80"), hasWkn(null), hasTicker("VWCE"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00B4L5Y983"), hasWkn(null), hasTicker("EUNL"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transactions
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-07T08:05:03"), hasShares(0.03377465), //
+                        hasSource("Aktivitaetsauszug02.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44514761133"), //
+                        hasAmount("EUR", 5.00), hasGrossValue("EUR", 5.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-07T08:05:24"), hasShares(0.04406062), //
+                        hasSource("Aktivitaetsauszug02.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44514762366"), //
+                        hasAmount("EUR", 5.00), hasGrossValue("EUR", 5.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-01-07T11:34:48"), hasShares(1.00035279), //
+                        hasSource("Aktivitaetsauszug02.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44551706884"), //
+                        hasAmount("EUR", 113.28), hasGrossValue("EUR", 113.42), //
+                        hasTaxes("EUR", 0.14), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-07T11:34:49"), hasShares(0.76659456), //
+                        hasSource("Aktivitaetsauszug02.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44551706892"), //
+                        hasAmount("EUR", 113.41), hasGrossValue("EUR", 113.41), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check removal transactions
+        assertThat(results, hasItem(removal(hasDate("2026-01-07T01:32:07"), hasAmount("EUR", 57.35), //
+                        hasSource("Aktivitaetsauszug02.txt"), hasNote("Kartenkauf"))));
+
+        assertThat(results, hasItem(removal(hasDate("2026-01-07T01:32:07"), hasAmount("EUR", 199.90), //
+                        hasSource("Aktivitaetsauszug02.txt"), hasNote("Kartenkauf"))));
+
+        // check interest transaction
+        assertThat(results, hasItem(interest( //
+                        hasDate("2026-01-07T02:10:10"), //
+                        hasSource("Aktivitaetsauszug02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 1.32), hasGrossValue("EUR", 1.79), //
+                        hasTaxes("EUR", 0.47), hasFees("EUR", 0.00))));
+
+        // check deposit transaction
+        assertThat(results, hasItem(deposit(hasDate("2026-01-07T11:30:16"), hasAmount("EUR", 22.33), //
+                        hasSource("Aktivitaetsauszug02.txt"), hasNote("JP Morgan Bankeinzahlung"))));
+    }
+
+    @Test
+    public void testAktivitaetsauszug03()
+    {
+        var extractor = new Trading212PDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Aktivitaetsauszug03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(22L));
+        assertThat(countBuySell(results), is(22L));
+        assertThat(countAccountTransactions(results), is(4L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(48));
+        new AssertImportActions().check(results, "EUR");
+
+        // check securities
+        assertThat(results, hasItem(security( //
+                        hasIsin("US20030N1019"), hasWkn(null), hasTicker("CTP2"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("NL0010273215"), hasWkn(null), hasTicker("ASML"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("US6541061031"), hasWkn(null), hasTicker("NKE"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00B3VVMM84"), hasWkn(null), hasTicker("VFEM"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("US7427181091"), hasWkn(null), hasTicker("PRG"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("US00123Q1040"), hasWkn(null), hasTicker("4OQ1"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("US1912161007"), hasWkn(null), hasTicker("CCC3"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("US94106L1098"), hasWkn(null), hasTicker("UWS"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("US5949181045"), hasWkn(null), hasTicker("MSF"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("US02209S1033"), hasWkn(null), hasTicker("PHM7"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE000S9YS762"), hasWkn(null), hasTicker("LIN"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00B8GKDB10"), hasWkn(null), hasTicker("VHYL"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("GB00BP6MXD84"), hasWkn(null), hasTicker("SHELL"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("US7561091049"), hasWkn(null), hasTicker("RY6"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00BKX55S42"), hasWkn(null), hasTicker("VERX"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("DK0062498333"), hasWkn(null), hasTicker("NOV"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("GB0007188757"), hasWkn(null), hasTicker("RIO1"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("US5801351017"), hasWkn(null), hasTicker("MDO"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE0000QLH0G6"), hasWkn(null), hasTicker("FTWD"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("US0304201033"), hasWkn(null), hasTicker("AWC"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("CA29250N1050"), hasWkn(null), hasTicker("EN3"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("US1491231015"), hasWkn(null), hasTicker("CAT1"), //
+                        hasName(null), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transactions
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:41"), hasShares(0.04070231), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850736"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:41"), hasShares(0.00092744), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850742"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:42"), hasShares(0.01810436), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850750"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:43"), hasShares(0.01522388), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850758"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:43"), hasShares(0.00827653), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850764"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:44"), hasShares(0.10393315), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850770"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:44"), hasShares(0.01696042), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850777"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:44"), hasShares(0.00543304), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850783"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:44"), hasShares(0.00249694), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850791"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:45"), hasShares(0.02034303), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850797"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:46"), hasShares(0.00268562), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850811"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:47"), hasShares(0.03549851), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850817"), //
+                        hasAmount("EUR", 2.55), hasGrossValue("EUR", 2.55), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:47"), hasShares(0.03286082), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850823"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:47"), hasShares(0.02020602), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850829"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:48"), hasShares(0.02148499), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850839"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:48"), hasShares(0.01969111), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850845"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:49"), hasShares(0.01424779), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850851"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:49"), hasShares(0.00387832), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850857"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:45:50"), hasShares(0.35971223), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853850864"), //
+                        hasAmount("EUR", 2.55), hasGrossValue("EUR", 2.55), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:46:00"), hasShares(0.00906666), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853851006"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:46:02"), hasShares(0.02579013), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853851023"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-01-13T13:47:23"), hasShares(0.00186813), //
+                        hasSource("Aktivitaetsauszug03.txt"), //
+                        hasNote("Auftrags-ID-Nr.: 44853851247"), //
+                        hasAmount("EUR", 1.02), hasGrossValue("EUR", 1.02), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check deposit transactions
+        assertThat(results, hasItem(deposit(hasDate("2026-01-12T22:15:23"), hasAmount("EUR", 0.39), //
+                        hasSource("Aktivitaetsauszug03.txt"), hasNote("JP Morgan Bankeinzahlung"))));
+
+        assertThat(results, hasItem(deposit(hasDate("2026-01-13T12:30:09"), hasAmount("EUR", 5.16), //
+                        hasSource("Aktivitaetsauszug03.txt"), hasNote("JP Morgan Bankeinzahlung"))));
+
+        assertThat(results, hasItem(deposit(hasDate("2026-01-13T12:30:09"), hasAmount("EUR", 10.00), //
+                        hasSource("Aktivitaetsauszug03.txt"), hasNote("JP Morgan Bankeinzahlung"))));
+
+        assertThat(results, hasItem(deposit(hasDate("2026-01-13T13:45:09"), hasAmount("EUR", 5.00), //
+                        hasSource("Aktivitaetsauszug03.txt"), hasNote("JP Morgan Bankeinzahlung"))));
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFImportAssistant.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFImportAssistant.java
@@ -147,6 +147,7 @@ public class PDFImportAssistant
         extractors.add(new TigerBrokersPteLtdPDFExtractor(client));
         extractors.add(new TradegateAGPDFExtractor(client));
         extractors.add(new TradeRepublicPDFExtractor(client));
+        extractors.add(new Trading212PDFExtractor(client));
         extractors.add(new UBSAGBankingAGPDFExtractor(client));
         extractors.add(new UmweltbankAGPDFExtractor(client));
         extractors.add(new UnicreditPDFExtractor(client));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Trading212PDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/Trading212PDFExtractor.java
@@ -1,0 +1,275 @@
+package name.abuchen.portfolio.datatransfer.pdf;
+
+import static name.abuchen.portfolio.util.TextUtil.trim;
+
+import name.abuchen.portfolio.datatransfer.ExtractorUtils;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
+import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.BuySellEntry;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.Values;
+
+/**
+ * @formatter:off
+ * @implNote Trading 212 is a trading name of FXFlat Bank GmbH.
+ *
+ *           The "Aktivitätsauszug" (activity statement) is a daily statement
+ *           listing executed orders, deposits, card purchases and interest on
+ *           cash. All amounts are formatted in US number format.
+ * @formatter:on
+ */
+@SuppressWarnings("nls")
+public class Trading212PDFExtractor extends AbstractPDFExtractor
+{
+    public Trading212PDFExtractor(Client client)
+    {
+        super(client);
+
+        addBankIdentifier("Trading 212");
+
+        addActivityStatementTransactions();
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return "Trading 212";
+    }
+
+    private void addActivityStatementTransactions()
+    {
+        final var type = new DocumentType("Aktivit.tsauszug");
+        this.addDocumentTyp(type);
+
+        // @formatter:off
+        // 2026-01-06 08:04:56 VWCE IE00BK5BQT80 EUR 44501427897 Kaufen 0.03398586 147.12 5 Market OTC Reguläre Zeiten 1 EUR - - - 5 -
+        // 2026-01-06 08:12:29 VWCE IE00BK5BQT80 EUR 44466988302 Verkaufen 1.73397226 147.02 254.9286 Market OTC Reguläre Zeiten 1 EUR - - -0.07 254.93 0.01
+        // 2026-01-07 11:34:48 EUNL IE00B4L5Y983 EUR 44551706884 Verkaufen 1.00035279 113.38 113.42 Market OTC Reguläre Zeiten 1 EUR - - 0.82 113.42 -0.14
+        // 2026-01-13 13:45:41 CTP2 US20030N1019 EUR 44853850736 Kaufen 0.04070231 25.06 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+        // @formatter:on
+        var buySellBlock = new Block("^[\\d]{4}\\-[\\d]{2}\\-[\\d]{2} [\\d]{2}\\:[\\d]{2}\\:[\\d]{2} "
+                        + "[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})? [A-Z]{2}[A-Z0-9]{9}[0-9] [A-Z]{3} [\\d]+ (Kaufen|Verkaufen) .*$");
+        type.addBlock(buySellBlock);
+        buySellBlock.set(new Transaction<BuySellEntry>()
+
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
+
+                        // Is type --> "Verkaufen" change from BUY to SELL
+                        .section("type").optional() //
+                        .match("^.* [A-Z]{3} [\\d]+ (?<type>(Kaufen|Verkaufen)) .*$") //
+                        .assign((t, v) -> {
+                            if ("Verkaufen".equals(v.get("type")))
+                                t.setType(PortfolioTransaction.Type.SELL);
+                        })
+
+                        // @formatter:off
+                        // 2026-01-06 08:04:56 VWCE IE00BK5BQT80 EUR 44501427897 Kaufen 0.03398586 147.12 5 Market OTC Reguläre Zeiten 1 EUR - - - 5 -
+                        // @formatter:on
+                        .section("tickerSymbol", "isin", "currency") //
+                        .match("^[\\d]{4}\\-[\\d]{2}\\-[\\d]{2} [\\d]{2}\\:[\\d]{2}\\:[\\d]{2} "
+                                        + "(?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) (?<currency>[A-Z]{3}) .*$") //
+                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+
+                        // @formatter:off
+                        // 2026-01-06 08:04:56 VWCE IE00BK5BQT80 EUR 44501427897 Kaufen 0.03398586 147.12 5 Market OTC Reguläre Zeiten 1 EUR - - - 5 -
+                        // @formatter:on
+                        .section("shares") //
+                        .match("^.* (Kaufen|Verkaufen) (?<shares>[\\.,\\d]+) .*$") //
+                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+
+                        // @formatter:off
+                        // 2026-01-06 08:04:56 VWCE IE00BK5BQT80 EUR 44501427897 Kaufen 0.03398586 147.12 5 Market OTC Reguläre Zeiten 1 EUR - - - 5 -
+                        // @formatter:on
+                        .section("date", "time") //
+                        .match("^(?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}) (?<time>[\\d]{2}\\:[\\d]{2}\\:[\\d]{2}) .*$") //
+                        .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
+
+                        // @formatter:off
+                        // The columns following the transaction currency are:
+                        // FX GEBÜHR | GEBÜHREN DER HANDELSPLATTFORM & STEUERN | RENDITE | WERT | STEUERN
+                        //
+                        // The two fee columns are matched as a literal "-": no sample document carries a
+                        // value in them, and it is unknown whether the WERT column would then be gross or
+                        // net of those fees. A statement carrying one fails the import instead of silently
+                        // importing an understated total.
+                        // @formatter:on
+                        .oneOf( //
+                                        // @formatter:off
+                                        // With trailing tax column:
+                                        // 2026-01-06 08:04:56 VWCE IE00BK5BQT80 EUR 44501427897 Kaufen 0.03398586 147.12 5 Market OTC Reguläre Zeiten 1 EUR - - - 5 -
+                                        // 2026-01-06 08:12:29 VWCE IE00BK5BQT80 EUR 44466988302 Verkaufen 1.73397226 147.02 254.9286 Market OTC Reguläre Zeiten 1 EUR - - -0.07 254.93 0.01
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("currency", "amount") //
+                                                        .match("^.* (?<currency>[A-Z]{3}) \\- \\- (\\-|\\-?[\\.,\\d]+) "
+                                                                        + "(?<amount>[\\.,\\d]+) (\\-|\\-?[\\.,\\d]+)$") //
+                                                        .assign((t, v) -> {
+                                                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                                                            t.setAmount(asAmount(v.get("amount")));
+                                                        }),
+                                        // @formatter:off
+                                        // Without trailing tax column:
+                                        // 2026-01-13 13:45:41 CTP2 US20030N1019 EUR 44853850736 Kaufen 0.04070231 25.06 1.02 Market OTC Reguläre Zeiten 1 EUR - - - 1.02
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("currency", "amount") //
+                                                        .match("^.* (?<currency>[A-Z]{3}) \\- \\- (\\-|\\-?[\\.,\\d]+) "
+                                                                        + "(?<amount>[\\.,\\d]+)$") //
+                                                        .assign((t, v) -> {
+                                                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                                                            t.setAmount(asAmount(v.get("amount")));
+                                                        }))
+
+                        // @formatter:off
+                        // A negative value in the trailing tax column is capital gains tax
+                        // withheld on the sale. The WERT column is the gross value, so the
+                        // tax is deducted from the total amount.
+                        // 2026-01-07 11:34:48 EUNL IE00B4L5Y983 EUR 44551706884 Verkaufen 1.00035279 113.38 113.42 Market OTC Reguläre Zeiten 1 EUR - - 0.82 113.42 -0.14
+                        // @formatter:on
+                        .section("currency", "tax").optional() //
+                        .match("^.* Verkaufen .* (?<currency>[A-Z]{3}) \\- \\- (\\-|\\-?[\\.,\\d]+) "
+                                        + "[\\.,\\d]+ \\-(?<tax>[\\.,\\d]+)$") //
+                        .assign((t, v) -> {
+                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+
+                            t.setMonetaryAmount(t.getPortfolioTransaction().getMonetaryAmount().subtract(tax));
+                            ExtractorUtils.checkAndSetTax(tax, t, type.getCurrentContext());
+                        })
+
+                        // @formatter:off
+                        // 2026-01-06 08:04:56 VWCE IE00BK5BQT80 EUR 44501427897 Kaufen 0.03398586 147.12 5 Market OTC Reguläre Zeiten 1 EUR - - - 5 -
+                        // @formatter:on
+                        .section("note") //
+                        .match("^.* [A-Z]{3} (?<note>[\\d]+) (Kaufen|Verkaufen) .*$") //
+                        .assign((t, v) -> t.setNote("Auftrags-ID-Nr.: " + v.get("note")))
+
+                        .wrap(BuySellEntryItem::new));
+
+        // @formatter:off
+        // A positive value in the trailing tax column of a sale is a tax refund
+        // (loss offsetting) credited to the account as a separate transaction.
+        // 2026-01-06 08:12:29 VWCE IE00BK5BQT80 EUR 44466988302 Verkaufen 1.73397226 147.02 254.9286 Market OTC Reguläre Zeiten 1 EUR - - -0.07 254.93 0.01
+        // @formatter:on
+        var taxRefundBlock = new Block("^[\\d]{4}\\-[\\d]{2}\\-[\\d]{2} [\\d]{2}\\:[\\d]{2}\\:[\\d]{2} "
+                        + "[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})? [A-Z]{2}[A-Z0-9]{9}[0-9] [A-Z]{3} [\\d]+ Verkaufen .* "
+                        + "[A-Z]{3} \\- \\- (\\-|\\-?[\\.,\\d]+) [\\.,\\d]+ [\\.,\\d]+$");
+        type.addBlock(taxRefundBlock);
+        taxRefundBlock.set(new Transaction<AccountTransaction>()
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
+
+                        .section("date", "time", "tickerSymbol", "isin", "currency", "note", "amount") //
+                        .match("^(?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}) (?<time>[\\d]{2}\\:[\\d]{2}\\:[\\d]{2}) "
+                                        + "(?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) (?<currency>[A-Z]{3}) (?<note>[\\d]+) Verkaufen .* "
+                                        + "[A-Z]{3} \\- \\- (\\-|\\-?[\\.,\\d]+) [\\.,\\d]+ (?<amount>[\\.,\\d]+)$") //
+                        .assign((t, v) -> {
+                            t.setSecurity(getOrCreateSecurity(v));
+                            t.setDateTime(asDate(v.get("date"), v.get("time")));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setNote("Auftrags-ID-Nr.: " + v.get("note"));
+                        })
+
+                        .wrap(TransactionItem::new));
+
+        // @formatter:off
+        // 2026-01-06 02:10:08 Verzinsung von Geld EUR 1.83 -0.48 €-0.48 1.35
+        // @formatter:on
+        var interestBlock = new Block("^[\\d]{4}\\-[\\d]{2}\\-[\\d]{2} [\\d]{2}\\:[\\d]{2}\\:[\\d]{2} Verzinsung von Geld [A-Z]{3} .*$");
+        type.addBlock(interestBlock);
+        interestBlock.set(new Transaction<AccountTransaction>()
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST))
+
+                        .section("date", "time", "currency", "tax", "amount") //
+                        .match("^(?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}) (?<time>[\\d]{2}\\:[\\d]{2}\\:[\\d]{2}) Verzinsung von Geld "
+                                        + "(?<currency>[A-Z]{3}) [\\.,\\d]+ \\-(?<tax>[\\.,\\d]+) \\p{Sc}\\-[\\.,\\d]+ (?<amount>[\\.,\\d]+)$") //
+                        .assign((t, v) -> {
+                            t.setDateTime(asDate(v.get("date"), v.get("time")));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setAmount(asAmount(v.get("amount")));
+
+                            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("tax")));
+                            ExtractorUtils.checkAndSetTax(tax, t, type.getCurrentContext());
+                        })
+
+                        .wrap(TransactionItem::new));
+
+        // @formatter:off
+        // 2026-01-07 11:30:16 JP Morgan Bankeinzahlung EUR 22.33 - - 22.33
+        // 2026-01-12 22:15:23 JP Morgan Bankeinzahlung EUR 0.39 €0.39
+        // @formatter:on
+        var depositBlock = new Block("^[\\d]{4}\\-[\\d]{2}\\-[\\d]{2} [\\d]{2}\\:[\\d]{2}\\:[\\d]{2} .*Bankeinzahlung [A-Z]{3} .*$");
+        type.addBlock(depositBlock);
+        depositBlock.set(new Transaction<AccountTransaction>()
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
+
+                        .oneOf( //
+                                        // @formatter:off
+                                        // 2026-01-07 11:30:16 JP Morgan Bankeinzahlung EUR 22.33 - - 22.33
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date", "time", "note", "currency", "amount") //
+                                                        .match("^(?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}) (?<time>[\\d]{2}\\:[\\d]{2}\\:[\\d]{2}) (?<note>.*Bankeinzahlung) "
+                                                                        + "(?<currency>[A-Z]{3}) [\\.,\\d]+ \\- \\- (?<amount>[\\.,\\d]+)$") //
+                                                        .assign((t, v) -> {
+                                                            t.setDateTime(asDate(v.get("date"), v.get("time")));
+                                                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                                                            t.setAmount(asAmount(v.get("amount")));
+                                                            t.setNote(trim(v.get("note")));
+                                                        }),
+                                        // @formatter:off
+                                        // 2026-01-12 22:15:23 JP Morgan Bankeinzahlung EUR 0.39 €0.39
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date", "time", "note", "currency", "amount") //
+                                                        .match("^(?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}) (?<time>[\\d]{2}\\:[\\d]{2}\\:[\\d]{2}) (?<note>.*Bankeinzahlung) "
+                                                                        + "(?<currency>[A-Z]{3}) (?<amount>[\\.,\\d]+) \\p{Sc}[\\.,\\d]+$") //
+                                                        .assign((t, v) -> {
+                                                            t.setDateTime(asDate(v.get("date"), v.get("time")));
+                                                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                                                            t.setAmount(asAmount(v.get("amount")));
+                                                            t.setNote(trim(v.get("note")));
+                                                        }))
+
+                        .wrap(TransactionItem::new));
+
+        // @formatter:off
+        // 2026-01-07 01:32:07 Kartenkauf EUR -57.35 - - -57.35
+        // @formatter:on
+        var removalBlock = new Block("^[\\d]{4}\\-[\\d]{2}\\-[\\d]{2} [\\d]{2}\\:[\\d]{2}\\:[\\d]{2} Kartenkauf [A-Z]{3} .*$");
+        type.addBlock(removalBlock);
+        removalBlock.set(new Transaction<AccountTransaction>()
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.REMOVAL))
+
+                        .section("date", "time", "currency", "amount") //
+                        .match("^(?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}) (?<time>[\\d]{2}\\:[\\d]{2}\\:[\\d]{2}) Kartenkauf "
+                                        + "(?<currency>[A-Z]{3}) \\-[\\.,\\d]+ \\- \\- \\-(?<amount>[\\.,\\d]+)$") //
+                        .assign((t, v) -> {
+                            t.setDateTime(asDate(v.get("date"), v.get("time")));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setNote("Kartenkauf");
+                        })
+
+                        .wrap(TransactionItem::new));
+    }
+
+    @Override
+    protected long asAmount(String value)
+    {
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount, "en", "US");
+    }
+
+    @Override
+    protected long asShares(String value)
+    {
+        return ExtractorUtils.convertToNumberLong(value, Values.Share, "en", "US");
+    }
+}


### PR DESCRIPTION
Closes #5379

Adds a new PDF importer for Trading 212 (a trading name of FXFlat Bank GmbH). Supported document: the German daily "Aktivitätsauszug" (activity statement), covering:

- Invest account buy/sell executions (fractional shares, US number format), in both observed table layouts — with and without the trailing tax column
- Capital gains tax withheld on sales is deducted from the sale amount; positive values in the trailing tax column (loss-offset credits) are imported as separate tax refund transactions linked to the security
- "Verzinsung von Geld" (interest on cash) with withheld tax
- Deposits ("… Bankeinzahlung", both layout variants) and card purchases ("Kartenkauf") as removals
- "Währungsumtausch" / "Währungsumtauschgebühr" rows are intentionally not imported (zero-fee wallet currency swaps, not representable in a single-account import)

The statement lists securities by ticker and ISIN only, so securities are created without a name.

Test fixtures are the three anonymized statements from #5379 (issue body and comment). Verified with Trading212PDFExtractorTest (3 tests) and the full core suite (4502 tests, all green).
