### PR TITLE
Fix: regression in shares-held for short trades

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/SharesHeldCalculationTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/SharesHeldCalculationTest.java
@@ -40,4 +40,23 @@ public class SharesHeldCalculationTest
         assertThat(snapshot.getRecords().get(0).getSharesHeld(), is(Values.Share.factorize(2)));
     }
 
+    @Test
+    public void testSharesHeldIfSecurityIsTemporarilyNegative()
+    {
+        Client client = new Client();
+        Security security = new Security();
+        client.addSecurity(security);
+
+        new PortfolioBuilder() //
+                        .sell(security, "2018-01-01", Values.Share.factorize(10), Values.Amount.factorize(100)) //$NON-NLS-1$
+                        .buy(security, "2018-02-01", Values.Share.factorize(10), Values.Amount.factorize(100)) //$NON-NLS-1$
+                        .addTo(client);
+
+        var interval = Interval.of(LocalDate.parse("2017-12-31"), LocalDate.parse("2018-03-01")); //$NON-NLS-1$ //$NON-NLS-2$
+        var snapshot = LazySecurityPerformanceSnapshot.create(client, new TestCurrencyConverter(), interval);
+
+        assertThat(snapshot.getRecords().size(), is(1));
+        assertThat(snapshot.getRecords().get(0).getSharesHeld(), is(0L));
+    }
+
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
@@ -148,6 +148,10 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
     private final LazyValue<CostCalculationResult> costCalculation = new LazyValue<>(
                     () -> Calculation.perform(CostCalculation.class, converter, security, lineItems).getResult());
 
+    private final LazyValue<Long> sharesHeld = new LazyValue<>(
+                    () -> Calculation.perform(SharesHeldCalculation.class, converter, security, lineItems)
+                                    .getSharesHeld());
+
     /**
      * cost of shares held
      */
@@ -274,15 +278,15 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
 
     public Long getSharesHeld()
     {
-        return costCalculation.get().sharesHeld();
+        return sharesHeld.get();
     }
 
     public Quote getCostPerSharesHeld(CostMethod costMethod, TaxesAndFees taxesAndFees)
     {
-        var sharesHeld = getSharesHeld();
+        var sharesHeldForCostCalculation = costCalculation.get().sharesHeld();
         Money cost = getCostMoney(costMethod, taxesAndFees);
 
-        return Quote.of(cost.getCurrencyCode(), Math.round(cost.getAmount() / (double) sharesHeld
+        return Quote.of(cost.getCurrencyCode(), Math.round(cost.getAmount() / (double) sharesHeldForCostCalculation
                         * Values.Share.factor() * Values.Quote.factorToMoney()));
     }
 


### PR DESCRIPTION
Problem described in #5616.

Support for calculating the correct final quantity in this situation was introduced in [66d0a436d](https://github.com/portfolio-performance/portfolio/commit/66d0a436dddae4b7a699dbaf2670add35dfe893c) for issue #930. It separated the holdings calculation from the FIFO cost inventory.

When the Securities Performance view was switched to `LazySecurityPerformanceRecord` in [7ee069440](https://github.com/portfolio-performance/portfolio/commit/7ee0694402fd2de9d46b936e4d2b1d4258e26ffc), `getSharesHeld()` once again derived its result from `CostCalculation`.

This reintroduced the original behavior: an unmatched sale is omitted from the FIFO inventory, so a later covering purchase appears as a positive holding.

It is well known that PP does not fully support short positions. Nonetheless, it works in some respects, and I champion an approach of taking whatever steps we can towards that goal, especially with respect to test coverage. This PR thus reverts to the old behaviour, and adds a test.

Closes #5616 .