### PR TITLE
PDF Import Raiffeisenbankgruppe: Exchange rates and fee information fix

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/Dividende15.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/Dividende15.txt
@@ -1,0 +1,71 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.1
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+d a 
+Raiffeisenbank Murau eGen (mbH) 
+Bundesstraße 5, 8850 Murau 
+b 
+BLZ: 38402     DVR: 0039063     UID: ATU28570409 
+a 
+a 
+Abrechnung Ereignis a 
+81935970 - 17.03.2026 a 
+Depot-Nr.: 60.026.259 
+OUEDX SrebDwG zpGBs zNNaeuS 
+Ro OQsmzTJN 6 
+3176 MmJbx SQJqfZ 002/138 
+YLmbKPbb 
+Wir haben für Sie am 17.03.2026 unten angeführtes Geschäft abgerechnet: 
+Geschäftsart: Ertrag 
+100 Stk    
+Titel: CH0012032113 ROCHE HOLDING AG 
+Inhaber-Aktien SF 1 
+Kup. 25  
+Dividende: 9,8 CHF 
+Verwahrart: WR 
+Positionsdaten: Loco: CH Olten 
+Bruttobetrag: 980,00 CHF  
+Quellensteuer: -343,00 CHF  
+Auslands-KESt: -122,50 CHF  
+514,50 CHF  
+Devisenkurs: 0,9086 (13.03.2026)  566,26 EUR  
+Devisenkomm/Courtage: -8,00 EUR  
+Zu Gunsten IBAN AT28 3840 2000 0006 8643 558,26 EUR  
+Valuta 16.03.2026 
+KESt wurde an das Finanzamt für Großbetriebe abgeführt. 
+Quellensteuer: 35% 
+Es wurde Auslands-KESt in der Höhe von 12,5 % berücksichtigt. 
+Extag: 12.03.2026 
+Record-Tag: 13.03.2026 
+Ausgangssituation: 
+KESt-Neubestand mit Anschaffungskosten nach dem gleitenden  
+Durchschnittsverfahren § 27a Abs. 4 Zi 3 EStG 100 Stk 
+steuerlicher Anschaffungswert: 30.179,03 EUR 
+KESt-Neubestand mit Anschaffungskosten nach dem gleitenden  
+Durchschnittsverfahren § 27a Abs. 4 Zi 3 EStG 100 Stk 
+Ertrag: 1.078,58 EUR 
+17.03.2026 1 / 2 
+Irrtum vorbehalten 
+Dieser Beleg trägt keine Unterschrift. 
+Raiffeisenbank Murau eGen (mbH) 
+Bundesstraße 5, 8850 Murau 
+b 
+BLZ: 38402     DVR: 0039063     UID: ATU28570409 
+a 
+a 
+Abrechnung Ereignis a 
+81935970 - 17.03.2026 a 
+Depot-Nr.: 60.026.259 
+XnYZM WlzAbPV 
+002/138 
+YHHNSAos 
+Steuerrelevante Daten (alle Beträge in EUR): 
+Bemessungsgrundlage KESt 
+Einkünfte/Verlustüberhang bisher 2.845,04 625,15 
+Bruttoeinkünfte/Verlust 1.078,58 134,82 
+Verlustausgleich (KESt-Gutschrift) 
+Einkünfte/Verlustüberhang aktuell 3.923,62 759,97 
+17.03.2026 2 / 2 
+Irrtum vorbehalten 
+Dieser Beleg trägt keine Unterschrift. 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/Dividende16.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/Dividende16.txt
@@ -1,0 +1,70 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.1
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+d a 
+Raiffeisenbank Murau eGen (mbH) 
+Bundesstraße 5, 8850 Murau 
+b 
+BLZ: 38402     DVR: 0039063     UID: ATU28570409 
+a 
+a 
+Abrechnung Ereignis a 
+80052452 - 22.01.2026 a 
+Depot-Nr.: 60.026.259 
+IIaYU hfIMmjb AEKnN Dvxqctp 
+gT YSLFivif 6 
+1991 QrVip QbpLwJ 002/138 
+BuDbOcqY 
+Wir haben für Sie am 22.01.2026 unten angeführtes Geschäft abgerechnet: 
+Geschäftsart: Ertrag 
+500 Stk    
+Titel: US17275R1023 CISCO SYSTEMS INC. 
+Registered Shares DL-,001 
+Dividende: 0,41 USD 
+Verwahrart: WR 
+Positionsdaten: Loco: US New York 
+Bruttobetrag: 205,00 USD  
+Quellensteuer: -30,75 USD  
+Auslands-KESt: -25,63 USD  
+148,62 USD  
+Devisenkurs: 1,1777 (20.01.2026)  126,20 EUR  
+Devisenkomm/Courtage: -8,00 EUR  
+Zu Gunsten IBAN AT28 3840 2000 0006 8643 118,20 EUR  
+Valuta 21.01.2026 
+KESt wurde an das Finanzamt für Großbetriebe abgeführt. 
+Quellensteuer: 15% 
+Es wurde Auslands-KESt in der Höhe von 12,5 % berücksichtigt. 
+Extag: 02.01.2026 
+Record-Tag: 02.01.2026 
+Ausgangssituation: 
+KESt-Neubestand mit Anschaffungskosten nach dem gleitenden  
+Durchschnittsverfahren § 27a Abs. 4 Zi 3 EStG 500 Stk 
+steuerlicher Anschaffungswert: 23.270,81 EUR 
+KESt-Neubestand mit Anschaffungskosten nach dem gleitenden  
+Durchschnittsverfahren § 27a Abs. 4 Zi 3 EStG 500 Stk 
+Ertrag: 174,07 EUR 
+22.01.2026 1 / 2 
+Irrtum vorbehalten 
+Dieser Beleg trägt keine Unterschrift. 
+Raiffeisenbank Murau eGen (mbH) 
+Bundesstraße 5, 8850 Murau 
+b 
+BLZ: 38402     DVR: 0039063     UID: ATU28570409 
+a 
+a 
+Abrechnung Ereignis a 
+80052452 - 22.01.2026 a 
+Depot-Nr.: 60.026.259 
+DXbnm qCUrBCx 
+002/138 
+PvPIgKTq 
+Steuerrelevante Daten (alle Beträge in EUR): 
+Bemessungsgrundlage KESt 
+Einkünfte/Verlustüberhang bisher 2.325,83 560,24 
+Bruttoeinkünfte/Verlust 174,07 21,76 
+Verlustausgleich (KESt-Gutschrift) 
+Einkünfte/Verlustüberhang aktuell 2.499,90 582,00 
+22.01.2026 2 / 2 
+Irrtum vorbehalten 
+Dieser Beleg trägt keine Unterschrift. 

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/RaiffeisenbankgruppePDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/raiffeisenbankgruppe/RaiffeisenbankgruppePDFExtractorTest.java
@@ -1700,6 +1700,78 @@ public class RaiffeisenbankgruppePDFExtractorTest
     }
 
     @Test
+    public void testDividende15()
+    {
+        var extractor = new RaiffeisenBankgruppePDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende15.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("CH0012032113"), hasWkn(null), hasTicker(null), //
+                        hasName("ROCHE HOLDING AG Inhaber-Aktien SF 1"), //
+                        hasCurrencyCode("CHF"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-03-16T00:00"), hasExDate("2026-03-12T00:00"), //
+                        hasShares(100.00), //
+                        hasSource("Dividende15.txt"), //
+                        hasNote(null), //
+                        hasForexGrossValue("CHF", 980.00), //
+                        hasAmount("EUR", 558.26), hasGrossValue("EUR", 1078.58), //
+                        hasTaxes("EUR", 512.32), hasFees("EUR", 8.00))));
+    }
+
+    @Test
+    public void testDividende16()
+    {
+        var extractor = new RaiffeisenBankgruppePDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende16.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US17275R1023"), hasWkn(null), hasTicker(null), //
+                        hasName("CISCO SYSTEMS INC. Registered Shares DL-,001"), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-01-21T00:00"), hasExDate("2026-01-02T00:00"), //
+                        hasShares(500.00), //
+                        hasSource("Dividende16.txt"), //
+                        hasNote(null), //
+                        hasForexGrossValue("USD", 205.00), //
+                        hasAmount("EUR", 118.20), hasGrossValue("EUR", 174.07), //
+                        hasTaxes("EUR", 47.87), hasFees("EUR", 8.00))));
+    }
+
+    @Test
     public void testKontoauszug01()
     {
         var extractor = new RaiffeisenBankgruppePDFExtractor(new Client());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFInputFile.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PDFInputFile.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Scanner;
 
 import name.abuchen.portfolio.datatransfer.Extractor;
@@ -41,7 +42,8 @@ public class PDFInputFile extends Extractor.InputFile
 
     public static PDFInputFile loadSingleTestCase(Class<?> testCase, String filename)
     {
-        try (Scanner scanner = new Scanner(testCase.getResourceAsStream(filename), StandardCharsets.UTF_8.name()))
+        try (Scanner scanner = new Scanner(Objects.requireNonNull(testCase.getResourceAsStream(filename), filename),
+                        StandardCharsets.UTF_8.name()))
         {
             String extractedText = scanner.useDelimiter("\\A").next(); //$NON-NLS-1$
             return new PDFInputFile(new File(filename), extractedText);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/RaiffeisenBankgruppePDFExtractor.java
@@ -207,7 +207,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("termCurrency", "fxGross", "exchangeRate", "baseCurrency").optional() //
                         .match("^Kurswert: (\\-)?(?<fxGross>[\\.,\\d]+) (?<termCurrency>[A-Z]{3}).*$") //
-                        .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}\\) (\\-)?[\\.,\\d]+ (?<baseCurrency>[A-Z]{3}).*$") //
+                        .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}\\)[\\s]+(\\-)?[\\.,\\d]+ (?<baseCurrency>[A-Z]{3}).*$") //
                         .assign((t, v) -> {
                             var rate = asExchangeRate(v);
                             type.getCurrentContext().putType(rate);
@@ -473,11 +473,14 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                                         // @formatter:off
                                         // Bruttoertrag: 119,37 USD
                                         // Devisenkurs: 1,0856 (13.01.2023) 109,37 EUR
+                                        //
+                                        // Bruttobetrag: 980,00 CHF
+                                        // Devisenkurs: 0,9086 (13.03.2026)  566,26 EUR
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("fxGross", "termCurrency", "exchangeRate", "baseCurrency") //
-                                                        .match("^Bruttoertrag: (?<fxGross>[\\.,\\d]+) (?<termCurrency>[A-Z]{3}).*$") //
-                                                        .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\([\\d]{2}\\.[\\d]{2}\\.[\\d]{4}\\) [\\.,\\d]+ (?<baseCurrency>[A-Z]{3}).*$") //
+                                                        .match("^Brutto(betrag|ertrag): (?<fxGross>[\\.,\\d]+) (?<termCurrency>[A-Z]{3}).*$") //
+                                                        .match("^Devisenkurs: (?<exchangeRate>[\\.,\\d]+) \\(\\d{2}\\.\\d{2}\\.\\d{4}\\)\\s+[\\.,\\d]+ (?<baseCurrency>[A-Z]{3}).*$") //
                                                         .assign((t, v) -> {
                                                             var rate = asExchangeRate(v);
                                                             type.getCurrentContext().putType(rate);
@@ -517,9 +520,7 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                             // @formatter:on
                             type.getCurrentContext().remove("noTax");
 
-                            var item = new TransactionItem(t);
-
-                            return item;
+                            return new TransactionItem(t);
                         });
 
         addTaxesSectionsTransaction(pdfTransaction, type);
@@ -1370,7 +1371,14 @@ public class RaiffeisenBankgruppePDFExtractor extends AbstractPDFExtractor
                         // Courtage CHF -3.17
                         // @formatter:on
                         .section("fee", "currency").optional() //
-                        .match("^Courtage (?<currency>[A-Z]{3}) \\-(?<fee>[\\.'\\d]+)[\\s]*$") //
+                        .match("^Courtage (?<currency>[A-Z]{3}) \\-(?<fee>[\\.',\\d]+)[\\s]*$") //
+                        .assign((t, v) -> processFeeEntries(t, v, type))
+
+                        // @formatter:off
+                        // Devisenkomm/Courtage: -8,00 EUR
+                        // @formatter:on
+                        .section("fee", "currency").optional() //
+                        .match("^Devisenkomm\\/Courtage: \\-(?<fee>[\\.',\\d]+)\\s+(?<currency>[A-Z]{3}).*$") //
                         .assign((t, v) -> processFeeEntries(t, v, type));
     }
 


### PR DESCRIPTION
Added support for ways how exchange rates and fee informations are provided by the bank

some house keeping on the test framework side: Provide the filename that can't be found when trying to load the test file. This is useful if you test an importer with multiple files being imported at the same time.

The test files were [provided by the forum](https://forum.portfolio-performance.info/t/pdf-import-von-raiffeisenbank-bankgruppe/12535/165?u=kimmerin).