### PR TITLE
Statement of Assets column: Quote Date & Update Status

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -151,6 +151,7 @@ public class Messages extends NLS
     public static String ColumnDateFirstHistoricalQuote_MenuLabel;
     public static String ColumnDateLatestExchangeRate;
     public static String ColumnDateOfQuote;
+    public static String ColumnDateOfQuoteWithUpdateStatus;
     public static String ColumnDaysBetweenPostfix;
     public static String ColumnDaysHigh;
     public static String ColumnDaysLow;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -352,7 +352,7 @@ ColumnDateLatestExchangeRate = Date of latest exchange rate
 
 ColumnDateOfQuote = Date of quote
 
-ColumnDateOfQuoteWithUpdateStatus = Date of quote & update status
+ColumnDateOfQuoteWithUpdateStatus = Date of quote and update status
 
 ColumnDaysBetweenPostfix = Days Between
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -352,6 +352,8 @@ ColumnDateLatestExchangeRate = Date of latest exchange rate
 
 ColumnDateOfQuote = Date of quote
 
+ColumnDateOfQuoteWithUpdateStatus = Date of quote & update status
+
 ColumnDaysBetweenPostfix = Days Between
 
 ColumnDaysHigh = Day's High

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -88,10 +89,15 @@ import name.abuchen.portfolio.ui.dnd.ImportFromFileDropAdapter;
 import name.abuchen.portfolio.ui.dnd.SecurityDragListener;
 import name.abuchen.portfolio.ui.dnd.SecurityTransfer;
 import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
+import name.abuchen.portfolio.ui.jobs.priceupdate.FeedUpdateStatus;
+import name.abuchen.portfolio.ui.jobs.priceupdate.PriceUpdateProgress;
+import name.abuchen.portfolio.ui.jobs.priceupdate.PriceUpdateSnapshot;
+import name.abuchen.portfolio.ui.jobs.priceupdate.UpdateStatus;
 import name.abuchen.portfolio.ui.selection.SecuritySelection;
 import name.abuchen.portfolio.ui.selection.SelectionService;
 import name.abuchen.portfolio.ui.util.AttributeComparator;
 import name.abuchen.portfolio.ui.util.CacheKey;
+import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.LabelOnly;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.ValueColorScheme;
@@ -321,6 +327,28 @@ public class StatementOfAssetsViewer
     private Taxonomy taxonomy;
     private Model model;
 
+    /**
+     * Latest snapshot of an ongoing (or just finished) price update job. Used
+     * by the "Date of Quote & Update Status" column to show the live update
+     * status while a job is running.
+     */
+    private PriceUpdateSnapshot priceUpdateSnapshot;
+    private final PriceUpdateProgress.Listener priceUpdateListener = snapshot -> {
+        this.priceUpdateSnapshot = snapshot;
+
+        if (assets != null && !assets.getTable().isDisposed())
+            assets.refresh(true);
+    };
+
+    private Optional<FeedUpdateStatus> getHistoricUpdateStatus(Element element)
+    {
+        var snapshot = priceUpdateSnapshot;
+        if (snapshot == null)
+            return Optional.empty();
+
+        return snapshot.getHistoricStatus(element.getSecurity());
+    }
+
     @Inject
     public StatementOfAssetsViewer(AbstractFinanceView owner, Client client)
     {
@@ -343,6 +371,8 @@ public class StatementOfAssetsViewer
         Control control = createColumns(parent, isConfigurable);
 
         this.assets.getTable().addDisposeListener(e -> StatementOfAssetsViewer.this.widgetDisposed());
+
+        PriceUpdateProgress.getInstance().register(client, priceUpdateListener);
 
         return control;
     }
@@ -500,6 +530,46 @@ public class StatementOfAssetsViewer
             Element element = (Element) e;
             return element.isSecurity() ? element.getSecurityPosition().getPrice().getDate() : null;
         }));
+        column.setComparator(new ElementComparator(new AttributeComparator(
+                        e -> ((Element) e).isSecurity() ? ((Element) e).getSecurityPosition().getPrice().getDate()
+                                        : null)));
+        column.setVisible(false);
+        support.addColumn(column);
+
+        column = new Column("qdate-status", Messages.ColumnDateOfQuoteWithUpdateStatus, SWT.LEFT, 80); //$NON-NLS-1$
+        column.setLabelProvider(new DateLabelProvider(e -> {
+            Element element = (Element) e;
+            return element.isSecurity() ? element.getSecurityPosition().getPrice().getDate() : null;
+        })
+        {
+            @Override
+            public String getText(Object e)
+            {
+                Element element = (Element) e;
+                if (!element.isSecurity())
+                    return null;
+
+                var status = getHistoricUpdateStatus(element);
+                if (status.isPresent() && !status.get().getStatus().isTerminal)
+                    return status.get().getStatus().toString();
+
+                return super.getText(e);
+            }
+
+            @Override
+            public Color getBackground(Object e)
+            {
+                Element element = (Element) e;
+                if (!element.isSecurity())
+                    return null;
+
+                var status = getHistoricUpdateStatus(element);
+                if (status.isPresent() && status.get().getStatus() == UpdateStatus.WAITING)
+                    return Colors.theme().warningBackground();
+
+                return null;
+            }
+        });
         column.setComparator(new ElementComparator(new AttributeComparator(
                         e -> ((Element) e).isSecurity() ? ((Element) e).getSecurityPosition().getPrice().getDate()
                                         : null)));
@@ -1226,6 +1296,8 @@ public class StatementOfAssetsViewer
 
         if (contextMenu != null)
             contextMenu.dispose();
+
+        PriceUpdateProgress.getInstance().unregister(client, priceUpdateListener);
     }
 
     public static class Element implements Adaptable

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -329,8 +329,8 @@ public class StatementOfAssetsViewer
 
     /**
      * Latest snapshot of an ongoing (or just finished) price update job. Used
-     * by the "Date of Quote & Update Status" column to show the live update
-     * status while a job is running.
+     * by the "Date of quote and update status" column to show the live
+     * update status while a job is running.
      */
     private PriceUpdateSnapshot priceUpdateSnapshot;
     private final PriceUpdateProgress.Listener priceUpdateListener = snapshot -> {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -327,11 +327,6 @@ public class StatementOfAssetsViewer
     private Taxonomy taxonomy;
     private Model model;
 
-    /**
-     * Latest snapshot of an ongoing (or just finished) price update job. Used
-     * by the "Date of quote and update status" column to show the live
-     * update status while a job is running.
-     */
     private PriceUpdateSnapshot priceUpdateSnapshot;
     private final PriceUpdateProgress.Listener priceUpdateListener = snapshot -> {
         this.priceUpdateSnapshot = snapshot;


### PR DESCRIPTION
Implement a new optional column for Statement of Assets that shows the quote date when not updating, and the status of the update when updating.

Avoids needing to switch to View->Price Update Status & makes it easier to see inline what's being waited on, especially with rate-limited providers like Coingecko.

<img width="746" height="623" alt="Peek 2026-08-04 20-09" src="https://github.com/user-attachments/assets/4290f748-f551-46a9-bde2-21e4f84baeed" />
