### PR TITLE
added support for dividends payed in USD with a conversion to EUR

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Dividende02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Dividende02.txt
@@ -1,0 +1,37 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Max Mustermann
+Privatkonto EUR
+Depot-Nr. 1234.1234.1234
+IBAN CH11 1234 1234 1234 1234 0
+St.Galler Kantonalbank AG
+St. Leonhardstrasse 25
+9001 St. Gallen
+www.sgkb.ch
+BIC KBSGCH22
+Ihr Kontakt:
+Max Mustermann Elektronisch versandt
+Telefon +41 12 345 67 89 Herr
+max.mustermann@sgkb.ch Max-Mustermann
+ Muster 10 A
+St. Gallen, 7. April 2026 43210 Musterhausen
+Referenznummer 1234123419 DEUTSCHLAND
+Barausschüttung
+Ihr Depotbestand per Ex-Datum 20. März 2026:
+10'000 N-Akt Sibanye Stillwater Limited
+Sponsored ADR Repr 4 Shs ADR/ADS
+Übrige Aktien Valoren-Nr.: 52619625, ISIN: US82575P1075
+Wir teilen Ihnen mit, dass wir die folgenden Erträgnisse unter Eingangsvorbehalt abgerechnet haben:
+Ausschüttung: USD 0.310942
+Ertragsart: Ordentliche Dividende
+Betrag USD 6'218.84
+Quellensteuer 20% USD 1'243.77
+Total USD 4'975.07
+Umrechnungskurs EUR/USD 1.175393
+Zu Ihren Gunsten Valuta 02.04.2026 EUR 4'232.69
+CHE-105.845.146 MWST
+Freundliche Grüsse
+St.Galler Kantonalbank AG
+123456 123412345 1234123419

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/StGallerKantonalbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/StGallerKantonalbankPDFExtractorTest.java
@@ -6,6 +6,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyC
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasExDate;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasForexGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasIsin;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasName;
@@ -143,5 +144,44 @@ public class StGallerKantonalbankPDFExtractorTest
                         hasNote("Referenznummer 1746312001"), //
                         hasAmount("EUR", 736.25), hasGrossValue("EUR", 1000.00), //
                         hasTaxes("EUR", 263.75), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende02()
+    {
+        var extractor = new StGallerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US82575P1075"), hasWkn("52619625"), hasTicker(null), //
+                        hasName("N-Akt Sibanye Stillwater Limited Sponsored ADR Repr 4 Shs ADR/ADS"), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-04-02"), //
+                        hasExDate("2026-03-20"), //
+                        hasShares(10000.00), //
+                        hasSource("Dividende02.txt"), //
+                        hasNote("Referenznummer 1234123419"), //
+                        hasAmount("EUR", 4232.69), //
+                        hasGrossValue("EUR", 5290.86), //
+                        hasForexGrossValue("USD", 6218.84), //
+                        hasTaxes("EUR", 1058.17), //
+                        hasFees("EUR", 0.00))));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/StGallerKantonalbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/StGallerKantonalbankPDFExtractor.java
@@ -1,6 +1,9 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
 import static name.abuchen.portfolio.util.TextUtil.trim;
+
+import java.math.BigDecimal;
 
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
@@ -10,6 +13,7 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 
 /**
@@ -137,17 +141,36 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
 
                         .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
-                        // @formatter:off
-                        // 10'000 N-Akt TUI AG Aus Konversion
-                        // Namenaktien Valoren-Nr.: 125205291, ISIN: DE000TUAG505
-                        // Ausschüttung: EUR 0.10
-                        // @formatter:on
-                        .section("name", "wkn", "isin", "currency") //
-                        .find("Ihr Depotbestand per Ex\\-Datum .*") //
-                        .match("^[\\.'\\d]+ (?<name>.*)$") //
-                        .match("^.* Valoren\\-Nr\\.: (?<wkn>[A-Z0-9]{5,9}), ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
-                        .match("^Aussch.ttung: (?<currency>[A-Z]{3}) [\\.'\\d]+$") //
-                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+                        .oneOf( //
+
+                                        // @formatter:off
+                                        // 10'000 N-Akt Sibanye Stillwater Limited
+                                        // Sponsored ADR Repr 4 Shs ADR/ADS
+                                        // Übrige Aktien Valoren-Nr.: 52619625, ISIN: US82575P1075
+                                        // Ausschüttung: USD 0.310942
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("name", "nameContinued", "wkn", "isin", "currency") //
+                                                        .find("Ihr Depotbestand per Ex\\-Datum .*") //
+                                                        .match("^[\\.'\\d]+ (?<name>.*)$") //
+                                                        .match("^(?<nameContinued>.*)$") //
+                                                        .match("^.* Valoren\\-Nr\\.: (?<wkn>[A-Z0-9]{5,9}), ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                                                        .match("^Aussch.ttung: (?<currency>[A-Z]{3}) [\\.'\\d]+$") //
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))) //
+                                        , //
+                                        // @formatter:off
+                                        // 10'000 N-Akt TUI AG Aus Konversion
+                                        // Namenaktien Valoren-Nr.: 125205291, ISIN: DE000TUAG505
+                                        // Ausschüttung: EUR 0.10
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("name", "wkn", "isin", "currency") //
+                                                        .find("Ihr Depotbestand per Ex\\-Datum .*") //
+                                                        .match("^[\\.'\\d]+ (?<name>.*)$") //
+                                                        .match("^.* Valoren\\-Nr\\.: (?<wkn>[A-Z0-9]{5,9}), ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                                                        .match("^Aussch.ttung: (?<currency>[A-Z]{3}) [\\.'\\d]+$") //
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))) //
+                        )
 
                         // @formatter:off
                         // 10'000 N-Akt TUI AG Aus Konversion
@@ -182,6 +205,23 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
                         })
 
                         // @formatter:off
+                        // Betrag USD 6'218.84
+                        // Umrechnungskurs EUR/USD 1.175393
+                        // @formatter:on
+                        .section("termCurrency", "baseCurrency", "exchangeRate", "fxGross").optional() //
+                        .match("^Betrag\\s+[A-Z]{3}\\s+(?<fxGross>['\\.,\\d]+)\\s*$") //
+                        .match("^Umrechnungskurs\\s+(?<baseCurrency>[A-Z]{3})\\/(?<termCurrency>[A-Z]{3})\\s+(?<exchangeRate>[\\.'\\d]+)\\s*$") //
+                        .assign((t, v) -> {
+                            var rate = asExchangeRate(v);
+                            type.getCurrentContext().putType(rate);
+
+                            var fxGross = Money.of(rate.getTermCurrency(), asAmount(v.get("fxGross")));
+                            var gross = rate.convert(rate.getBaseCurrency(), fxGross);
+
+                            checkAndSetGrossUnit(gross, fxGross, t, type.getCurrentContext());
+                        })
+
+                        // @formatter:off
                         // Referenznummer 1746312001 DEUTSCHLAND
                         // @formatter:on
                         .section("note").optional() //
@@ -204,12 +244,32 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
                         .match("^Eidg\\. Stempelsteuer ?(\\(.*\\))? (?<currency>[A-Z]{3}) (\\-)?(?<tax>[\\.'\\d]+)$") //
                         .assign((t, v) -> processTaxEntries(t, v, type))
 
-                        // @formatter:off
-                        // Quellensteuer 26.375% EUR 263.75
-                        // @formatter:on
-                        .section("withHoldingTax", "currency").optional() //
-                        .match("^Quellensteuer [\\.,'\\d]+% (?<currency>[A-Z]{3}) (\\-)?(?<withHoldingTax>[\\.'\\d]+)$") //
-                        .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type));
+                        .optionalOneOf( //
+                                        // @formatter:off
+                                        // Quellensteuer 20% USD 1'243.77
+                                        // Umrechnungskurs EUR/USD 1.175393
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("withHoldingTax", "currency", "termCurrency",
+                                                                        "baseCurrency", "exchangeRate")
+                                                        .match("^Quellensteuer [\\.,'\\d]+% (?<currency>[A-Z]{3}) (\\-)?(?<withHoldingTax>[\\.'\\d]+)$") //
+                                                        .match("^Umrechnungskurs\\s+(?<baseCurrency>[A-Z]{3})\\/(?<termCurrency>[A-Z]{3})\\s+(?<exchangeRate>[\\.'\\d]+)\\s*$") //
+                                                        .assign((t, v) -> {
+                                                            var rate = asExchangeRate(v);
+                                                            type.getCurrentContext().putType(rate);
+                                                            processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
+                                                        }) //
+                                        ,
+                                        // @formatter:off
+                                        // Quellensteuer 26.375% EUR 263.75
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("withHoldingTax", "currency") //
+                                                        .match("^Quellensteuer [\\.,'\\d]+% (?<currency>[A-Z]{3}) (\\-)?(?<withHoldingTax>[\\.'\\d]+)$") //
+                                                        .assign((t, v) -> processWithHoldingTaxEntries(t, v,
+                                                                        "withHoldingTax", type)) //
+                        )
+        ;
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
@@ -229,6 +289,12 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
                         .section("fee", "currency").optional() //
                         .match("^Fremde Courtage (?<currency>[A-Z]{3}) (\\-)?(?<fee>[\\.'\\d]+)$") //
                         .assign((t, v) -> processFeeEntries(t, v, type));
+    }
+
+    @Override
+    protected BigDecimal asExchangeRate(String value)
+    {
+        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, "de", "CH");
     }
 
     @Override


### PR DESCRIPTION
This PR extends the regexes to catch exchange-rate-informations and use that to calculate the gross amount and holding taxes because it's not in the PDF itself (only the fxgross-amount).

I've also extended the logic to obtain the share's name because that particular PDF contains a name that spans over two lines so it could be done in a tested way. I've considered adding this to the buy/sell-block as well but in the end refrained from it because there is no test PDF data to test against I didn't want to create a synthetic one.

This is my first implementation with different currencies in place, I hope I've covered everything ;-)

The PDF was provided in the [PP-forum](https://forum.portfolio-performance.info/t/pdf-import-von-st-galler-kantonalbank/39539/6?u=kimmerin).