### PR TITLE
Fix risk indicator terminology in English tooltips

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1814,7 +1814,7 @@ LabelSelectYearSince = Since
 
 LabelSelectedTransactions = Selected transactions
 
-LabelSemiVolatility = Semivariance
+LabelSemiVolatility = Semideviation
 
 LabelSettings = Settings
 
@@ -2960,13 +2960,13 @@ TooltipRebalancingIndicator = Color coding according to the {0}/{1} Rule:\n\n{0}
 
 TooltipSecurityLatestPrice = Latest security price of {0} from {1}
 
-TooltipSemiVolatility = Semivariance only looks at the negative fluctuations of an asset.\n\nIf the negative and postive fluctuations are equal, then the following holds:\n\nVolatility (v) = Semi-variance (s) \u00D7 \u221A2\n\nIf the current data set is evenly distributed, then the semivariance is:\n\n  s = v \u00F7 \u221A2 = {2} \u00F7 \u221A2 = {0}\n\nCompare that with the actual semivariance:\n\n  {0} {1} {3}\n  evenly distributed {1} actual semivariance\n\n\nThe semivariance is calculated using the "cumulative" data series. Therefore performance-neutral transactions have no impact. Weekends and public holidays are ignored (for example Easter and Christmas days).
+TooltipSemiVolatility = The semideviation (downside volatility) only looks at the negative fluctuations of an asset. It is the standard deviation of those returns that fall below the average return.\n\nIf the negative and positive fluctuations are equal, then the following holds:\n\nVolatility (v) = Semideviation (s) \u00D7 \u221A2\n\nIf the current data set is evenly distributed, then the semideviation is:\n\n  s = v \u00F7 \u221A2 = {2} \u00F7 \u221A2 = {0}\n\nCompare that with the actual semideviation:\n\n  {0} {1} {3}\n  evenly distributed {1} actual semideviation\n\n\nThe semideviation is calculated using the "cumulative" data series. Therefore performance-neutral transactions have no impact. Weekends and public holidays are ignored (for example Easter and Christmas days).
 
 TooltipSharpeRatio = Sharpe Ratio\n\n(Internal rate of return - Risk free rate of return) / Volatility\n({0} - {1}) / {2} = {3}\n\nThe Sharpe ratio measures the performance of an investment such as a security or portfolio compared to a risk-free asset, after adjusting for its risk. It is defined as the difference between the returns of the investment and the risk-free return, divided by the standard deviation of the investment returns. It represents the additional amount of return that an investor receives per unit of increase in risk.\n\n(Source: Wikipedia)
 
 TooltipTurnoverRate = The Portfolio Turnover Rate measures how much of the portfolio was "replaced" throughout the holding period, as a fraction of the average portfolio value.\n\nPurchases: {0}\nSales: {1}\nAverage portfolio volume: {2}\nPortfolio Turnover Rate: {3}
 
-TooltipVolatility = Volatility (or variance) is a measure for variation of price of a financial instrument over time.\n\nThe volatility is calculated using the "cumulative" data series. Therefore performance-neutral transactions have no impact. Weekends and public holidays are ignored (for example Easter and Christmas days).
+TooltipVolatility = Volatility is a measure for variation of price of a financial instrument over time. It is defined as the standard deviation of the returns relative to their average return.\n\nThe volatility is calculated using the "cumulative" data series. Therefore performance-neutral transactions have no impact. Weekends and public holidays are ignored (for example Easter and Christmas days).
 
 TransactionFilter = Filter data by transaction type
 


### PR DESCRIPTION
The English labels conflated a standard deviation with a variance:

  * "Volatility (or variance)" - volatility is the standard deviation of the returns, not their variance (the variance is its square).
  * "Semivariance" - Risk.Volatility#getSemiDeviation takes the square root of the sum of the squared negative deviations and the widget formats the result as a percentage. That value is the semideviation (downside volatility), the square root of the semivariance, which would have to be expressed in %^2.

Issue: #5917