### PR TITLE
S Broker: support Zinsgutschrift documents

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/Dividende18.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/Dividende18.txt
@@ -1,0 +1,55 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.83.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Sparkasse Pfaffenhofen · Postfach 12 51 · 85262 Pfaffenhofen a. d. Ilm  Seite 1
+Depotnummer
+ 1234567
+ Kundennummer 7654321
+ Max Mustermannn
+Abrechnungsnr. 60357534450
+Herrn Datum 13.04.2026
+Max Mustermann Ihr Berater XXXXX XXXXXXX
+Musterstraße 8 Telefon 00000-755-000
+12345 Musterhausen
+ 
+  
+ 
+Zinsgutschrift
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 100 LEVERAGE SHARES PLC XS3068771271 (A4AN04)
+ETP 19.06.75 INCOMESHARES 20+
+Zahlbarkeitstag 10.04.2026 Ertrag pro St. 0,3807 USD
+Bestandsstichtag 31.03.2026 Herkunftsland Irland
+Kupon per 31.03.2026
+Zinstermin Monat(e) April 
+Devisenkurs EUR / USD 1,1713 
+Devisenkursdatum 13.04.2026
+Zinsertrag 38,07 USD 32,50+ EUR
+Umrechnung in EUR 32,50 EUR
+Kapitalertragsteuerpflichtiger Ertrag 32,50 EUR
+Verrechneter Sparer-Pauschbetrag 32,50 - EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 0,00 EUR
+Ausmachender Betrag 32,50+ EUR
+Lagerstelle Clearstream Banking Lux (849133 / 64003)
+Den Betrag buchen wir mit Wertstellung 13.04.2026 zu Gunsten des Kontos 9876543 (IBAN DE15 XXXX XXXX XXXX XXXX
+XX), BLZ 721 516 50 (BIC BYLADEM1PAF). 
+Keine Steuerbescheinigung. 
+Bitte ggf. Rückseite beachten.
+2247.04140100.0000005ER02
+
+Seite 2
+Depotnummer 7654321
+Kundennummer 7654321
+Abrechnungsnr. 60357534450
+Datum 13.04.2026
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verrechnungstöpfe 2026 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien und Sonstige
+Pauschbetrag Quellensteuer
+Vorher 0,00 0,00 737,48 0,00 0,00
+Ertrag 0,00 0,00 32,50- 0,00 0,00
+Nachher 0,00 0,00 704,98 0,00 0,00
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+2247.04140100.0000006ER02

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/SBrokerPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/sbroker/SBrokerPDFExtractorTest.java
@@ -2426,6 +2426,85 @@ public class SBrokerPDFExtractorTest
     }
 
     @Test
+    public void testDividende18()
+    {
+        var extractor = new SBrokerPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende18.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("XS3068771271"), hasWkn("A4AN04"), hasTicker(null), //
+                        hasName("LEVERAGE SHARES PLC ETP 19.06.75 INCOMESHARES 20+"), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividende transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-04-10T00:00"), hasExDate(null), //
+                        hasShares(100.00), //
+                        hasSource("Dividende18.txt"), //
+                        hasNote("Abrechnungsnr. 60357534450"), //
+                        hasAmount("EUR", 32.50), hasGrossValue("EUR", 32.50), //
+                        hasForexGrossValue("USD", 38.07), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende18WithSecurityInEUR()
+    {
+        var security = new Security("LEVERAGE SHARES PLC ETP 19.06.75 INCOMESHARES 20+", "EUR");
+        security.setIsin("XS3068771271");
+        security.setWkn("A4AN04");
+
+        var client = new Client();
+        client.addSecurity(security);
+
+        var extractor = new SBrokerPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende18.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "EUR");
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-04-10T00:00"), hasExDate(null), //
+                        hasShares(100.00), //
+                        hasSource("Dividende18.txt"), //
+                        hasNote("Abrechnungsnr. 60357534450"), //
+                        hasAmount("EUR", 32.50), hasGrossValue("EUR", 32.50), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        check(tx -> {
+                            var c = new CheckCurrenciesAction();
+                            var account = new Account();
+                            account.setCurrencyCode("EUR");
+                            var s = c.process((AccountTransaction) tx, account);
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
+    }
+
+    @Test
     public void testVorabpauschale01()
     {
         var extractor = new SBrokerPDFExtractor(new Client());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SBrokerPDFExtractor.java
@@ -268,6 +268,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
     {
         final var type = new DocumentType("(Dividendengutschrift|" //
                         + "Aussch.ttung|" //
+                        + "Zinsgutschrift|" //
                         + "Kapitalr.ckzahlung)");
         this.addDocumentTyp(type);
 
@@ -275,6 +276,7 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
 
         var firstRelevantLine = new Block("^(Dividendengutschrift" //
                         + "|Aussch.ttung (f.r|Investmentfonds)" //
+                        + "|Zinsgutschrift" //
                         + "|Gutschrift)" //
                         + "( [^\\.,\\d]+.*)?$");
         type.addBlock(firstRelevantLine);
@@ -338,12 +340,17 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                                         // Stück 250 GLADSTONE COMMERCIAL CORP. US3765361080 (260884)
                                         // REGISTERED SHARES DL -,01
                                         // Zahlbarkeitstag 31.12.2021 Ausschüttung pro St. 0,125275000 USD
+                                        //
+                                        // Nominale Wertpapierbezeichnung ISIN (WKN)
+                                        // Stück 100 LEVERAGE SHARES PLC XS3068771271 (A4AN04)
+                                        // ETP 19.06.75 INCOMESHARES 20+
+                                        // Zahlbarkeitstag 10.04.2026 Ertrag pro St. 0,3807 USD
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "isin", "wkn", "name1", "currency") //
                                                         .match("^St.ck [\\.,\\d]+ (?<name>.*) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\((?<wkn>[A-Z0-9]{6})\\)$") //
                                                         .match("^(?<name1>.*)$") //
-                                                        .match("^Zahlbarkeitstag [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (Aussch.ttung|Dividende|Auszahlung) pro (St\\.|St.ck) [\\.,\\d]+ (?<currency>[\\w]{3})$") //
+                                                        .match("^Zahlbarkeitstag [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (Aussch.ttung|Dividende|Auszahlung|Ertrag) pro (St\\.|St.ck) [\\.,\\d]+ (?<currency>[\\w]{3})$") //
                                                         .assign((t, v) -> {
                                                             if (!v.get("name1").startsWith("Zahlbarkeitstag"))
                                                                 v.put("name", trim(v.get("name")) + " " + trim(v.get("name1")));
@@ -463,11 +470,14 @@ public class SBrokerPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:off
                                         // Devisenkurs EUR / PLN 4,5044
                                         // Ausschüttung 31,32 USD 27,48+ EUR
+                                        //
+                                        // Devisenkurs EUR / USD 1,1713
+                                        // Zinsertrag 38,07 USD 32,50+ EUR
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("baseCurrency", "termCurrency", "exchangeRate", "fxGross", "gross") //
-                                                        .match("^Devisenkurs (?<baseCurrency>[\\w]{3}) \\/ (?<termCurrency>[\\w]{3})[\\s]*(?<exchangeRate>[\\.,\\d]+)$") //
-                                                        .match("^(Dividendengutschrift|Aussch.ttung|Kurswert) (?<fxGross>[\\.,\\d]+) [\\w]{3} (?<gross>[\\.,\\d]+)\\+ [\\w]{3}$") //
+                                                        .match("^Devisenkurs (?<baseCurrency>[\\w]{3}) \\/ (?<termCurrency>[\\w]{3})[\\s]*(?<exchangeRate>[\\.,\\d]+)[\\s]*$") //
+                                                        .match("^(Dividendengutschrift|Aussch.ttung|Kurswert|Zinsertrag) (?<fxGross>[\\.,\\d]+) [\\w]{3} (?<gross>[\\.,\\d]+)\\+ [\\w]{3}$") //
                                                         .assign((t, v) -> {
                                                             var rate = asExchangeRate(v);
                                                             type.getCurrentContext().putType(rate);


### PR DESCRIPTION
Closes #5686

Interest credits for certificates and ETPs are issued by the Sparkassen with the `Zinsgutschrift` document header. Neither the header nor the two value lines specific to it were recognized, so the document was rejected as unsupported.

### Changes in `SBrokerPDFExtractor.addDividendTransaction()`

- `Zinsgutschrift` added to the `DocumentType` and to the block start pattern
- `Ertrag` added to the `Zahlbarkeitstag ... pro St.` alternation (security currency)
- `Zinsertrag` added to the forex gross value alternation
- the `Devisenkurs` line of this layout carries a trailing blank, so the pattern now ends with `[\s]*$`

Everything else of the document (`Stück ... ISIN (WKN)`, `Ausmachender Betrag`, `Abrechnungsnr.`) was already covered by the existing sections.

### Test

New fixture `sbroker/Dividende18.txt` from the issue with `testDividende18()` and `testDividende18WithSecurityInEUR()`. The full `SBrokerPDFExtractorTest` passes (107 tests).
