### PR TITLE
Add weekend date adjustment to investment plans

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/InvestmentPlanTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/model/InvestmentPlanTest.java
@@ -380,4 +380,37 @@ public class InvestmentPlanTest
         assertThat(tx.get(3).getDateTime(), is(LocalDateTime.parse("2024-04-08T00:00")));
     }
 
+    @Test
+    public void testWeekendAdjustmentNextBusinessDay()
+    {
+        investmentPlan.setStart(LocalDateTime.parse("2024-04-20T00:00:00")); // Saturday
+        investmentPlan.setWeekendAdjustment(WeekendAdjustment.NEXT_BUSINESS_DAY);
+
+        // Saturday April 20 should adjust forward to Monday April 22
+        assertThat(investmentPlan.getDateOfNextTransactionToBeGenerated(), is(LocalDate.parse("2024-04-22")));
+    }
+
+    @Test
+    public void testWeekendAdjustmentPreviousBusinessDay()
+    {
+        investmentPlan.setStart(LocalDateTime.parse("2024-04-20T00:00:00"));
+        investmentPlan.setWeekendAdjustment(WeekendAdjustment.PREVIOUS_BUSINESS_DAY);
+
+        assertThat(investmentPlan.getDateOfNextTransactionToBeGenerated(), is(LocalDate.parse("2024-04-19")));
+    }
+
+    @Test
+    public void testWeekendAdjustmentPreviousBusinessDayAcrossHolidays()
+    {
+        investmentPlan.setStart(LocalDateTime.parse("2016-03-28T00:00:00"));
+        investmentPlan.setWeekendAdjustment(WeekendAdjustment.PREVIOUS_BUSINESS_DAY);
+
+        assertThat(investmentPlan.getDateOfNextTransactionToBeGenerated(), is(LocalDate.parse("2016-03-24")));
+    }
+
+    @Test
+    public void testWeekendAdjustmentDefaultValue()
+    {
+        assertThat(investmentPlan.getWeekendAdjustment(), is(WeekendAdjustment.NEXT_BUSINESS_DAY));
+    }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -530,6 +530,9 @@ public class Messages extends NLS
     public static String InvestmentPlanTypeDeposit;
     public static String InvestmentPlanTypeInterest;
     public static String InvestmentPlanTypeRemoval;
+    public static String InvestmentPlanWeekendAdjustment;
+    public static String InvestmentPlanWeekendAdjustment_PREVIOUS_BUSINESS_DAY;
+    public static String InvestmentPlanWeekendAdjustment_NEXT_BUSINESS_DAY;
     public static String JobLabelAutoSave;
     public static String JobLabelSyncSecuritiesOnline;
     public static String JobLabelUpdateCPI;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/InvestmentPlanDialog.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/InvestmentPlanDialog.java
@@ -21,6 +21,8 @@ import org.eclipse.core.databinding.validation.ValidationStatus;
 import org.eclipse.e4.ui.services.IServiceConstants;
 import org.eclipse.e4.ui.services.IStylingEngine;
 import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
+import org.eclipse.jface.viewers.ArrayContentProvider;
+import org.eclipse.jface.viewers.ComboViewer;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
@@ -35,6 +37,7 @@ import name.abuchen.portfolio.model.InvestmentPlan;
 import name.abuchen.portfolio.model.InvestmentPlan.Type;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.WeekendAdjustment;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.dialogs.transactions.InvestmentPlanModel.Properties;
@@ -246,13 +249,46 @@ public class InvestmentPlanDialog extends AbstractTransactionDialog
 
         startingWith(valueDate.getControl()).thenRight(interval.label).thenRight(interval.value.getControl());
 
+        // Weekend Adjustment Label and Viewer
+        var lblWeekendAdjustment = new Label(editArea, SWT.NONE);
+        lblWeekendAdjustment.setText(Messages.InvestmentPlanWeekendAdjustment);
+
+        var weekendAdjustmentViewer = new ComboViewer(editArea, SWT.READ_ONLY);
+        weekendAdjustmentViewer.setContentProvider(ArrayContentProvider.getInstance());
+        weekendAdjustmentViewer.setLabelProvider(LabelProvider.createTextProvider(element -> {
+            if (element instanceof WeekendAdjustment adjustment)
+            {
+                return switch (adjustment)
+                {
+                    case PREVIOUS_BUSINESS_DAY -> Messages.InvestmentPlanWeekendAdjustment_PREVIOUS_BUSINESS_DAY;
+                    case NEXT_BUSINESS_DAY -> Messages.InvestmentPlanWeekendAdjustment_NEXT_BUSINESS_DAY;
+                };
+            }
+            return element.toString();
+        }));
+        weekendAdjustmentViewer.setInput(WeekendAdjustment.values());
+
+        weekendAdjustmentViewer.setSelection(new org.eclipse.jface.viewers.StructuredSelection(
+                        ((InvestmentPlanModel) model).getWeekendAdjustment()));
+
+        weekendAdjustmentViewer.addSelectionChangedListener(event -> {
+            var selection = (org.eclipse.jface.viewers.IStructuredSelection) event.getSelection();
+            if (!selection.isEmpty())
+            {
+                ((InvestmentPlanModel) model).setWeekendAdjustment((WeekendAdjustment) selection.getFirstElement());
+            }
+        });
+
         // measuring the width requires that the font has been applied before
         stylingEngine.style(editArea);
 
         int widest = widest(lblName, securities != null ? securities.label : null,
                         portfolio != null ? portfolio.label : null, account.label, lblDate, interval.label,
-                        amount.label, fees != null ? fees.label : null, taxes != null ? taxes.label : null);
+                        amount.label, fees != null ? fees.label : null, taxes != null ? taxes.label : null,
+                        lblWeekendAdjustment);
+
         startingWith(lblName).width(widest);
+        startingWith(amount.value).thenBelow(weekendAdjustmentViewer.getControl(), 10).label(lblWeekendAdjustment);
 
         WarningMessages warnings = new WarningMessages(this);
         warnings.add(() -> model().getStart().isAfter(LocalDate.now()) ? Messages.MsgDateIsInTheFuture : null);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/InvestmentPlanModel.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dialogs/transactions/InvestmentPlanModel.java
@@ -12,13 +12,14 @@ import name.abuchen.portfolio.model.InvestmentPlan;
 import name.abuchen.portfolio.model.InvestmentPlan.Type;
 import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.WeekendAdjustment;
 import name.abuchen.portfolio.ui.Messages;
 
 public class InvestmentPlanModel extends AbstractModel
 {
     public enum Properties
     {
-        calculationStatus, name, security, securityCurrencyCode, portfolio, account, accountCurrencyCode, start, interval, amount, grossAmount, fees, taxes, transactionCurrencyCode, autoGenerate; // NOSONAR
+        calculationStatus, name, security, securityCurrencyCode, portfolio, account, accountCurrencyCode, start, interval, amount, grossAmount, fees, taxes, transactionCurrencyCode, autoGenerate, weekendAdjustment; // NOSONAR
     }
 
     public static final Account DELIVERY = new Account(Messages.InvestmentPlanOptionDelivery);
@@ -34,6 +35,7 @@ public class InvestmentPlanModel extends AbstractModel
     private Account account;
 
     private boolean autoGenerate;
+    private WeekendAdjustment weekendAdjustment = WeekendAdjustment.NEXT_BUSINESS_DAY;
 
     private LocalDate start = LocalDate.now();
 
@@ -147,6 +149,7 @@ public class InvestmentPlanModel extends AbstractModel
         plan.setAutoGenerate(autoGenerate);
         plan.setStart(start);
         plan.setInterval(interval);
+        plan.setWeekendAdjustment(this.weekendAdjustment);
         plan.setAmount(amount);
         plan.setFees(fees);
         plan.setTaxes(taxes);
@@ -186,6 +189,7 @@ public class InvestmentPlanModel extends AbstractModel
         this.autoGenerate = plan.isAutoGenerate();
         this.start = plan.getStart();
         this.interval = plan.getInterval();
+        this.weekendAdjustment = plan.getWeekendAdjustment();
         this.amount = plan.getAmount();
         this.grossAmount = switch (planType)
         {
@@ -286,6 +290,17 @@ public class InvestmentPlanModel extends AbstractModel
     public Account getAccount()
     {
         return account;
+    }
+
+    public WeekendAdjustment getWeekendAdjustment()
+    {
+        return weekendAdjustment;
+    }
+
+    public void setWeekendAdjustment(WeekendAdjustment weekendAdjustment)
+    {
+        firePropertyChange(Properties.weekendAdjustment.name(), this.weekendAdjustment,
+                        this.weekendAdjustment = weekendAdjustment);
     }
 
     public void setAccount(Account account)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1052,6 +1052,12 @@ InvestmentPlanTypeInterest = Interest
 
 InvestmentPlanTypeRemoval = Withdrawal
 
+InvestmentPlanWeekendAdjustment=Weekend Adjustment
+
+InvestmentPlanWeekendAdjustment_PREVIOUS_BUSINESS_DAY=Previous Business Day
+
+InvestmentPlanWeekendAdjustment_NEXT_BUSINESS_DAY=Next Business Day
+
 JobLabelAutoSave = Saving backup file
 
 JobLabelSyncSecuritiesOnline = Sync investment vehicles with {0}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/InvestmentPlan.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/InvestmentPlan.java
@@ -34,6 +34,7 @@ public class InvestmentPlan implements Named, Adaptable, Attributable
     private Security security;
     private Portfolio portfolio;
     private Account account;
+    private WeekendAdjustment weekendAdjustment = WeekendAdjustment.NEXT_BUSINESS_DAY;
 
     private Attributes attributes;
 
@@ -154,6 +155,49 @@ public class InvestmentPlan implements Named, Adaptable, Attributable
     public LocalDate getStart()
     {
         return start.toLocalDate();
+    }
+
+    public WeekendAdjustment getWeekendAdjustment()
+    {
+        // Fallback for existing XML files where this might be null
+        return weekendAdjustment == null ? WeekendAdjustment.NEXT_BUSINESS_DAY : weekendAdjustment;
+    }
+
+    private Object readResolve()
+    {
+        if (weekendAdjustment == null)
+            weekendAdjustment = WeekendAdjustment.NEXT_BUSINESS_DAY;
+        return this;
+    }
+
+    private LocalDate adjustForWeekend(LocalDate date, TradeCalendar tradeCalendar)
+    {
+        if (date == null)
+            return null;
+
+        var adjustment = getWeekendAdjustment();
+        if (adjustment == null || adjustment == WeekendAdjustment.NEXT_BUSINESS_DAY)
+        {
+            // Push forward (Next business day / Monday)
+            while (tradeCalendar.isHoliday(date))
+            {
+                date = date.plusDays(1);
+            }
+        }
+        else if (adjustment == WeekendAdjustment.PREVIOUS_BUSINESS_DAY)
+        {
+            // Pull backward (Previous business day / Friday)
+            while (tradeCalendar.isHoliday(date))
+            {
+                date = date.minusDays(1);
+            }
+        }
+        return date;
+    }
+
+    public void setWeekendAdjustment(WeekendAdjustment weekendAdjustment)
+    {
+        this.weekendAdjustment = weekendAdjustment;
     }
 
     public void setStart(LocalDate start)
@@ -382,10 +426,8 @@ public class InvestmentPlan implements Named, Adaptable, Attributable
         // do not generate a investment plan transaction on a public holiday
         TradeCalendar tradeCalendar = security != null ? TradeCalendarManager.getInstance(security)
                         : TradeCalendarManager.getDefaultInstance();
-        while (tradeCalendar.isHoliday(next))
-            next = next.plusDays(1);
 
-        return next;
+        return adjustForWeekend(next, tradeCalendar);
     }
 
     public LocalDate getDateOfNextTransactionToBeGenerated()
@@ -400,13 +442,12 @@ public class InvestmentPlan implements Named, Adaptable, Attributable
         {
             LocalDate startDate = start.toLocalDate();
 
-            // do not generate a investment plan transaction on a public holiday
+            // do not generate an investment plan transaction on a
+            // holiday/weekend, and apply push/pull adjustment
             TradeCalendar tradeCalendar = security != null ? TradeCalendarManager.getInstance(security)
                             : TradeCalendarManager.getDefaultInstance();
-            while (tradeCalendar.isHoliday(startDate))
-                startDate = startDate.plusDays(1);
 
-            return startDate;
+            return adjustForWeekend(startDate, tradeCalendar);
         }
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/WeekendAdjustment.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/WeekendAdjustment.java
@@ -1,0 +1,6 @@
+package name.abuchen.portfolio.model;
+
+public enum WeekendAdjustment
+{
+    NEXT_BUSINESS_DAY, PREVIOUS_BUSINESS_DAY;
+}


### PR DESCRIPTION
Allow investment plans to configure whether execution dates that fall on weekends or holidays are shifted to the next business day (push) or previous business day (pull).
By default, dates continue to adjust to the next business day to preserve existing application behavior.

**Problem**: For some of the SIP's like employer run 401k's in US and RRSP's and RPP in Canada, The transaction happens on the day of pay check and typically they tend to take previous business day if the date happens to be a holiday or weekend. 