### PR TITLE
Add Thurgauer Kantonalbank PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/thurgauerkantonalbank/Kauf01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/thurgauerkantonalbank/Kauf01.txt
@@ -1,0 +1,46 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.0
+System: macosx | aarch64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Wilhem Tell
+Wertschriftenkonto CHF
+TKB Beratungsdepot 1234.5678.9012
+Private Banking Oberthurgau IBAN CH12 3456 7890 1234 5678 9
+Rheinstrasse 17
+8500 Frauenfeld
+Telefon 0848 111 444
+info@tkb.ch
+www.tkb.ch
+BIC KBTGCH22
+CHE-108.954.458 MWST
+Elektronisch versandt
+Für Auskünfte: Herr
+Urs Casch Wilhelm Tell
++41 12 345 67 89 Am Äpfeli 2B
+urs.casch@tkb.ch 8572 Berg
+
+
+
+Frauenfeld, 20. Juli 2026
+Referenznummer 1234567890
+Abrechnung: Ihr Kauf
+Wir haben für Sie am 20. Juli 2026, 9:33:00 Uhr gekauft (Ausserbörslich Ausland):
+AUD 40'000.00 4.55% Obl Nestle Capital Corp 2025- Valoren-Nr. 142923838
+13.03.30 ISIN AU3CB0319416
+Währung Betrag
+Kurs 98.594% AUD 39'437.60
+Marchzinsen (131 Tage) AUD 648.00
+Kurswert AUD 40'085.60
+Courtage AUD 160.34
+Umsatzabgabe AUD 60.13
+Gebühren Gegenpartei AUD 8.85
+Total AUD 40'314.92
+Wechselkurs AUD/CHF 0.5751
+Zu Ihren Lasten Valuta 22.07.2026 CHF 23'185.11
+Den Betrag haben wir dem Konto belastet.
+Die Titel haben wir in das Depot eingebucht.
+Wir danken für Ihren Auftrag.
+Freundliche Grüsse
+Thurgauer Kantonalbank
+XDNI stex   1234567890 20260720
+123456 123456789

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/thurgauerkantonalbank/ThurgauerKantonalbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/thurgauerkantonalbank/ThurgauerKantonalbankPDFExtractorTest.java
@@ -1,0 +1,113 @@
+package name.abuchen.portfolio.datatransfer.pdf.thurgauerkantonalbank;
+
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasForexGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasIsin;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasName;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countItemsWithFailureMessage;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
+import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSkippedItems;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
+import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
+import name.abuchen.portfolio.datatransfer.pdf.ThurgauerKantonalbankPDFExtractor;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.Security;
+
+@SuppressWarnings("nls")
+public class ThurgauerKantonalbankPDFExtractorTest
+{
+    @Test
+    public void testWertpapierKauf01()
+    {
+        var extractor = new ThurgauerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("AU3CB0319416"), hasWkn("142923838"), hasTicker(null), //
+                        hasName("4.55% Obl Nestle Capital Corp 2025-13.03.30"), //
+                        hasCurrencyCode("AUD"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-07-20T09:33:00"), hasShares(400.00), //
+                        hasSource("Kauf01.txt"), //
+                        hasNote("Referenznummer 1234567890 | Marchzinsen (131 Tage): 648.00 AUD"), //
+                        hasAmount("CHF", 23185.11), hasGrossValue("CHF", 23053.23), //
+                        hasForexGrossValue("AUD", 40085.60), //
+                        hasTaxes("CHF", 34.58), hasFees("CHF", (92.21 + 5.09)))));
+    }
+
+    @Test
+    public void testWertpapierKauf01WithSecurityInCHF()
+    {
+        var security = new Security("4.55% Obl Nestle Capital Corp 2025-13.03.30", "CHF");
+        security.setIsin("AU3CB0319416");
+        security.setWkn("142923838");
+
+        var client = new Client();
+        client.addSecurity(security);
+
+        var extractor = new ThurgauerKantonalbankPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "CHF");
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-07-20T09:33:00"), hasShares(400.00), //
+                        hasSource("Kauf01.txt"), //
+                        hasNote("Referenznummer 1234567890 | Marchzinsen (131 Tage): 648.00 AUD"), //
+                        hasAmount("CHF", 23185.11), hasGrossValue("CHF", 23053.23), //
+                        hasTaxes("CHF", 34.58), hasFees("CHF", (92.21 + 5.09)))));
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
@@ -226,6 +226,7 @@ public class ExtractorUtils
                     createFormatter("dd MMMM yyyy HH:mm:ss", Locale.GERMANY), //
                     createFormatter("d. MMMM yyyy HH:mm:ss", Locale.GERMANY), //
                     createFormatter("dd. MMMM yyyy HH:mm:ss", Locale.GERMANY), //
+                    createFormatter("d. MMMM yyyy H:mm:ss", Locale.GERMANY), //
                     createFormatter("d.M.yyyy HH:mm:ss", Locale.GERMANY), //
                     createFormatter("dd.M.yyyy HH:mm:ss", Locale.GERMANY), //
                     createFormatter("d/MM/yyyy HH:mm:ss", Locale.GERMANY), //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFImportAssistant.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFImportAssistant.java
@@ -143,6 +143,7 @@ public class PDFImportAssistant
         extractors.add(new SwissquotePDFExtractor(client));
         extractors.add(new SydbankASPDFExtractor(client));
         extractors.add(new TargobankPDFExtractor(client));
+        extractors.add(new ThurgauerKantonalbankPDFExtractor(client));
         extractors.add(new TigerBrokersPteLtdPDFExtractor(client));
         extractors.add(new TradegateAGPDFExtractor(client));
         extractors.add(new TradeRepublicPDFExtractor(client));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ThurgauerKantonalbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ThurgauerKantonalbankPDFExtractor.java
@@ -1,0 +1,199 @@
+package name.abuchen.portfolio.datatransfer.pdf;
+
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
+import static name.abuchen.portfolio.util.TextUtil.concatenate;
+import static name.abuchen.portfolio.util.TextUtil.trim;
+
+import java.math.BigDecimal;
+
+import name.abuchen.portfolio.datatransfer.ExtractorUtils;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
+import name.abuchen.portfolio.model.BuySellEntry;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.Values;
+
+/**
+ * Thurgauer Kantonalbank
+ *
+ * @implSpec The VALOR number is the WKN number with 5 to 9 digits/characters.
+ */
+
+@SuppressWarnings("nls")
+public class ThurgauerKantonalbankPDFExtractor extends AbstractPDFExtractor
+{
+    public ThurgauerKantonalbankPDFExtractor(Client client)
+    {
+        super(client);
+
+        addBankIdentifier("Thurgauer Kantonalbank");
+
+        addBuySellTransaction();
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return "Thurgauer Kantonalbank";
+    }
+
+    private void addBuySellTransaction()
+    {
+        final var type = new DocumentType("Abrechnung: Ihr Kauf");
+        this.addDocumentTyp(type);
+
+        var pdfTransaction = new Transaction<BuySellEntry>();
+
+        var firstRelevantLine = new Block("^Referenznummer .*$");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
+
+        pdfTransaction //
+
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
+
+                        // @formatter:off
+                        // AUD 40'000.00 4.55% Obl Nestle Capital Corp 2025- Valoren-Nr. 142923838
+                        // 13.03.30 ISIN AU3CB0319416
+                        // Währung Betrag
+                        // Kurs 98.594% AUD 39'437.60
+                        // @formatter:on
+                        .section("name", "wkn", "maturity", "isin", "currency") //
+                        .match("^[A-Z]{3} [\\.'\\d]+ (?<name>.*) Valoren\\-Nr\\. (?<wkn>[A-Z0-9]{5,9})$") //
+                        .match("^(?<maturity>.*) ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                        .match("^Kurs [\\.,'\\d]+% (?<currency>[A-Z]{3}) [\\.'\\d]+$") //
+                        .assign((t, v) -> {
+                            // @formatter:off
+                            // The security name is wrapped over two lines and continues
+                            // with the maturity date directly after the trailing hyphen.
+                            // @formatter:on
+                            v.put("name", trim(v.get("name")) + trim(v.get("maturity")));
+
+                            t.setSecurity(getOrCreateSecurity(v));
+                        })
+
+                        // @formatter:off
+                        // AUD 40'000.00 4.55% Obl Nestle Capital Corp 2025- Valoren-Nr. 142923838
+                        // @formatter:on
+                        .section("shares") //
+                        .match("^[A-Z]{3} (?<shares>[\\.'\\d]+) .* Valoren\\-Nr\\. [A-Z0-9]{5,9}$") //
+                        .assign((t, v) -> {
+                            // @formatter:off
+                            // Percentage quotation, workaround for bonds
+                            // @formatter:on
+                            var shares = asExchangeRate(v.get("shares"));
+                            t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
+                        })
+
+                        // @formatter:off
+                        // Wir haben für Sie am 20. Juli 2026, 9:33:00 Uhr gekauft (Ausserbörslich Ausland):
+                        // @formatter:on
+                        .section("date", "time") //
+                        .match("^Wir haben f.r Sie am (?<date>[\\d]{1,2}\\. .* [\\d]{4}), (?<time>[\\d]{1,2}\\:[\\d]{2}\\:[\\d]{2}) Uhr gekauft.*$") //
+                        .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
+
+                        // @formatter:off
+                        // Zu Ihren Lasten Valuta 22.07.2026 CHF 23'185.11
+                        // @formatter:on
+                        .section("currency", "amount") //
+                        .match("^Zu Ihren Lasten Valuta [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<currency>[A-Z]{3}) (?<amount>[\\.'\\d]+)$") //
+                        .assign((t, v) -> {
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setAmount(asAmount(v.get("amount")));
+                        })
+
+                        // @formatter:off
+                        // Kurswert AUD 40'085.60
+                        // Wechselkurs AUD/CHF 0.5751
+                        // @formatter:on
+                        .section("fxGross", "baseCurrency", "termCurrency", "exchangeRate").optional() //
+                        .match("^Kurswert [A-Z]{3} (?<fxGross>[\\.'\\d]+)$") //
+                        .match("^Wechselkurs (?<baseCurrency>[A-Z]{3})\\/(?<termCurrency>[A-Z]{3}) (?<exchangeRate>[\\.'\\d]+)$") //
+                        .assign((t, v) -> {
+                            var rate = asExchangeRate(v);
+                            type.getCurrentContext().putType(rate);
+
+                            var fxGross = Money.of(rate.getBaseCurrency(), asAmount(v.get("fxGross")));
+                            var gross = rate.convert(rate.getTermCurrency(), fxGross);
+
+                            checkAndSetGrossUnit(gross, fxGross, t, type.getCurrentContext());
+                        })
+
+                        // @formatter:off
+                        // Referenznummer 1234567890
+                        // @formatter:on
+                        .section("note").optional() //
+                        .match("^(?<note>Referenznummer [\\d]+).*$") //
+                        .assign((t, v) -> t.setNote(trim(v.get("note"))))
+
+                        // @formatter:off
+                        // Marchzinsen (131 Tage) AUD 648.00
+                        // @formatter:on
+                        .section("note1", "note2", "note3").optional() //
+                        .match("^(?<note1>Marchzinsen \\([\\d]+ Tage\\)) (?<note3>[A-Z]{3}) (?<note2>[\\.'\\d]+)$") //
+                        .assign((t, v) -> {
+                            t.setNote(concatenate(t.getNote(), v.get("note1"), " | "));
+                            t.setNote(concatenate(t.getNote(), v.get("note2"), ": "));
+                            t.setNote(concatenate(t.getNote(), v.get("note3"), " "));
+                        })
+
+                        .conclude(ExtractorUtils.fixGrossValueBuySell())
+
+                        .wrap(BuySellEntryItem::new);
+
+        addTaxesSectionsTransaction(pdfTransaction, type);
+        addFeesSectionsTransaction(pdfTransaction, type);
+    }
+
+    private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
+    {
+        transaction //
+
+                        // @formatter:off
+                        // Umsatzabgabe AUD 60.13
+                        // @formatter:on
+                        .section("tax", "currency").optional() //
+                        .match("^Umsatzabgabe (?<currency>[A-Z]{3}) (?<tax>[\\.'\\d]+)$") //
+                        .assign((t, v) -> processTaxEntries(t, v, type));
+    }
+
+    private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
+    {
+        transaction //
+
+                        // @formatter:off
+                        // Courtage AUD 160.34
+                        // @formatter:on
+                        .section("fee", "currency").optional() //
+                        .match("^Courtage (?<currency>[A-Z]{3}) (?<fee>[\\.'\\d]+)$") //
+                        .assign((t, v) -> processFeeEntries(t, v, type))
+
+                        // @formatter:off
+                        // Gebühren Gegenpartei AUD 8.85
+                        // @formatter:on
+                        .section("fee", "currency").optional() //
+                        .match("^Geb.hren Gegenpartei (?<currency>[A-Z]{3}) (?<fee>[\\.'\\d]+)$") //
+                        .assign((t, v) -> processFeeEntries(t, v, type));
+    }
+
+    @Override
+    protected long asAmount(String value)
+    {
+        return ExtractorUtils.convertToNumberLong(value, Values.Amount, "de", "CH");
+    }
+
+    @Override
+    protected long asShares(String value)
+    {
+        return ExtractorUtils.convertToNumberLong(value, Values.Share, "de", "CH");
+    }
+
+    @Override
+    protected BigDecimal asExchangeRate(String value)
+    {
+        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share, "de", "CH");
+    }
+}


### PR DESCRIPTION
Adds a PDF importer for Thurgauer Kantonalbank (TKB).

Closes #5898

### Sample

One document was provided in the issue: a bond purchase (`Abrechnung: Ihr Kauf`) — nominal AUD 40'000.00 at 98.594%, settled in CHF.

### Notes

- TKB uses the same Finnova document template as St.Galler Kantonalbank, so `StGallerKantonalbankPDFExtractor` served as the reference.
- **Scope is deliberately limited to `Kauf`.** Only the one fixture exists, so the `Verkauf` path and the plain equity `Kurs <CUR> <price>` layout are not matched yet. Happy to extend once further samples turn up.
- **`Marchzinsen`** (accrued interest) is recorded as a note only and stays inside the gross value — consistent with how `BaaderBankPDFExtractor` and `INGDiBaPDFExtractor` handle `Stückzinsen`.
- Percentage-quoted bond: shares = nominal / 100, using the existing `// Percentage quotation, workaround for bonds` idiom.
- `Umsatzabgabe` is treated as tax, `Courtage` and `Gebühren Gegenpartei` as fees. All three are quoted in AUD and converted through the document's `Wechselkurs AUD/CHF`.

### Change outside the extractor

`ExtractorUtils.DATE_TIME_FORMATTER` gained `d. MMMM yyyy H:mm:ss` and `dd. MMMM yyyy H:mm:ss`. TKB prints a single-digit hour (`9:33:00 Uhr`), and since `createFormatter` uses `appendPattern`, the existing `HH` variants require two digits. The new entries are appended after the `HH` ones, so existing extractors keep matching first.

Full core test suite is green (4512 tests).
