### PR TITLE
Add tooltip to Absolute performance column

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DeltaCalculationTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/security/DeltaCalculationTest.java
@@ -1,0 +1,190 @@
+package name.abuchen.portfolio.snapshot.security;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.LocalDate;
+
+import org.junit.Test;
+
+import name.abuchen.portfolio.junit.AccountBuilder;
+import name.abuchen.portfolio.junit.PortfolioBuilder;
+import name.abuchen.portfolio.junit.SecurityBuilder;
+import name.abuchen.portfolio.junit.TestCurrencyConverter;
+import name.abuchen.portfolio.model.Account;
+import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.Client;
+import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.money.CurrencyUnit;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.Values;
+import name.abuchen.portfolio.snapshot.security.BaseSecurityPerformanceRecord.Trails;
+import name.abuchen.portfolio.snapshot.trail.Trail;
+import name.abuchen.portfolio.util.Interval;
+
+@SuppressWarnings("nls")
+public class DeltaCalculationTest
+{
+    /**
+     * The absolute performance trail must reconstruct exactly the value shown
+     * in the "Absolute performance" column, i.e.
+     * {@link LazySecurityPerformanceRecord#getDelta()}.
+     */
+    private void assertTrailMatchesDelta(Client client, Security security, Interval interval)
+    {
+        LazySecurityPerformanceSnapshot snapshot = LazySecurityPerformanceSnapshot.create(client,
+                        new TestCurrencyConverter(), interval);
+        LazySecurityPerformanceRecord record = snapshot.getRecord(security)
+                        .orElseThrow(IllegalArgumentException::new);
+
+        Trail trail = record.explain(Trails.ABSOLUTE_PERFORMANCE).orElseThrow(IllegalArgumentException::new);
+
+        assertThat(trail.getRecord().getValue(), is(record.getDelta()));
+    }
+
+    /**
+     * Adds a security-linked account transaction (the {@link AccountBuilder}
+     * fee/tax helpers do not attach a security, but only security-linked
+     * transactions reach {@link DeltaCalculation}).
+     */
+    private void addSecurityTransaction(Account account, AccountTransaction.Type type, String date, long amount,
+                    Security security)
+    {
+        account.addTransaction(new AccountTransaction(LocalDate.parse(date).atStartOfDay(), CurrencyUnit.EUR, amount,
+                        security, type));
+    }
+
+    @Test
+    public void testBuyAndEndValuation()
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder() //
+                        .addPrice("2020-01-01", Values.Quote.factorize(100)) //
+                        .addPrice("2021-01-31", Values.Quote.factorize(120)) //
+                        .addTo(client);
+
+        new PortfolioBuilder() //
+                        .buy(security, "2020-06-01", Values.Share.factorize(10), Values.Amount.factorize(1000)) //
+                        .addTo(client);
+
+        assertTrailMatchesDelta(client, security,
+                        Interval.of(LocalDate.parse("2020-01-01"), LocalDate.parse("2021-01-31")));
+    }
+
+    @Test
+    public void testBuySellAndDividend()
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder() //
+                        .addPrice("2020-01-01", Values.Quote.factorize(100)) //
+                        .addPrice("2021-01-31", Values.Quote.factorize(120)) //
+                        .addTo(client);
+
+        Account account = new AccountBuilder() //
+                        .dividend("2020-09-01", Values.Amount.factorize(25), security) //
+                        .addTo(client);
+
+        new PortfolioBuilder(account) //
+                        .buy(security, "2020-06-01", Values.Share.factorize(20), Values.Amount.factorize(2000)) //
+                        .sell(security, "2020-12-01", Values.Share.factorize(5), Values.Amount.factorize(560)) //
+                        .addTo(client);
+
+        assertTrailMatchesDelta(client, security,
+                        Interval.of(LocalDate.parse("2020-01-01"), LocalDate.parse("2021-01-31")));
+    }
+
+    /**
+     * A security whose only line item in the interval is a standalone fee (no
+     * holdings, no valuation at start/end, no trades). The delta is a pure
+     * outflow, so the trail must still reconstruct it rather than being empty.
+     */
+    @Test
+    public void testOnlyOutflow()
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder() //
+                        .addPrice("2020-01-01", Values.Quote.factorize(100)) //
+                        .addTo(client);
+
+        Account account = new AccountBuilder().addTo(client);
+        account.addTransaction(new AccountTransaction(LocalDate.parse("2020-07-01").atStartOfDay(),
+                        CurrencyUnit.EUR, Values.Amount.factorize(10), security, AccountTransaction.Type.FEES));
+
+        LazySecurityPerformanceSnapshot snapshot = LazySecurityPerformanceSnapshot.create(client,
+                        new TestCurrencyConverter(),
+                        Interval.of(LocalDate.parse("2020-01-01"), LocalDate.parse("2021-01-31")));
+        LazySecurityPerformanceRecord record = snapshot.getRecord(security)
+                        .orElseThrow(IllegalArgumentException::new);
+
+        // sanity: the delta really is a non-zero outflow
+        assertThat(record.getDelta(), is(Money.of(CurrencyUnit.EUR, -Values.Amount.factorize(10))));
+
+        Trail trail = record.explain(Trails.ABSOLUTE_PERFORMANCE).orElseThrow(IllegalArgumentException::new);
+        assertThat(trail.getRecord().getValue(), is(record.getDelta()));
+    }
+
+    /**
+     * Locks the trail-total-equals-delta invariant across <em>every</em>
+     * contributing line-item type at once: valuation at start and end, buy,
+     * sell, dividend, taxes, tax refund, fees and fee refund. If a future
+     * change updates {@code delta} for one of these without adding the matching
+     * entry to the positive/negative trail lists (or vice versa), the trail
+     * total will diverge from {@link LazySecurityPerformanceRecord#getDelta()}
+     * and this test will fail.
+     */
+    @Test
+    public void testAllContributionTypes()
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder() //
+                        .addPrice("2019-12-31", Values.Quote.factorize(100)) //
+                        .addPrice("2021-01-31", Values.Quote.factorize(120)) //
+                        .addTo(client);
+
+        // a position held before the interval start produces a valuation at
+        // start; shares still held at the end produce a valuation at end
+        Account account = new AccountBuilder() //
+                        .dividend("2020-09-01", Values.Amount.factorize(25), security) //
+                        .addTo(client);
+
+        new PortfolioBuilder(account) //
+                        .buy(security, "2019-06-01", Values.Share.factorize(20), Values.Amount.factorize(2000)) //
+                        .buy(security, "2020-06-01", Values.Share.factorize(10), Values.Amount.factorize(1100)) //
+                        .sell(security, "2020-12-01", Values.Share.factorize(5), Values.Amount.factorize(560)) //
+                        .addTo(client);
+
+        addSecurityTransaction(account, AccountTransaction.Type.TAXES, "2020-09-02", Values.Amount.factorize(7),
+                        security);
+        addSecurityTransaction(account, AccountTransaction.Type.TAX_REFUND, "2020-10-01", Values.Amount.factorize(3),
+                        security);
+        addSecurityTransaction(account, AccountTransaction.Type.FEES, "2020-07-01", Values.Amount.factorize(10),
+                        security);
+        addSecurityTransaction(account, AccountTransaction.Type.FEES_REFUND, "2020-08-01", Values.Amount.factorize(4),
+                        security);
+
+        assertTrailMatchesDelta(client, security,
+                        Interval.of(LocalDate.parse("2020-01-01"), LocalDate.parse("2021-01-31")));
+    }
+
+    @Test
+    public void testForeignCurrencySecurity()
+    {
+        Client client = new Client();
+
+        Security security = new SecurityBuilder(CurrencyUnit.USD) //
+                        .addPrice("2020-01-01", Values.Quote.factorize(100)) //
+                        .addPrice("2021-01-31", Values.Quote.factorize(130)) //
+                        .addTo(client);
+
+        new PortfolioBuilder() //
+                        .buy(security, "2020-06-01", Values.Share.factorize(10), Values.Amount.factorize(1000)) //
+                        .addTo(client);
+
+        assertTrailMatchesDelta(client, security,
+                        Interval.of(LocalDate.parse("2020-01-01"), LocalDate.parse("2021-01-31")));
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesPerformanceView.java
@@ -1380,6 +1380,8 @@ public class SecuritiesPerformanceView extends AbstractFinanceView implements Re
                         aggregate -> Values.Money.format(
                                         aggregate.sum(getClient().getBaseCurrency(), r -> r.getDelta()),
                                         getClient().getBaseCurrency())));
+        column.setToolTipProvider(element -> ((RowElement) element)
+                        .explain(LazySecurityPerformanceRecord.Trails.ABSOLUTE_PERFORMANCE));
         column.setSorter(ColumnViewerSorter.create(e -> ((LazySecurityPerformanceRecord) e).getDelta()));
         recordColumns.addColumn(column);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/BaseSecurityPerformanceRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/BaseSecurityPerformanceRecord.java
@@ -32,6 +32,7 @@ public class BaseSecurityPerformanceRecord
         String REALIZED_CAPITAL_GAINS_FOREX = "realizedCapitalGainsForex"; //$NON-NLS-1$
         String UNREALIZED_CAPITAL_GAINS = "unrealizedCapitalGains"; //$NON-NLS-1$
         String UNREALIZED_CAPITAL_GAINS_FOREX = "unrealizedCapitalGainsForex"; //$NON-NLS-1$
+        String ABSOLUTE_PERFORMANCE = "absolutePerformance"; //$NON-NLS-1$
     }
 
     protected final Client client;

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DeltaCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DeltaCalculation.java
@@ -1,16 +1,29 @@
 package name.abuchen.portfolio.snapshot.security;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.AccountTransaction.Type;
+import name.abuchen.portfolio.model.Portfolio;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.MutableMoney;
+import name.abuchen.portfolio.snapshot.trail.TrailRecord;
 
 /* package */class DeltaCalculation extends Calculation
 {
     private MutableMoney delta;
     private MutableMoney cost;
+
+    // the delta is built from contributions that either increase it (market
+    // value at end, sells, dividends, refunds) or decrease it (valuation at
+    // start, buys, taxes, fees). They are collected separately so the trail can
+    // be rendered as "sum of inflows - sum of outflows"
+    private final List<TrailRecord> positive = new ArrayList<>();
+    private final List<TrailRecord> negative = new ArrayList<>();
 
     @Override
     public void setTermCurrency(String termCurrency)
@@ -26,33 +39,45 @@ import name.abuchen.portfolio.money.MutableMoney;
         Money amount = t.getValue().with(converter.at(t.getDateTime()));
         delta.subtract(amount);
         cost.add(amount);
+
+        negative.add(valuationTrail(converter, t, amount));
     }
 
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.ValuationAtEnd t)
     {
-        delta.add(t.getValue().with(converter.at(t.getDateTime())));
+        Money amount = t.getValue().with(converter.at(t.getDateTime()));
+        delta.add(amount);
+
+        positive.add(valuationTrail(converter, t, amount));
     }
 
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.DividendPayment t)
     {
-        delta.add(t.getValue().with(converter.at(t.getDateTime())));
+        Money amount = t.getValue().with(converter.at(t.getDateTime()));
+        delta.add(amount);
+
+        positive.add(transactionTrail(converter, t, amount));
     }
 
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.TransactionItem item, AccountTransaction t)
     {
+        Money amount = t.getMonetaryAmount().with(converter.at(t.getDateTime()));
+
         Type type = t.getType();
         switch (type)
         {
             case TAXES:
             case FEES:
-                delta.subtract(t.getMonetaryAmount().with(converter.at(t.getDateTime())));
+                delta.subtract(amount);
+                negative.add(transactionTrail(converter, item, amount));
                 break;
             case TAX_REFUND:
             case FEES_REFUND:
-                delta.add(t.getMonetaryAmount().with(converter.at(t.getDateTime())));
+                delta.add(amount);
+                positive.add(transactionTrail(converter, item, amount));
                 break;
             default:
                 throw new IllegalArgumentException("unsupported type " + type); //$NON-NLS-1$
@@ -63,18 +88,21 @@ import name.abuchen.portfolio.money.MutableMoney;
     @Override
     public void visit(CurrencyConverter converter, CalculationLineItem.TransactionItem item, PortfolioTransaction t)
     {
+        Money amount = t.getMonetaryAmount().with(converter.at(t.getDateTime()));
+
         name.abuchen.portfolio.model.PortfolioTransaction.Type type = t.getType();
         switch (type)
         {
             case BUY:
             case DELIVERY_INBOUND:
-                Money amount = t.getMonetaryAmount().with(converter.at(t.getDateTime()));
                 delta.subtract(amount);
                 cost.add(amount);
+                negative.add(transactionTrail(converter, item, amount));
                 break;
             case SELL:
             case DELIVERY_OUTBOUND:
-                delta.add(t.getMonetaryAmount().with(converter.at(t.getDateTime())));
+                delta.add(amount);
+                positive.add(transactionTrail(converter, item, amount));
                 break;
             case TRANSFER_IN:
             case TRANSFER_OUT:
@@ -96,5 +124,47 @@ import name.abuchen.portfolio.money.MutableMoney;
             return 0d;
 
         return delta.getAmount() / (double) cost.getAmount();
+    }
+
+    /**
+     * Builds the trail that explains how {@link #getDelta()} is calculated:
+     * the sum of all inflows minus the sum of all outflows.
+     */
+    public TrailRecord getDeltaTrail()
+    {
+        if (negative.isEmpty())
+            return TrailRecord.of(positive);
+
+        // TrailRecord.subtract() cannot be called on an empty trail. When there
+        // are no inflows the delta is a pure outflow (e.g. a standalone fee),
+        // so use a zero-valued trail as the minuend to render "0 - outflows".
+        TrailRecord inflows = positive.isEmpty() ? TrailRecord.ofZero(getTermCurrency()) : TrailRecord.of(positive);
+
+        return inflows.subtract(TrailRecord.of(negative));
+    }
+
+    private TrailRecord valuationTrail(CurrencyConverter converter, CalculationLineItem.Valuation valuation,
+                    Money converted)
+    {
+        var position = valuation.getSecurityPosition().orElseThrow(IllegalArgumentException::new);
+        TrailRecord trail = TrailRecord.ofPosition(valuation.getDateTime().toLocalDate(),
+                        (Portfolio) valuation.getOwner(), position);
+        return convertIfNeeded(converter, trail, valuation.getValue(), converted, valuation.getDateTime());
+    }
+
+    private TrailRecord transactionTrail(CurrencyConverter converter, CalculationLineItem.TransactionItem item,
+                    Money converted)
+    {
+        var transaction = item.getTransaction().orElseThrow(IllegalArgumentException::new);
+        TrailRecord trail = TrailRecord.ofTransaction(transaction);
+        return convertIfNeeded(converter, trail, transaction.getMonetaryAmount(), converted, item.getDateTime());
+    }
+
+    private TrailRecord convertIfNeeded(CurrencyConverter converter, TrailRecord trail, Money original,
+                    Money converted, LocalDateTime date)
+    {
+        if (original.getCurrencyCode().equals(getTermCurrency()))
+            return trail;
+        return trail.convert(converted, converter.getRate(date, original.getCurrencyCode()));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/LazySecurityPerformanceRecord.java
@@ -382,6 +382,8 @@ public final class LazySecurityPerformanceRecord extends BaseSecurityPerformance
             case Trails.UNREALIZED_CAPITAL_GAINS_FOREX:
                 return Trail.of(getSecurityName(),
                                 getUnrealizedCapitalGains(CostMethod.FIFO).getForexCapitalGainsTrail());
+            case Trails.ABSOLUTE_PERFORMANCE:
+                return Trail.of(getSecurityName(), deltaCalculation.get().getDeltaTrail());
             default:
                 return Optional.empty();
         }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trail/TrailRecord.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trail/TrailRecord.java
@@ -32,6 +32,17 @@ public interface TrailRecord
         return EmptyTrail.INSTANCE;
     }
 
+    /**
+     * Returns a trail with a value of zero in the given currency. Unlike
+     * {@link #empty()} this trail is not empty and can be used as the minuend
+     * of a {@link #subtract(TrailRecord)} (which {@link #empty()} does not
+     * support), e.g. to render "0 - outflows" when there are no inflows.
+     */
+    public static TrailRecord ofZero(String currencyCode)
+    {
+        return new DefaultTrail(null, Messages.LabelSum, null, Money.of(currencyCode, 0));
+    }
+
     public static TrailRecord of(List<TrailRecord> trails)
     {
         if (trails.isEmpty())


### PR DESCRIPTION
The Absolute performance ("Perf. abs.") column in the Securities Performance view showed no tooltip, unlike the capital-gains columns which explain how their value is computed via a hover trail. This extends the same explanation to the absolute performance.

The tooltip reconstructs the displayed value as the sum of inflows (market value at end, sells, dividends, refunds) minus the sum of outflows (valuation at start, buys, taxes, fees), so a user can see exactly which transactions contribute to the figure.

A security with only outflows in an interval (e.g. a standalone fee) has a purely negative value; that edge case still produces a complete trail rather than an empty tooltip.

Tests assert the trail total equals the displayed value across a plain buy, a buy/sell/dividend mix, a foreign-currency security, an outflow-only case, and a scenario covering every contribution type.


I reviewed CONTRIBUTING.md, and hopefully didn't miss too many relevant items...