### PR TITLE
Fix "No more handles" when importing many PDF documents

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/datatransfer/ImportExtractedItemsWizard.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/datatransfer/ImportExtractedItemsWizard.java
@@ -16,6 +16,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Composite;
 
 import name.abuchen.portfolio.datatransfer.Extractor;
 import name.abuchen.portfolio.datatransfer.Extractor.Item;
@@ -222,6 +223,30 @@ public final class ImportExtractedItemsWizard extends Wizard
                         });
 
         AbstractWizardPage.attachPageListenerTo(getContainer());
+    }
+
+    @Override
+    public void createPageControls(Composite pageContainer)
+    {
+        // Create the controls of the review pages up front (there are only a
+        // few of them: one per detected bank plus the error page), but not
+        // those of the manual entry pages: there is one such page per
+        // unrecognized PDF document and each holds a PDF viewer plus a table,
+        // i.e. dozens of operating system widget handles. Importing a few
+        // hundred documents would create them all at once and exhaust the
+        // handle limit, so the wizard fails to even open with "SWTError: No
+        // more handles".
+        //
+        // Instead the manual pages create their controls on demand when the
+        // user navigates to them (WizardDialog#updateForPage creates the
+        // control of a page whose getControl() is null) and dispose them again
+        // when the user leaves (ManualTransactionEntryPage#afterPage), which
+        // bounds the number of handles regardless of the number of documents.
+        for (IWizardPage page : getPages())
+        {
+            if (!(page instanceof ManualTransactionEntryPage))
+                page.createControl(pageContainer);
+        }
     }
 
     @Override

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/datatransfer/ManualTransactionEntryPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/datatransfer/ManualTransactionEntryPage.java
@@ -99,9 +99,14 @@ public class ManualTransactionEntryPage extends AbstractWizardPage
 
     private final List<ExtractedEntry> entries = new ArrayList<>();
 
+    // widgets are created lazily and disposed again whenever the user leaves
+    // the page (see #disposeControl), i.e. they are null while the page is not
+    // being displayed. Everything that must survive lives in #entries and in
+    // the plain fields below.
     private PDFViewer pdfViewer;
     private ExtractedItemsTable itemsTable;
     private Composite buttonRow;
+    private int[] sashWeights = new int[] { 50, 50 };
     private boolean editorOpen;
     private boolean capturedForDebug;
 
@@ -132,21 +137,75 @@ public class ManualTransactionEntryPage extends AbstractWizardPage
         pdfViewer = new PDFViewer(sash, SWT.NONE, inputFile);
         createRightPane(sash);
 
-        sash.setWeights(50, 50);
+        sash.setWeights(sashWeights);
     }
 
     @Override
     public void beforePage()
     {
-        pdfViewer.initialize();
+        // the wizard dialog (re)creates the control before the page becomes
+        // visible; guard anyway because the page may be disposed (see
+        // #disposeControl)
+        if (pdfViewer != null)
+            pdfViewer.initialize();
     }
 
     @Override
     public void afterPage()
     {
-        // free the document and cached page images so that only the currently
-        // viewed document stays in memory
-        pdfViewer.release();
+        disposeControl();
+    }
+
+    @Override
+    public void setVisible(boolean visible)
+    {
+        // the base implementation dereferences the control unconditionally; the
+        // control does not exist while the user is on another page
+        if (getControl() != null && !getControl().isDisposed())
+            super.setVisible(visible);
+    }
+
+    /**
+     * Disposes the page's widgets when the user navigates away, so that only
+     * the pages actually being looked at hold operating system widget handles.
+     * <p>
+     * An import creates one manual entry page per unrecognized PDF document,
+     * and each page holds a PDF viewer plus a table, i.e. dozens of handles.
+     * Keeping all of them alive exhausts the handle limit of the operating
+     * system on larger imports ({@code SWTError: No more handles}).
+     * <p>
+     * No user data is lost: the transactions created on this page are kept in
+     * {@link #entries} and the remaining page state lives in plain fields, none
+     * of which are touched here. The table is repopulated from
+     * {@link #entries} when the wizard dialog recreates the control on the next
+     * visit, and {@link #getItems()} keeps returning the transactions when the
+     * wizard is finished, whether or not the page is currently displayed.
+     */
+    private void disposeControl()
+    {
+        // never pull the widgets out from underneath an open transaction editor
+        // (the wizard is frozen while one is open, but be defensive because the
+        // editor's dispose listener still refers to the widgets)
+        if (editorOpen)
+            return;
+
+        var control = getControl();
+        if (control != null && !control.isDisposed())
+        {
+            // keep the splitter position across the recreation
+            var weights = ((SashForm) control).getWeights();
+            if (weights.length == 2)
+                sashWeights = weights;
+
+            control.dispose();
+        }
+
+        // signals the wizard dialog to recreate the control on the next visit
+        setControl(null);
+
+        pdfViewer = null;
+        itemsTable = null;
+        buttonRow = null;
     }
 
     private void createRightPane(Composite parent)
@@ -344,7 +403,7 @@ public class ManualTransactionEntryPage extends AbstractWizardPage
                         debugCache.add(inputFile.getName(), inputFile.getText(), inputFile.getPDFBoxVersion());
                         capturedForDebug = true;
                     }
-                    if (!itemsTable.getTableViewer().getControl().isDisposed())
+                    if (itemsTable != null && !itemsTable.getTableViewer().getControl().isDisposed())
                         itemsTable.refresh();
                 }
             }
@@ -356,7 +415,7 @@ public class ManualTransactionEntryPage extends AbstractWizardPage
                     importDialog.setEditing(false);
                     getContainer().updateButtons();
                 }
-                if (!buttonRow.isDisposed())
+                if (buttonRow != null && !buttonRow.isDisposed())
                     setButtonRowEnabled(true);
                 editorOpen = false;
             }


### PR DESCRIPTION
Importing a large number of PDF documents could crash the application before the import wizard even opened:

  org.eclipse.swt.SWTError: No more handles
    at name.abuchen.portfolio.ui.util.swt.PDFViewer.<init>
    at ...ManualTransactionEntryPage.createControl
    at org.eclipse.jface.wizard.Wizard.createPageControls

JFace creates the SWT controls of all wizard pages up front. The import wizard adds one ManualTransactionEntryPage per unrecognized document, and each of those pages builds a PDF viewer plus a transaction table, i.e. dozens of operating system widget handles. With a few hundred documents the handle limit of the operating system is exhausted while the dialog is being created.

Only the review pages (one per detected bank plus the error page) are now created up front. The manual entry pages create their controls on demand when the user navigates to them and dispose them again when the user leaves, so the number of live handles no longer depends on the number of imported documents.

The pages keep their data across this: the transactions created on a page live in the page's entry list and the remaining state in plain fields, so they are shown again when the user navigates back and are still imported into the client when the wizard is finished. The splitter position is carried over as well, and a page is never disposed while one of its modeless transaction editors is still open.

Issue:
https://forum.portfolio-performance.info/t/pdf-import-scheitert-bei-grosser-dokumentenanzahl/39625