### PR TITLE
added (more) support for bonds for Consors and DAB

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/InsertActionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/InsertActionTest.java
@@ -2,7 +2,6 @@ package name.abuchen.portfolio.datatransfer.actions;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsIterableContaining.hasItem;
 
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
@@ -117,17 +116,16 @@ public class InsertActionTest
         Set<String> properties = Arrays.stream(info.getPropertyDescriptors()).filter(p -> p.getWriteMethod() != null)
                         .map(PropertyDescriptor::getName).collect(Collectors.toSet());
 
-        assertThat(properties, hasItem("security"));
-        assertThat(properties, hasItem("monetaryAmount"));
-        assertThat(properties, hasItem("currencyCode"));
-        assertThat(properties, hasItem("amount"));
-        assertThat(properties, hasItem("shares"));
-        assertThat(properties, hasItem("dateTime"));
-        assertThat(properties, hasItem("type"));
-        assertThat(properties, hasItem("note"));
-        assertThat(properties, hasItem("source"));
-        assertThat(properties, hasItem("updatedAt"));
-
-        assertThat(properties.size(), is(10));
+        assertThat(properties.stream().sorted(String.CASE_INSENSITIVE_ORDER).collect(Collectors.joining(",")), is("" //
+                        + "amount," //
+                        + "currencyCode," //
+                        + "dateTime," //
+                        + "monetaryAmount," //
+                        + "note," //
+                        + "security," //
+                        + "shares," //
+                        + "source," //
+                        + "type," //
+                        + "updatedAt"));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/InsertActionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/InsertActionTest.java
@@ -7,6 +7,7 @@ import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
+import java.beans.Transient;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Set;
@@ -113,7 +114,9 @@ public class InsertActionTest
 
         BeanInfo info = Introspector.getBeanInfo(PortfolioTransaction.class);
 
-        Set<String> properties = Arrays.stream(info.getPropertyDescriptors()).filter(p -> p.getWriteMethod() != null)
+        Set<String> properties = Arrays.stream(info.getPropertyDescriptors()) //
+                        .filter(p -> p.getWriteMethod() != null)
+                        .filter(p -> !p.getWriteMethod().isAnnotationPresent(Transient.class))
                         .map(PropertyDescriptor::getName).collect(Collectors.toSet());
 
         assertThat(properties.stream().sorted(String.CASE_INSENSITIVE_ORDER).collect(Collectors.joining(",")), is("" //

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/AnleiheEinlösung01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/AnleiheEinlösung01.txt
@@ -1,0 +1,73 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.2.qualifier
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Consorsbank • 90318 Nürnberg
+Depotnummer: 1234567890
+1504753979/00
+Vermerk der Bank: 2000
+05
+Vorname Nachname
+Adress Str. 1
+Datum: 14.05.2025
+01234 Stadt
+Seite: 1 von 2
+Einlösung
+Wertpapierbezeichnung Zinssatz WKN ISIN
+Griechenland 0,00000 A1G1UW GRR000000010
+EO-FLR Secs 12(23-42) 1 IO GDP
+Einheit Nominale Zinstermin Fällig per
+EUR 2.100.000 15.Oktober 14.05.2025
+Einlösung zu 0,25228 % Schlusstag 14.05.2025
+Brutto 5.297,88 EUR
+Netto zugunsten IBAN DE00701204009876543210 5.297,88 EUR
+Valuta 14.05.2025 BIC DABBDEMMXXX
+Wertpapiere zulasten Girosammelverwahrung
+Bitte beachten Sie auch die Hinweise auf Seite 2.
+Veräusserungsverlust nach Differenzmethode 3.368,85 EUR
+Kapitalmaßnahme als PURCHASE OPTION
+mit Barabfindung als Call Price
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland (AG nach franz. Recht).
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+135037FC-13AF-9C0F-9187-B559B0B93B36
+Depotnummer: 1234567890
+1504753979/00
+Vermerk der Bank: 2000
+05
+Datum: 14.05.2025
+Seite: 2 von 2
+Details zu den Verrechnungstöpfen
+Verrechnungstopf Allgemein vor der Gutschrift 0,00 EUR
+Mit Verrechnungstopf Allgemein verrechnet 3.368,85 EUR
+Verrechnungstopf Allgemein nach der Abrechnung 3.368,85 EUR
+Sparerpauschbetrag vor der Gutschrift 0,00 EUR
+Mit Sparerpauschbetrag verrechnet 0,00 EUR
+Sparerpauschbetrag nach der Abrechnung 0,00 EUR
+Verrechnungstopf Quellensteuer vor der Gutschrift 0,00 EUR
+Mit Verrechnungstopf Quellensteuer verrechnet 0,00 EUR
+Verrechnungstopf Quellensteuer nach der Abrechnung 0,00 EUR
+Handelt es sich bei dem umseitig genannten Wertpapier um einen endfälligen Optionsschein, beachten Sie bitte den folgenden wichtigen Hinweis:
+Die umseitig genannten Optionsscheine werden zum mit FÄLLIG PER angegebenen Termin endfällig. Der Börsenhandel wird je nach Emittent und Produkt bereits
+vorher zum mit LETZTER HANDELSTAG angegebenen Termin eingestellt. Je nach Emittent und Produkt findet zwischen beiden Terminen noch ein außerbörslicher
+Handel statt. Die Ausübungsmodalitäten ergeben sich aus den Optionsscheinbedingungen des jeweiligen Emittenten. Bitte informieren Sie sich rechtzeitig, ob /
+welche speziellen Fälligkeitsregelungen für den von Ihnen gehaltenen Optionsschein gelten (z.B. Knock out).
+Optionsscheine mit automatischer Ausübung:
+Optionsscheine, die bis zum Endfälligkeitstermin nicht wirksam ausgeübt wurden, gelten an diesem Tag automatisch als ausgeübt. Sofern der Optionsschein am
+Stichtag einen inneren Wert hat, erfolgt ein Geldausgleich bzw. eine Lieferung in Wertpapieren. Anderenfalls verfällt der Optionsschein wertlos und wird ersatzlos
+ausgebucht.
+Optionsscheine mit freiwilliger Ausübung:
+Falls Sie derartige Optionsscheine ausüben wollen, erteilen Sie uns bitte rechtzeitig einen entsprechenden Auftrag. Ohne Ihre Weisung werden wir nicht tätig.
+Freiwillig auszuübende Optionsscheine, für die bis zum genannten Termin kein wirksamer Ausübungsauftrag vorliegt, verfallen - auch wenn sie einen inneren Wert
+haben - wertlos und werden nach Fälligkeit ersatzlos ausgebucht.
+Bei den hier übermittelten Informationen handelt es sich um solche, die wir im Rahmen der allgemeinen Informationspflichten gemäß Ziffer 16 der
+"Sonderbedingungen für den Handel in Finanzinstrumenten" an Sie weitergeben. Richtigkeit und Vollständigkeit der Informationen werden von der Consorsbank nicht
+geprüft. Die Consorsbank haftet als Kommissionärin nicht für die Höhe oder die Erfüllung der verbrieften Rechte.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland (AG nach franz. Recht).
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/AnleiheKauf01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/AnleiheKauf01.txt
@@ -1,0 +1,38 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.2.qualifier
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Consorsbank • 90318 Nürnberg
+Depotnummer 1234567890
+1504753979/00
+Vorname Nachname
+Adress Str. 1
+01234 Stadt Vermerk der Bank 2000
+02
+ORDERABRECHNUNG
+KAUF AM 19.12.2017  UM 17:00:34 INL.AUSSERBOERSLICH NR. 120321388.001
+Bezeichnung WKN ISIN
+0,0 % GRIECHENLAND 12-42 IO GDP   15.OKT A1G1UW GRR000000010
+Einheit Umsatz
+EUR 400.000,00000
+Kurs 0,550000  % FRANCO COURTAGE  
+Kurswert EUR 2.200,00
+Provision EUR 5,50
+Grundgebühr EUR 4,95
+Wert 21.12.2017 EUR 2.210,45
+zulasten Konto-Nr. 9876543210
+Bestand zugunsten Wertpapierrechnung Griechenland
+CBL 62126
+Der Abrechnung wurde der Poolfaktor 1,000000000 zugrunde gelegt
+Limitkurs  0,550000 %
+Hinweis für Orderabrechnungen und Depotbuchungsanzeigen:
+Einwendungen wegen Unrichtigkeit oder Unvollständigkeit dieser Mitteilung müssen unverzüglich erhoben werden, vgl. Nummer B. Ziffer I. 11 (4) und (5) der
+Allgemeinen Geschäftsbedingungen (AGB Banken).
+Machen Sie Ihre Einwendungen in Textform geltend, genügt die Absendung innerhalb der Sechs-Wochen-Frist an die Consorsbank (Revision) oder per Fax oder
+Mail an die unten angegebenen Adressen. Das Unterlassen rechtzeitiger Einwendungen gilt als Genehmigung.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland.
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/AnleiheKauf02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/AnleiheKauf02.txt
@@ -1,0 +1,45 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.2.qualifier
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Consorsbank • 90318 Nürnberg
+Depotnummer: 1234 567 890
+1504753979/00
+Vermerk der Bank: 2000
+2
+Vorname Nachname
+Datum: 09.04.2025
+Adress Str. 1
+01234 Stadt
+Seite: 1 von 1
+Ordernummer 329893673.001
+Orderdatum 09.04.2025
+ORDERABRECHNUNG
+KAUF AM 09.04.2025 UM 12:03:33 INL.AUSSERBOERSLICH NR. 329893673.001
+Bezeichnung WKN ISIN
+0,0 % GRIECHENLAND 12-42 IO GDP 15.OKT A1G1UW GRR000000010
+Einheit Umsatz Poolfaktor
+EUR 1.000.000,00000 0,904761904
+Preis pro Anteil 0,280000 % FRANCO COURTAGE
+Kurswert 2.533,33 EUR
+Handelsplatzkosten 1,95 EUR
+Provision 6,33 EUR
+Grundgebühr 4,95 EUR
+zulasten Konto-Nr. 9876543210 2.546,56 EUR
+Valuta 11.04.2025
+Bestand zugunsten Girosammelverwahrung
+CBF 2126
+Limitkurs 0,280000 %
+Beratungsfreies Geschäft
+Hinweis für Orderabrechnungen und Depotbuchungsanzeigen:
+Einwendungen wegen Unrichtigkeit oder Unvollständigkeit dieser Mitteilung müssen unverzüglich erhoben werden, vgl. Nummer B. Ziffer I. 11 (4) und (5) der
+Allgemeinen Geschäftsbedingungen (AGB Banken).
+Machen Sie Ihre Einwendungen in Textform geltend, genügt die Absendung innerhalb der Sechs-Wochen-Frist an die Consorsbank oder per Fax oder Mail an die
+unten angegebenen Adressen. Das Unterlassen rechtzeitiger Einwendungen gilt als Genehmigung.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland (AG nach franz. Recht).
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+1EE785B1-0BEB-255E-1737-70F159B0B93B
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/AnleiheZinsen01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/AnleiheZinsen01.txt
@@ -1,0 +1,63 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.2.qualifier
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Consorsbank • 90318 Nürnberg
+Depotnummer 1234567890
+1504753979/00
+Vorname Nachname
+Adress Str. 1
+01234 Stadt Vermerk der Bank 2000
+02
+NUERNBERG, 27.02.2017
+ZINSGUTSCHRIFT                                                          
+EUR                     150,00000          WKN:  A1G1UA                 
+ 3,00000 % Griechenland                    ZINSTERMIN:  24.FEBRUAR      
+           EO-Bonds 2012(23) Ser.1                                      
+ZINS-/DIVIDENDENSATZ            3,000000  %   SCHLUSSTAG PER 23.02.2017 
+KUPON-NR./PER       24.02.2017                       EX-TAG  24.02.2017 
+BRUTTO                                        EUR                  4,50 
+KAPST                                 25,00 % EUR                  1,13 
+SOLZ                                   5,50 % EUR                  0,06 
+WERT 24.02.2017                               EUR                  3,31 
+ZU GUNSTEN KONTO-NR. 9876 123 001 / IBAN DE00701204009876123001
+(BIC 70120400)
+KAPST-PFLICHTIGER KAPITALERTRAG               EUR                 4,50  
+BEMESSUNGSGRUNDLAGE FUER KAPST                EUR                 4,50  
+VERRECHNUNGSTOPF ALLGEMEIN NACH ERTRAG        EUR                 0,00  
+SPARERPAUSCHBETRAG NACH ERTRAG                EUR                 0,00  
+KEIN QUELLENSTEUERABZUG (EINKOMMEN- BZW. KOERPERSCHAFTSTEUERPFLICHTIG)  
+ES WURDE KEINE KIRCHENSTEUER EINBEHALTEN                                
+JAHRESSTEUERBESCHEINIGUNG FOLGT                                         
+          KAPITALERTRAEGE SIND EINKOMMENSTEUERPFLICHTIG                 
+           DIESE MITTEILUNG WIRD NICHT UNTERSCHRIEBEN                   
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland.
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+Hinweis für Zins- und Dividendengutschriften:
+Einwendungen wegen Unrichtigkeit oder Unvollständigkeit dieser Mitteilung müssen unverzüglich erhoben werden, vgl.
+Nummer B. Ziffer I. 11 (4) und (5) der Allgemeine Geschäftsbedingungen (AGB Banken). Umsätze und Kontobuchungen, die
+nach dem Erstellungsdatum anfallen und sich auf den Abrechnungssaldo des abgelaufenen Abrechnungszeitraumes
+auswirken, werden erst mit dem folgenden Kontoauszug ausgewiesen. Korrekturen werden seitens der Bank gekennzeichnet.
+Machen Sie Ihre Einwendungen in Textform geltend, genügt die Absendung innerhalb der Sechs-Wochen-Frist an
+die Consorsbank (Revision) oder per Fax oder Mail an die unten angegebenen Adressen. Das Unterlassen rechtzeitiger
+Einwendungen gilt als Genehmigung.
+Die mit „Steuerbescheinigung“ gekennzeichneten Abrechnungen sind sorgfältig aufzubewahren, da nur gegen Vorlage
+dieser Belege die Abrechnung im Rahmen der steuerlichen Veranlagung möglich ist. Bei Stornierung ist die Bank verpflichtet,
+die falsche Steuerbescheinigung zurückzufordern. Andernfalls ist sie verpflichtet, nach Ablauf eines Monats dem
+Wohnsitzfinanzamt des Depotinhabers Meldung zu machen. Gebietsansässige machen wir auf die ggf. bestehende
+Meldepflicht an die Landeszentralbank gemäß Außenwirtschaftsverordnung aufmerksam. Für weitere Auskünfte stehen wir
+Ihnen gerne zur Verfügung. Meldevordrucke sind bei uns erhältlich.
+Erträge unterliegen der Einkommen- bzw Körperschaftssteuer. Falls Doppelbesteuerungsabkommen bestehen, ist die
+einbehaltene ausländische Quellensteuer, soweit diese nicht erstattungspflichtig ist, auf die zu zahlende Einkommen- bzw.
+Körperschaftssteuer anrechenbar. Besteht mit dem Staat, aus dem die Erträge zufließen, kein
+Doppelbesteuerungsabkommen und werden ausländische Steuern auf diese Erträge einbehalten, so ist die Steuer gemäß
+§34 c EStG auf die deutsche Einkommen- bzw. Körperschaftssteuer anrechenbar.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland.
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/AnleiheZinsen02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/AnleiheZinsen02.txt
@@ -1,0 +1,50 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.2.qualifier
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Consorsbank • 90318 Nürnberg
+Depotnummer: 1234567890
+1504753979/00
+Vermerk der Bank: 2000
+Vorname Nachname 2
+Adress Str. 1
+01234 Stadt Datum: 27.02.2018
+Seite: 1 von 2
+Zinsgutschrift
+Wertpapierbezeichnung WKN ISIN
+Griechenland EO-Bonds 2012(23) Ser.1 A1G1UA GR0128010676
+Bestand Kupontag
+150 EUR 24.02.2018
+Zinssatz 3,00 % Schlusstag 21.02.2018
+Brutto 4,50 EUR
+Netto zugunsten IBAN DE34 7012 0400 9876 5432 10 4,50 EUR
+Valuta 26.02.2018 BIC DABBDEMMXXX
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland (AG nach franz. Recht).
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+Depotnummer: 1234567890
+1504753979/00
+Vermerk der Bank: 2000
+2
+Datum: 27.02.2018
+Seite: 2 von 2
+Details zur Abrechnung
+Steuerpflichtiger Gesamtertrag 4,50 EUR
+Mit Verrechnungstopf "Allgemein" verrechnet -4,50 EUR
+Mit Sparerpauschbetrag verrechnet 0,00 EUR
+Mit Quellensteuer verrechnet 0,00 EUR
+somit verrechnete Quellensteuer 0,00 EUR
+Bemessungsgrundlage für Kapitalertragsteuer gesamt 0,00 EUR
+Details zu den Verrechnungstöpfen
+Verrechnungstopf "Allgemein" vor der Abrechnung 420,18 EUR
+Mit Verrechnungstopf "Allgemein" verrechnet -4,50 EUR
+Verrechnungstopf "Allgemein" nach der Abrechnung 415,68 EUR
+Sparerpauschbetrag vor der Abrechnung 0,00 EUR
+Mit Sparerpauschbetrag verrechnet 0,00 EUR
+Sparerpauschbetrag nach der Abrechnung 0,00 EUR
+Verrechnungstopf "Quellensteuer" vor der Abrechnung 170,09 EUR
+Änderung Verrechnungstopf "Quellensteuer" 0,00 EUR
+Verrechnungstopf "Quellensteuer" nach der Abrechnung 170,09 EUR
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
@@ -1332,6 +1332,74 @@ public class ConsorsbankPDFExtractorTest
     }
 
     @Test
+    public void testAnleiheKauf01()
+    {
+        var extractor = new ConsorsbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "AnleiheKauf01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("GRR000000010"), hasWkn("A1G1UW"), hasTicker(null), //
+                        hasName("0,0 % GRIECHENLAND 12-42 IO GDP   15.OKT"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2017-12-19T17:00:34"), hasShares(4000), //
+                        hasSource("AnleiheKauf01.txt"), //
+                        hasNote("120321388.001 | Limitkurs  0,550000 %"), //
+                        hasAmount("EUR", 2210.45), hasGrossValue("EUR", 2200.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 5.50 + 4.95))));
+    }
+
+    @Test
+    public void testAnleiheKauf02()
+    {
+        var extractor = new ConsorsbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "AnleiheKauf02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("GRR000000010"), hasWkn("A1G1UW"), hasTicker(null), //
+                        hasName("0,0 % GRIECHENLAND 12-42 IO GDP 15.OKT"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2025-04-09T12:03:33"), hasShares(10000), //
+                        hasSource("AnleiheKauf02.txt"), //
+                        hasNote("329893673.001 | Limitkurs 0,280000 %"), //
+                        hasAmount("EUR", 2546.56), hasGrossValue("EUR", 2533.33), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 1.95 + 6.33 + 4.95))));
+    }
+
+    @Test
     public void testWertpapierBezug01()
     {
         var extractor = new ConsorsbankPDFExtractor(new Client());
@@ -1873,6 +1941,40 @@ public class ConsorsbankPDFExtractorTest
                         hasNote("15681369.001"), //
                         hasAmount("EUR", 211.30), hasGrossValue("EUR", 222.20), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.95 + 5.00 + 4.95))));
+    }
+
+    @Test
+    public void testAnleiheEinloesung01()
+    {
+        var extractor = new ConsorsbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "AnleiheEinlösung01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("GRR000000010"), hasWkn("A1G1UW"), hasTicker(null), //
+                        hasName("Griechenland EO-FLR Secs 12(23-42) 1 IO GDP"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2025-05-14T00:00"), hasShares(21000), //
+                        hasSource("AnleiheEinlösung01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 5297.88), hasGrossValue("EUR", 5297.88), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -3832,6 +3934,76 @@ public class ConsorsbankPDFExtractorTest
                         hasAmount("USD", 78.68), hasGrossValue("USD", 105.68), //
                         hasForexGrossValue("EUR", 90.99), //
                         hasTaxes("USD", 27.00), hasFees("USD", 0.00))));
+    }
+
+    @Test
+    public void testAnleiheZinsen01()
+    {
+        var extractor = new ConsorsbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "AnleiheZinsen01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin(null), hasWkn("A1G1UA"), hasTicker(null), //
+                        hasName("3,00000 % Griechenland EO-Bonds 2012(23) Ser.1"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2017-02-24T00:00"), hasExDate("2017-02-24T00:00"), //
+                        hasShares(1.5), //
+                        hasSource("AnleiheZinsen01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 3.31), hasGrossValue("EUR", 4.50), //
+                        hasTaxes("EUR", 1.13 + 0.06), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testAnleiheZinsen02()
+    {
+        var extractor = new ConsorsbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "AnleiheZinsen02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("GR0128010676"), hasWkn("A1G1UA"), hasTicker(null), //
+                        hasName("Griechenland EO-Bonds 2012(23) Ser.1"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2018-02-26T00:00"), hasExDate("2018-02-21T00:00"), //
+                        hasShares(1.5), //
+                        hasSource("AnleiheZinsen02.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 4.50), hasGrossValue("EUR", 4.50), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/AnleiheZinsen01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/AnleiheZinsen01.txt
@@ -1,0 +1,63 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.1
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+ EMAILVERSAND=N
+DEPOTNUMMER=1234567890
+          DEPOTUNTERBEZEICHNUNG=
+Erträgnisgutschrift VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+aus Wertpapieren ADRESSZEILE2=Vorname Nachname
+ADRESSZEILE3=Adresse Str. 1
+Zinsen für ADRESSZEILE4=01234 Stadt
+Herr 2 0.08.2010 - 19.08.2011 ADRESSZEILE5=
+ADRESSZEILE6=
+Vorname Nachname Depot-Nr. Abrechnungs-Nr. BELEGNUMMER=1217
+Adresse Str. 1 1234567890 85374419 / 23.08.2011 SEITENNUMMER=1
+01234 Stadt STEUERERSTATTUNG=N
+Depotinhaber
+Vorname Nachname
+  
+Kupongutschrift Stadt, 23.08.2011
+  
+Gattungsbezeichnung Fälligkeit Zinstermin ISIN
+4,1% Griechenland EO-Bonds 2007(12) 20.08.2012 20.08.2011 GR0114020457
+Nominal Zahltag Zinssatz
+EUR 4.000,000 20.08.2011 4,100000 %
+ 
+Wert  Konto-Nr. Betrag zu Ihren Gunsten  
+22.08.2011 1234567890 EUR 120,74
+ 
+ 
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+Zinsertrag EUR            164,00     
+Aktienverlusttopf EUR              0,00                  0,00     
+allgemeiner Verlusttopf EUR              0,00                  0,00     
+Quellensteuertopf EUR              0,00                  0,00     
+zu versteuern  EUR            164,00     
+einbehaltene Kapitalertragsteuer EUR             41,00     
+einbehaltener Solidaritätszuschlag  EUR              2,26     
+ 
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR            101,33     
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR              5,57     
+ 
+Kapitalertragsteuer, Solidaritätszuschlag und ggf. Kirchensteuer nach gemeldetem Kirchensteuersatz verrechnet mit dem
+Finanzamt Stadt für Körperschaften, Steuernummer 143/800/13803.
+ 
+Zahlungstag 20.08.2011
+Zinsen für 365 Tage
+ 
+Jahressteuerbescheinigung folgt
+  
+ 
+Verwahrart: Wertpapierrechnung
+Lagerland: Griechenland
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+DAB bank AG > Landsberger Straße 300 > 80687 Stadt > BLZ 701 204 00 > BIC (SWIFT-Code): DABBDEMMXXX > Tel. 0 89 / 88 95 - 60 00 > Sitz: Stadt > AG Stadt, HRB 118190 
+USt.-Ident.-Nr.: DE 161864563 > Aufsichtsratsvorsitzender: Dr. Theodor Weimer > Vorstand: Markus Gunter, Dr. Markus Walch
+ 
+3.31/ABREEREIERTR/GDBERTRG/001217/240811/000253
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
@@ -631,7 +631,7 @@ public class DABPDFExtractorTest
     }
 
     @Test
-    public void testAnleihekauf01()
+    public void testAnleiheKauf01()
     {
         var extractor = new DABPDFExtractor(new Client());
 
@@ -642,11 +642,11 @@ public class DABPDFExtractorTest
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
         assertThat(countBuySell(results), is(1L));
-        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
         assertThat(countAccountTransfers(results), is(0L));
         assertThat(countItemsWithFailureMessage(results), is(0L));
         assertThat(countSkippedItems(results), is(0L));
-        assertThat(results.size(), is(2));
+        assertThat(results.size(), is(3));
         new AssertImportActions().check(results, "EUR");
 
         // check security
@@ -662,6 +662,14 @@ public class DABPDFExtractorTest
                         hasNote("Abrechnungs-Nr. 67009861"), //
                         hasAmount("EUR", 1553.80), hasGrossValue("EUR", 1540.77), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 8.63 + 2.90 + 1.50))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(taxRefund( //
+                        hasDate("2011-06-28T00:00:00"), hasShares(20), //
+                        hasSource("KaufAnleihe01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 17.70 + 0.98), hasGrossValue("EUR", 17.70 + 0.98), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/DABPDFExtractorTest.java
@@ -631,6 +631,40 @@ public class DABPDFExtractorTest
     }
 
     @Test
+    public void testAnleihekauf01()
+    {
+        var extractor = new DABPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "KaufAnleihe01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("GR0114020457"), hasWkn(null), hasTicker(null), //
+                        hasName("4,1% Griechenland EO-Bonds 2007(12)"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2011-06-28T08:09:00"), hasShares(20), //
+                        hasSource("KaufAnleihe01.txt"), //
+                        hasNote("Abrechnungs-Nr. 67009861"), //
+                        hasAmount("EUR", 1553.80), hasGrossValue("EUR", 1540.77), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 8.63 + 2.90 + 1.50))));
+    }
+
+    @Test
     public void testWertpapierVerkauf01()
     {
         var extractor = new DABPDFExtractor(new Client());
@@ -1286,6 +1320,40 @@ public class DABPDFExtractorTest
                         hasNote("Abrechnungs-Nr. 64518224"), //
                         hasAmount("EUR", 11.60), hasGrossValue("EUR", 11.67), //
                         hasTaxes("EUR", 0.07), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testAnleiheVerkauf01()
+    {
+        var extractor = new DABPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "VerkaufAnleihe01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("GRR000000010"), hasWkn(null), hasTicker(null), //
+                        hasName("Griechenland EO-FLR Secs 12(23-42) 1 IO GDP"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2012-03-27T16:15"), hasShares(0.5), //
+                        hasSource("VerkaufAnleihe01.txt"), //
+                        hasNote("Abrechnungs-Nr. 69859650"), //
+                        hasAmount("EUR", 0.30), hasGrossValue("EUR", 0.30), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -2320,6 +2388,41 @@ public class DABPDFExtractorTest
                         hasNote("Abrechnungs-Nr. 12345678"), //
                         hasAmount("EUR", 21.38), hasGrossValue("EUR", 28.73), //
                         hasTaxes("EUR", 4.31 + 2.88 + 0.16), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testAnleiheZinsen01()
+    {
+        var extractor = new DABPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "AnleiheZinsen01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("GR0114020457"), hasWkn(null), hasTicker(null), //
+                        hasName("4,1% Griechenland EO-Bonds 2007(12)"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2011-08-22T00:00"), hasExDate("2011-08-20T00:00"), //
+                        hasShares(40), //
+                        hasSource("AnleiheZinsen01.txt"), //
+                        hasNote("Abrechnungs-Nr. 85374419"), //
+                        hasAmount("EUR", 120.74), hasGrossValue("EUR", 164.00), //
+                        hasTaxes("EUR", 41.00 + 2.26), hasFees("EUR", 0.00))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/KaufAnleihe01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/KaufAnleihe01.txt
@@ -1,0 +1,89 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.1
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+ EMAILVERSAND=N
+DEPOTNUMMER=1234567890
+          DEPOTUNTERBEZEICHNUNG=
+Wertpapierabrechnung VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+ADRESSZEILE2=Vorname Nachname
+Kauf Limitauftrag ADRESSZEILE3=Adresse Str. 1
+ADRESSZEILE4=01234 Stadt
+Kommissionsgeschäft ADRESSZEILE5=
+Herr ADRESSZEILE6=
+Vorname Nachname Depot-Nr. Abrechnungs-Nr. BELEGNUMMER=1984
+Adresse Str. 1 1234567890 67009861 / 28.06.2011 SEITENNUMMER=1
+01234 Stadt STEUERERSTATTUNG=N
+Depotinhaber
+Vorname Nachname
+  
+Wir haben für Sie gekauft Stadt, 28.06.2011
+  
+Gattungsbezeichnung Fälligkeit näch. Zinstermin ISIN
+4,1% Griechenland EO-Bonds 2007(12) 20.08.2012 20.08.2011 GR0114020457
+Nominal Kurs
+EUR 2.000,000 73,5000 %
+  
+Handelstag 28.06.2011  Kurswert                    EUR 1.470,00-
+Handelszeit 08:09* Stückzinsen                 EUR 70,77-
+Zinstage 315 Provision                   EUR 8,63-
+Börse Stuttgart/EDS Fremde Spesen Xontro        EUR 2,90-
+Verwahrart Wertpapierrechnung Variabl. Transaktionsentgelt EUR 1,50-
+Lagerland Griechenland
+ 
+Wert  Konto-Nr. Betrag zu Ihren Lasten  
+01.07.2011 1234567890 EUR 1.553,80
+  
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+Stückzinsaufwand EUR             70,77     
+Aktienverlusttopf EUR              0,00                  0,00     
+allgemeiner Verlusttopf EUR              0,00                  0,00     
+Quellensteuertopf EUR              0,00                  0,00     
+zu versteuern (negativ) EUR             70,77     
+Steuerausgleich nach § 43a Abs. 3 Satz 2 EStG:  
+Kapitalertragsteuer EUR             17,70     
+Solidaritätszuschlag EUR              0,98     
+ 
+Wert Konto-Nr. Abrechnungs-Nr. Betrag zu Ihren Gunsten  
+28.06.2011 1234567890 85552617 EUR             18,68     
+ 
+Es folgt Seite 2
+DAB bank AG > Landsberger Straße 300 > 80687 Stadt > BLZ 701 204 00 > BIC (SWIFT-Code): DABBDEMMXXX > Tel. 0 89 / 88 95 - 60 00 > Sitz: Stadt > AG Stadt, HRB 118190 
+USt.-Ident.-Nr.: DE 161864563 > Aufsichtsratsvorsitzender: Dr. Theodor Weimer > Vorstand: Markus Gunter, Dr. Markus Walch
+ 
+3.31/ABREABHNHANDKFDI/GAAASAFG/001984/280611/111642
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+EMAILVERSAND=N
+Depot-Nr. Abrechnungs-Nr. Seite-Nr. DEPOTNUMMER=1234567890
+DEPOTUNTERBEZEICHNUNG=
+1234567890 67009861 2 VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+ADRESSZEILE2=Vorname Nachname
+ADRESSZEILE3=Adresse Str. 1
+ADRESSZEILE4=01234 Stadt
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR             22,68     ADRESSZEILE5=
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR              1,24     ADRESSZEILE6=
+ BELEGNUMMER=1984
+Kapitalertragsteuer, Solidaritätszuschlag und ggf. Kirchensteuer nach gemeldetem Kirchensteuersatz verrechnet mit dem SEITENNUMMER=2
+Finanzamt Stadt für Körperschaften, Steuernummer 143/800/13803. STEUERERSTATTUNG=N
+ 
+Jahressteuerbescheinigung folgt
+ 
+Wichtiger Hinweis: Das gewählte Finanzinstrument entspricht nicht Ihren uns bekannten Kenntnissen und Erfahrungen
+und ist daher nicht angemessen für Sie. Bitte informieren Sie sich anhand der Ihnen bei der Depoteröffnung überlassenen
+Broschüre / CD-Rom  Basisinformation über die Vermögensanlage in Wertpapieren  über das Finanzinstrument. Diese
+Broschüre kann auf unseren Webseiten kostenfrei abgerufen werden und wird auf Wunsch kostenfrei zugesendet.
+ 
+* Die angegebene Zeit entspricht den Angaben der Handelspartner gemäß der lokalen Zeit in Deutschland
+  (Mitteleuropäische Zeit bzw. Mitteleuropäische Sommerzeit).
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+DAB bank AG > Landsberger Straße 300 > 80687 Stadt > BLZ 701 204 00 > BIC (SWIFT-Code): DABBDEMMXXX > Tel. 0 89 / 88 95 - 60 00 > Sitz: Stadt > AG Stadt, HRB 118190 
+USt.-Ident.-Nr.: DE 161864563 > Aufsichtsratsvorsitzender: Dr. Theodor Weimer > Vorstand: Markus Gunter, Dr. Markus Walch
+ 
+3.31/ABREABHNHANDKFDI/GAAASAFG/001984/280611/111642

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/VerkaufAnleihe01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/dab/VerkaufAnleihe01.txt
@@ -1,0 +1,59 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.1
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+BELEGDRUCK=J
+ORIGINAL=1
+FAXVERSAND=N
+ EMAILVERSAND=N
+DEPOTNUMMER=1234567890
+          DEPOTUNTERBEZEICHNUNG=
+Wertpapierabrechnung VERSANDARTENSCHLUESSEL=DRUCK
+ADRESSZEILE1=Herr
+ADRESSZEILE2=Vorname Nachname
+Spitze Verkauf ADRESSZEILE3=Adresse Str. 1
+ADRESSZEILE4=01234 Stadt
+Kommissionsgeschäft ADRESSZEILE5=
+Herr ADRESSZEILE6=
+Vorname Nachname Depot-Nr. Abrechnungs-Nr. BELEGNUMMER=11548
+Adresse Str. 1 1234567890 69859650 / 27.03.2012 SEITENNUMMER=1
+01234 Stadt STEUERERSTATTUNG=N
+Depotinhaber
+Vorname Nachname
+  
+Wir haben für Sie verkauft Stadt, 27.03.2012
+  
+Gattungsbezeichnung Fälligkeit näch. Zinstermin ISIN
+Griechenland EO-FLR Secs 12(23-42) 1 IO 15.10.2015 GRR000000010
+GDP
+Nominal Kurs
+EUR 50,000 0,59761 %
+  
+Handelstag 27.03.2012  Kurswert                    EUR 0,30
+Handelszeit 16:15*
+Börse
+Verwahrart Wertpapierrechnung
+Lagerland Griechenland
+ 
+Wert  Konto-Nr. Betrag zu Ihren Gunsten  
+27.03.2012 1234567890 EUR 0,30
+  
+Hinweise zur steuerlichen Verrechnung: vorher aktuell
+Veräußerungsgewinn Sonstige EUR              0,30     
+Aktienverlusttopf EUR          3.109,93              3.109,93     
+allgemeiner Verlusttopf EUR          2.454,52              2.454,22     
+Quellensteuertopf EUR              4,27                  4,27     
+zu versteuern EUR              0,00     
+ 
+im laufenden Jahr einbehaltene Kapitalertragsteuer EUR              0,00     
+im laufenden Jahr einbehaltener Solidaritätszuschlag EUR              0,00     
+ 
+Jahressteuerbescheinigung folgt
+ 
+* Die angegebene Zeit entspricht den Angaben der Handelspartner gemäß der lokalen Zeit in Deutschland
+  (Mitteleuropäische Zeit bzw. Mitteleuropäische Sommerzeit).
+Dieser Beleg wird maschinell erstellt und daher nicht unterschrieben.
+DAB bank AG > Landsberger Straße 300 > 80687 Stadt > BLZ 701 204 00 > BIC (SWIFT-Code): DABBDEMMXXX > Tel. 0 89 / 88 95 - 60 00 > Sitz: Stadt > AG Stadt, HRB 118190 
+USt.-Ident.-Nr.: DE 161864563 > Aufsichtsratsvorsitzender: Dr. Theodor Weimer > Vorstand: Markus Gunter (Sprecher des Vorstands), Dr. Niklas Dieterich
+ 
+3.31/ABREABHNHANDSPVK/GAAASAFG/011548/280312/013726

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/AbstractPDFExtractor.java
@@ -314,6 +314,18 @@ public abstract class AbstractPDFExtractor implements Extractor
         }
     }
 
+    protected long asBondNominal(String value)
+    {
+        try
+        {
+            return Math.round(numberFormat.parse(value).doubleValue() * Values.Share.factor() / 100);
+        }
+        catch (ParseException e)
+        {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
     protected long asShares(String value, Locale locale)
     {
         return ExtractorUtils.asShares(value, locale.getLanguage(), locale.getCountry());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -19,7 +19,6 @@ import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.money.Values;
 
 @SuppressWarnings("nls")
 public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
@@ -92,16 +91,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         .match("^(?i).*(?<type>Verkauf" //
                                         + "|VERK\\. TEIL\\-\\/BEZUGSR\\." //
                                         + "|VERKAUF KAPITALMA.*) .*AM .*$")
-                        .assign((t, v) -> {
-                            if ("VERKAUF".equalsIgnoreCase(v.get("type")) //
-                                            || "Verkauf".equalsIgnoreCase(v.get("type")) //
-                                            || "VERK. TEIL-/BEZUGSR.".equalsIgnoreCase(v.get("type")) //
-                                            || "VERKAUF KAPITALMAßN.".equalsIgnoreCase(v.get("type")) //
-                                            || "VERKAUF KAPITALMASSN.".equalsIgnoreCase(v.get("type")))
-                            {
-                                t.setType(PortfolioTransaction.Type.SELL);
-                            }
-                        })
+                        .assign((t, v) -> t.setType(PortfolioTransaction.Type.SELL))
 
                         .oneOf( //
                                         // @formatter:off
@@ -175,13 +165,16 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                         // 0,375 % VOLKSWAGEN LEASING 21/26 20.JULI A2YN0C XS2343822842
                                         // Einheit Umsatz Fälligkeit
                                         // EUR 7.000,00000 Letzte Fälligkeit 20.07.2026
+                                        //
+                                        // Einheit Umsatz
+                                        // EUR 400.000,00000
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "wkn", "isin", "currency") //
                                                         .match("^(?<name>[\\.,\\d]+ % .*) (?<wkn>[A-Z0-9]{6}) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
-                                                        .find("Einheit Umsatz F.lligkeit") //
-                                                        .match("^(?<currency>[A-Z]{3}) [\\.,\\d]+ .* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}$") //
-                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
+                                                        .find("Einheit Umsatz( F.lligkeit| Poolfaktor)?") //
+                                                        .match("^(?<currency>[A-Z]{3})\\s+[\\.,\\d]+\\s*(.*[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}\\s*)?$") //
+                                                        .assign((t, v) -> t.setBond(getOrCreateSecurity(v))))
 
                         .oneOf( //
                                         // @formatter:off
@@ -200,11 +193,21 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("shares") //
                                                         .match("^[A-Z]{3}[\\s]{1,}(?<shares>[\\.,\\d]+) .* [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}$") //
-                                                        .assign((t, v) -> {
-                                                            // Percentage quotation, workaround for bonds
-                                                            var shares = asBigDecimal(v.get("shares"));
-                                                            t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
-                                                        }))
+                                                        .assign((t, v) -> t.setBondNominal(asBondNominal(v.get("shares")))), //
+                                        
+                                        // @formatter:off
+                                        // Einheit Umsatz
+                                        // EUR 400.000,00000
+                                        //
+                                        // Einheit Umsatz Poolfaktor
+                                        // EUR 1.000.000,00000 0,904761904
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares") //
+                                                        .match("^Einheit Umsatz.*$")
+                                                        .match("^[A-Z]{3}\\s+(?<shares>[\\.,\\d]+)\\s*.*$") //
+                                                        .assign((t, v) -> t.setBondNominal(asBondNominal(v.get("shares")))) //
+                        )
 
                         // @formatter:off
                         // KAUF AM 15.01.2015  UM 08:13:35 MUENCHEN NR. 12345670.001
@@ -462,7 +465,36 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                                         .attributes("name", "wkn", "isin", "currency") //
                                                         .match("^(?<name>.*) (?<wkn>[A-Z0-9]{6}) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
                                                         .match("^(Steuerfreie )?(Dividende pro St.ck|Ertragsaussch.ttung je Anteil|Zinssatz) [\\.,\\d]+ (?<currency>[A-Z]{3}) Schlusstag [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}$") //
-                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
+                                                        
+                                        // @formatter:off
+                                        // EUR                     150,00000          WKN:  A1G1UA                 
+                                        //  3,00000 % Griechenland                    ZINSTERMIN:  24.FEBRUAR      
+                                        // EO-Bonds 2012(23) Ser.1                                      
+                                        // ZINS-/DIVIDENDENSATZ            3,000000  %   SCHLUSSTAG PER 23.02.2017 
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("wkn", "name", "nameContinued", "currency") //
+                                                        .match("^(?<currency>[A-Z]{3})\\s+[\\.,\\d]+\\s+WKN:\\s+(?<wkn>[A-Z0-9]{6}).*$") //
+                                                        .match("^(?<name>.*?)(ZINSTERMIN.*)$") //
+                                                        .match("^(?<nameContinued>.*)$") //
+                                                        .match("^(?i)(ZINS-\\/DIVIDENDENSATZ|(ERTRAGSAUSSCHUETTUNG|ERTRAGSTHESAURIERUNG) P\\. ST\\.) .* ([\\d,.]+\\s+%|(?<currency>[A-Z]{3}))\\s+SCHLUSSTAG PER [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}.*$") //
+                                                        .assign((t, v) -> t.setBond(getOrCreateSecurity(v))),
+                                        
+                                        // @formatter:off
+                                        // Wertpapierbezeichnung WKN ISIN
+                                        // Griechenland EO-Bonds 2012(23) Ser.1 A1G1UA GR0128010676
+                                        // Bestand Kupontag
+                                        // 150 EUR 24.02.2018
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("wkn", "isin", "name", "currency") //
+                                                        .match("^Wertpapierbezeichnung\\s+WKN\\s+ISIN$") //
+                                                        .match("^(?<name>.*?)(?<wkn>[A-Z0-9]{6}) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                                                        .match("^Bestand Kupontag.*$")
+                                                        .match("^[\\d,.]+\\s+(?<currency>[A-Z]{3}) \\d{2}\\.\\d{2}\\.\\d{4}$") //
+                                                        .assign((t, v) -> t.setBond(getOrCreateSecurity(v)))
+                        )
 
                         .oneOf( //
                                         // @formatter:off
@@ -479,7 +511,25 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("shares") //
                                                         .match("^(?<shares>[\\.,\\d]+) St.ck.*$") //
-                                                        .assign((t, v) -> t.setShares(asShares(v.get("shares")))))
+                                                        .assign((t, v) -> t.setShares(asShares(v.get("shares")))), //
+                                                        
+                                        // @formatter:off
+                                        // EUR                     150,00000          WKN:  A1G1UA                 
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares") //
+                                                        .match("^\\s*[A-Z]{3}\\s+(?<shares>[\\.,\\d]+)\\s+WKN.*$") //
+                                                        .assign((t, v) -> t.setBondNominal(asBondNominal(v.get("shares")))), //
+                                         
+                                        // @formatter:off
+                                        // 150 EUR 24.02.2018: false
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares") //
+                                                        .match("^Bestand Kupontag\\s*")
+                                                        .match("^\\s*(?<shares>[\\.,\\d]+)\\s+[A-Z]{3}\\s+\\d{2}\\.\\d{2}\\.\\d{4}\\s*$") //
+                                                        .assign((t, v) -> t.setBondNominal(asBondNominal(v.get("shares")))) //
+                        )
 
                         .oneOf( //
                                         // @formatter:off
@@ -504,7 +554,17 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("exDate") //
                                                         .match("^(?i).*EX\\-TAG[\\s]{1,}(?<exDate>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$") //
-                                                        .assign((t, v) -> t.setExDate(asDate(v.get("exDate")))))
+                                                        .assign((t, v) -> t.setExDate(asDate(v.get("exDate")))), //
+                                                        
+                                        // @formatter:off
+                                        // Zinssatz 3,00 % Schlusstag 21.02.2018
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("exDate") //
+                                                        .match("^Zinssatz\\s+[\\d,.]+ %\\s+Schlu..?tag\\s+(?<exDate>\\d{2}\\.\\d{2}\\.\\d{4})\\s*$") //
+                                                        .assign((t, v) -> t.setExDate(asDate(v.get("exDate")))) //
+                        )
+                        
 
                         .oneOf( //
                                         // @formatter:off
@@ -736,27 +796,60 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
                         .subject(() -> new BuySellEntry(PortfolioTransaction.Type.SELL))
 
-                        // @formatter:off
-                        // Wertpapierbezeichnung WKN ISIN
-                        // Lang & Schwarz AG LS846N DE000LS846N5
-                        // @formatter:on
-                        .section("wkn", "isin", "name", "name1") //
-                        .find("Wertpapierbezeichnung WKN ISIN") //
-                        .match("^(?<name>.*) (?<wkn>[A-Z0-9]{6}) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
-                        .match("^(?<name1>.*)$") //
-                        .assign((t, v) -> {
-                            if (!v.get("name1").startsWith("Einheit"))
-                                v.put("name", v.get("name") + " " + v.get("name1"));
-
-                            t.setSecurity(getOrCreateSecurity(v));
-                        })
-
-                        // @formatter:off
-                        // Stück 1.000 20.05.2021
-                        // @formatter:on
-                        .section("shares") //
-                        .match("^St.ck (?<shares>[\\.,\\d]+) [\\d]+.[\\d]+.[\\d]{4}$") //
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+                        .oneOf(
+                            // @formatter:off
+                            // Wertpapierbezeichnung WKN ISIN
+                            // Lang & Schwarz AG LS846N DE000LS846N5
+                            // @formatter:on
+                            section -> section //
+                            .attributes("wkn", "isin", "name", "name1") //
+                            .find("Wertpapierbezeichnung WKN ISIN") //
+                            .match("^(?<name>.*?) (?<wkn>[A-Z0-9]{6}) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                            .match("^(?<name1>.*)$") //
+                            .assign((t, v) -> {
+                                if (!v.get("name1").startsWith("Einheit"))
+                                    v.put("name", v.get("name") + " " + v.get("name1"));
+    
+                                t.setSecurity(getOrCreateSecurity(v));
+                            }),
+                            
+                            // @formatter:off
+                            // Wertpapierbezeichnung WKN ISIN
+                            // Lang & Schwarz AG LS846N DE000LS846N5
+                            // @formatter:on
+                            section -> section //
+                            .attributes("wkn", "isin", "name", "name1") //
+                            .find("Wertpapierbezeichnung Zinssatz WKN ISIN") //
+                            .match("^(?<name>.*?) [\\d,.]+ (?<wkn>[A-Z0-9]{6}) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                            .match("^(?<name1>.*)$") //
+                            .assign((t, v) -> {
+                                if (!v.get("name1").startsWith("Einheit"))
+                                    v.put("name", v.get("name") + " " + v.get("name1"));
+    
+                                t.setBond(getOrCreateSecurity(v));
+                            })
+                            
+                        )
+                        .oneOf(
+                            // @formatter:off
+                            // Stück 1.000 20.05.2021
+                            // @formatter:on
+                            section -> section //
+                            .attributes("shares") //
+                            .match("^St.ck (?<shares>[\\.,\\d]+) [\\d]+.[\\d]+.[\\d]{4}$") //
+                            .assign((t, v) -> t.setShares(asShares(v.get("shares")))), //
+                            
+                            // @formatter:off
+                            // Einheit Nominale Zinstermin Fällig per
+                            // EUR 2.100.000 15.Oktober 14.05.2025
+                            // @formatter:on
+                            section -> section //
+                            .attributes("shares") //
+                            .match("^Einheit Nominale .*$")
+                            .match("^[A-Z]{3} (?<shares>[\\.,\\d]+) .* \\d{2}\\.\\d{2}\\.\\d{4}$") //
+                            .assign((t, v) -> t.setBondNominal(asBondNominal(v.get("shares")))) //
+                            
+                        )
 
                         // @formatter:off
                         // Einlösung zu 0,001 EUR Schlusstag 20.05.2021

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -947,7 +947,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
     {
         var pdfTransaction = new Transaction<AccountTransaction>();
 
-        var firstRelevantLine = new Block("^(Kauf|Verkauf|Gesamtf.lligkeit) .*$", "Dieser Beleg wird .*$");
+        var firstRelevantLine = new Block("^" + TRANSACTIONTYPE_REGEX + ".*$", "Dieser Beleg wird .*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -1082,10 +1082,13 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         // zu versteuern (negativ) EUR 59,20
                         // Wert Konto-Nr. Abrechnungs-Nr. Betrag zu Ihren Gunsten
                         // 07.07.2020 1234567 1234567 EUR 16,46
+                        //
+                        // Wert Konto-Nr. Abrechnungs-Nr. Betrag zu Ihren Gunsten  
+                        // 28.06.2011 1234567890 85552617 EUR             18,68     
                         // @formatter:on
                         .section("currency", "amount").optional() //
                         .find("zu versteuern \\(negativ\\).*") //
-                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ [\\d]+ (?<currency>[A-Z]{3}) (?<amount>[\\.,\\d]+)$") //
+                        .match("^\\d{2}\\.\\d{2}\\.\\d{4}\\s+[\\d]+ [\\d]+\\s+(?<currency>[A-Z]{3})\\s+(?<amount>[\\.,\\d]+).*$") //
                         .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/DABPDFExtractor.java
@@ -4,6 +4,8 @@ import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGros
 import static name.abuchen.portfolio.util.TextUtil.concatenate;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
+import java.util.Objects;
+
 import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
@@ -19,6 +21,8 @@ import name.abuchen.portfolio.money.Values;
 @SuppressWarnings("nls")
 public class DABPDFExtractor extends AbstractPDFExtractor
 {
+    private static final String TRANSACTIONTYPE_REGEX = "(Kauf|(Spitze )?Verkauf|Gesamtf.lligkeit)";
+
     public DABPDFExtractor(Client client)
     {
         super(client);
@@ -43,12 +47,12 @@ public class DABPDFExtractor extends AbstractPDFExtractor
 
     private void addBuySellTransaction()
     {
-        final var type = new DocumentType("(Kauf|Verkauf|Gesamtf.lligkeit)");
+        final var type = new DocumentType(TRANSACTIONTYPE_REGEX);
         this.addDocumentTyp(type);
 
         var pdfTransaction = new Transaction<BuySellEntry>();
 
-        var firstRelevantLine = new Block("^(Kauf|Verkauf|Gesamtf.lligkeit) .*$", "Dieser Beleg wird .*$");
+        var firstRelevantLine = new Block("^" + TRANSACTIONTYPE_REGEX + " .*$", "Dieser Beleg wird .*$");
         type.addBlock(firstRelevantLine);
         firstRelevantLine.set(pdfTransaction);
 
@@ -57,12 +61,13 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
 
                         .section("type").optional() //
-                        .match("^(?<type>(Kauf|Verkauf|Gesamtf.lligkeit)) .*$") //
+                        .match("^(?<type>" + TRANSACTIONTYPE_REGEX + ") .*$") //
                         .assign((t, v) -> {
                             // @formatter:off
                             // Is type --> "Verkauf" change from BUY to SELL
                             // @formatter:on
-                            if ("Verkauf".equals(v.get("type")) || "Gesamtfälligkeit".equals(v.get("type")))
+                            var tType = Objects.toString(v.get("type"), "");
+                            if (tType.endsWith("Verkauf") || "Gesamtfälligkeit".equals(tType))
                                 t.setType(PortfolioTransaction.Type.SELL);
                         })
 
@@ -244,7 +249,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         // 03.08.2015 0000000000 EUR/USD 1,100297 EUR 4.798,86
                         // @formatter:on
                         .section("fxCurrency", "fxGross", "baseCurrency", "termCurrency", "exchangeRate", "currency").optional() //
-                        .match("^.* Kurswert[\\s]{1,}(?<fxCurrency>[A-Z]{3}) (?<fxGross>[\\.,\\d]+)([\\-\\s]+)?$") //
+                        .match("^.* Kurswert\\s+(?<fxCurrency>[A-Z]{3}) (?<fxGross>[\\.,\\d]+)([\\-\\s]+)?$") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ (?<baseCurrency>[A-Z]{3})\\/(?<termCurrency>[A-Z]{3}) (?<exchangeRate>[\\.,\\d]+) (?<currency>[A-Z]{3}) [\\.,\\d]+$") //
                         .assign((t, v) -> {
                             var rate = asExchangeRate(v);
@@ -319,7 +324,23 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                                                         .find("Wertpapierbezeichnung WKN ISIN") //
                                                         .match("^(?<name>.*) (?<wkn>[A-Z0-9]{6}) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
                                                         .match("^(Dividende pro St.ck|Ertragsaussch.ttung je Anteil) [\\.,\\d]+ (?<currency>[A-Z]{3}) .*$") //
-                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
+                        
+                                        // @formatter:off
+                                        // Gattungsbezeichnung Fälligkeit Zinstermin ISIN
+                                        // 4,1% Griechenland EO-Bonds 2007(12) 20.08.2012 20.08.2011 GR0114020457
+                                        // Nominal Zahltag Zinssatz
+                                        // EUR 4.000,000 20.08.2011 4,100000 %
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("name", "isin", "currency") //
+                                                        .find("Gattungsbezeichnung F.lligkeit Zinstermin ISIN") //
+                                                        .match("^(?<name>.*) \\d{2}\\.\\d{2}\\.\\d{4} \\d{2}\\.\\d{2}\\.\\d{4} (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                                                        .match("^Nominal .*$")
+                                                        .match("^(?<currency>[A-Z]{3}) [\\.,\\d]+ .* [\\.,\\d]+\\s+%.*$")
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))) //
+                        )
+                                        
 
                         .oneOf( //
                                         // @formatter:off
@@ -335,7 +356,19 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("shares") //
                                                         .match("(?<shares>[\\.,\\d]+) St.ck") //
-                                                        .assign((t, v) -> t.setShares(asShares(v.get("shares")))))
+                                                        .assign((t, v) -> t.setShares(asShares(v.get("shares")))),
+                                    
+                        
+                                        // @formatter:off
+                                        // Nominal Zahltag Zinssatz
+                                        // EUR 4.000,000 20.08.2011 4,100000 %
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares") //
+                                                        .match("^Nominal .*")
+                                                        .match("^[A-Z]{3} (?<shares>[\\.,\\d]+) .* [\\.,\\d]+\\s+%.*$") //
+                                                        .assign((t, v) -> t.setBondNominal(asBondNominal(v.get("shares")))) //
+                        )
 
                         .oneOf( //
                                         // @formatter:off
@@ -368,7 +401,18 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("exDate") //
                                                         .match("^STK [\\.,\\d]+ (?<exDate>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} .*$")
-                                                        .assign((t, v) -> t.setExDate(asDate(v.get("exDate")))))
+                                                        .assign((t, v) -> t.setExDate(asDate(v.get("exDate")))), //
+                                                        
+                                        // @formatter:off
+                                        // Gattungsbezeichnung Fälligkeit Zinstermin ISIN
+                                        // 4,1% Griechenland EO-Bonds 2007(12) 20.08.2012 20.08.2011 GR0114020457
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("exDate") //
+                                                        .match("^Gattungsbezeichnung F.lligkeit Zinstermin.*$")
+                                                        .match("^.* \\d{2}\\.\\d{2}\\.\\d{4} (?<exDate>\\d{2}\\.\\d{2}\\.\\d{4}) .*$")
+                                                        .assign((t, v) -> t.setExDate(asDate(v.get("exDate")))) //
+                        )
 
                         .oneOf( //
                                         // @formatter:off
@@ -420,7 +464,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("fxGross", "exchangeRate", "termCurrency", "baseCurrency") //
-                                                        .match("^ausl.ndische Dividende [A-Z]{3}[\\s]{1,}(?<fxGross>[\\.,\\d]+).*$") //
+                                                        .match("^ausl.ndische Dividende [A-Z]{3}\\s+(?<fxGross>[\\.,\\d]+).*$") //
                                                         .match("^Devisenkurs: (?<termCurrency>[A-Z]{3})\\/(?<baseCurrency>[A-Z]{3}) (?<exchangeRate>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
                                                             var rate = asExchangeRate(v);
@@ -438,7 +482,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("baseCurrency", "termCurrency", "exchangeRate", "gross") //
                                                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ (?<baseCurrency>[A-Z]{3})\\/(?<termCurrency>[A-Z]{3}) (?<exchangeRate>[\\.,\\d]+) [A-Z]{3} [\\.,\\d]+$") //
-                                                        .match("^ausl.ndische Dividende [A-Z]{3}[\\s]{1,}(?<gross>[\\.,\\d]+).*$") //
+                                                        .match("^ausl.ndische Dividende [A-Z]{3}\\s+(?<gross>[\\.,\\d]+).*$") //
                                                         .assign((t, v) -> {
                                                             var rate = asExchangeRate(v);
                                                             type.getCurrentContext().putType(rate);
@@ -455,7 +499,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("baseCurrency", "termCurrency", "exchangeRate", "gross") //
                                                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ (?<baseCurrency>[A-Z]{3})\\/(?<termCurrency>[A-Z]{3}) (?<exchangeRate>[\\.,\\d]+) [A-Z]{3} [\\.,\\d]+$") //
-                                                        .match("^Steuerpflichtiger Aussch.ttungsbetrag [A-Z]{3}[\\s]{1,}(?<gross>[\\.,\\d]+).*$") //
+                                                        .match("^Steuerpflichtiger Aussch.ttungsbetrag [A-Z]{3}\\s+(?<gross>[\\.,\\d]+).*$") //
                                                         .assign((t, v) -> {
                                                             var rate = asExchangeRate(v);
                                                             type.getCurrentContext().putType(rate);
@@ -472,7 +516,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("baseCurrency", "termCurrency", "exchangeRate", "fxGross") //
                                                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]+ (?<baseCurrency>[A-Z]{3})\\/(?<termCurrency>[A-Z]{3}) (?<exchangeRate>[\\.,\\d]+) [A-Z]{3} [\\.,\\d]+$") //
-                                                        .match("^Ertrag f.r [\\d]{4} [A-Z]{3}[\\s]{1,}(?<fxGross>[\\.,\\d]+).*$") //
+                                                        .match("^Ertrag f.r [\\d]{4} [A-Z]{3}\\s+(?<fxGross>[\\.,\\d]+).*$") //
                                                         .assign((t, v) -> {
                                                             var rate = asExchangeRate(v);
                                                             type.getCurrentContext().putType(rate);
@@ -529,7 +573,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("gross", "termCurrency", "baseCurrency", "exchangeRate") //
-                                                        .match("^Ertrag f.r [\\d]{4}\\/[\\d]{2} [A-Z]{3}[\\s]{1,}(?<gross>[\\.,\\d]+).*$") //
+                                                        .match("^Ertrag f.r [\\d]{4}\\/[\\d]{2} [A-Z]{3}\\s+(?<gross>[\\.,\\d]+).*$") //
                                                         .match("^Devisenkurs: (?<baseCurrency>[A-Z]{3})\\/(?<termCurrency>[A-Z]{3}) (?<exchangeRate>[\\.,\\d]+)$") //
                                                         .assign((t, v) -> {
                                                             var rate = asExchangeRate(v);
@@ -1344,7 +1388,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         .section("amount", "date", "isin", "shares", "type") //
                         .documentContext("currency", "year") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\. (?<date>[\\d]{2}\\.[\\d]{2}\\.) (?<type>Wertpapierverkauf|Wertpapierkauf) (?<amount>[\\.,\\d]+)[\\+\\-]$") //
-                        .match("^.* (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\*[\\s]{1,}(?<shares>[\\.,\\d]+)$") //
+                        .match("^.* (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])\\*\\s+(?<shares>[\\.,\\d]+)$") //
                         .assign((t, v) -> {
                             // @formatter:off
                             // Is type --> "Wertpapierverkauf" change from BUY to SELL
@@ -1380,7 +1424,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         // ausländische Quellensteuer 15,315% JPY 95
                         // @formatter:on
                         .section("currency", "withHoldingTax").optional() //
-                        .match("^ausl.ndische Quellensteuer .*[\\s]{1,}(?<currency>[A-Z]{3})[\\s]{1,}(?<withHoldingTax>[\\.,\\d]+)(\\-)?$") //
+                        .match("^ausl.ndische Quellensteuer .*\\s+(?<currency>[A-Z]{3})\\s+(?<withHoldingTax>[\\.,\\d]+)(\\-)?$") //
                         .assign((t, v) -> {
                             if (!type.getCurrentContext().getBoolean("negative"))
                                 processWithHoldingTaxEntries(t, v, "withHoldingTax", type);
@@ -1400,7 +1444,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         // davon anrechenbare US-Quellensteuer  15% USD             2,430
                         // @formatter:on
                         .section("currency", "creditableWithHoldingTax").optional() //
-                        .match("^.*davon anrechenbare (US\\-)?Quellensteuer .*[\\s]{1,}(?<currency>[A-Z]{3})[\\s]{1,}(?<creditableWithHoldingTax>[\\.,\\d]+)(\\-|[\\s]+)?$") //
+                        .match("^.*davon anrechenbare (US\\-)?Quellensteuer .*\\s+(?<currency>[A-Z]{3})\\s+(?<creditableWithHoldingTax>[\\.,\\d]+)(\\-|[\\s]+)?$") //
                         .assign((t, v) -> {
                             if (!type.getCurrentContext().getBoolean("negative"))
                                 processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type);
@@ -1410,7 +1454,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         // Börse Sekunden-Handel Fonds L&S Kapitalertragsteuer EUR 45,88-
                         // @formatter:on
                         .section("label", "currency", "tax").optional() //
-                        .match("^(?<label>.*) Kapitalertrags(s)?teuer[\\s]{1,}(?<currency>[A-Z]{3})[\\s]{1,}(?<tax>[\\.,\\d]+)(\\-)?$") //
+                        .match("^(?<label>.*) Kapitalertrags(s)?teuer\\s+(?<currency>[A-Z]{3})\\s+(?<tax>[\\.,\\d]+)(\\-)?.*$") //
                         .assign((t, v) -> {
                             if (!type.getCurrentContext().getBoolean("negative")
                                             && !v.get("label").trim().startsWith("im laufenden Jahr einbehaltene"))
@@ -1421,7 +1465,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         // Kapitalertragsteuer EUR 14,51
                         // @formatter:on
                         .section("currency", "tax").optional() //
-                        .match("^Kapitalertrags(s)?teuer (?<currency>[A-Z]{3}) (?<tax>[\\.,\\d]+)(\\-)?$") //
+                        .match("^Kapitalertrags(s)?teuer\\s+(?<currency>[A-Z]{3})\\s+(?<tax>[\\.,\\d]+)(\\-)?.*$") //
                         .assign((t, v) -> {
                             if (!type.getCurrentContext().getBoolean("negative"))
                                 processTaxEntries(t, v, type);
@@ -1431,7 +1475,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         // Verwahrart Girosammelverwahrung Solidaritätszuschlag EUR 2,52-
                         // @formatter:on
                         .section("label", "currency", "tax").optional() //
-                        .match("^(?<label>.*) Solidarit.tszuschlag[\\s]{1,}(?<currency>[A-Z]{3})[\\s]{1,}(?<tax>[\\.,\\d]+)(\\-)?$") //
+                        .match("^(?<label>.*) Solidarit.tszuschlag\\s+(?<currency>[A-Z]{3})\\s+(?<tax>[\\.,\\d]+)(\\-)?.*$") //
                         .assign((t, v) -> {
                             if (!type.getCurrentContext().getBoolean("negative")
                                             && !v.get("label").trim().startsWith("im laufenden Jahr einbehaltener"))
@@ -1442,7 +1486,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         // Solidaritätszuschlag EUR 0,79
                         // @formatter:on
                         .section("currency", "tax").optional() //
-                        .match("^Solidarit.tszuschlag[\\s]{1,}(?<currency>[A-Z]{3})[\\s]{1,}(?<tax>[\\.,\\d]+)(\\-)?$") //
+                        .match("^Solidarit.tszuschlag\\s+(?<currency>[A-Z]{3})\\s+(?<tax>[\\.,\\d]+)(\\-)?.*$") //
                         .assign((t, v) -> {
                             if (!type.getCurrentContext().getBoolean("negative"))
                                 processTaxEntries(t, v, type);
@@ -1452,7 +1496,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         // einbehaltene Kirchensteuer EUR 0,15
                         // @formatter:on
                         .section("label", "currency", "tax").optional() //
-                        .match("^(?<label>.*) Kirchensteuer[\\s]{1,}(?<currency>[A-Z]{3})[\\s]{1,}(?<tax>[\\.,\\d]+)(\\-)?$") //
+                        .match("^(?<label>.*) Kirchensteuer\\s+(?<currency>[A-Z]{3})\\s+(?<tax>[\\.,\\d]+)(\\-)?$") //
                         .assign((t, v) -> {
                             if (!type.getCurrentContext().getBoolean("negative")
                                             && !v.get("label").trim().startsWith("im laufenden Jahr einbehaltene"))
@@ -1463,7 +1507,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         // Kirchensteuer EUR 4,12-
                         // @formatter:on
                         .section("currency", "tax").optional() //
-                        .match("^Kirchensteuer[\\s]{1,}(?<currency>[A-Z]{3})[\\s]{1,}(?<tax>[\\.,\\d]+)(\\-)?$") //
+                        .match("^Kirchensteuer\\s+(?<currency>[A-Z]{3})\\s+(?<tax>[\\.,\\d]+)(\\-)?$") //
                         .assign((t, v) -> {
                             if (!type.getCurrentContext().getBoolean("negative"))
                                 processTaxEntries(t, v, type);
@@ -1520,7 +1564,7 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         // Handelszeit 14:15* Registrierungsspesen EUR 0,58-
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("^.* Registrierungsspesen[\\s]{1,}(?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)\\-$") //
+                        .match("^.* Registrierungsspesen\\s+(?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)\\-$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
@@ -1528,21 +1572,21 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         // Handelszeit 12:34* Provision                   EUR 10,00-
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("^.* Provision[\\s]{1,}(?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)\\-$") //
+                        .match("^.* Provision\\s+(?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)\\-$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // Börse USA/NAN Handelsplatzentgelt USD 17,44-
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("^.*[\\s]{1,}Handelsplatzentgelt (?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)\\-$") //
+                        .match("^.*\\s+Handelsplatzentgelt (?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)\\-$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
                         // Verwahrart Wertpapierrechnung Abwicklungskosten Ausland USD 0,10-
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("^.*[\\s]{1,}Abwicklungskosten .* (?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)\\-$") //
+                        .match("^.*\\s+Abwicklungskosten .* (?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)\\-$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
@@ -1560,10 +1604,17 @@ public class DABPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
+                        // Börse Stuttgart/EDS Fremde Spesen Xontro        EUR 2,90-
+                        // @formatter:on
+                        .section("currency", "fee").optional() //
+                        .match("^.*Fremde Spesen.+(?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)\\-$") //
+                        .assign((t, v) -> processFeeEntries(t, v, type))
+
+                        // @formatter:off
                         // Verwahrart Girosammelverwahrung Variabl. Transaktionsentgelt EUR 0,75-
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("^.*[\\s]{1,}Transaktionsentgelt (?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)\\-$") //
+                        .match("^.*\\s+Transaktionsentgelt (?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)\\-$") //
                         .assign((t, v) -> processFeeEntries(t, v, type));
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/BuySellEntry.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/BuySellEntry.java
@@ -78,9 +78,19 @@ public class BuySellEntry implements CrossEntry, Annotated
         this.accountTransaction.setSecurity(security);
     }
 
+    public void setBond(Security security)
+    {
+        setSecurity(security);
+    }
+
     public void setShares(long shares)
     {
         this.portfolioTransaction.setShares(shares);
+    }
+
+    public void setBondNominal(long nominal)
+    {
+        setShares(nominal);
     }
 
     public void setAmount(long amount)

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Transaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Transaction.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.model;
 
+import java.beans.Transient;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -357,6 +358,7 @@ public abstract class Transaction implements Annotated, Adaptable
         this.updatedAt = Instant.now();
     }
 
+    @Transient
     public void setBond(Security security)
     {
         setSecurity(security);
@@ -384,6 +386,7 @@ public abstract class Transaction implements Annotated, Adaptable
         this.updatedAt = Instant.now();
     }
 
+    @Transient
     public void setBondNominal(long nominal)
     {
         setShares(nominal);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Transaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Transaction.java
@@ -357,6 +357,11 @@ public abstract class Transaction implements Annotated, Adaptable
         this.updatedAt = Instant.now();
     }
 
+    public void setBond(Security security)
+    {
+        setSecurity(security);
+    }
+
     public CrossEntry getCrossEntry()
     {
         return crossEntry;
@@ -377,6 +382,11 @@ public abstract class Transaction implements Annotated, Adaptable
     {
         this.shares = shares;
         this.updatedAt = Instant.now();
+    }
+
+    public void setBondNominal(long nominal)
+    {
+        setShares(nominal);
     }
 
     @Override


### PR DESCRIPTION
Being hinted in #5896 that better support for bonds is appreciated I've gone through my archive of PDFs (and bad business decisions ;-) and tried the import of PDFs that contained transactions of bonds. The problems that showed up I've fixed, also I've done a bit of preparation for #5453 by extending the PDF importer's data structure to handle bonds and nominals. The former in the form of `asBond` currently only calls `asSecurity` but might do other things in the future, e.g. set the correct type, etc. The latter in the form of `asBondNominal` does the division by 100 so that importer don't need to do that all the time by themselves.

I haven't searched through the code base where this division currently takes place in a copy/paste manner, that's something that can be done if my idea is accepted and merged.