### PR TITLE
issues 4475: PDF Import chosen Filepath saved per depot, not globally

### DIFF
--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/editor/FilePathHelperTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/editor/FilePathHelperTest.java
@@ -1,0 +1,118 @@
+package name.abuchen.portfolio.ui.editor;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferenceStore;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import name.abuchen.portfolio.model.Account;
+import name.abuchen.portfolio.model.Portfolio;
+
+@SuppressWarnings("nls")
+public class FilePathHelperTest
+{
+    private static final String KEY = "pdf.import.path";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private PortfolioPart part;
+    private IPreferenceStore preferenceStore;
+    private IEclipsePreferences eclipsePreferences;
+
+    @Before
+    public void setUp()
+    {
+        part = mock(PortfolioPart.class);
+        preferenceStore = new PreferenceStore();
+        eclipsePreferences = mock(IEclipsePreferences.class);
+
+        when(part.getPreferenceStore()).thenReturn(preferenceStore);
+        when(part.getEclipsePreferences()).thenReturn(eclipsePreferences);
+    }
+
+    @Test
+    public void testGetPathReturnsOwnerSpecificPath() throws IOException
+    {
+        File ownerDir = folder.newFolder("ownerDir");
+        File globalDir = folder.newFolder("globalDir");
+
+        var account = new Account();
+        preferenceStore.setValue(KEY + "." + account.getUUID(), ownerDir.getAbsolutePath());
+        preferenceStore.setValue(KEY, globalDir.getAbsolutePath());
+
+        var helper = new FilePathHelper(part, KEY, account);
+
+        assertThat(helper.getPath(), is(ownerDir.getAbsolutePath()));
+    }
+
+    @Test
+    public void testGetPathFallsBackToGlobalPreferenceIfOwnerPathMissing() throws IOException
+    {
+        File globalDir = folder.newFolder("globalDir");
+
+        var portfolio = new Portfolio();
+        preferenceStore.setValue(KEY, globalDir.getAbsolutePath());
+
+        var helper = new FilePathHelper(part, KEY, portfolio);
+
+        assertThat(helper.getPath(), is(globalDir.getAbsolutePath()));
+    }
+
+    @Test
+    public void testGetPathFallsBackToEclipsePreferences() throws IOException
+    {
+        File eclipseDir = folder.newFolder("eclipseDir");
+        when(eclipsePreferences.get(KEY, null)).thenReturn(eclipseDir.getAbsolutePath());
+
+        var helper = new FilePathHelper(part, KEY);
+
+        assertThat(helper.getPath(), is(eclipseDir.getAbsolutePath()));
+    }
+
+    @Test
+    public void testGetPathFallsBackToUserHomeIfNoPreferenceValid()
+    {
+        var helper = new FilePathHelper(part, KEY);
+
+        assertThat(helper.getPath(), is(System.getProperty("user.home")));
+    }
+
+    @Test
+    public void testSavePathWithTransactionOwner() throws IOException
+    {
+        File newDir = folder.newFolder("newDir");
+        var account = new Account();
+
+        var helper = new FilePathHelper(part, KEY, account);
+        helper.savePath(newDir.getAbsolutePath());
+
+        assertThat(preferenceStore.getString(KEY), is(newDir.getAbsolutePath()));
+        assertThat(preferenceStore.getString(KEY + "." + account.getUUID()), is(newDir.getAbsolutePath()));
+        verify(eclipsePreferences).put(KEY, newDir.getAbsolutePath());
+    }
+
+    @Test
+    public void testSavePathWithoutTransactionOwner() throws IOException
+    {
+        File newDir = folder.newFolder("newDir");
+
+        var helper = new FilePathHelper(part, KEY);
+        helper.savePath(newDir.getAbsolutePath());
+
+        assertThat(preferenceStore.getString(KEY), is(newDir.getAbsolutePath()));
+        verify(eclipsePreferences).put(KEY, newDir.getAbsolutePath());
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/FilePathHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/FilePathHelper.java
@@ -30,8 +30,7 @@ public class FilePathHelper
 
     public String getPath()
     {
-        // postfix-specific preferences (e.g. per-account/portfolio
-        // path)
+        // first, postfix-specific preferences (e.g. per-account/portfolio)
         if (postfix != null)
         {
             String path = part.getPreferenceStore().getString(getKeyWithPostfix());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/FilePathHelper.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/FilePathHelper.java
@@ -3,26 +3,49 @@ package name.abuchen.portfolio.ui.editor;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import name.abuchen.portfolio.model.TransactionOwner;
+
 public class FilePathHelper
 {
     private PortfolioPart part;
     private String key;
+    private String postfix;
 
     public FilePathHelper(PortfolioPart part, String key)
     {
+        this(part, key, (TransactionOwner<?>) null);
+    }
+
+    public FilePathHelper(PortfolioPart part, String key, TransactionOwner<?> owner)
+    {
         this.part = part;
         this.key = key;
+        this.postfix = owner != null ? owner.getUUID() : null;
+    }
+
+    private String getKeyWithPostfix()
+    {
+        return key + "." + postfix; //$NON-NLS-1$
     }
 
     public String getPath()
     {
-        // first, check file-specific preferences
+        // postfix-specific preferences (e.g. per-account/portfolio
+        // path)
+        if (postfix != null)
+        {
+            String path = part.getPreferenceStore().getString(getKeyWithPostfix());
+            if (!path.isEmpty() && Files.isDirectory(Paths.get(path)))
+                return path;
+        }
+
+        // second, check file-specific preferences
         String path = part.getPreferenceStore().getString(key);
 
         if (path.isEmpty() || !Files.isDirectory(Paths.get(path)))
             path = null;
 
-        // second, check application-wide preferences
+        // third, check application-wide preferences
         if (path == null)
         {
             String p = part.getEclipsePreferences().get(key, null);
@@ -30,7 +53,7 @@ public class FilePathHelper
                 path = p;
         }
 
-        // third, fall back to the user directory
+        // fourth, fall back to the user directory
         if (path == null)
             path = System.getProperty("user.home"); //$NON-NLS-1$
 
@@ -41,5 +64,8 @@ public class FilePathHelper
     {
         part.getPreferenceStore().setValue(key, path);
         part.getEclipsePreferences().put(key, path);
+
+        if (postfix != null)
+            part.getPreferenceStore().setValue(getKeyWithPostfix(), path);
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportPDFHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportPDFHandler.java
@@ -39,6 +39,7 @@ import name.abuchen.portfolio.model.Account;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.model.TransactionOwner;
 import name.abuchen.portfolio.ui.PortfolioPlugin;
 import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.editor.FilePathHelper;
@@ -105,7 +106,9 @@ public class ImportPDFHandler
             return;
         }
 
-        FilePathHelper helper = new FilePathHelper(part, UIConstants.Preferences.PDF_IMPORT_PATH);
+        // determine the preferred transaction owner (portfolio > account)
+        TransactionOwner<?> owner = portfolio != null ? portfolio : account;
+        FilePathHelper helper = new FilePathHelper(part, UIConstants.Preferences.PDF_IMPORT_PATH, owner);
 
         FileDialog fileDialog = new FileDialog(shell, SWT.OPEN | SWT.MULTI);
         fileDialog.setText(Messages.PDFImportWizardAssistant);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/UnrecognizedPDFCache.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/UnrecognizedPDFCache.java
@@ -62,7 +62,7 @@ public class UnrecognizedPDFCache
         private static final long serialVersionUID = 1L;
 
         @Override
-        protected boolean removeEldestEntry(Map.Entry<Key, Entry> eldest)
+        protected boolean removeEldestEntry(Map.Entry<Key, UnrecognizedPDFCache.Entry> eldest)
         {
             return size() > MAXIMUM;
         }


### PR DESCRIPTION
 PDF Import should remember last chosen directory/path based on depot (not global).

Idee:
Postfix mit Depot/Account UUID gespeichert. Wenn er keinen Eintrag mit dem Postfix findet, Fallback auf bestehendes Verhalten

Löst das Issue https://github.com/portfolio-performance/portfolio/issues/4475