### PR TITLE
Let capital gains be measured against a fee-inclusive cost basis

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationTest.java
@@ -19,10 +19,14 @@ import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransferEntry;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.snapshot.trades.Trade;
+import name.abuchen.portfolio.snapshot.trades.TradeCollector;
+import name.abuchen.portfolio.snapshot.trades.TradeCollectorException;
 import name.abuchen.portfolio.util.Interval;
 
 @SuppressWarnings("nls")
@@ -313,5 +317,170 @@ public class CapitalGainsCalculationTest
 
         assertThat(unrealizedFifo.getForexCaptialGains(), //
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0))));
+    }
+
+    /**
+     * Safeguards the {@link TaxesAndFees#INCLUDED} cost basis: with a purchase
+     * and a sale carrying taxes and fees inside the reporting period, the gains
+     * measured against the fee-inclusive basis must differ from the ex-fee
+     * basis by exactly those embedded charges, on both the FIFO and the
+     * moving-average engine. Crucially the fee-inclusive unrealized gains have
+     * to reconcile with
+     * {@link LazySecurityPerformanceRecord#getCapitalGainsOnHoldings} - i.e.
+     * subtract cleanly from the cost basis reported next to them - which is the
+     * mismatch this change fixes.
+     */
+    @Test
+    public void testCapitalGainsAgainstFeeInclusiveBasis()
+    {
+        var client = new Client();
+
+        Security security = new SecurityBuilder().addPrice("2024-01-01", Values.Quote.factorize(120)) //
+                        .addTo(client);
+
+        // buy inside the interval: pays 10100 including 80 fees + 20 taxes, so
+        // the ex-fee basis is 10000 (100/share) and the fee-inclusive basis is
+        // 10100 (101/share)
+        new PortfolioBuilder() //
+                        .buy(security, "2024-02-01", Values.Share.factorize(100), Values.Amount.factorize(10100),
+                                        Values.Amount.factorize(80), Values.Amount.factorize(20)) //
+                        // sell 40 inside the interval: receives 4550 net after
+                        // 30 fees + 20 taxes, so the gross proceeds are 4600
+                        .sell(security, "2024-03-01", Values.Share.factorize(40), Values.Amount.factorize(4550),
+                                        Values.Amount.factorize(30), Values.Amount.factorize(20)) //
+                        .addTo(client);
+
+        var interval = Interval.of(LocalDate.parse("2023-12-31"), LocalDate.parse("2024-12-31"));
+        LazySecurityPerformanceSnapshot snapshot = LazySecurityPerformanceSnapshot.create(client,
+                        new TestCurrencyConverter(), interval);
+        LazySecurityPerformanceRecord record = snapshot.getRecord(security).orElseThrow(IllegalArgumentException::new);
+
+        // 60 shares remain, valued at 60 * 120 = 7200
+
+        // single buy lot, so FIFO and moving average coincide - both engines
+        // are exercised through the loop
+        for (var method : new CostMethod[] { CostMethod.FIFO, CostMethod.MOVING_AVERAGE })
+        {
+            // realized, ex-fee: gross proceeds - relieved gross cost
+            // 4600 - (40/100) * 10000 = 600
+            var realizedExFee = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(600));
+            assertThat(record.getRealizedCapitalGains(method).getCapitalGains(), is(realizedExFee));
+            assertThat(record.getRealizedCapitalGains(method, TaxesAndFees.NOT_INCLUDED).getCapitalGains(),
+                            is(realizedExFee));
+
+            // realized, fee-inclusive: net proceeds - relieved fee-inclusive
+            // cost
+            // 4550 - (40/100) * 10100 = 510
+            // differs from the ex-fee gains by the sale's 50 charges plus the
+            // relieved 40 of the buy's charges
+            assertThat(record.getRealizedCapitalGains(method, TaxesAndFees.INCLUDED).getCapitalGains(),
+                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(510))));
+
+            // unrealized, ex-fee: market value - remaining gross cost
+            // 7200 - (60/100) * 10000 = 1200
+            var unrealizedExFee = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1200));
+            assertThat(record.getUnrealizedCapitalGains(method).getCapitalGains(), is(unrealizedExFee));
+            assertThat(record.getUnrealizedCapitalGains(method, TaxesAndFees.NOT_INCLUDED).getCapitalGains(),
+                            is(unrealizedExFee));
+
+            // unrealized, fee-inclusive: market value - remaining fee-inclusive
+            // cost
+            // 7200 - (60/100) * 10100 = 1140
+            var unrealizedInclusive = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1140));
+            assertThat(record.getUnrealizedCapitalGains(method, TaxesAndFees.INCLUDED).getCapitalGains(),
+                            is(unrealizedInclusive));
+
+            // the reconciliation this change is about: the fee-inclusive
+            // unrealized gains subtract cleanly from the fee-inclusive cost
+            // reported next to them (market value - cost with charges)
+            assertThat(record.getUnrealizedCapitalGains(method, TaxesAndFees.INCLUDED).getCapitalGains(),
+                            is(record.getCapitalGainsOnHoldings(method)));
+            assertThat(record.getCapitalGainsOnHoldings(method), is(unrealizedInclusive));
+        }
+    }
+
+    /**
+     * Reconciles the two cost bases against the second engine that computes the
+     * very same figures: a closed {@link Trade} reports its profit and loss
+     * both including the taxes and fees embedded in its trades
+     * ({@link Trade#getProfitLoss()}) and without them
+     * ({@link Trade#getProfitLossWithoutTaxesAndFees()}), which must be the
+     * realized capital gains measured against the fee-inclusive and the ex-fee
+     * basis respectively.
+     * <p>
+     * The comparison only holds under three conditions, hence the scenario
+     * below: the trade has to be closed, because {@link Trade} values an open
+     * position at today's price instead of at the end of the reporting period;
+     * the reporting period has to span the entire history, because the capital
+     * gains are scoped to the interval while the trade is not; and the
+     * scenario has to be single-currency, because {@link Trade} converts with
+     * the historic day rate whereas the capital gains use the exchange rate
+     * recorded on the transaction itself.
+     */
+    @Test
+    public void testTradeProfitLossMatchesRealizedCapitalGains() throws TradeCollectorException
+    {
+        var client = new Client();
+
+        Security security = new SecurityBuilder().addPrice("2024-01-01", Values.Quote.factorize(120)) //
+                        .addTo(client);
+
+        // buy: pays 10100 including 80 fees + 20 taxes, so the ex-fee basis is
+        // 10000; sell all of it: receives 11400 net after 60 fees + 40 taxes,
+        // so the gross proceeds are 11500
+        new PortfolioBuilder() //
+                        .buy(security, "2024-02-01", Values.Share.factorize(100), Values.Amount.factorize(10100),
+                                        Values.Amount.factorize(80), Values.Amount.factorize(20)) //
+                        .sell(security, "2024-03-01", Values.Share.factorize(100), Values.Amount.factorize(11400),
+                                        Values.Amount.factorize(60), Values.Amount.factorize(40)) //
+                        .addTo(client);
+
+        var converter = new TestCurrencyConverter();
+
+        var trades = new TradeCollector(client, converter).collect(security);
+        assertThat(trades.size(), is(1));
+
+        Trade trade = trades.get(0);
+        assertThat(trade.getEnd().isPresent(), is(true));
+
+        var interval = Interval.of(LocalDate.parse("2023-12-31"), LocalDate.parse("2024-12-31"));
+        LazySecurityPerformanceRecord record = LazySecurityPerformanceSnapshot.create(client, converter, interval)
+                        .getRecord(security).orElseThrow(IllegalArgumentException::new);
+
+        // 11500 - 10000 = 1500
+        var gainsExFee = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1500));
+        // 11400 - 10100 = 1300, i.e. less by the 200 of charges on both legs
+        var gainsInclusive = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1300));
+
+        assertThat(trade.getProfitLossWithoutTaxesAndFees(), is(gainsExFee));
+        assertThat(trade.getProfitLoss(), is(gainsInclusive));
+
+        // a single lot bought and sold in one go, so FIFO and moving average
+        // arrive at the same figures - both engines are exercised through the
+        // loop
+        for (var method : new CostMethod[] { CostMethod.FIFO, CostMethod.MOVING_AVERAGE })
+        {
+            assertThat(record.getRealizedCapitalGains(method, TaxesAndFees.NOT_INCLUDED).getCapitalGains(),
+                            is(gainsExFee));
+            assertThat(record.getRealizedCapitalGains(method, TaxesAndFees.INCLUDED).getCapitalGains(),
+                            is(gainsInclusive));
+
+            // nothing held at the end, hence the trade's profit and loss is
+            // realized in full and nothing may leak into the unrealized gains
+            assertThat(record.getUnrealizedCapitalGains(method, TaxesAndFees.NOT_INCLUDED).getCapitalGains(),
+                            is(Money.of(CurrencyUnit.EUR, 0)));
+            assertThat(record.getUnrealizedCapitalGains(method, TaxesAndFees.INCLUDED).getCapitalGains(),
+                            is(Money.of(CurrencyUnit.EUR, 0)));
+        }
+
+        assertThat(record.getRealizedCapitalGains(CostMethod.FIFO, TaxesAndFees.NOT_INCLUDED).getCapitalGains(),
+                        is(trade.getProfitLossWithoutTaxesAndFees()));
+        assertThat(record.getRealizedCapitalGains(CostMethod.FIFO, TaxesAndFees.INCLUDED).getCapitalGains(),
+                        is(trade.getProfitLoss()));
+
+        assertThat(record.getRealizedCapitalGains(CostMethod.MOVING_AVERAGE, TaxesAndFees.NOT_INCLUDED)
+                        .getCapitalGains(), is(trade.getProfitLossMovingAverageWithoutTaxesAndFees()));
+        assertThat(record.getRealizedCapitalGains(CostMethod.MOVING_AVERAGE, TaxesAndFees.INCLUDED).getCapitalGains(),
+                        is(trade.getProfitLossMovingAverage()));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationTest.java
@@ -19,6 +19,7 @@ import name.abuchen.portfolio.model.CostMethod;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransferEntry;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
@@ -313,5 +314,85 @@ public class CapitalGainsCalculationTest
 
         assertThat(unrealizedFifo.getForexCaptialGains(), //
                         is(Money.of(CurrencyUnit.USD, Values.Amount.factorize(0))));
+    }
+
+    /**
+     * Safeguards the {@link TaxesAndFees#INCLUDED} cost basis: with a purchase
+     * and a sale carrying taxes and fees inside the reporting period, the gains
+     * measured against the fee-inclusive basis must differ from the ex-fee
+     * basis by exactly those embedded charges, on both the FIFO and the
+     * moving-average engine. Crucially the fee-inclusive unrealized gains have
+     * to reconcile with
+     * {@link LazySecurityPerformanceRecord#getCapitalGainsOnHoldings} - i.e.
+     * subtract cleanly from the cost basis reported next to them - which is the
+     * mismatch this change fixes.
+     */
+    @Test
+    public void testCapitalGainsAgainstFeeInclusiveBasis()
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder().addPrice("2024-01-01", Values.Quote.factorize(120)) //
+                        .addTo(client);
+
+        // buy inside the interval: pays 10100 including 80 fees + 20 taxes, so
+        // the ex-fee basis is 10000 (100/share) and the fee-inclusive basis is
+        // 10100 (101/share)
+        new PortfolioBuilder() //
+                        .buy(security, "2024-02-01", Values.Share.factorize(100), Values.Amount.factorize(10100),
+                                        Values.Amount.factorize(80), Values.Amount.factorize(20)) //
+                        // sell 40 inside the interval: receives 4550 net after
+                        // 30 fees + 20 taxes, so the gross proceeds are 4600
+                        .sell(security, "2024-03-01", Values.Share.factorize(40), Values.Amount.factorize(4550),
+                                        Values.Amount.factorize(30), Values.Amount.factorize(20)) //
+                        .addTo(client);
+
+        var interval = Interval.of(LocalDate.parse("2023-12-31"), LocalDate.parse("2024-12-31"));
+        LazySecurityPerformanceSnapshot snapshot = LazySecurityPerformanceSnapshot.create(client,
+                        new TestCurrencyConverter(), interval);
+        LazySecurityPerformanceRecord record = snapshot.getRecord(security).orElseThrow(IllegalArgumentException::new);
+
+        // 60 shares remain, valued at 60 * 120 = 7200
+
+        // single buy lot, so FIFO and moving average coincide - both engines
+        // are exercised through the loop
+        for (var method : new CostMethod[] { CostMethod.FIFO, CostMethod.MOVING_AVERAGE })
+        {
+            // realized, ex-fee: gross proceeds - relieved gross cost
+            // 4600 - (40/100) * 10000 = 600
+            var realizedExFee = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(600));
+            assertThat(record.getRealizedCapitalGains(method).getCapitalGains(), is(realizedExFee));
+            assertThat(record.getRealizedCapitalGains(method, TaxesAndFees.NOT_INCLUDED).getCapitalGains(),
+                            is(realizedExFee));
+
+            // realized, fee-inclusive: net proceeds - relieved fee-inclusive
+            // cost
+            // 4550 - (40/100) * 10100 = 510
+            // differs from the ex-fee gains by the sale's 50 charges plus the
+            // relieved 40 of the buy's charges
+            assertThat(record.getRealizedCapitalGains(method, TaxesAndFees.INCLUDED).getCapitalGains(),
+                            is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(510))));
+
+            // unrealized, ex-fee: market value - remaining gross cost
+            // 7200 - (60/100) * 10000 = 1200
+            var unrealizedExFee = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1200));
+            assertThat(record.getUnrealizedCapitalGains(method).getCapitalGains(), is(unrealizedExFee));
+            assertThat(record.getUnrealizedCapitalGains(method, TaxesAndFees.NOT_INCLUDED).getCapitalGains(),
+                            is(unrealizedExFee));
+
+            // unrealized, fee-inclusive: market value - remaining fee-inclusive
+            // cost
+            // 7200 - (60/100) * 10100 = 1140
+            var unrealizedInclusive = Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1140));
+            assertThat(record.getUnrealizedCapitalGains(method, TaxesAndFees.INCLUDED).getCapitalGains(),
+                            is(unrealizedInclusive));
+
+            // the reconciliation this change is about: the fee-inclusive
+            // unrealized gains subtract cleanly from the fee-inclusive cost
+            // reported next to them (market value - cost with charges)
+            assertThat(record.getUnrealizedCapitalGains(method, TaxesAndFees.INCLUDED).getCapitalGains(),
+                            is(record.getCapitalGainsOnHoldings(method)));
+            assertThat(record.getCapitalGainsOnHoldings(method), is(unrealizedInclusive));
+        }
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/Calculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/Calculation.java
@@ -108,17 +108,26 @@ import name.abuchen.portfolio.money.CurrencyConverter;
     {
         try
         {
-            T thing = type.getDeclaredConstructor().newInstance();
-            thing.setSecurity(security);
-            thing.setTermCurrency(converter.getTermCurrency());
-            thing.prepare();
-            thing.visitAll(converter, lineItems);
-            thing.finish(converter, lineItems);
-            return thing;
+            return perform(type.getDeclaredConstructor().newInstance(), converter, security, lineItems);
         }
         catch (Exception e)
         {
             throw new UnsupportedOperationException(e);
         }
+    }
+
+    /**
+     * Runs an already constructed calculation, for the calculations that are
+     * parameterized and hence cannot be created from a no-argument constructor.
+     */
+    public static <T extends Calculation> T perform(T calculation, CurrencyConverter converter, Security security,
+                    List<CalculationLineItem> lineItems)
+    {
+        calculation.setSecurity(security);
+        calculation.setTermCurrency(converter.getTermCurrency());
+        calculation.prepare();
+        calculation.visitAll(converter, lineItems);
+        calculation.finish(converter, lineItems);
+        return calculation;
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculation.java
@@ -14,6 +14,7 @@ import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.PortfolioLog;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.TransactionOwner;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.ExchangeRate;
@@ -77,6 +78,20 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
 
     private List<LineItem> fifo = new ArrayList<>();
 
+    private final TaxesAndFees taxesAndFees;
+
+    /**
+     * Measures gains against the cost basis with or without the taxes and fees
+     * embedded in a trade. {@link TaxesAndFees#NOT_INCLUDED} is the basis
+     * {@link name.abuchen.portfolio.snapshot.ClientPerformanceSnapshot} needs,
+     * because it carries fees and taxes as separate terms of its breakdown and
+     * would otherwise subtract them twice.
+     */
+    public CapitalGainsCalculation(TaxesAndFees taxesAndFees)
+    {
+        this.taxesAndFees = taxesAndFees;
+    }
+
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.ValuationAtStart valuation)
     {
@@ -107,22 +122,33 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
         String termCurrency = getTermCurrency();
         String securityCurrency = t.getSecurity().getCurrencyCode();
 
-        Money grossValue = t.getGrossValue();
+        // the lot basis: the gross value leaves out the taxes and fees embedded
+        // in the trade, the monetary amount takes them in. The selection applies
+        // to both legs of a trade - a sale's gross value is the proceeds
+        // *before* the charges are deducted, so relieving a fee-inclusive lot
+        // against it would book the charges as a gain
+        var basis = taxesAndFees.isIncluded() ? t.getMonetaryAmount() : t.getGrossValue();
 
         // prefer the exchange rate recorded on the transaction (via
-        // getGrossValue(converter)) over the historic day rate of the
-        // exchange-rate provider, in both the term and the security currency
-        Money termBasis = t.getGrossValue(converter);
-        Money forexBasis = t.getGrossValue(converter.with(securityCurrency));
+        // getGrossValue/getMonetaryAmount(converter)) over the historic day rate
+        // of the exchange-rate provider, in both the term and the security
+        // currency
+        var termBasis = taxesAndFees.isIncluded() ? t.getMonetaryAmount(converter) : t.getGrossValue(converter);
+        var forexBasis = taxesAndFees.isIncluded() ? t.getMonetaryAmount(converter.with(securityCurrency))
+                        : t.getGrossValue(converter.with(securityCurrency));
 
-        TrailRecord txTrail = TrailRecord.ofTransaction(t).asGrossValue(grossValue);
-        if (!grossValue.getCurrencyCode().equals(termCurrency))
-            txTrail = txTrail.convert(termBasis, impliedRate(grossValue, termBasis, t.getDateTime().toLocalDate()));
+        // asGrossValue adds the "without taxes and fees" step only when the
+        // basis differs from the transaction's own amount, hence it collapses
+        // to nothing under TaxesAndFees.INCLUDED
 
-        TrailRecord forexTxTrail = TrailRecord.ofTransaction(t).asGrossValue(grossValue);
-        if (!grossValue.getCurrencyCode().equals(securityCurrency))
+        TrailRecord txTrail = TrailRecord.ofTransaction(t).asGrossValue(basis);
+        if (!basis.getCurrencyCode().equals(termCurrency))
+            txTrail = txTrail.convert(termBasis, impliedRate(basis, termBasis, t.getDateTime().toLocalDate()));
+
+        TrailRecord forexTxTrail = TrailRecord.ofTransaction(t).asGrossValue(basis);
+        if (!basis.getCurrencyCode().equals(securityCurrency))
             forexTxTrail = forexTxTrail.convert(forexBasis,
-                            impliedRate(grossValue, forexBasis, t.getDateTime().toLocalDate()));
+                            impliedRate(basis, forexBasis, t.getDateTime().toLocalDate()));
 
         switch (t.getType())
         {
@@ -173,10 +199,10 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
                         // holding the money as cash in the security's
                         // currency).
 
-                        // derive the exchange rate from netAmount /
-                        // netAmountForex because a) we want the actual exchange
-                        // rate of the transaction and b) the account currency
-                        // might be different than the reporting currency
+                        // derive the exchange rate from value / valueForex
+                        // because a) we want the actual exchange rate of the
+                        // transaction and b) the account currency might be
+                        // different than the reporting currency
 
                         BigDecimal exchangeRate = BigDecimal.valueOf(value).divide(BigDecimal.valueOf(valueForex),
                                         Values.MC);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculation.java
@@ -14,6 +14,7 @@ import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.PortfolioLog;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.model.TransactionOwner;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.ExchangeRate;
@@ -77,6 +78,20 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
 
     private List<LineItem> fifo = new ArrayList<>();
 
+    private final TaxesAndFees taxesAndFees;
+
+    /**
+     * Measures gains against the cost basis with or without the taxes and fees
+     * embedded in a trade. {@link TaxesAndFees#NOT_INCLUDED} is the basis
+     * {@link name.abuchen.portfolio.snapshot.ClientPerformanceSnapshot} needs,
+     * because it carries fees and taxes as separate terms of its breakdown and
+     * would otherwise subtract them twice.
+     */
+    public CapitalGainsCalculation(TaxesAndFees taxesAndFees)
+    {
+        this.taxesAndFees = taxesAndFees;
+    }
+
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.ValuationAtStart valuation)
     {
@@ -107,22 +122,33 @@ import name.abuchen.portfolio.snapshot.trail.TrailRecord;
         String termCurrency = getTermCurrency();
         String securityCurrency = t.getSecurity().getCurrencyCode();
 
-        Money grossValue = t.getGrossValue();
+        // the lot basis: the gross value leaves out the taxes and fees embedded
+        // in the trade, the monetary amount takes them in. The selection applies
+        // to both legs of a trade - a sale's gross value is the proceeds
+        // *before* the charges are deducted, so relieving a fee-inclusive lot
+        // against it would book the charges as a gain
+        var basis = taxesAndFees.isIncluded() ? t.getMonetaryAmount() : t.getGrossValue();
 
         // prefer the exchange rate recorded on the transaction (via
-        // getGrossValue(converter)) over the historic day rate of the
-        // exchange-rate provider, in both the term and the security currency
-        Money termBasis = t.getGrossValue(converter);
-        Money forexBasis = t.getGrossValue(converter.with(securityCurrency));
+        // getGrossValue/getMonetaryAmount(converter)) over the historic day rate
+        // of the exchange-rate provider, in both the term and the security
+        // currency
+        var termBasis = taxesAndFees.isIncluded() ? t.getMonetaryAmount(converter) : t.getGrossValue(converter);
+        var forexBasis = taxesAndFees.isIncluded() ? t.getMonetaryAmount(converter.with(securityCurrency))
+                        : t.getGrossValue(converter.with(securityCurrency));
 
-        TrailRecord txTrail = TrailRecord.ofTransaction(t).asGrossValue(grossValue);
-        if (!grossValue.getCurrencyCode().equals(termCurrency))
-            txTrail = txTrail.convert(termBasis, impliedRate(grossValue, termBasis, t.getDateTime().toLocalDate()));
+        // asGrossValue adds the "without taxes and fees" step only when the
+        // basis differs from the transaction's own amount, hence it collapses
+        // to nothing under TaxesAndFees.INCLUDED
 
-        TrailRecord forexTxTrail = TrailRecord.ofTransaction(t).asGrossValue(grossValue);
-        if (!grossValue.getCurrencyCode().equals(securityCurrency))
+        TrailRecord txTrail = TrailRecord.ofTransaction(t).asGrossValue(basis);
+        if (!basis.getCurrencyCode().equals(termCurrency))
+            txTrail = txTrail.convert(termBasis, impliedRate(basis, termBasis, t.getDateTime().toLocalDate()));
+
+        TrailRecord forexTxTrail = TrailRecord.ofTransaction(t).asGrossValue(basis);
+        if (!basis.getCurrencyCode().equals(securityCurrency))
             forexTxTrail = forexTxTrail.convert(forexBasis,
-                            impliedRate(grossValue, forexBasis, t.getDateTime().toLocalDate()));
+                            impliedRate(basis, forexBasis, t.getDateTime().toLocalDate()));
 
         switch (t.getType())
         {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationMovingAverage.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationMovingAverage.java
@@ -9,6 +9,7 @@ import java.util.List;
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.PortfolioLog;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MoneyCollectors;
@@ -18,8 +19,22 @@ import name.abuchen.portfolio.snapshot.SecurityPosition;
 /* package */class CapitalGainsCalculationMovingAverage extends AbstractCapitalGainsCalculation
 {
     private long heldShares = 0;
-    private long movingAverageNetCost = 0;
-    private long movingAverageNetCostForex = 0;
+    private long movingAverageCost = 0;
+    private long movingAverageCostForex = 0;
+
+    private final TaxesAndFees taxesAndFees;
+
+    /**
+     * Measures gains against the cost basis with or without the taxes and fees
+     * embedded in a trade. {@link TaxesAndFees#NOT_INCLUDED} is the basis
+     * {@link name.abuchen.portfolio.snapshot.ClientPerformanceSnapshot} needs,
+     * because it carries fees and taxes as separate terms of its breakdown and
+     * would otherwise subtract them twice.
+     */
+    public CapitalGainsCalculationMovingAverage(TaxesAndFees taxesAndFees)
+    {
+        this.taxesAndFees = taxesAndFees;
+    }
 
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.ValuationAtStart valuation)
@@ -29,8 +44,8 @@ import name.abuchen.portfolio.snapshot.SecurityPosition;
         Money value = valuation.getValue();
         Money converted = value.with(converter.at(valuation.getDateTime()));
 
-        movingAverageNetCost += converted.getAmount();
-        movingAverageNetCostForex += value.getAmount();
+        movingAverageCost += converted.getAmount();
+        movingAverageCostForex += value.getAmount();
         heldShares += position.getShares();
     }
 
@@ -41,14 +56,20 @@ import name.abuchen.portfolio.snapshot.SecurityPosition;
         String termCurrency = getTermCurrency();
         String securityCurrency = getSecurity().getCurrencyCode();
 
-        long netAmountForex = t.getGrossValue(converter.with(securityCurrency)).getAmount();
-        long netAmount = t.getGrossValue(converter).getAmount();
+        // the basis: the gross value leaves out the taxes and fees embedded in
+        // the trade, the monetary amount takes them in - on both legs, as a
+        // sale's gross value is the proceeds before the charges are deducted
+        var forexBasis = taxesAndFees.isIncluded()
+                        ? t.getMonetaryAmount(converter.with(securityCurrency)).getAmount()
+                        : t.getGrossValue(converter.with(securityCurrency)).getAmount();
+        var termBasis = taxesAndFees.isIncluded() ? t.getMonetaryAmount(converter).getAmount()
+                        : t.getGrossValue(converter).getAmount();
 
         switch (t.getType())
         {
             case BUY, DELIVERY_INBOUND:
-                movingAverageNetCost += netAmount;
-                movingAverageNetCostForex += netAmountForex;
+                movingAverageCost += termBasis;
+                movingAverageCostForex += forexBasis;
                 heldShares += t.getShares();
                 break;
 
@@ -57,8 +78,8 @@ import name.abuchen.portfolio.snapshot.SecurityPosition;
                 long remaining = heldShares - sold;
                 if (remaining < 0)
                 {
-                    movingAverageNetCost = 0;
-                    movingAverageNetCostForex = 0;
+                    movingAverageCost = 0;
+                    movingAverageCostForex = 0;
                     heldShares = 0;
                     // FIXME Oops. More sold than bought.
                     PortfolioLog.warning(MessageFormat.format(Messages.MsgNegativeHoldingsDuringFIFOCostCalculation,
@@ -67,15 +88,15 @@ import name.abuchen.portfolio.snapshot.SecurityPosition;
                 }
                 else
                 {
-                    var averageCosts = Math.round(movingAverageNetCost / (double) heldShares * sold);
-                    var averageCostsForex = Math.round(movingAverageNetCostForex / (double) heldShares * sold);
+                    var averageCosts = Math.round(movingAverageCost / (double) heldShares * sold);
+                    var averageCostsForex = Math.round(movingAverageCostForex / (double) heldShares * sold);
 
-                    long gain = netAmount - averageCosts;
+                    long gain = termBasis - averageCosts;
                     long gainForex = 0L;
 
-                    // netAmountForex can be zero because an outbound delivery
-                    // can be zero value
-                    if (!termCurrency.equals(securityCurrency) && netAmountForex != 0)
+                    // forexBasis can be zero because an outbound delivery can
+                    // be zero value
+                    if (!termCurrency.equals(securityCurrency) && forexBasis != 0)
                     {
                         // Calculate currency gains as the difference between
                         // the average costs in the security currency with the
@@ -89,14 +110,14 @@ import name.abuchen.portfolio.snapshot.SecurityPosition;
                         // [average costs in USD] * [sale transaction exchange
                         // rate] - [average costs in EUR]
 
-                        // calculate the exchange rate out of netAmount /
-                        // netAmountForex because
+                        // calculate the exchange rate out of termBasis /
+                        // forexBasis because
                         // a) we want to take the actual exchange rate of the
                         // transaction and
                         // b) the account currency might be different that the
                         // reporting currency
 
-                        var exchangeRate = BigDecimal.valueOf(netAmount / (double) netAmountForex)
+                        var exchangeRate = BigDecimal.valueOf(termBasis / (double) forexBasis)
                                         .setScale(Values.MC.getPrecision(), Values.MC.getRoundingMode());
 
                         gainForex = BigDecimal.valueOf(averageCostsForex) //
@@ -107,8 +128,8 @@ import name.abuchen.portfolio.snapshot.SecurityPosition;
                     realizedCapitalGains.addCapitalGains(Money.of(termCurrency, gain));
                     realizedCapitalGains.addForexCaptialGains(Money.of(termCurrency, gainForex));
 
-                    movingAverageNetCost -= averageCosts;
-                    movingAverageNetCostForex -= averageCostsForex;
+                    movingAverageCost -= averageCosts;
+                    movingAverageCostForex -= averageCostsForex;
                     heldShares = remaining;
                 }
                 break;
@@ -150,22 +171,21 @@ import name.abuchen.portfolio.snapshot.SecurityPosition;
                         .collect(MoneyCollectors.sum(getSecurity().getCurrencyCode()));
         Money convertedEndValue = endValue.with(converter.at(valuationAtEndDate));
 
-        var netAmount = convertedEndValue.getAmount();
-        var netAmountForex = endValue.getAmount();
+        var endAmount = convertedEndValue.getAmount();
+        var endAmountForex = endValue.getAmount();
 
-        long gain = netAmount - movingAverageNetCost;
+        long gain = endAmount - movingAverageCost;
         long gainForex = 0L;
 
-        // netAmountForex can be zero because an outbound delivery can be zero
-        // value
-        if (!termCurrency.equals(securityCurrency) && netAmountForex != 0)
+        // endAmountForex can be zero if there is no holding value at the end
+        if (!termCurrency.equals(securityCurrency) && endAmountForex != 0)
         {
-            var exchangeRate = BigDecimal.valueOf(netAmount / (double) netAmountForex)
+            var exchangeRate = BigDecimal.valueOf(endAmount / (double) endAmountForex)
                             .setScale(Values.MC.getPrecision(), Values.MC.getRoundingMode());
 
-            gainForex = BigDecimal.valueOf(movingAverageNetCostForex) //
+            gainForex = BigDecimal.valueOf(movingAverageCostForex) //
                             .multiply(exchangeRate) //
-                            .subtract(BigDecimal.valueOf(movingAverageNetCost)) //
+                            .subtract(BigDecimal.valueOf(movingAverageCost)) //
                             .setScale(0, RoundingMode.HALF_DOWN).longValue();
         }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationMovingAverage.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/CapitalGainsCalculationMovingAverage.java
@@ -9,6 +9,7 @@ import java.util.List;
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.PortfolioLog;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.TaxesAndFees;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MoneyCollectors;
@@ -20,6 +21,20 @@ import name.abuchen.portfolio.snapshot.SecurityPosition;
     private long heldShares = 0;
     private long movingAverageNetCost = 0;
     private long movingAverageNetCostForex = 0;
+
+    private final TaxesAndFees taxesAndFees;
+
+    /**
+     * Measures gains against the cost basis with or without the taxes and fees
+     * embedded in a trade. {@link TaxesAndFees#NOT_INCLUDED} is the basis
+     * {@link name.abuchen.portfolio.snapshot.ClientPerformanceSnapshot} needs,
+     * because it carries fees and taxes as separate terms of its breakdown and
+     * would otherwise subtract them twice.
+     */
+    public CapitalGainsCalculationMovingAverage(TaxesAndFees taxesAndFees)
+    {
+        this.taxesAndFees = taxesAndFees;
+    }
 
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.ValuationAtStart valuation)
@@ -41,8 +56,14 @@ import name.abuchen.portfolio.snapshot.SecurityPosition;
         String termCurrency = getTermCurrency();
         String securityCurrency = getSecurity().getCurrencyCode();
 
-        long netAmountForex = t.getGrossValue(converter.with(securityCurrency)).getAmount();
-        long netAmount = t.getGrossValue(converter).getAmount();
+        // the basis: the gross value leaves out the taxes and fees embedded in
+        // the trade, the monetary amount takes them in - on both legs, as a
+        // sale's gross value is the proceeds before the charges are deducted
+        var netAmountForex = taxesAndFees.isIncluded()
+                        ? t.getMonetaryAmount(converter.with(securityCurrency)).getAmount()
+                        : t.getGrossValue(converter.with(securityCurrency)).getAmount();
+        var netAmount = taxesAndFees.isIncluded() ? t.getMonetaryAmount(converter).getAmount()
+                        : t.getGrossValue(converter).getAmount();
 
         switch (t.getType())
         {

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
@@ -175,11 +175,26 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
     });
 
     private final LazyValue<CapitalGainsCalculation> capitalGains = new LazyValue<>(
-                    () -> Calculation.perform(CapitalGainsCalculation.class, converter, security, lineItems));
+                    () -> Calculation.perform(new CapitalGainsCalculation(TaxesAndFees.NOT_INCLUDED), converter,
+                                    security, lineItems));
 
     private final LazyValue<CapitalGainsCalculationMovingAverage> capitalGainsMovingAvg = new LazyValue<>(
-                    () -> Calculation.perform(CapitalGainsCalculationMovingAverage.class, converter, security,
+                    () -> Calculation.perform(new CapitalGainsCalculationMovingAverage(TaxesAndFees.NOT_INCLUDED),
+                                    converter, security, lineItems));
+
+    /**
+     * The same two engines, but measuring against the cost basis that includes
+     * the taxes and fees embedded in a trade. Kept as separate lazy values
+     * because - unlike the cost variants, which one pass yields together - each
+     * basis drives its own pass.
+     */
+    private final LazyValue<CapitalGainsCalculation> capitalGainsWithCharges = new LazyValue<>(
+                    () -> Calculation.perform(new CapitalGainsCalculation(TaxesAndFees.INCLUDED), converter, security,
                                     lineItems));
+
+    private final LazyValue<CapitalGainsCalculationMovingAverage> capitalGainsMovingAvgWithCharges = new LazyValue<>(
+                    () -> Calculation.perform(new CapitalGainsCalculationMovingAverage(TaxesAndFees.INCLUDED),
+                                    converter, security, lineItems));
 
     /* package */ LazySecurityPerformanceRecord(Client client, Security security, CurrencyConverter converter,
                     Interval interval)
@@ -332,19 +347,52 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
 
     public CapitalGainsRecord getRealizedCapitalGains(CostMethod costMethod)
     {
+        return getRealizedCapitalGains(costMethod, TaxesAndFees.NOT_INCLUDED);
+    }
+
+    /**
+     * The gains realized during the interval, measured against a cost basis
+     * that includes or excludes the taxes and fees embedded in a trade.
+     * <p>
+     * {@link TaxesAndFees#NOT_INCLUDED} is what
+     * {@link name.abuchen.portfolio.snapshot.ClientPerformanceSnapshot} needs:
+     * its breakdown carries fees and taxes as separate terms and would
+     * otherwise subtract them twice. {@link TaxesAndFees#INCLUDED} is the basis
+     * that lines up with {@link #getCost(CostMethod, TaxesAndFees)}.
+     */
+    public CapitalGainsRecord getRealizedCapitalGains(CostMethod costMethod, TaxesAndFees taxesAndFees)
+    {
         return switch (costMethod)
         {
-            case FIFO -> capitalGains.get().getRealizedCapitalGains();
-            case MOVING_AVERAGE -> capitalGainsMovingAvg.get().getRealizedCapitalGains();
+            case FIFO -> taxesAndFees.isIncluded() ? capitalGainsWithCharges.get().getRealizedCapitalGains()
+                            : capitalGains.get().getRealizedCapitalGains();
+
+            case MOVING_AVERAGE -> taxesAndFees.isIncluded()
+                            ? capitalGainsMovingAvgWithCharges.get().getRealizedCapitalGains()
+                            : capitalGainsMovingAvg.get().getRealizedCapitalGains();
         };
     }
 
     public CapitalGainsRecord getUnrealizedCapitalGains(CostMethod costMethod)
     {
+        return getUnrealizedCapitalGains(costMethod, TaxesAndFees.NOT_INCLUDED);
+    }
+
+    /**
+     * The gains on the positions still held at the end of the interval. See
+     * {@link #getRealizedCapitalGains(CostMethod, TaxesAndFees)} for the
+     * meaning of the cost basis.
+     */
+    public CapitalGainsRecord getUnrealizedCapitalGains(CostMethod costMethod, TaxesAndFees taxesAndFees)
+    {
         return switch (costMethod)
         {
-            case FIFO -> capitalGains.get().getUnrealizedCapitalGains();
-            case MOVING_AVERAGE -> capitalGainsMovingAvg.get().getUnrealizedCapitalGains();
+            case FIFO -> taxesAndFees.isIncluded() ? capitalGainsWithCharges.get().getUnrealizedCapitalGains()
+                            : capitalGains.get().getUnrealizedCapitalGains();
+
+            case MOVING_AVERAGE -> taxesAndFees.isIncluded()
+                            ? capitalGainsMovingAvgWithCharges.get().getUnrealizedCapitalGains()
+                            : capitalGainsMovingAvg.get().getUnrealizedCapitalGains();
         };
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trail/TrailRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trail/TrailRecord.java
@@ -99,6 +99,14 @@ public interface TrailRecord
                         this.getShares(), this.getValue(), this);
     }
 
+    /**
+     * Restates this trail at the given basis. If the basis differs from the
+     * trail's own value, it is rendered as a "without taxes and fees"
+     * derivation step; if it equals the value - as it does when the basis
+     * already includes the taxes and fees embedded in the trade - the trail is
+     * returned unchanged and no such step is added. Hence the label is only ever
+     * emitted for a basis that genuinely has those charges stripped.
+     */
     default TrailRecord asGrossValue(Money grossValue)
     {
         if (grossValue.equals(getValue()))


### PR DESCRIPTION
CostCalculation reports a cost basis both with and without the taxes and fees embedded in a trade, but the two capital gains engines only ever measured against the basis excluding them. Anything reporting a cost basis next to the gains on it therefore published two numbers that do not subtract: they differ by the charges embedded in the still-open lots.

The divergence arises only from purchases made inside the interval. A lot carried in is seeded from the same opening valuation by both engines, so a position held across the whole period reconciles either way - which is what makes the mismatch easy to miss.

CapitalGainsCalculation and CapitalGainsCalculationMovingAverage now take a TaxesAndFees, selecting the basis on both legs of a trade: a sale's gross value is the proceeds *before* the charges are deducted, so relieving a fee-inclusive lot against it would book the fees as a gain. The trails follow the selected basis on their own, as asGrossValue only inserts its "without taxes and fees" step when the basis differs from the transaction's own amount.

The change is additive. Each engine now names its basis explicitly at construction; the ex-fee basis - TaxesAndFees.NOT_INCLUDED - is the one ClientPerformanceSnapshot needs: its breakdown carries fees and taxes as separate terms and would subtract them twice if the gains absorbed them into the lot basis. The record's existing accessors default to that basis, so only a caller passing the new argument sees the other, and the existing snapshot and performance tests pass unchanged.

Calculation gains a perform overload taking an instance, since the existing one reflects a no-argument constructor.