### PR TITLE
Fix FIFO capital gains ignoring the transaction exchange rate

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshotTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/ClientPerformanceSnapshotTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
@@ -623,12 +624,43 @@ public class ClientPerformanceSnapshotTest
                                                         // start of period
                                                         - (90.0 * 5)))));
 
+        // exchange rate purchase
+        var ratePurchase = client.getPortfolios().stream().flatMap(p -> p.getTransactions().stream())
+                        .filter(p -> p.getDateTime().equals(LocalDateTime.parse("2015-01-02T00:00"))).findFirst().get()
+                        .getUnit(Transaction.Unit.Type.GROSS_VALUE).get().getExchangeRate();
+
+        var rateSale = client.getPortfolios().stream().flatMap(p -> p.getTransactions().stream())
+                        .filter(p -> p.getDateTime().equals(LocalDateTime.parse("2015-01-09T00:00"))).findFirst().get()
+                        .getUnit(Transaction.Unit.Type.GROSS_VALUE).get().getExchangeRate();
+
+        // relieved USD cost basis in minor units, matching
+        // CapitalGainsCalculation#startForex (Math.round == HALF_UP)
+        var relievedForexBasis = Math.round(90.0 * 5 / ratePurchase.doubleValue() * 100);
+
+        // that basis valued at the sale's exchange rate, rounded like the
+        // production code (CapitalGainsCalculation#relievedForexInTerm), which
+        // uses RoundingMode.HALF_DOWN rather than Math.round's HALF_UP
+        var relievedForexBasisInTerm = BigDecimal.valueOf(relievedForexBasis)
+                        .multiply(BigDecimal.valueOf(rateSale.doubleValue()))
+                        .setScale(0, RoundingMode.HALF_DOWN).longValue();
+
         assertThat(snapshot.getCategoryByType(CategoryType.REALIZED_CAPITAL_GAINS).getPositions().get(0).getForexGain(),
                         is(Money.of(CurrencyUnit.EUR,
-                                        // value at start -> to USD with rate at
-                                        // start -> back to EUR with rate at end
-                                        // -> minus start value
-                                        Values.Amount.factorize((90.0 * 5 * 1.2043 / 1.1813) - (90.0 * 5)))));
+                                        // currency gains now use the exchange
+                                        // rate recorded on the transaction
+                                        // (matching the moving-average method):
+                                        // the relieved USD cost basis valued at
+                                        // the sale's exchange rate, less the
+                                        // relieved EUR cost basis. Because the
+                                        // USD basis is carried in minor units
+                                        // it differs from the historic
+                                        // round-trip (EUR 8.76) by one cent of
+                                        // rounding.
+                                        relievedForexBasisInTerm - Values.Amount.factorize(90.0 * 5))));
+
+        // with the explicit monetary amount
+        assertThat(snapshot.getCategoryByType(CategoryType.REALIZED_CAPITAL_GAINS).getPositions().get(0).getForexGain(),
+                        is(Money.of(CurrencyUnit.EUR, 877L)));
 
         assertThat(snapshot.getAbsoluteDelta(),
                         is(snapshot.getValue(CategoryType.FINAL_VALUE)

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationTest.java
@@ -243,4 +243,75 @@ public class CapitalGainsCalculationTest
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(-97.54))));
 
     }
+
+    /**
+     * Same portfolio as {@link #testFifoBuySellTransactions3()} but reported in
+     * the security's currency (USD) rather than the transaction/account currency
+     * (EUR). In that case the FIFO lot basis must be the {@code GROSS_VALUE}
+     * unit's forex amount (the rate recorded on the transaction) rather than the
+     * historic day rate published by the exchange-rate provider, matching the
+     * moving-average sibling and {@code CostCalculation}. See
+     * https://github.com/portfolio-performance/portfolio/issues/5908
+     */
+    @Test
+    public void testFifoBuySellTransactions3ReportedInSecurityCurrency()
+    {
+        var client = new Client();
+        client.setBaseCurrency(CurrencyUnit.EUR);
+
+        var security = new SecurityBuilder(CurrencyUnit.USD) //
+                        .addPrice("2025-01-01", Values.Quote.factorize(80)) //
+                        .addTo(client);
+
+        var account = new AccountBuilder(CurrencyUnit.EUR) //
+                        .addTo(client);
+
+        new PortfolioBuilder(account) //
+                        .inbound_delivery(security, "2024-01-01", Values.Share.factorize(100),
+                                        new Transaction.Unit(Transaction.Unit.Type.GROSS_VALUE,
+                                                        Money.of(CurrencyUnit.EUR, Values.Amount.factorize(4500)),
+                                                        Money.of(CurrencyUnit.USD, Values.Amount.factorize(5000)),
+                                                        BigDecimal.valueOf(0.90)) //
+                        )
+                        .inbound_delivery(security, "2024-02-01", Values.Share.factorize(50),
+                                        new Transaction.Unit(Transaction.Unit.Type.GROSS_VALUE,
+                                                        Money.of(CurrencyUnit.EUR, Values.Amount.factorize(2550)),
+                                                        Money.of(CurrencyUnit.USD, Values.Amount.factorize(3000)),
+                                                        BigDecimal.valueOf(0.85)) //
+                        )
+                        .outbound_delivery(security, "2024-03-01", Values.Share.factorize(50),
+                                        new Transaction.Unit(Transaction.Unit.Type.GROSS_VALUE,
+                                                        Money.of(CurrencyUnit.EUR, Values.Amount.factorize(3080)),
+                                                        Money.of(CurrencyUnit.USD, Values.Amount.factorize(3500)),
+                                                        BigDecimal.valueOf(0.88)) //
+                        ).addTo(client);
+
+        var interval = Interval.of(LocalDate.parse("2023-12-31"), LocalDate.parse("2024-12-31"));
+        LazySecurityPerformanceSnapshot snapshot = LazySecurityPerformanceSnapshot.create(client,
+                        new TestCurrencyConverter(CurrencyUnit.USD), interval);
+        LazySecurityPerformanceRecord record = snapshot.getRecord(security).orElseThrow(IllegalArgumentException::new);
+
+        // realized gains reported in USD
+        // [revenue in USD] - [partial cost of first buy in USD]
+        // the basis must be the GROSS_VALUE unit's forex amount (USD 5000), not
+        // the historic conversion of EUR 4500
+        // 3500 - (50/100) * 5000 = 1000
+        var realizedFifo = record.getRealizedCapitalGains(CostMethod.FIFO);
+        assertThat(realizedFifo.getCapitalGains(), //
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(1000))));
+
+        // no currency gains when reporting in the security's own currency
+        assertThat(realizedFifo.getForexCaptialGains(), //
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0))));
+
+        // unrealized gains reported in USD
+        // [current valuation in USD] - [remaining basis of both buys in USD]
+        // 100 * 80 - ((50/100) * 5000 + 3000) = 8000 - 5500 = 2500
+        var unrealizedFifo = record.getUnrealizedCapitalGains(CostMethod.FIFO);
+        assertThat(unrealizedFifo.getCapitalGains(), //
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(2500))));
+
+        assertThat(unrealizedFifo.getForexCaptialGains(), //
+                        is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0))));
+    }
 }

--- a/name.abuchen.portfolio.tests/src/scenarios/CurrencyTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/CurrencyTestCase.java
@@ -271,8 +271,11 @@ public class CurrencyTestCase
         assertThat(record.getRealizedCapitalGains(CostMethod.MOVING_AVERAGE).getCapitalGains(),
                         is(Money.of("EUR", 0L)));
         assertThat(record.getUnrealizedCapitalGains(CostMethod.FIFO).getCapitalGains(), is(Money.of("EUR", 8771L)));
+        // FIFO currency gains now use the transaction's exchange rate and thus
+        // match the moving-average figure asserted below (was EUR 43.39 when
+        // derived from the historic round-trip)
         assertThat(record.getUnrealizedCapitalGains(CostMethod.FIFO).getForexCaptialGains(),
-                        is(Money.of("EUR", 4339L)));
+                        is(Money.of("EUR", 4335L)));
         assertThat(record.getUnrealizedCapitalGains(CostMethod.MOVING_AVERAGE).getCapitalGains(),
                         is(Money.of("EUR", 8771L)));
         assertThat(record.getUnrealizedCapitalGains(CostMethod.MOVING_AVERAGE).getForexCaptialGains(),

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculation.java
@@ -1,5 +1,7 @@
 package name.abuchen.portfolio.snapshot.security;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -14,6 +16,7 @@ import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.TransactionOwner;
 import name.abuchen.portfolio.money.CurrencyConverter;
+import name.abuchen.portfolio.money.ExchangeRate;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MoneyCollectors;
 import name.abuchen.portfolio.money.Values;
@@ -26,9 +29,28 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
     {
         private long shares;
         private LocalDate date;
+
+        /**
+         * Lot cost basis in the term (reporting) currency.
+         */
         private long value;
 
+        /**
+         * Lot cost basis in the security's currency. Carried alongside
+         * {@link #value} so that the currency component can be derived from the
+         * exchange rate recorded on the transaction rather than the historic
+         * day rate of the exchange-rate provider - matching the moving-average
+         * sibling and {@code CostCalculation}.
+         */
+        private long valueForex;
+
         private final TrailRecord trail;
+
+        /**
+         * Trail for {@link #valueForex}, i.e. the cost basis in the security's
+         * currency.
+         */
+        private final TrailRecord forexTrail;
 
         /**
          * Holds the original number of shares (of the transaction). The
@@ -39,12 +61,15 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
 
         private final CalculationLineItem source;
 
-        public LineItem(long shares, LocalDate date, long value, TrailRecord trail, CalculationLineItem source)
+        public LineItem(long shares, LocalDate date, long value, long valueForex, TrailRecord trail,
+                        TrailRecord forexTrail, CalculationLineItem source)
         {
             this.shares = shares;
             this.date = Objects.requireNonNull(date);
             this.value = value;
+            this.valueForex = valueForex;
             this.trail = trail;
+            this.forexTrail = forexTrail;
             this.originalShares = shares;
             this.source = source;
         }
@@ -57,16 +82,22 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
     {
         SecurityPosition position = valuation.getSecurityPosition().orElseThrow(IllegalArgumentException::new);
 
-        Money value = valuation.getValue();
-        Money converted = value.with(converter.at(valuation.getDateTime()));
+        // the valuation is expressed in the security's currency
+        Money valueForex = valuation.getValue();
+        Money converted = valueForex.with(converter.at(valuation.getDateTime()));
 
-        TrailRecord trail = TrailRecord.ofPosition(valuation.getDateTime().toLocalDate(),
+        // the valuation carries no transaction exchange rate, hence the
+        // historic conversion at that date is correct for the term-currency
+        // basis
+
+        TrailRecord forexTrail = TrailRecord.ofPosition(valuation.getDateTime().toLocalDate(),
                         (Portfolio) valuation.getOwner(), position);
-        if (!value.getCurrencyCode().equals(converter.getTermCurrency()))
-            trail = trail.convert(converted, converter.getRate(valuation.getDateTime(), value.getCurrencyCode()));
+        TrailRecord trail = forexTrail;
+        if (!valueForex.getCurrencyCode().equals(converter.getTermCurrency()))
+            trail = trail.convert(converted, converter.getRate(valuation.getDateTime(), valueForex.getCurrencyCode()));
 
-        fifo.add(new LineItem(position.getShares(), valuation.getDateTime().toLocalDate(), converted.getAmount(), trail,
-                        valuation));
+        fifo.add(new LineItem(position.getShares(), valuation.getDateTime().toLocalDate(), converted.getAmount(),
+                        valueForex.getAmount(), trail, forexTrail, valuation));
     }
 
     @Override
@@ -74,26 +105,38 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
                     PortfolioTransaction t)
     {
         String termCurrency = getTermCurrency();
+        String securityCurrency = t.getSecurity().getCurrencyCode();
+
         Money grossValue = t.getGrossValue();
-        Money convertedGrossValue = grossValue.with(converter.at(t.getDateTime()));
+
+        // prefer the exchange rate recorded on the transaction (via
+        // getGrossValue(converter)) over the historic day rate of the
+        // exchange-rate provider, in both the term and the security currency
+        Money termBasis = t.getGrossValue(converter);
+        Money forexBasis = t.getGrossValue(converter.with(securityCurrency));
 
         TrailRecord txTrail = TrailRecord.ofTransaction(t).asGrossValue(grossValue);
-        if (!grossValue.getCurrencyCode().equals(converter.getTermCurrency()))
-            txTrail = txTrail.convert(convertedGrossValue, converter
-                            .getRate(transactionItem.getDateTime().toLocalDate(), grossValue.getCurrencyCode()));
+        if (!grossValue.getCurrencyCode().equals(termCurrency))
+            txTrail = txTrail.convert(termBasis, impliedRate(grossValue, termBasis, t.getDateTime().toLocalDate()));
+
+        TrailRecord forexTxTrail = TrailRecord.ofTransaction(t).asGrossValue(grossValue);
+        if (!grossValue.getCurrencyCode().equals(securityCurrency))
+            forexTxTrail = forexTxTrail.convert(forexBasis,
+                            impliedRate(grossValue, forexBasis, t.getDateTime().toLocalDate()));
 
         switch (t.getType())
         {
             case BUY:
             case DELIVERY_INBOUND:
-                fifo.add(new LineItem(t.getShares(), t.getDateTime().toLocalDate(), convertedGrossValue.getAmount(),
-                                txTrail, transactionItem));
+                fifo.add(new LineItem(t.getShares(), t.getDateTime().toLocalDate(), termBasis.getAmount(),
+                                forexBasis.getAmount(), txTrail, forexTxTrail, transactionItem));
                 break;
 
             case SELL:
             case DELIVERY_OUTBOUND:
 
-                long value = convertedGrossValue.getAmount();
+                long value = termBasis.getAmount();
+                long valueForex = forexBasis.getAmount();
 
                 long sold = t.getShares();
 
@@ -110,6 +153,7 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
 
                     long soldShares = Math.min(sold, item.shares);
                     long start = Math.round((double) soldShares / item.shares * item.value);
+                    long startForex = Math.round((double) soldShares / item.shares * item.valueForex);
                     long end = Math.round((double) soldShares / t.getShares() * value);
 
                     TrailRecord startTrail = item.trail.fraction(Money.of(termCurrency, start), soldShares,
@@ -118,24 +162,34 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
                     long forexGain = 0L;
                     TrailRecord forexGainTrail = TrailRecord.empty();
 
-                    if (!termCurrency.equals(t.getSecurity().getCurrencyCode()))
+                    // valueForex can be zero because an outbound delivery can
+                    // be zero value
+                    if (!termCurrency.equals(securityCurrency) && valueForex != 0)
                     {
-                        // calculate currency gains (if the security is
-                        // traded in forex) by converting the start value to
-                        // forex and converting it back with the exchange
-                        // rate at the end of the period (equivalent to
-                        // holding the money as cash in forex currency)
+                        // calculate currency gains as the relieved cost basis
+                        // in the security currency, valued at the exchange rate
+                        // recorded on the sale transaction, less the relieved
+                        // cost basis in the term currency (equivalent to
+                        // holding the money as cash in the security's
+                        // currency).
 
-                        CurrencyConverter convert2forex = converter.with(t.getSecurity().getCurrencyCode());
+                        // derive the exchange rate from netAmount /
+                        // netAmountForex because a) we want the actual exchange
+                        // rate of the transaction and b) the account currency
+                        // might be different than the reporting currency
 
-                        Money forex = convert2forex.convert(item.date, Money.of(termCurrency, start));
-                        Money back = forex.with(converter.at(t.getDateTime()));
-                        forexGain = back.getAmount() - start;
+                        BigDecimal exchangeRate = BigDecimal.valueOf(value).divide(BigDecimal.valueOf(valueForex),
+                                        Values.MC);
 
-                        forexGainTrail = startTrail //
-                                        .convert(forex, convert2forex.getRate(item.date, termCurrency)) //
-                                        .convert(back, converter.getRate(t.getDateTime(),
-                                                        t.getSecurity().getCurrencyCode()))
+                        long relievedForexInTerm = BigDecimal.valueOf(startForex).multiply(exchangeRate)
+                                        .setScale(0, RoundingMode.HALF_DOWN).longValue();
+                        forexGain = relievedForexInTerm - start;
+
+                        forexGainTrail = item.forexTrail
+                                        .fraction(Money.of(securityCurrency, startForex), soldShares,
+                                                        item.originalShares)
+                                        .convert(Money.of(termCurrency, relievedForexInTerm),
+                                                        new ExchangeRate(t.getDateTime().toLocalDate(), exchangeRate))
                                         .subtract(startTrail);
                     }
 
@@ -148,6 +202,7 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
 
                     item.shares -= soldShares;
                     item.value -= start;
+                    item.valueForex -= startForex;
 
                     sold -= soldShares;
                 }
@@ -180,13 +235,21 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
                         continue;
 
                     long n = Math.min(moved, entry.shares);
-                    
-                    long transferredValue = Math.round(n / (double) entry.shares * entry.value);                    
+
+                    long transferredValue = Math.round(n / (double) entry.shares * entry.value);
+                    long transferredValueForex = Math.round(n / (double) entry.shares * entry.valueForex);
                     LineItem transfer = new LineItem(n, t.getDateTime().toLocalDate(), transferredValue,
-                                    entry.trail.fraction(
-                                                    Money.of(getTermCurrency(), transferredValue),
-                                                    n,
-                                                    entry.originalShares
+                                    transferredValueForex, //
+                                    entry.trail.fraction( //
+                                                    Money.of(termCurrency, transferredValue), //
+                                                    n, //
+                                                    entry.originalShares //
+                                    ).transfer(t.getDateTime().toLocalDate(), entry.source.getOwner(),
+                                                    transactionItem.getOwner()),
+                                    entry.forexTrail.fraction( //
+                                                    Money.of(securityCurrency, transferredValueForex), //
+                                                    n, //
+                                                    entry.originalShares //
                                     ).transfer(t.getDateTime().toLocalDate(), entry.source.getOwner(),
                                                     transactionItem.getOwner()),
                                     transactionItem);
@@ -199,6 +262,7 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
                     else
                     {
                         entry.value -= transferredValue;
+                        entry.valueForex -= transferredValueForex;
                         entry.shares -= n;
 
                         fifo.add(fifo.indexOf(entry) + 1, transfer);
@@ -234,6 +298,7 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
         // up the trails into very many fractions
 
         String termCurrency = getTermCurrency();
+        String securityCurrency = getSecurity().getCurrencyCode();
 
         List<CalculationLineItem.ValuationAtEnd> valuationsAtEnd = lineItems.stream()
                         .filter(item -> item instanceof CalculationLineItem.ValuationAtEnd)
@@ -265,10 +330,17 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
         // starting valuation (based on open line items)
 
         long start = fifo.stream().mapToLong(item -> item.value).sum();
+        long startForex = fifo.stream().mapToLong(item -> item.valueForex).sum();
 
         TrailRecord startTrail = TrailRecord.of(fifo.stream() //
                         .filter(item -> item.shares != 0).map(item -> item.trail
                                         .fraction(Money.of(termCurrency, item.value), item.shares, item.originalShares))
+                        .collect(Collectors.toList()));
+
+        TrailRecord startForexTrail = TrailRecord.of(fifo.stream() //
+                        .filter(item -> item.shares != 0)
+                        .map(item -> item.forexTrail.fraction(Money.of(securityCurrency, item.valueForex), item.shares,
+                                        item.originalShares))
                         .collect(Collectors.toList()));
 
         // end value (based on the security positions)
@@ -284,50 +356,37 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
                                         item.getSecurityPosition().orElseThrow(IllegalArgumentException::new)))
                         .collect(Collectors.toList()));
 
+        // the valuation at the end carries no transaction exchange rate, hence
+        // the historic conversion at that date is correct
+
         Money convertedEndValue = endValue.with(converter.at(valuationAtEndDate));
         if (!endValue.getCurrencyCode().equals(converter.getTermCurrency()))
             endTrail = endTrail.convert(convertedEndValue,
                             converter.getRate(valuationAtEndDate, endValue.getCurrencyCode()));
 
         long end = convertedEndValue.getAmount();
+        long endForex = endValue.getAmount();
         long forexGain = 0L;
         TrailRecord forexGainTrail = TrailRecord.empty();
 
-        if (!termCurrency.equals(getSecurity().getCurrencyCode()))
+        // endForex can be zero if there is no holding value at the end
+        if (!termCurrency.equals(securityCurrency) && endForex != 0)
         {
-            // calculate forex gains: use exchange rate of
-            // each date of investment
+            // calculate currency gains as the accumulated cost basis of the
+            // still-open lots in the security currency, valued at the closing
+            // exchange rate, less the accumulated cost basis in the term
+            // currency - mirroring the realized calculation, but with the
+            // closing valuation providing the rate
 
-            CurrencyConverter convert2Forex = converter.with(getSecurity().getCurrencyCode());
+            BigDecimal exchangeRate = BigDecimal.valueOf(end).divide(BigDecimal.valueOf(endForex), Values.MC);
 
-            Money forex = fifo.stream() //
-                            .filter(item -> item.value != 0) //
-                            .map(item -> convert2Forex.convert(item.date, Money.of(termCurrency, item.value)))
-                            .collect(MoneyCollectors.sum(getSecurity().getCurrencyCode()));
+            long forexInTerm = BigDecimal.valueOf(startForex).multiply(exchangeRate).setScale(0, RoundingMode.HALF_DOWN)
+                            .longValue();
+            forexGain = forexInTerm - start;
 
-            Money back = forex.with(converter.at(valuationAtEndDate));
-
-            forexGain = back.getAmount() - start;
-
-            // collect all start values and convert to forex
-            // using the start date
-
-            forexGainTrail = TrailRecord.of(fifo.stream() //
-                            .filter(item -> item.value != 0) //
-                            .map(item -> item.trail
-                                            .fraction(Money.of(termCurrency, item.value), item.shares,
-                                                            item.originalShares)
-                                            .convert(convert2Forex.convert(item.date,
-                                                            Money.of(termCurrency, item.value)),
-                                                            convert2Forex.getRate(item.date, termCurrency)))
-                            .collect(Collectors.toList()));
-
-            // convert the forex amount back with the
-            // exchange rate at the end (=snapshot end) and
-            // subtract start value
-
-            forexGainTrail = forexGainTrail
-                            .convert(back, converter.getRate(valuationAtEndDate, getSecurity().getCurrencyCode()))
+            forexGainTrail = startForexTrail
+                            .convert(Money.of(termCurrency, forexInTerm),
+                                            new ExchangeRate(valuationAtEndDate.toLocalDate(), exchangeRate))
                             .subtract(startTrail);
         }
 
@@ -335,8 +394,21 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
         unrealizedCapitalGains.addCapitalGainsTrail(endTrail.subtract(startTrail));
         unrealizedCapitalGains.addForexCaptialGains(Money.of(termCurrency, forexGain));
         unrealizedCapitalGains.addForexCapitalGainsTrail(forexGainTrail);
-        
+
         fifo.clear();
+    }
+
+    /**
+     * Derives the exchange rate implied by two amounts (from {@code from} to
+     * {@code to}). Used to label the conversion step of a trail so that the
+     * rate shown is the one actually applied to the value rather than the
+     * historic day rate.
+     */
+    private static ExchangeRate impliedRate(Money from, Money to, LocalDate date)
+    {
+        BigDecimal rate = from.getAmount() == 0 ? BigDecimal.ONE
+                        : BigDecimal.valueOf(to.getAmount()).divide(BigDecimal.valueOf(from.getAmount()), Values.MC);
+        return new ExchangeRate(date, rate);
     }
 
     private void squashForexValuationsAtStart(CurrencyConverter converter)
@@ -368,16 +440,17 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
                         .collect(MoneyCollectors.sum(getSecurity().getCurrencyCode()));
         Money converted = value.with(converter.at(valuationAtStartDate));
 
-        TrailRecord trail = TrailRecord.of(itemsToSquash.stream()
+        TrailRecord forexTrail = TrailRecord.of(itemsToSquash.stream()
                         .map(item -> TrailRecord.ofPosition(valuationAtStartDate.toLocalDate(),
                                         (Portfolio) item.source.getOwner(),
                                         item.source.getSecurityPosition().orElseThrow(IllegalArgumentException::new)))
                         .collect(Collectors.toList()));
 
-        trail = trail.convert(converted, converter.getRate(valuationAtStartDate, value.getCurrencyCode()));
+        TrailRecord trail = forexTrail.convert(converted,
+                        converter.getRate(valuationAtStartDate, value.getCurrencyCode()));
 
-        LineItem replacement = new LineItem(shares, valuationAtStartDate.toLocalDate(), converted.getAmount(), trail,
-                        null);
+        LineItem replacement = new LineItem(shares, valuationAtStartDate.toLocalDate(), converted.getAmount(),
+                        value.getAmount(), trail, forexTrail, null);
 
         fifo.removeAll(itemsToSquash);
         fifo.add(0, replacement);


### PR DESCRIPTION
CapitalGainsCalculation (FIFO) converted a trade into the reporting currency with the historic day rate of the exchange-rate provider, while its moving-average sibling and CostCalculation both prefer the exchange rate recorded on the transaction. For a foreign security bought through an account in a third currency, the FIFO figures therefore disagreed with the moving-average figures and the cost basis when reported in the security's own currency.

Carry the lot cost basis in both the term and the security currency and derive the currency component from the transaction rate (via getGrossValue(converter)) rather than round-tripping through the rate provider, matching CapitalGainsCalculationMovingAverage. Valuations, squashForexValuationsAtStart, the TRANSFER branches and CostCalculation are left unchanged.

The realized/unrealized currency components now equal the moving-average figures on a single-lot portfolio. Two guard tests pinned the previous FIFO forex sub-component and are updated accordingly; the reconciling totals are unchanged.

Closes #5908