### PR TITLE
Handle delayed NAV funds when calculating quote change

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -1246,7 +1246,7 @@ public final class SecuritiesTable implements ModificationListener
             return Double.valueOf(Math.pow(totalGain, 365 / totalDays)) - 1;
         }
 
-        private static Optional<Pair<SecurityPrice, SecurityPrice>> getPrices(Security security,ReportingPeriod period)
+        private static Optional<Pair<SecurityPrice, SecurityPrice>> getPrices(Security security, ReportingPeriod period)
         {
             Interval interval = period.toInterval(LocalDate.now());
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -1246,7 +1246,7 @@ public final class SecuritiesTable implements ModificationListener
             return Double.valueOf(Math.pow(totalGain, 365 / totalDays)) - 1;
         }
 
-        private static Optional<Pair<SecurityPrice, SecurityPrice>> getPrices(Security security, ReportingPeriod period)
+        private static Optional<Pair<SecurityPrice, SecurityPrice>> getPrices(Security security,ReportingPeriod period)
         {
             Interval interval = period.toInterval(LocalDate.now());
 
@@ -1262,9 +1262,36 @@ public final class SecuritiesTable implements ModificationListener
             if (previous.getDate().isAfter(interval.getStart()))
                 return Optional.empty();
 
+            // Delayed-NAV funds may return the same published quote for both
+            // ends of the reporting interval. In that case fall back to the
+            // latest two published prices, matching the behaviour of FT and
+            // Morningstar.
+
+            if (latest.getDate().equals(previous.getDate()))
+            {
+                List<SecurityPrice> history = security.getPricesIncludingLatest();
+
+                if (history.size() < 2)
+                    return Optional.empty();
+
+                latest = history.get(history.size() - 1);
+
+                for (int i = history.size() - 2; i >= 0; i--)
+                {
+                    previous = history.get(i);
+
+                    if (previous.getValue() != 0
+                            && !previous.getDate().equals(latest.getDate()))
+                    {
+                        return Optional.of(new Pair<>(previous, latest));
+                    }
+                }
+
+                return Optional.empty();
+            }
+
             return Optional.of(new Pair<>(previous, latest));
         }
-
         @Override
         public Image getImage(Object e)
         {


### PR DESCRIPTION
Fixes #5790

This changes the behaviour of the "Change in Price" reporting-period calculation when both ends of the reporting interval resolve to the same published quote.

Security.getSecurityPrice(date) carries the latest available quote forward. For instruments with delayed NAV publication, such as weekly-priced Credo Growth Fund (IE00BDFZR430), both the start and end of a short reporting period (for example, "1 trading day") may therefore resolve to the same published quote.

Instead of returning no result in this situation, this change falls back to the latest two distinct published prices, matching the behaviour of Financial Times and Morningstar for delayed-NAV funds.

Daily-priced securities are unaffected because the fallback is only used when both sampling points resolve to the same quote date.

Example:

Fri 26 Jun   NAV = 2.192
Fri 03 Jul   NAV = 2.260

For "1 trading day", Portfolio Performance currently shows 0.00% because
both interval endpoints resolve to the 03 Jul quote.

After this change it reports the change between 26 Jun and 03 Jul (+3.09%),
which matches FT and Morningstar.