### PR TITLE
Modify DADAT PDF-Importer to support bond transactions

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dadatbankenhaus/DADATBankenhausPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dadatbankenhaus/DADATBankenhausPDFExtractorTest.java
@@ -22,6 +22,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.inboundCash;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interest;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.outboundCash;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxRefund;
@@ -1618,6 +1619,93 @@ public class DADATBankenhausPDFExtractorTest
                         hasNote("Depotgebührenabrechnung per 31.12.2024"), //
                         hasAmount("EUR", 277.33), hasGrossValue("EUR", 277.33), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testKontoauszug29()
+    {
+        var extractor = new DADATBankenhausPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kontoauszug29.txt"), errors);
+
+        // This fixture holds two documents in one PDF text extraction: the
+        // KONTOAUSZUG (lines 5-32) and a full "Abrechnung Handel" settlement
+        // note for the same trade (lines 33-76). Only the KONTOAUSZUG is
+        // imported -- addBuySellTransaction() is scoped to
+        // "(Abrechnungsauskunft|Kauf Depot)" and neither token appears here, so
+        // the settlement note is ignored. Whether DADAT always appends it is
+        // unknown; both forms import correctly, because each path has its own
+        // DocumentType. Accepted deliberately in #5896: if countBuySell() below
+        // ever becomes 2, the settlement note has started matching a
+        // DocumentType and this trade is being imported twice.
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("XS1458408561"), hasWkn(null), hasTicker(null), //
+                        hasName("1.625% GOLDM.S.GRP 16/26 MT"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2024-11-19T00:00"), hasShares(160.00), //
+                        hasSource("Kontoauszug29.txt"), //
+                        hasNote("Stückzinsen 83,34 EUR"), //
+                        hasAmount("EUR", 15812.91), hasGrossValue("EUR", 15794.54), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", (16.27 + 1.00 + 1.10)))));
+
+        // check deposit transaction
+        assertThat(results, hasItem(deposit(hasDate("2024-11-19"), hasAmount("EUR", 16000.00), //
+                        hasSource("Kontoauszug29.txt"), hasNote("Max Mustermann"))));
+    }
+
+    @Test
+    public void testKontoauszug30()
+    {
+        var extractor = new DADATBankenhausPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kontoauszug30.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(2L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("XS1074144871"), hasWkn(null), hasTicker(null), //
+                        hasName("2.875% GOLDM.S.GRP 14/26 MT"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-06-04T00:00"), hasExDate(null), //
+                        hasShares(130.00), //
+                        hasSource("Kontoauszug30.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 270.97), hasGrossValue("EUR", 373.75), //
+                        hasTaxes("EUR", 102.78), hasFees("EUR", 0.00))));
+
+        // check removal transaction
+        assertThat(results, hasItem(removal(hasDate("2025-06-04"), hasAmount("EUR", 270.00), //
+                        hasSource("Kontoauszug30.txt"), hasNote("Max Mustermann"))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dadatbankenhaus/Kontoauszug29.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dadatbankenhaus/Kontoauszug29.txt
@@ -1,0 +1,76 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+DADAT-Bank KONTOAUSZUG
+Schelhammer Capital Bank AG vom 19.11.2024
+133333
+Kundennummer
+Alter Saldo per 11.11.2024 0,00
+Summe der Gutschriften 16.000,00
+Summe der Lastschriften 15.812,91-
+Schelhammer, PF 1000, A-5021 Salzburg
+Neuer Saldo zu Ihren Gunsten
+Max Mustermann EUR 187,09
+Musterstraße 1
+8000 Stadt
+Konto-Nr.: 00339456246 Bankleitzahl: 19190
+Empfängerhinweis:
+Datum Buchungstext Wert Betrag
+19.11 Max Mustermann 19.11 16.000,00
+IBAN: AT39 1234 5678 1234 5678
+Eigenübertrag Dadat Werpapierdepot
+REF: 208152411192CDC-00FWIJDNCZEU
+19.11 Kauf                             Depot     123456246/20241119-55110950 21.11 15.812,91-
+ISIN XS1458408561 1.625% GOLDM.S.GRP 16/26 MT        16.000,00000 EUR
+Kurs                     98,195000  Kurswert           -15.711,20 EUR
+Stückzinsen             -83,34 EUR  Handelsspesen          -16,27 EUR
+DADAT Handelsspesen      -1,00 EUR  Clearing Gebühr         -1,10 EUR
+Neuer Saldo zu Ihren Gunsten 187,09
+AT39 1919 1919 1919 1919 BSSWATWW 01 0001 1/1
+IBAN BIC Filiale Auszug Blatt/Gesamt
+R0042 06390 Doknr.: EK00-045-0324002269
+Abrechnung Handel
+55110950-19.11.2024
+Depot-Nr.: 123456246
+Max Mustermann
+01/5020
+DADAT-Bank
+Herrn
+Max Mustermann
+Musterstraße 1
+8000 Stadt
+Wir haben für Sie am 19.11.2024 unten angeführtes Geschäft abgerechnet:
+Geschäftsart: Kauf
+Auftrags-Nr.: 39279541-19.11.2024
+Auftragseingang: 19.11.2024-17:06:52
+Zugang: 16.000 EUR
+Titel: XS1458408561  G o l d m a n  S a c hs Group Inc., The
+EO-Medium-Term Notes 2016(26)
+Kup. 27.7.2025/GZJ Endfälligkeit 27.7.2026
+aktueller Zinssatz: 1,625 %
+Kurs: 98,195 %
+Handelsplatz: XBER     Börse Berlin
+Handelszeit: 19.11.2024 um 17:07:19 Uhr
+Verwahrart: WR
+Positionsdaten: Loco: München
+Kurswert: -15.711,20 EUR
+Stückzinsen für 117 Tage: -83,34 EUR
+Handelsspesen: -16,27 EUR
+DADAT Handelsspesen: -1,-- EUR
+Clearing Gebühr: -1,10 EUR
+Zu Lasten IBAN AT39 1919 1919 1919 1919 -15.812,91 EUR
+Valuta 21.11.2024
+Schlusstag: 19.11.2024
+Kassatag: 21.11.2024
+Bestand nach Buchung:
+KESt-Neubestand mit Anschaffungskosten nach dem gleitenden
+Durchschnittsverfahren § 27a Abs. 4 Zi 3 EStG 16.000 EUR
+steuerlicher Anschaffungswert: 15.794,54 EUR
+Stückzinsen: 83,34 EUR
+Freundliche Grüße
+DADAT - Schelhammer Capital Bank AG
+19.11.2024 Seite 1
+DVR 0060011 ,HG WIEN ,FN58248i, Irrtum vorbehalten! Dieser Beleg wird von der Bank
+nicht unterschrieben!
+06391 Doknr.: EK00-045-0324002269

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dadatbankenhaus/Kontoauszug30.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dadatbankenhaus/Kontoauszug30.txt
@@ -1,0 +1,31 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+DADAT-Bank KONTOAUSZUG
+Schelhammer Capital Bank AG vom 04.06.2025
+133333
+Kundennummer
+Alter Saldo per 24.04.2025 7,35
+Summe der Gutschriften 270,97
+Summe der Lastschriften 270,00-
+Schelhammer, PF 1000, A-5021 Salzburg
+Neuer Saldo zu Ihren Gunsten
+Max Mustermann EUR 8,32
+Musterstraße 1
+8000 Stadt
+Konto-Nr.: 00339456246 Bankleitzahl: 19190
+Empfängerhinweis:
+Datum Buchungstext Wert Betrag
+04.06 Ertrag              2,8750 %     Depot     639456246/20250603-64126838 03.06 270,97
+ISIN XS1074144871 2.875% GOLDM.S.GRP 14/26 MT        13.000,00000 EUR
+Kurs                      2,875000  Zinsen/Dividenden       373,75 EUR
+Kapitalertragsteuer    -102,78 EUR
+04.06 IBAN: AT39 1234 5678 1234 5678 04.06 270,00-
+Max Mustermann
+EIGENÜBERTRAG
+REF: 19190250604O3136
+Neuer Saldo zu Ihren Gunsten 8,32
+AT39 1919 1919 1919 1919 BSSWATWW 01 0005 1/1
+IBAN BIC Filiale Auszug Blatt/Gesamt
+R0042 05965 Doknr.: EK00-045-0302255761

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DADATBankenhausPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DADATBankenhausPDFExtractor.java
@@ -1,6 +1,7 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
+import static name.abuchen.portfolio.util.TextUtil.concatenate;
 import static name.abuchen.portfolio.util.TextUtil.replaceMultipleBlanks;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
@@ -15,6 +16,7 @@ import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.Values;
 
 @SuppressWarnings("nls")
 public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
@@ -304,16 +306,30 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
                         // 16.12 Kauf aus Dauerauftrag            Depot    7800000000/20191216-45514943 18.12 99,68-
                         // ISIN LU0378449770 COMST.-NASDAQ-100 U.ETF I               1,22000 STK
                         // Kurs                     80,340000  KURSWERT               -98,01 EUR
+                        //
+                        // 19.11 Kauf                             Depot     123456246/20241119-55110950 21.11 15.812,91-
+                        // ISIN XS1458408561 1.625% GOLDM.S.GRP 16/26 MT        16.000,00000 EUR
+                        // Kurs                     98,195000  Kurswert           -15.711,20 EUR
                         // @formatter:on
-                        .section("date", "isin", "name", "shares", "currency") //
+                        .section("date", "isin", "name", "shares", "notation", "currency") //
                         .documentContext("year") //
                         .match("^(?<date>[\\d]{1,2}\\.[\\d]{1,2}) (Kauf|Kauf aus Dauerauftrag|Verkauf)[\\s]{1,}Depot[\\s]{1,}[\\d]+\\/[\\d]+\\-[\\d]+ [\\d]{1,2}\\.[\\d]{1,2} [\\.,\\d]+(\\-)?$") //
-                        .match("^ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) (?<name>.*)[\\s]{1,}(?<shares>[\\.,\\d]+) STK$") //
+                        .match("^ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) (?<name>.*)[\\s]{1,}(?<shares>[\\.,\\d]+) (?<notation>[A-Z]{3})$") //
                         .match("^(?i).* KURSWERT[\\s]{1,}(\\-)?[\\.,\\d]+ (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> {
                             v.put("name", replaceMultipleBlanks(v.get("name")));
                             t.setDate(asDate(v.get("date") + "." + v.get("year")));
-                            t.setShares(asShares(v.get("shares")));
+
+                            if (!"STK".equalsIgnoreCase(v.get("notation")))
+                            {
+                                // Percentage quotation, workaround for bonds
+                                var shares = asBigDecimal(v.get("shares"));
+                                t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
+                            }
+                            else
+                            {
+                                t.setShares(asShares(v.get("shares")));
+                            }
 
                             t.setSecurity(getOrCreateSecurity(v));
                         })
@@ -346,6 +362,16 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
                             var gross = rate.convert(rate.getBaseCurrency(), fxGross);
 
                             checkAndSetGrossUnit(gross, fxGross, t, type.getCurrentContext());
+                        })
+
+                        // @formatter:off
+                        // Stückzinsen             -83,34 EUR  Handelsspesen          -16,27 EUR
+                        // @formatter:on
+                        .section("note1", "note2").optional() //
+                        .match("^(?<note1>St.ckzinsen)[\\s]{1,}\\-(?<note2>[\\-\\.,\\d]+ [A-Z]{3}).*$") //
+                        .assign((t, v) -> {
+                            t.setNote(concatenate(t.getNote(), v.get("note1"), " | "));
+                            t.setNote(concatenate(t.getNote(), v.get("note2"), " "));
                         })
 
                         .wrap(BuySellEntryItem::new);
@@ -424,14 +450,38 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
                                                             t.setShares(asShares(v.get("shares")));
 
                                                             t.setSecurity(getOrCreateSecurity(v));
+                                                        }),
+                                        // @formatter:off
+                                        // 04.06 Ertrag              2,8750 %     Depot     639456246/20250603-64126838 03.06 270,97
+                                        // ISIN XS1074144871 2.875% GOLDM.S.GRP 14/26 MT        13.000,00000 EUR
+                                        // Kurs                      2,875000  Zinsen/Dividenden       373,75 EUR
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date", "isin", "name", "shares", "currency") //
+                                                        .documentContext("year") //
+                                                        .match("^(?i)(?<date>[\\d]{1,2}\\.[\\d]{1,2}) Ertrag[\\s]{1,}[\\.,\\d]+ %[\\s]{1,}Depot[\\s]{1,}[\\d]+\\/[\\d]+\\-[\\d]+ [\\d]{1,2}\\.[\\d]{1,2} [\\.,\\d]+(\\-)?$") //
+                                                        .match("^(?i)ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) (?<name>.*)[\\s]{1,}(?<shares>[\\.,\\d]+) [A-Z]{3}$") //
+                                                        .match("^(?i).* Zinsen\\/Dividenden[\\s]{1,}(\\-)?[\\.,\\d]+ (?<currency>[A-Z]{3})$") //
+                                                        .assign((t, v) -> {
+                                                            v.put("name", replaceMultipleBlanks(v.get("name")));
+                                                            t.setDateTime(asDate(v.get("date") + "." + v.get("year")));
+
+                                                            // @formatter:off
+                                                            // Percentage quotation, workaround for bonds
+                                                            // @formatter:on
+                                                            var shares = asBigDecimal(v.get("shares"));
+                                                            t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
+
+                                                            t.setSecurity(getOrCreateSecurity(v));
                                                         }))
 
                         // @formatter:off
                         // 30.07 Kauf                             Depot    780680000/20200730-45125411 31.07 1.250,01-
+                        // 04.06 Ertrag              2,8750 %     Depot     639456246/20250603-64126838 03.06 270,97
                         // @formatter:on
                         .section("amount") //
                         .documentContext("currency") //
-                        .match("^[\\d]{1,2}\\.[\\d]{1,2} Ertrag[\\s]{1,}Depot[\\s]{1,}[\\d]+\\/[\\d]{4}[\\d]+\\-[\\d]+ [\\d]{1,2}\\.[\\d]{1,2} (?<amount>[\\.,\\d]+)(\\-)?$") //
+                        .match("^[\\d]{1,2}\\.[\\d]{1,2} Ertrag[\\s]{1,}([\\.,\\d]+ %[\\s]{1,})?Depot[\\s]{1,}[\\d]+\\/[\\d]{4}[\\d]+\\-[\\d]+ [\\d]{1,2}\\.[\\d]{1,2} (?<amount>[\\.,\\d]+)(\\-)?$") //
                         .assign((t, v) -> {
                             t.setCurrencyCode(v.get("currency"));
                             t.setAmount(asAmount(v.get("amount")));
@@ -888,6 +938,27 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
                                                             t.setCurrencyCode(v.get("currency"));
                                                             t.setAmount(asAmount(v.get("amount")));
                                                             t.setNote(v.get("note"));
+                                                        }),
+                                        // @formatter:off
+                                        // 04.06 IBAN: AT39 1234 5678 1234 5678 04.06 270,00-
+                                        // Max Mustermann
+                                        // EIGENÜBERTRAG
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date", "amount", "note") //
+                                                        .documentContext("year", "currency") //
+                                                        .match("^(?i)(?<date>[\\d]{1,2}\\.[\\d]{1,2}) IBAN: .* [\\d]{1,2}\\.[\\d]{1,2} (?<amount>[\\.,\\d]+)\\-$") //
+                                                        .match("^(?<note>.*)$") //
+                                                        .assign((t, v) -> {
+                                                            // @formatter:off
+                                                            // Change from DEPOSIT to REMOVAL
+                                                            // @formatter:on
+                                                            t.setType(AccountTransaction.Type.REMOVAL);
+
+                                                            t.setDateTime(asDate(v.get("date") + "." + v.get("year")));
+                                                            t.setCurrencyCode(v.get("currency"));
+                                                            t.setAmount(asAmount(v.get("amount")));
+                                                            t.setNote(v.get("note"));
                                                         }))
 
                         .wrap(t -> {
@@ -984,6 +1055,13 @@ public class DADATBankenhausPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("tax", "currency").optional() //
                         .match("^(?i)KEST[\\s]{1,}\\-(?<tax>[\\-\\.,\\d]+) (?<currency>[A-Z]{3}).*$") //
+                        .assign((t, v) -> processTaxEntries(t, v, type))
+
+                        // @formatter:off
+                        // Kapitalertragsteuer    -102,78 EUR
+                        // @formatter:on
+                        .section("tax", "currency").optional() //
+                        .match("^(?i)Kapitalertragsteuer[\\s]{1,}\\-(?<tax>[\\-\\.,\\d]+) (?<currency>[A-Z]{3}).*$") //
                         .assign((t, v) -> processTaxEntries(t, v, type));
     }
 


### PR DESCRIPTION
Closes #5316

Account statements (KONTOAUSZUG) containing bonds quoted as a percentage of nominal were not imported. Adds support for:

- **Bond purchases** with nominal notation (e.g. `16.000,00000 EUR` instead of `… STK`). Uses the established `shares = nominal / 100` workaround for percentage quotation (16.000 nominal → 160 shares), so the percent quote becomes the implied per-share price. Accrued interest (Stückzinsen) folds into the gross value, matching the document's "steuerlicher Anschaffungswert".
- **Bond coupon payments** (`Ertrag`) whose booking line carries the interest-rate token (`Ertrag 2,8750 % Depot …`); nominal shares handled the same way.
- **Kapitalertragsteuer** withheld on coupon payments (line-anchored so it does not collide with the `Kurs 0,000000 Kapitalertragsteuer …` lines of the separate Steuern blocks).
- **Outgoing transfers** where the IBAN sits on the same line as the amount and date, imported as removals.

Test fixtures are the two anonymized statements from #5316. Verified with DADATBankenhausPDFExtractorTest (49 tests, all green).