### PR TITLE
Fix trades ignoring the transaction exchange rate

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeTest.java
@@ -7,16 +7,22 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.Test;
 
+import name.abuchen.portfolio.junit.AccountBuilder;
 import name.abuchen.portfolio.junit.PortfolioBuilder;
 import name.abuchen.portfolio.junit.SecurityBuilder;
 import name.abuchen.portfolio.junit.TestCurrencyConverter;
 import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.Portfolio;
+import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.PortfolioTransaction.Type;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.CurrencyUnit;
 import name.abuchen.portfolio.money.Money;
 
@@ -218,5 +224,173 @@ public class TradeTest
         assertThat(trade2.getEnd().isPresent(), is(false));
         assertThat(trade2.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, amountOf(1 * 120 + 2 * 50 - 0))));
         assertThat(trade2.getReturn(), is(1.0));
+    }
+
+    /**
+     * The scenario reported in
+     * https://github.com/portfolio-performance/portfolio/pull/5910#issuecomment-5123694459:
+     * an open position of 100 shares of a USD security, delivered inbound into
+     * an EUR account at 100 x USD 50 = USD 5,000 with the exchange rate USD/EUR
+     * 0.90 recorded on the transaction, i.e. EUR 4,500.
+     */
+    private static Client createClientWithSecurityInForeignCurrency()
+    {
+        var client = new Client();
+        client.setBaseCurrency(CurrencyUnit.EUR);
+
+        var security = new SecurityBuilder(CurrencyUnit.USD) //
+                        .addPrice("2025-01-01", quoteOf(80)) //
+                        .addTo(client);
+
+        var account = new AccountBuilder(CurrencyUnit.EUR).addTo(client);
+
+        new PortfolioBuilder(account) //
+                        .inbound_delivery(security, "2024-01-01", sharesOf(100),
+                                        new Unit(Unit.Type.GROSS_VALUE, //
+                                                        Money.of(CurrencyUnit.EUR, amountOf(4500)),
+                                                        Money.of(CurrencyUnit.USD, amountOf(5000)),
+                                                        BigDecimal.valueOf(0.90)))
+                        .addTo(client);
+
+        return client;
+    }
+
+    @Test
+    public void testForeignCurrencySecurityReportedInAccountCurrency() throws TradeCollectorException
+    {
+        Client client = createClientWithSecurityInForeignCurrency();
+        Security security = client.getSecurities().get(0);
+
+        TradeCollector collector = new TradeCollector(client, new TestCurrencyConverter(CurrencyUnit.EUR));
+
+        List<Trade> trades = collector.collect(security);
+        assertThat(trades.size(), is(1));
+
+        Trade trade = trades.get(0);
+        assertThat(trade.isClosed(), is(false));
+        assertThat(trade.getShares(), is(sharesOf(100)));
+        assertThat(trade.getStart(), is(LocalDateTime.parse("2024-01-01T00:00")));
+
+        // the transaction is booked in EUR, hence both cost methods report the
+        // amount of the transaction
+        assertThat(trade.getEntryValue(), is(Money.of(CurrencyUnit.EUR, amountOf(4500))));
+        assertThat(trade.getEntryValueMovingAverage(), is(Money.of(CurrencyUnit.EUR, amountOf(4500))));
+
+        // the position is still open: 100 x USD 80 converted with the exchange
+        // rate of the currency converter (EUR/USD 1.1588) = 6903.69
+        assertThat(trade.getExitValue(), is(Money.of(CurrencyUnit.EUR, amountOf(6903.69))));
+        assertThat(trade.getProfitLoss(), is(Money.of(CurrencyUnit.EUR, amountOf(6903.69 - 4500))));
+        assertThat(trade.getProfitLossMovingAverage(), is(Money.of(CurrencyUnit.EUR, amountOf(6903.69 - 4500))));
+    }
+
+    @Test
+    public void testForeignCurrencySecurityReportedInSecurityCurrency() throws TradeCollectorException
+    {
+        Client client = createClientWithSecurityInForeignCurrency();
+        Security security = client.getSecurities().get(0);
+
+        TradeCollector collector = new TradeCollector(client, new TestCurrencyConverter(CurrencyUnit.USD));
+
+        List<Trade> trades = collector.collect(security);
+        assertThat(trades.size(), is(1));
+
+        Trade trade = trades.get(0);
+        assertThat(trade.isClosed(), is(false));
+        assertThat(trade.getShares(), is(sharesOf(100)));
+        assertThat(trade.getStart(), is(LocalDateTime.parse("2024-01-01T00:00")));
+
+        // reported in the currency of the security, the entry value is what has
+        // been bought: 100 x USD 50. It must be derived from the exchange rate
+        // recorded on the transaction and not from the historical rate of that
+        // day (which would give EUR 4,500 x 1.1588 = USD 5,214.60)
+        assertThat(trade.getEntryValue(), is(Money.of(CurrencyUnit.USD, amountOf(5000))));
+        assertThat(trade.getEntryValueMovingAverage(), is(Money.of(CurrencyUnit.USD, amountOf(5000))));
+
+        // the position is still open: 100 x USD 80
+        assertThat(trade.getExitValue(), is(Money.of(CurrencyUnit.USD, amountOf(8000))));
+        assertThat(trade.getProfitLoss(), is(Money.of(CurrencyUnit.USD, amountOf(8000 - 5000))));
+        assertThat(trade.getProfitLossMovingAverage(), is(Money.of(CurrencyUnit.USD, amountOf(8000 - 5000))));
+    }
+
+    /**
+     * A closed trade in a USD security bought and later sold via an EUR
+     * account, with the exchange rate recorded on each transaction (buy at
+     * USD/EUR 0.90, sell at USD/EUR 0.80) plus non-zero fees and taxes.
+     * Reported in the security's currency, both the exit value and the
+     * profit/loss must be derived from the recorded transaction rates and not
+     * from the historical day rate.
+     */
+    private static Client createClientWithClosedForeignCurrencyTrade()
+    {
+        var client = new Client();
+        client.setBaseCurrency(CurrencyUnit.EUR);
+
+        var security = new SecurityBuilder(CurrencyUnit.USD).addTo(client);
+
+        var account = new AccountBuilder(CurrencyUnit.EUR).addTo(client);
+
+        var portfolio = new Portfolio();
+        portfolio.setName("pf");
+        portfolio.setReferenceAccount(account);
+
+        // buy 100 x USD 50 = USD 5,000 gross (EUR 4,500 at USD/EUR 0.90) plus
+        // USD 100 fees and USD 50 taxes, i.e. EUR 4,635 paid = USD 5,150
+        var buy = new PortfolioTransaction(LocalDateTime.parse("2024-01-01T00:00"), CurrencyUnit.EUR, amountOf(4635),
+                        security, sharesOf(100), Type.DELIVERY_INBOUND, amountOf(90), amountOf(45));
+        buy.addUnit(new Unit(Unit.Type.GROSS_VALUE, //
+                        Money.of(CurrencyUnit.EUR, amountOf(4500)), //
+                        Money.of(CurrencyUnit.USD, amountOf(5000)), //
+                        BigDecimal.valueOf(0.90)));
+        portfolio.addTransaction(buy);
+
+        // sell 100 x USD 80 = USD 8,000 gross (EUR 6,400 at USD/EUR 0.80) less
+        // USD 100 fees and USD 50 taxes, i.e. EUR 6,280 received = USD 7,850
+        var sell = new PortfolioTransaction(LocalDateTime.parse("2024-12-31T00:00"), CurrencyUnit.EUR, amountOf(6280),
+                        security, sharesOf(100), Type.DELIVERY_OUTBOUND, amountOf(80), amountOf(40));
+        sell.addUnit(new Unit(Unit.Type.GROSS_VALUE, //
+                        Money.of(CurrencyUnit.EUR, amountOf(6400)), //
+                        Money.of(CurrencyUnit.USD, amountOf(8000)), //
+                        BigDecimal.valueOf(0.80)));
+        portfolio.addTransaction(sell);
+
+        client.addPortfolio(portfolio);
+
+        return client;
+    }
+
+    @Test
+    public void testForeignCurrencyClosedTradeReportedInSecurityCurrency() throws TradeCollectorException
+    {
+        var client = createClientWithClosedForeignCurrencyTrade();
+        var security = client.getSecurities().get(0);
+
+        var collector = new TradeCollector(client, new TestCurrencyConverter(CurrencyUnit.USD));
+
+        var trades = collector.collect(security);
+        assertThat(trades.size(), is(1));
+
+        var trade = trades.get(0);
+        assertThat(trade.isClosed(), is(true));
+        assertThat(trade.isLong(), is(true));
+        assertThat(trade.getShares(), is(sharesOf(100)));
+        assertThat(trade.getStart(), is(LocalDateTime.parse("2024-01-01T00:00")));
+        assertThat(trade.getEnd().get(), is(LocalDateTime.parse("2024-12-31T00:00")));
+
+        // entry and exit are derived from the exchange rate recorded on each
+        // transaction and not from the historical rate of that day: buy
+        // EUR 4,635 / 0.90 = USD 5,150, sell EUR 6,280 / 0.80 = USD 7,850
+        assertThat(trade.getEntryValue(), is(Money.of(CurrencyUnit.USD, amountOf(5150))));
+        assertThat(trade.getExitValue(), is(Money.of(CurrencyUnit.USD, amountOf(7850))));
+
+        // net profit/loss after fees and taxes: USD 7,850 - USD 5,150
+        assertThat(trade.getProfitLoss(), is(Money.of(CurrencyUnit.USD, amountOf(7850 - 5150))));
+
+        // gross profit/loss before fees and taxes: USD 8,000 - USD 5,000
+        assertThat(trade.getProfitLossWithoutTaxesAndFees(), is(Money.of(CurrencyUnit.USD, amountOf(8000 - 5000))));
+
+        // the position is held for a full year, hence the IRR equals the
+        // simple return of USD 7,850 / USD 5,150 - 1
+        assertThat(trade.getReturn(), is(7850 / 5150.0 - 1));
+        assertEquals(0.52427, trade.getIRR(), 0.0001);
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -81,19 +81,19 @@ public class Trade implements Adaptable
         boolean isLong = this.isLong();
 
         // for purchases, getMonetaryAmount() returns the value including taxes
-        // and fees paid
+        // and fees paid. Passing the converter applies the exchange rate
+        // recorded on the transaction (if applicable) instead of the historical
+        // rate of that day
         this.entryValue = transactions.stream() //
                         .filter(t -> t.getTransaction().getType().isPurchase() == isLong)
-                        .map(t -> t.getTransaction().getMonetaryAmount()
-                                        .with(converter.at(t.getTransaction().getDateTime())))
+                        .map(t -> t.getTransaction().getMonetaryAmount(converter))
                         .collect(MoneyCollectors.sum(converter.getTermCurrency()));
 
         // for purchases, getGrossValue() returns the value without taxes and
         // fees paid
         this.entryValueWithoutTaxesAndFees = transactions.stream() //
                         .filter(t -> t.getTransaction().getType().isPurchase() == isLong)
-                        .map(t -> t.getTransaction().getGrossValue()
-                                        .with(converter.at(t.getTransaction().getDateTime())))
+                        .map(t -> t.getTransaction().getGrossValue(converter))
                         .collect(MoneyCollectors.sum(converter.getTermCurrency()));
 
         if (end != null)
@@ -102,16 +102,14 @@ public class Trade implements Adaptable
             // (after) taxes and fees deducted
             this.exitValue = transactions.stream() //
                             .filter(t -> t.getTransaction().getType().isLiquidation() == isLong)
-                            .map(t -> t.getTransaction().getMonetaryAmount()
-                                            .with(converter.at(t.getTransaction().getDateTime())))
+                            .map(t -> t.getTransaction().getMonetaryAmount(converter))
                             .collect(MoneyCollectors.sum(converter.getTermCurrency()));
 
             // for sales, getGrossValue() returns the sales proceeds without
             // (before) taxes and fees deducted
             this.exitValueWithoutTaxesAndFees = transactions.stream() //
                             .filter(t -> t.getTransaction().getType().isLiquidation() == isLong)
-                            .map(t -> t.getTransaction().getGrossValue()
-                                            .with(converter.at(t.getTransaction().getDateTime())))
+                            .map(t -> t.getTransaction().getGrossValue(converter))
                             .collect(MoneyCollectors.sum(converter.getTermCurrency()));
 
             this.holdingPeriod = Math.round(transactions.stream() //
@@ -168,8 +166,7 @@ public class Trade implements Adaptable
         transactions.stream().forEach(t -> {
             dates.add(t.getTransaction().getDateTime().toLocalDate());
 
-            double amount = t.getTransaction().getMonetaryAmount().with(converter.at(t.getTransaction().getDateTime()))
-                            .getAmount() / Values.Amount.divider();
+            double amount = t.getTransaction().getMonetaryAmount(converter).getAmount() / Values.Amount.divider();
 
             if (t.getTransaction().getType().isPurchase() == isLong())
             {


### PR DESCRIPTION
Trade.calculate() converted entry/exit values with the historic day rate of the exchange-rate provider instead of the rate recorded on the transaction, so a trade reported in the security's currency showed an entry value that did not match what was actually bought. CapitalGainsCalculation and CostCalculation already prefer the transaction rate; Trade now does too by calling getMonetaryAmount(converter)/getGrossValue(converter) instead of converting with the day rate.

Reported by @mierin12 on #5910.