### PR TITLE
Fix NullPointerException when searching for a new instrument

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/SecuritySearchProviderTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/SecuritySearchProviderTest.java
@@ -1,0 +1,279 @@
+package name.abuchen.portfolio.online.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+import org.junit.Test;
+
+import name.abuchen.portfolio.online.SecuritySearchProvider.ResultItem;
+
+/**
+ * Malformed responses of a search provider must not throw a
+ * {@link NullPointerException} because that aborts the search of all other
+ * providers as well.
+ *
+ * @see <a href=
+ *      "https://github.com/portfolio-performance/portfolio/issues/5919">Issue
+ *      #5919</a>
+ */
+@SuppressWarnings("nls")
+public class SecuritySearchProviderTest
+{
+    @Test
+    public void testYahooSearchIgnoresMalformedDocuments()
+    {
+        var json = """
+                        {"finance":{"result":[{"documents":[
+                          null,
+                          "not an object",
+                          {"noSymbol":"value"},
+                          {"symbol":"META","shortName":"Meta Platforms, Inc.","quoteType":"EQUITY","exchange":"NMS"}
+                        ]}]}}
+                        """;
+
+        List<ResultItem> answer = new ArrayList<>();
+        new YahooSearchProvider().extractFrom(answer, json);
+
+        assertThat(answer.size(), is(1));
+        assertThat(answer.get(0).getSymbol(), is("META"));
+        assertThat(answer.get(0).getName(), is("Meta Platforms, Inc."));
+    }
+
+    @Test
+    public void testYahooSearchIgnoresUnexpectedJsonStructure()
+    {
+        List<ResultItem> answer = new ArrayList<>();
+        var provider = new YahooSearchProvider();
+
+        // the response is an array instead of an object
+        provider.extractFrom(answer, "[\"service unavailable\"]");
+
+        // the nested attributes have an unexpected type
+        provider.extractFrom(answer, "{\"finance\":\"error\"}");
+        provider.extractFrom(answer, "{\"finance\":{\"result\":\"error\"}}");
+        provider.extractFrom(answer, "{\"finance\":{\"result\":[\"not an object\"]}}");
+        provider.extractFrom(answer, "{\"finance\":{\"result\":[{\"documents\":\"error\"}]}}");
+
+        assertTrue(answer.isEmpty());
+    }
+
+    @Test
+    public void testYahooSymbolSearchIgnoresNullQuote()
+    {
+        assertTrue(YahooSymbolSearch.Result.from(null).isEmpty());
+    }
+
+    @Test
+    public void testPortfolioPerformanceSearchIgnoresMalformedMarkets()
+    {
+        var json = """
+                        {"provider":"PP","description":"Meta Platforms","isin":"US30303M1027","markets":[
+                          null,
+                          "not an object",
+                          {"symbol":"META","currency":"USD","exchange":"XNAS"},
+                          {"symbol":"FB2A","currency":"EUR","exchange":"XETR"}
+                        ]}
+                        """;
+
+        var item = PortfolioPerformanceSearchProvider.Result.from((JSONObject) JSONValue.parse(json));
+
+        assertTrue(item.isPresent());
+        assertThat(item.get().getMarkets().size(), is(2));
+    }
+
+    @Test
+    public void testPortfolioPerformanceSearchIgnoresUnexpectedJsonStructure()
+    {
+        var json = """
+                        {"provider":"PP","description":"Meta Platforms","markets":"error"}
+                        """;
+
+        var item = PortfolioPerformanceSearchProvider.Result.from((JSONObject) JSONValue.parse(json));
+
+        assertTrue(item.isPresent());
+        assertTrue(item.get().getMarkets().isEmpty());
+    }
+
+    @Test
+    public void testPortfolioPerformanceSearchIgnoresNullItem()
+    {
+        assertTrue(PortfolioPerformanceSearchProvider.Result.from(null).isEmpty());
+    }
+
+    @Test
+    public void testTwelveDataSearchIgnoresMalformedResponse()
+    {
+        List<ResultItem> answer = new ArrayList<>();
+        var provider = new TwelveDataSearchProvider();
+
+        // response is not valid JSON at all
+        provider.extract(answer, "<html>service unavailable</html>");
+        assertTrue(answer.isEmpty());
+
+        // response is an array instead of an object
+        provider.extract(answer, "[\"service unavailable\"]");
+        assertTrue(answer.isEmpty());
+
+        // the data attribute has an unexpected type
+        provider.extract(answer, "{\"data\":\"error\"}");
+        assertTrue(answer.isEmpty());
+
+        provider.extract(answer, """
+                        {"data":[
+                          null,
+                          "not an object",
+                          {"instrument_name":"Meta Platforms Inc"},
+                          {"symbol":"META","instrument_name":"Meta Platforms Inc","instrument_type":"Common Stock","currency":"USD"},
+                          {"symbol":"META","instrument_name":"Meta Platforms Inc","mic_code":"XNAS","currency":"USD"}
+                        ],"status":"ok"}
+                        """);
+
+        assertThat(answer.size(), is(2));
+
+        // without a market identifier code, no suffix is added to the symbol
+        assertThat(answer.get(0).getSymbol(), is("META"));
+        assertThat(answer.get(1).getSymbol(), is("META.XNAS"));
+    }
+
+    @Test
+    public void testLeewaySearchIgnoresMalformedResponse()
+    {
+        var provider = new LeewaySearchProvider();
+
+        // response is not valid JSON at all
+        assertTrue(provider.extract("<html>service unavailable</html>").isEmpty());
+
+        // response is an object instead of an array
+        assertTrue(provider.extract("{\"error\":\"service unavailable\"}").isEmpty());
+
+        var result = provider.extract("""
+                        [
+                          null,
+                          "not an object",
+                          {"Name":"Meta Platforms Inc"},
+                          {"Code":"META","Name":"Meta Platforms Inc","Type":"Common Stock","ISIN":"US30303M1027","currencyCode":"USD"},
+                          {"Code":"FB2A","Exchange":"XETRA","Name":"Meta Platforms Inc","ISIN":"US30303M1027","currencyCode":"EUR"}
+                        ]
+                        """);
+
+        assertThat(result.size(), is(2));
+
+        // without an exchange, no suffix is added to the symbol
+        assertThat(result.get(0).getSymbol(), is("META"));
+        assertThat(result.get(1).getSymbol(), is("FB2A.XETRA"));
+    }
+
+    @Test
+    public void testFinnhubSearchIgnoresNullResult()
+    {
+        assertTrue(FinnhubSearchProvider.Result.from(new JSONObject()).isEmpty());
+    }
+
+    @Test
+    public void testFinnhubSearchDoesNotCreateNullLiterals()
+    {
+        var json = (JSONObject) JSONValue.parse("""
+                        {"symbol":"META"}
+                        """);
+
+        var item = FinnhubSearchProvider.Result.from(json).orElseThrow();
+
+        assertThat(item.getSymbol(), is("META"));
+        assertNull(item.getName());
+        assertNull(item.getType());
+    }
+
+    @Test
+    public void testEODHistoricalDataSearchIgnoresNullResult()
+    {
+        assertTrue(EODHistoricalDataSearchProvider.Result.from(new JSONObject()).isEmpty());
+    }
+
+    @Test
+    public void testEODHistoricalDataSearchDoesNotCreateNullLiterals()
+    {
+        var json = (JSONObject) JSONValue.parse("""
+                        {"Code":"META"}
+                        """);
+
+        var item = EODHistoricalDataSearchProvider.Result.from(json).orElseThrow();
+
+        // without an exchange, no suffix is added to the symbol
+        assertThat(item.getSymbol(), is("META"));
+        assertNull(item.getName());
+        assertNull(item.getType());
+        assertNull(item.getExchange());
+        assertNull(item.getCountry());
+        assertNull(item.getCurrency());
+        assertNull(item.getPreviousClose());
+        assertNull(item.getPreviousCloseDate());
+    }
+
+    @Test
+    public void testCoinGeckoSearchIgnoresIncompleteCoins()
+    {
+        var json = """
+                        [
+                          null,
+                          "not an object",
+                          {"symbol":"meta","name":"Metadium"},
+                          {"id":"metadium","name":"Metadium"},
+                          {"id":"metadium","symbol":"meta","name":"Metadium"}
+                        ]
+                        """;
+
+        var coins = CoinGeckoQuoteFeed.extractCoins(json);
+
+        assertThat(coins.size(), is(1));
+        assertThat(coins.get(0).getId(), is("metadium"));
+
+        // response is not valid JSON at all
+        assertTrue(CoinGeckoQuoteFeed.extractCoins("<html>service unavailable</html>").isEmpty());
+
+        // response is the error object returned when the rate limit is exceeded
+        assertTrue(CoinGeckoQuoteFeed.extractCoins("{\"status\":{\"error_code\":429}}").isEmpty());
+    }
+
+    @Test
+    public void testCoinGeckoDoesNotCacheRejectedCoinList() throws IOException
+    {
+        // the error object returned if the rate limit is exceeded
+        var responses = new ArrayDeque<>(List.of("{\"status\":{\"error_code\":429}}",
+                        "[{\"id\":\"metadium\",\"symbol\":\"meta\",\"name\":\"Metadium\"}]"));
+
+        var feed = new CoinGeckoQuoteFeed()
+        {
+            @Override
+            String requestCoinList() throws IOException
+            {
+                return responses.poll();
+            }
+        };
+
+        assertTrue(feed.getCoins().isEmpty());
+
+        // the rejected response must not be cached
+        assertThat(feed.getCoins().size(), is(1));
+    }
+
+    @Test
+    public void testCoinGeckoSearchIgnoresCoinsWithoutName()
+    {
+        var coins = List.of(new CoinGeckoQuoteFeed.Coin("metadium", "meta", null),
+                        new CoinGeckoQuoteFeed.Coin("meta-masters", "mms", "Meta Masters"));
+
+        var items = CoinGeckoSearchProvider.filter(coins, "Meta");
+
+        assertThat(items.size(), is(1));
+        assertThat(items.get(0).getName(), is("Meta Masters"));
+    }
+}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/SecuritySearchProviderTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/online/impl/SecuritySearchProviderTest.java
@@ -1,0 +1,255 @@
+package name.abuchen.portfolio.online.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+import org.junit.Test;
+
+import name.abuchen.portfolio.online.SecuritySearchProvider.ResultItem;
+
+/**
+ * Malformed responses of a search provider must not throw a
+ * {@link NullPointerException} because that aborts the search of all other
+ * providers as well.
+ *
+ * @see <a href=
+ *      "https://github.com/portfolio-performance/portfolio/issues/5919">Issue
+ *      #5919</a>
+ */
+@SuppressWarnings("nls")
+public class SecuritySearchProviderTest
+{
+    @Test
+    public void testYahooSearchIgnoresMalformedDocuments()
+    {
+        var json = """
+                        {"finance":{"result":[{"documents":[
+                          null,
+                          "not an object",
+                          {"noSymbol":"value"},
+                          {"symbol":"META","shortName":"Meta Platforms, Inc.","quoteType":"EQUITY","exchange":"NMS"}
+                        ]}]}}
+                        """;
+
+        List<ResultItem> answer = new ArrayList<>();
+        new YahooSearchProvider().extractFrom(answer, json);
+
+        assertThat(answer.size(), is(1));
+        assertThat(answer.get(0).getSymbol(), is("META"));
+        assertThat(answer.get(0).getName(), is("Meta Platforms, Inc."));
+    }
+
+    @Test
+    public void testYahooSearchIgnoresUnexpectedJsonStructure()
+    {
+        List<ResultItem> answer = new ArrayList<>();
+        var provider = new YahooSearchProvider();
+
+        // the response is an array instead of an object
+        provider.extractFrom(answer, "[\"service unavailable\"]");
+
+        // the nested attributes have an unexpected type
+        provider.extractFrom(answer, "{\"finance\":\"error\"}");
+        provider.extractFrom(answer, "{\"finance\":{\"result\":\"error\"}}");
+        provider.extractFrom(answer, "{\"finance\":{\"result\":[\"not an object\"]}}");
+        provider.extractFrom(answer, "{\"finance\":{\"result\":[{\"documents\":\"error\"}]}}");
+
+        assertTrue(answer.isEmpty());
+    }
+
+    @Test
+    public void testYahooSymbolSearchIgnoresNullQuote()
+    {
+        assertTrue(YahooSymbolSearch.Result.from(null).isEmpty());
+    }
+
+    @Test
+    public void testPortfolioPerformanceSearchIgnoresMalformedMarkets()
+    {
+        var json = """
+                        {"provider":"PP","description":"Meta Platforms","isin":"US30303M1027","markets":[
+                          null,
+                          "not an object",
+                          {"symbol":"META","currency":"USD","exchange":"XNAS"},
+                          {"symbol":"FB2A","currency":"EUR","exchange":"XETR"}
+                        ]}
+                        """;
+
+        var item = PortfolioPerformanceSearchProvider.Result.from((JSONObject) JSONValue.parse(json));
+
+        assertTrue(item.isPresent());
+        assertThat(item.get().getMarkets().size(), is(2));
+    }
+
+    @Test
+    public void testPortfolioPerformanceSearchIgnoresUnexpectedJsonStructure()
+    {
+        var json = """
+                        {"provider":"PP","description":"Meta Platforms","markets":"error"}
+                        """;
+
+        var item = PortfolioPerformanceSearchProvider.Result.from((JSONObject) JSONValue.parse(json));
+
+        assertTrue(item.isPresent());
+        assertTrue(item.get().getMarkets().isEmpty());
+    }
+
+    @Test
+    public void testPortfolioPerformanceSearchIgnoresNullItem()
+    {
+        assertTrue(PortfolioPerformanceSearchProvider.Result.from(null).isEmpty());
+    }
+
+    @Test
+    public void testTwelveDataSearchIgnoresMalformedResponse()
+    {
+        List<ResultItem> answer = new ArrayList<>();
+        var provider = new TwelveDataSearchProvider();
+
+        // response is not valid JSON at all
+        provider.extract(answer, "<html>service unavailable</html>");
+        assertTrue(answer.isEmpty());
+
+        // response is an array instead of an object
+        provider.extract(answer, "[\"service unavailable\"]");
+        assertTrue(answer.isEmpty());
+
+        // the data attribute has an unexpected type
+        provider.extract(answer, "{\"data\":\"error\"}");
+        assertTrue(answer.isEmpty());
+
+        provider.extract(answer, """
+                        {"data":[
+                          null,
+                          "not an object",
+                          {"instrument_name":"Meta Platforms Inc"},
+                          {"symbol":"META","instrument_name":"Meta Platforms Inc","instrument_type":"Common Stock","currency":"USD"},
+                          {"symbol":"META","instrument_name":"Meta Platforms Inc","mic_code":"XNAS","currency":"USD"}
+                        ],"status":"ok"}
+                        """);
+
+        assertThat(answer.size(), is(2));
+
+        // without a market identifier code, no suffix is added to the symbol
+        assertThat(answer.get(0).getSymbol(), is("META"));
+        assertThat(answer.get(1).getSymbol(), is("META.XNAS"));
+    }
+
+    @Test
+    public void testLeewaySearchIgnoresMalformedResponse()
+    {
+        var provider = new LeewaySearchProvider();
+
+        // response is not valid JSON at all
+        assertTrue(provider.extract("<html>service unavailable</html>").isEmpty());
+
+        // response is an object instead of an array
+        assertTrue(provider.extract("{\"error\":\"service unavailable\"}").isEmpty());
+
+        var result = provider.extract("""
+                        [
+                          null,
+                          "not an object",
+                          {"Name":"Meta Platforms Inc"},
+                          {"Code":"META","Name":"Meta Platforms Inc","Type":"Common Stock","ISIN":"US30303M1027","currencyCode":"USD"},
+                          {"Code":"FB2A","Exchange":"XETRA","Name":"Meta Platforms Inc","ISIN":"US30303M1027","currencyCode":"EUR"}
+                        ]
+                        """);
+
+        assertThat(result.size(), is(2));
+
+        // without an exchange, no suffix is added to the symbol
+        assertThat(result.get(0).getSymbol(), is("META"));
+        assertThat(result.get(1).getSymbol(), is("FB2A.XETRA"));
+    }
+
+    @Test
+    public void testFinnhubSearchIgnoresNullResult()
+    {
+        assertTrue(FinnhubSearchProvider.Result.from(new JSONObject()).isEmpty());
+    }
+
+    @Test
+    public void testFinnhubSearchDoesNotCreateNullLiterals()
+    {
+        var json = (JSONObject) JSONValue.parse("""
+                        {"symbol":"META"}
+                        """);
+
+        var item = FinnhubSearchProvider.Result.from(json).orElseThrow();
+
+        assertThat(item.getSymbol(), is("META"));
+        assertNull(item.getName());
+        assertNull(item.getType());
+    }
+
+    @Test
+    public void testEODHistoricalDataSearchIgnoresNullResult()
+    {
+        assertTrue(EODHistoricalDataSearchProvider.Result.from(new JSONObject()).isEmpty());
+    }
+
+    @Test
+    public void testEODHistoricalDataSearchDoesNotCreateNullLiterals()
+    {
+        var json = (JSONObject) JSONValue.parse("""
+                        {"Code":"META"}
+                        """);
+
+        var item = EODHistoricalDataSearchProvider.Result.from(json).orElseThrow();
+
+        // without an exchange, no suffix is added to the symbol
+        assertThat(item.getSymbol(), is("META"));
+        assertNull(item.getName());
+        assertNull(item.getType());
+        assertNull(item.getExchange());
+        assertNull(item.getCountry());
+        assertNull(item.getCurrency());
+        assertNull(item.getPreviousClose());
+        assertNull(item.getPreviousCloseDate());
+    }
+
+    @Test
+    public void testCoinGeckoSearchIgnoresIncompleteCoins()
+    {
+        var json = """
+                        [
+                          null,
+                          "not an object",
+                          {"symbol":"meta","name":"Metadium"},
+                          {"id":"metadium","name":"Metadium"},
+                          {"id":"metadium","symbol":"meta","name":"Metadium"}
+                        ]
+                        """;
+
+        var coins = CoinGeckoQuoteFeed.extractCoins(json);
+
+        assertThat(coins.size(), is(1));
+        assertThat(coins.get(0).getId(), is("metadium"));
+
+        // response is not valid JSON at all
+        assertTrue(CoinGeckoQuoteFeed.extractCoins("<html>service unavailable</html>").isEmpty());
+
+        // response is the error object returned when the rate limit is exceeded
+        assertTrue(CoinGeckoQuoteFeed.extractCoins("{\"status\":{\"error_code\":429}}").isEmpty());
+    }
+
+    @Test
+    public void testCoinGeckoSearchIgnoresCoinsWithoutName()
+    {
+        var coins = List.of(new CoinGeckoQuoteFeed.Coin("metadium", "meta", null),
+                        new CoinGeckoQuoteFeed.Coin("meta-masters", "mms", "Meta Masters"));
+
+        var items = CoinGeckoSearchProvider.filter(coins, "Meta");
+
+        assertThat(items.size(), is(1));
+        assertThat(items.get(0).getName(), is("Meta Masters"));
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/search/SearchSecurityWizardPage.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/wizards/search/SearchSecurityWizardPage.java
@@ -1,6 +1,5 @@
 package name.abuchen.portfolio.ui.wizards.search;
 
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -370,8 +369,13 @@ public class SearchSecurityWizardPage extends WizardPage
                         progressMonitor.setTaskName(provider.getName());
                         result.addAll(provider.search(query));
                     }
-                    catch (IOException e)
+                    catch (Exception e) // NOSONAR
                     {
+                        // catch any exception (not only IOException) because a
+                        // single failing search provider must not abort the
+                        // search of the other providers. Instead the error is
+                        // reported in the error message area of the wizard.
+
                         PortfolioPlugin.log(e);
                         errors.add(provider.getName() + ": " + e.getMessage()); //$NON-NLS-1$
                     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/CoinGeckoQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/CoinGeckoQuoteFeed.java
@@ -407,37 +407,55 @@ public class CoinGeckoQuoteFeed implements QuoteFeed
     {
         if (coins == null)
         {
-            List<Coin> coinList = new ArrayList<>();
+            var extracted = extractCoins(requestCoinList());
 
-            WebAccess webaccess = new WebAccess(getHost(), "/api/v3/coins/list"); //$NON-NLS-1$
+            // do not cache a rejected response - for example the error object
+            // returned if the rate limit is exceeded - but retry with the next
+            // call instead
+            if (extracted.isEmpty())
+                return extracted;
 
-            if (hasPlan())
-                webaccess.addHeader("x-cg-pro-api-key", this.apiKey); //$NON-NLS-1$
-            else if (hasDemoAccount())
-                webaccess.addHeader("x-cg-demo-api-key", this.demoApiKey); //$NON-NLS-1$
-
-            String html = webaccess.get();
-
-            JSONArray coinArray = (JSONArray) JSONValue.parse(html);
-
-            if (coinArray != null)
-            {
-                for (Object object : coinArray)
-                {
-                    JSONObject coinObject = (JSONObject) object;
-
-                    Coin coin = new Coin();
-                    coin.id = (String) coinObject.get("id"); //$NON-NLS-1$
-                    coin.symbol = (String) coinObject.get("symbol"); //$NON-NLS-1$
-                    coin.name = (String) coinObject.get("name"); //$NON-NLS-1$
-
-                    coinList.add(coin);
-                }
-            }
-
-            coins = coinList;
+            coins = extracted;
         }
 
         return coins;
+    }
+
+    /* package */ String requestCoinList() throws IOException
+    {
+        WebAccess webaccess = new WebAccess(getHost(), "/api/v3/coins/list"); //$NON-NLS-1$
+
+        if (hasPlan())
+            webaccess.addHeader("x-cg-pro-api-key", this.apiKey); //$NON-NLS-1$
+        else if (hasDemoAccount())
+            webaccess.addHeader("x-cg-demo-api-key", this.demoApiKey); //$NON-NLS-1$
+
+        return webaccess.get();
+    }
+
+    /* package */ static List<Coin> extractCoins(String html)
+    {
+        List<Coin> coinList = new ArrayList<>();
+
+        if (JSONValue.parse(html) instanceof JSONArray coinArray)
+        {
+            for (Object object : coinArray)
+            {
+                if (!(object instanceof JSONObject coinObject))
+                    continue;
+
+                Coin coin = new Coin();
+                coin.id = (String) coinObject.get("id"); //$NON-NLS-1$
+                coin.symbol = (String) coinObject.get("symbol"); //$NON-NLS-1$
+                coin.name = (String) coinObject.get("name"); //$NON-NLS-1$
+
+                if (coin.id == null || coin.symbol == null)
+                    continue;
+
+                coinList.add(coin);
+            }
+        }
+
+        return coinList;
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/CoinGeckoQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/CoinGeckoQuoteFeed.java
@@ -407,8 +407,6 @@ public class CoinGeckoQuoteFeed implements QuoteFeed
     {
         if (coins == null)
         {
-            List<Coin> coinList = new ArrayList<>();
-
             WebAccess webaccess = new WebAccess(getHost(), "/api/v3/coins/list"); //$NON-NLS-1$
 
             if (hasPlan())
@@ -416,28 +414,35 @@ public class CoinGeckoQuoteFeed implements QuoteFeed
             else if (hasDemoAccount())
                 webaccess.addHeader("x-cg-demo-api-key", this.demoApiKey); //$NON-NLS-1$
 
-            String html = webaccess.get();
-
-            JSONArray coinArray = (JSONArray) JSONValue.parse(html);
-
-            if (coinArray != null)
-            {
-                for (Object object : coinArray)
-                {
-                    JSONObject coinObject = (JSONObject) object;
-
-                    Coin coin = new Coin();
-                    coin.id = (String) coinObject.get("id"); //$NON-NLS-1$
-                    coin.symbol = (String) coinObject.get("symbol"); //$NON-NLS-1$
-                    coin.name = (String) coinObject.get("name"); //$NON-NLS-1$
-
-                    coinList.add(coin);
-                }
-            }
-
-            coins = coinList;
+            coins = extractCoins(webaccess.get());
         }
 
         return coins;
+    }
+
+    /* package */ static List<Coin> extractCoins(String html)
+    {
+        List<Coin> coinList = new ArrayList<>();
+
+        if (JSONValue.parse(html) instanceof JSONArray coinArray)
+        {
+            for (Object object : coinArray)
+            {
+                if (!(object instanceof JSONObject coinObject))
+                    continue;
+
+                Coin coin = new Coin();
+                coin.id = (String) coinObject.get("id"); //$NON-NLS-1$
+                coin.symbol = (String) coinObject.get("symbol"); //$NON-NLS-1$
+                coin.name = (String) coinObject.get("name"); //$NON-NLS-1$
+
+                if (coin.id == null || coin.symbol == null)
+                    continue;
+
+                coinList.add(coin);
+            }
+        }
+
+        return coinList;
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/CoinGeckoSearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/CoinGeckoSearchProvider.java
@@ -100,13 +100,19 @@ public class CoinGeckoSearchProvider implements SecuritySearchProvider
     public List<ResultItem> search(String query) throws IOException
     {
         CoinGeckoQuoteFeed feed = Factory.getQuoteFeed(CoinGeckoQuoteFeed.class);
+        return filter(feed.getCoins(), query);
+    }
 
+    /* package */ static List<ResultItem> filter(List<Coin> coins, String query)
+    {
         List<ResultItem> items = new ArrayList<>();
-        List<Coin> coins = feed.getCoins();
 
         for (Coin coin : coins)
         {
-            if (coin.getName().contains(query) || coin.getId().contains(query))
+            // name is optional and therefore can be null
+            var name = coin.getName();
+
+            if ((name != null && name.contains(query)) || coin.getId().contains(query))
                 items.add(new Result(coin));
         }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/DivvyDiarySearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/DivvyDiarySearchProvider.java
@@ -444,8 +444,7 @@ public class DivvyDiarySearchProvider implements SecuritySearchProvider
                             .addHeader("X-API-KEY", apiKey) //
                             .get();
 
-            JSONObject responseData = (JSONObject) JSONValue.parse(html);
-            if (responseData != null)
+            if (JSONValue.parse(html) instanceof JSONObject responseData)
             {
                 Result.from(responseData).ifPresent(answer::add);
             }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/EODHistoricalDataSearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/EODHistoricalDataSearchProvider.java
@@ -83,8 +83,8 @@ public class EODHistoricalDataSearchProvider implements SecuritySearchProvider
             var symbol = String.valueOf(code);
 
             // exchange is a 2-character code that can be appended to the symbol
-            var exchange = String.valueOf(json.get("Exchange")); //$NON-NLS-1$
-            if (!exchange.isBlank())
+            var exchange = asString(json.get("Exchange")); //$NON-NLS-1$
+            if (exchange != null && !exchange.isBlank())
             {
                 symbol += '.' + exchange;
             }
@@ -120,9 +120,14 @@ public class EODHistoricalDataSearchProvider implements SecuritySearchProvider
                 }
             }
 
-            return Optional.of(new Result(symbol, String.valueOf(name), String.valueOf(type), String.valueOf(exchange),
-                            String.valueOf(country), String.valueOf(currency), isin, String.valueOf(previousClose),
-                            String.valueOf(previousCloseDate), latestSecurityPrice));
+            return Optional.of(new Result(symbol, asString(name), asString(type), exchange, asString(country),
+                            asString(currency), isin, asString(previousClose), asString(previousCloseDate),
+                            latestSecurityPrice));
+        }
+
+        private static String asString(Object value)
+        {
+            return value != null ? String.valueOf(value) : null;
         }
 
         private Result(String symbol, String name, String type, String exchange, String country, String currency,
@@ -332,12 +337,12 @@ public class EODHistoricalDataSearchProvider implements SecuritySearchProvider
 
             var html = webAccess.get();
 
-            var responseData = (JSONArray) JSONValue.parse(html);
-            if (responseData != null)
+            if (JSONValue.parse(html) instanceof JSONArray responseData)
             {
                 for (int i = 0; i < responseData.size(); i++)
                 {
-                    Result.from((JSONObject) responseData.get(i)).ifPresent(answer::add);
+                    if (responseData.get(i) instanceof JSONObject item)
+                        Result.from(item).ifPresent(answer::add);
                 }
             }
         }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/FinnhubSearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/FinnhubSearchProvider.java
@@ -41,7 +41,12 @@ public class FinnhubSearchProvider implements SecuritySearchProvider
 
             Object type = json.get("type"); //$NON-NLS-1$
 
-            return Optional.of(new Result(String.valueOf(symbol), String.valueOf(description), String.valueOf(type)));
+            return Optional.of(new Result(String.valueOf(symbol), asString(description), asString(type)));
+        }
+
+        private static String asString(Object value)
+        {
+            return value != null ? String.valueOf(value) : null;
         }
 
         private Result(String symbol, String description, String type)
@@ -173,16 +178,13 @@ public class FinnhubSearchProvider implements SecuritySearchProvider
             String html = new WebAccess("finnhub.io", "api/v1/search").addParameter("q", query)
                             .addHeader("X-Finnhub-Token", apiKey).get();
 
-            JSONObject responseData = (JSONObject) JSONValue.parse(html);
-            if (responseData != null)
+            if (JSONValue.parse(html) instanceof JSONObject responseData
+                            && responseData.get("result") instanceof JSONArray result) //$NON-NLS-1$
             {
-                JSONArray result = (JSONArray) responseData.get("result"); //$NON-NLS-1$
-                if (result != null)
+                for (int ii = 0; ii < result.size(); ii++)
                 {
-                    for (int ii = 0; ii < result.size(); ii++)
-                    {
-                        Result.from((JSONObject) result.get(ii)).ifPresent(answer::add);
-                    }
+                    if (result.get(ii) instanceof JSONObject item)
+                        Result.from(item).ifPresent(answer::add);
                 }
             }
         }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/LeewaySearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/LeewaySearchProvider.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.json.simple.JSONArray;
@@ -56,10 +57,16 @@ public class LeewaySearchProvider implements SecuritySearchProvider
         private List<ResultItem> markets = new ArrayList<>();
 
         @SuppressWarnings("nls")
-        public static Result from(JSONObject json)
+        public static Optional<Result> from(JSONObject json)
         {
+            if (json == null)
+                return Optional.empty();
+
             // Extract values from the JSON object
             var tickerSymbol = (String) json.get("Code");
+            if (tickerSymbol == null)
+                return Optional.empty();
+
             var exchange = (String) json.get("Exchange");
             var name = (String) json.get("Name");
             var type = (String) json.get("Type");
@@ -72,10 +79,13 @@ public class LeewaySearchProvider implements SecuritySearchProvider
 
             // Combine the symbol and exchange codes to create the security ID
             var symbol = new StringBuilder(tickerSymbol);
-            symbol.append(".");
-            symbol.append(exchange);
+            if (exchange != null && !exchange.isBlank())
+            {
+                symbol.append(".");
+                symbol.append(exchange);
+            }
 
-            return new Result(isin, symbol.toString(), currencyCode, name, type, exchange);
+            return Optional.of(new Result(isin, symbol.toString(), currencyCode, name, type, exchange));
         }
 
         public Result(String isin, String symbol, String currencyCode, String name, String type, String exchange)
@@ -237,18 +247,16 @@ public class LeewaySearchProvider implements SecuritySearchProvider
         }
     }
 
-    private List<Result> extract(String array)
+    /* package */ List<Result> extract(String array)
     {
-        var jsonArray = (JSONArray) JSONValue.parse(array);
-
-        if (jsonArray.isEmpty())
+        if (!(JSONValue.parse(array) instanceof JSONArray jsonArray) || jsonArray.isEmpty())
             return Collections.emptyList();
 
         List<Result> answer = new ArrayList<>();
         for (Object element : jsonArray)
         {
-            var item = (JSONObject) element;
-            answer.add(Result.from(item));
+            if (element instanceof JSONObject item)
+                Result.from(item).ifPresent(answer::add);
         }
         return answer;
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioPerformanceSearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/PortfolioPerformanceSearchProvider.java
@@ -56,6 +56,9 @@ public class PortfolioPerformanceSearchProvider implements SecuritySearchProvide
 
         public static Optional<ResultItem> from(JSONObject json)
         {
+            if (json == null)
+                return Optional.empty();
+
             var answer = new Result();
 
             answer.provider = (String) json.get("provider"); //$NON-NLS-1$
@@ -65,13 +68,12 @@ public class PortfolioPerformanceSearchProvider implements SecuritySearchProvide
 
             answer.type = SecurityType.convertType(answer.type);
 
-            var markets = (JSONArray) json.get("markets"); //$NON-NLS-1$
-
-            if (markets != null)
+            if (json.get("markets") instanceof JSONArray markets) //$NON-NLS-1$
             {
                 for (var m : markets)
                 {
-                    var market = (JSONObject) m;
+                    if (!(m instanceof JSONObject market))
+                        continue;
 
                     var item = new Result();
                     item.provider = answer.provider;
@@ -83,8 +85,7 @@ public class PortfolioPerformanceSearchProvider implements SecuritySearchProvide
                     item.exchange = (String) market.get("exchange"); //$NON-NLS-1$
                     item.url = (String) market.get("url"); //$NON-NLS-1$
 
-                    var properties = (JSONObject) market.get("properties"); //$NON-NLS-1$
-                    if (properties != null)
+                    if (market.get("properties") instanceof JSONObject properties) //$NON-NLS-1$
                     {
                         item.properties = new HashMap<>();
                         for (var key : properties.keySet()) // NOSONAR
@@ -252,14 +253,14 @@ public class PortfolioPerformanceSearchProvider implements SecuritySearchProvide
             var json = new WebAccess("api.portfolio-performance.info", "/v1/search") //
                             .addParameter(parameter.value, query).get();
 
-            var response = (JSONArray) JSONValue.parse(json);
-            if (response != null)
+            if (JSONValue.parse(json) instanceof JSONArray response)
             {
                 List<ResultItem> answer = new ArrayList<>();
 
                 for (var ii = 0; ii < response.size(); ii++)
                 {
-                    Result.from((JSONObject) response.get(ii)).ifPresent(answer::add);
+                    if (response.get(ii) instanceof JSONObject item)
+                        Result.from(item).ifPresent(answer::add);
                 }
                 return answer;
             }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/TwelveDataSearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/TwelveDataSearchProvider.java
@@ -3,6 +3,7 @@ package name.abuchen.portfolio.online.impl;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -50,10 +51,16 @@ public class TwelveDataSearchProvider implements SecuritySearchProvider
         private String currencyCode;
 
         @SuppressWarnings("nls")
-        public static Result from(JSONObject json)
+        public static Optional<Result> from(JSONObject json)
         {
+            if (json == null)
+                return Optional.empty();
+
             // Extract values from the JSON object
             var tickerSymbol = (String) json.get("symbol");
+            if (tickerSymbol == null)
+                return Optional.empty();
+
             var name = (String) json.get("instrument_name");
             var exchange = (String) json.get("mic_code");
             var type = (String) json.get("instrument_type");
@@ -65,10 +72,13 @@ public class TwelveDataSearchProvider implements SecuritySearchProvider
 
             // Combine the symbol and exchange codes to create the security ID
             var symbol = new StringBuilder(tickerSymbol);
-            symbol.append(".");
-            symbol.append(exchange);
+            if (exchange != null && !exchange.isBlank())
+            {
+                symbol.append(".");
+                symbol.append(exchange);
+            }
 
-            return new Result(symbol.toString(), name, exchange, type, currencyCode);
+            return Optional.of(new Result(symbol.toString(), name, exchange, type, currencyCode));
         }
 
         public Result(String symbol, String name, String exchange, String type, String currencyCode)
@@ -188,20 +198,16 @@ public class TwelveDataSearchProvider implements SecuritySearchProvider
 
     void extract(List<ResultItem> answer, String json)
     {
-        var jsonObject = (JSONObject) JSONValue.parse(json);
-
-        if (jsonObject.isEmpty())
+        if (!(JSONValue.parse(json) instanceof JSONObject jsonObject) || jsonObject.isEmpty())
             return;
 
-        var jsonArray = (JSONArray) jsonObject.get("data"); //$NON-NLS-1$
-
-        if (jsonArray == null || jsonArray.isEmpty())
+        if (!(jsonObject.get("data") instanceof JSONArray jsonArray) || jsonArray.isEmpty()) //$NON-NLS-1$
             return;
 
         for (Object element : jsonArray)
         {
-            var item = (JSONObject) element;
-            answer.add(Result.from(item));
+            if (element instanceof JSONObject item)
+                Result.from(item).ifPresent(answer::add);
         }
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooSearchProvider.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooSearchProvider.java
@@ -68,30 +68,25 @@ public class YahooSearchProvider implements SecuritySearchProvider
 
     /* protected */void extractFrom(List<ResultItem> answer, String html)
     {
-        JSONObject jsonObject = (JSONObject) JSONValue.parse(html);
-        if (jsonObject == null)
+        if (!(JSONValue.parse(html) instanceof JSONObject jsonObject))
             return;
 
-        jsonObject = (JSONObject) jsonObject.get("finance"); //$NON-NLS-1$
-        if (jsonObject == null)
+        if (!(jsonObject.get("finance") instanceof JSONObject finance)) //$NON-NLS-1$
             return;
 
-        JSONArray jsonArray = (JSONArray) jsonObject.get("result"); //$NON-NLS-1$
-        if (jsonArray == null || jsonArray.isEmpty())
+        if (!(finance.get("result") instanceof JSONArray results) || results.isEmpty()) //$NON-NLS-1$
             return;
 
-        jsonObject = (JSONObject) jsonArray.get(0);
-        if (jsonObject == null)
+        if (!(results.get(0) instanceof JSONObject firstResult))
             return;
 
-        JSONArray items = (JSONArray) jsonObject.get("documents"); //$NON-NLS-1$
-        if (items == null || items.isEmpty())
+        if (!(firstResult.get("documents") instanceof JSONArray items) || items.isEmpty()) //$NON-NLS-1$
             return;
 
         for (int ii = 0; ii < items.size(); ii++)
         {
-            JSONObject item = (JSONObject) items.get(ii);
-            YahooSymbolSearch.Result.from(item).ifPresent(answer::add);
+            if (items.get(ii) instanceof JSONObject item)
+                YahooSymbolSearch.Result.from(item).ifPresent(answer::add);
         }
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooSymbolSearch.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/YahooSymbolSearch.java
@@ -31,6 +31,9 @@ import name.abuchen.portfolio.util.WebAccess.WebAccessException;
 
         public static Optional<Result> from(JSONObject json)
         {
+            if (json == null)
+                return Optional.empty();
+
             var symbol = (String) json.get("symbol"); //$NON-NLS-1$
             if (symbol == null)
                 return Optional.empty();
@@ -152,14 +155,13 @@ import name.abuchen.portfolio.util.WebAccess.WebAccessException;
                             .addParameter("enableEnhancedTrivialQuery", "false") //
                             .get();
 
-            var responseData = (JSONObject) JSONValue.parse(html);
-            if (responseData != null)
+            if (JSONValue.parse(html) instanceof JSONObject responseData
+                            && responseData.get("quotes") instanceof JSONArray result) //$NON-NLS-1$
             {
-                var result = (JSONArray) responseData.get("quotes"); //$NON-NLS-1$
-                if (result != null)
+                for (var ii = 0; ii < result.size(); ii++)
                 {
-                    for (var ii = 0; ii < result.size(); ii++)
-                        Result.from((JSONObject) result.get(ii)).ifPresent(answer::add);
+                    if (result.get(ii) instanceof JSONObject quote)
+                        Result.from(quote).ifPresent(answer::add);
                 }
             }
         }


### PR DESCRIPTION
Searching for an instrument aborted with an InvocationTargetException caused by a NullPointerException: the provider loop in SearchSecurityWizardPage only caught IOException, so any runtime exception thrown by a single search provider terminated the search for all providers and popped up an error dialog instead of showing results.

Catch any exception per provider and report it in the error message area of the wizard page - just like IOExceptions are reported today.

Additionally harden the search providers against malformed responses, which is where the NullPointerException originated:

* check the type of the answer instead of casting the result of JSONValue#parse: it is null if the answer is not valid JSON at all, and it is an object where an array is expected (or vice versa) if the service reports an error instead, for example when the rate limit is exceeded

* skip array elements and nested attributes that do not have the expected JSON type (Yahoo, Portfolio Performance, Finnhub, EODHistoricalData, Twelve Data, Leeway, CoinGecko, DivvyDiary)

* Twelve Data and Leeway created the ticker symbol via new StringBuilder(code) which fails if the code is missing; skip such entries and do not append the exchange if it is not available

* EODHistoricalData and Finnhub converted missing attributes with String#valueOf and therefore created the literal "null" as name, type or currency - and ticker symbols such as "BBVAI.null"

* CoinGecko: the coin name is optional and must not be dereferenced when filtering; skip coins without id or ticker symbol while parsing

Closes #5919