### PR TITLE
support for PDFs containing a "Barausschüttung".

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/InsertActionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/InsertActionTest.java
@@ -2,7 +2,6 @@ package name.abuchen.portfolio.datatransfer.actions;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsIterableContaining.hasItem;
 
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
@@ -117,17 +116,17 @@ public class InsertActionTest
         Set<String> properties = Arrays.stream(info.getPropertyDescriptors()).filter(p -> p.getWriteMethod() != null)
                         .map(PropertyDescriptor::getName).collect(Collectors.toSet());
 
-        assertThat(properties, hasItem("security"));
-        assertThat(properties, hasItem("monetaryAmount"));
-        assertThat(properties, hasItem("currencyCode"));
-        assertThat(properties, hasItem("amount"));
-        assertThat(properties, hasItem("shares"));
-        assertThat(properties, hasItem("dateTime"));
-        assertThat(properties, hasItem("type"));
-        assertThat(properties, hasItem("note"));
-        assertThat(properties, hasItem("source"));
-        assertThat(properties, hasItem("updatedAt"));
-
-        assertThat(properties.size(), is(10));
+        assertThat(properties.stream().sorted(String.CASE_INSENSITIVE_ORDER).collect(Collectors.joining(",")),
+                        is("" //
+                                        + "amount," //
+                                        + "currencyCode," //
+                                        + "dateTime," //
+                                        + "monetaryAmount," //
+                                        + "note," //
+                                        + "security," //
+                                        + "shares," //
+                                        + "source," //
+                                        + "type," //
+                                        + "updatedAt"));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/InsertActionTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/actions/InsertActionTest.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.datatransfer.actions;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsIterableContaining.hasItem;
 
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
@@ -116,17 +117,17 @@ public class InsertActionTest
         Set<String> properties = Arrays.stream(info.getPropertyDescriptors()).filter(p -> p.getWriteMethod() != null)
                         .map(PropertyDescriptor::getName).collect(Collectors.toSet());
 
-        assertThat(properties.stream().sorted(String.CASE_INSENSITIVE_ORDER).collect(Collectors.joining(",")),
-                        is("" //
-                                        + "amount," //
-                                        + "currencyCode," //
-                                        + "dateTime," //
-                                        + "monetaryAmount," //
-                                        + "note," //
-                                        + "security," //
-                                        + "shares," //
-                                        + "source," //
-                                        + "type," //
-                                        + "updatedAt"));
+        assertThat(properties, hasItem("security"));
+        assertThat(properties, hasItem("monetaryAmount"));
+        assertThat(properties, hasItem("currencyCode"));
+        assertThat(properties, hasItem("amount"));
+        assertThat(properties, hasItem("shares"));
+        assertThat(properties, hasItem("dateTime"));
+        assertThat(properties, hasItem("type"));
+        assertThat(properties, hasItem("note"));
+        assertThat(properties, hasItem("source"));
+        assertThat(properties, hasItem("updatedAt"));
+
+        assertThat(properties.size(), is(10));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Barausschüttung01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/Barausschüttung01.txt
@@ -1,0 +1,61 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+WVWALg GXtQ SEITE 1 von 2
+WeRluHlXGxKaMl mHi DATUM 01.07.2026
+63736 uzE FxIKdNoOWF DEPOT 6096738343
+BARAUSSCHÜTTUNG
+ÜBERSICHT
+Barausschüttung mit Ex-Datum 15.06.2026.
+POSITION ANZAHL ERTRAG BETRAG
+Strategy 57.50 USD
+60.000000 Stücke 0.958333 USD
+US5949728530
+GESAMT 57.50 USD
+ABRECHNUNG
+POSITION BETRAG
+Zwischensumme 57.50 USD
+Zwischensumme 1.1406 USD/EUR 50.41 EUR
+Kapitalertragsteuer 1.1406 USD/EUR -12.61 EUR
+Solidaritätszuschlag 1.1406 USD/EUR -0.69 EUR
+GESAMT 37.11 EUR
+BUCHUNG
+VERRECHNUNGSKONTO DATUM DER ZAHLUNG BETRAG
+Fn62341011168861814346 30.06.2026 37.11 EUR
+US5949728530 im Girosammelverwahrung in Deutschland
+Diese Abrechnung wird maschinell erstellt und daher nicht unterschrieben.
+Wird keine Umsatzsteuer ausgewiesen, handelt es sich um eine umsatzsteuerfreie Leistung gemäß § 4 Nr. 8 UStG
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke
+TRADE REPUBLIC BANK GMBH  BRUNNENSTRASSE 19-21  10119 BERLIN
+uIPZNP ilBm SEITE 2 von 2
+WeRluHlXGxKaMl BuJ 5h DATUM 01.07.2026
+93252 UIB bxzDhjeUsr DEPOT 7049348757
+STEUERLICHE BEHANDLUNG
+BERECHNUNG DER STEUERBEMESSUNGSGRUNDLAGE BETRAG
+Kapitalertrag 57,50 USD
+Zwischensumme 1.1406 EUR/USD 50,41 EUR
+STEUERBEMESSUNGSGRUNDLAGE 50,41 EUR
+BERECHNUNG DER STEUERN BETRAG
+Quellensteuer für US-Emittenten 0,00 USD
+Quellensteuer 0,00 USD
+Steuerbemessungsgrundlage 50,41 EUR
+Kapitalertragsteuer -12,61 EUR
+Solidaritätszuschlag -0,69 EUR
+GESAMTE STEUERN 13,30 EUR
+VERRECHNUNGSTÖPFE
+VERRECHNUNGSTÖPFE VORHER VERÄNDERUNG NACHHER
+Verlustverrechnungstopf Aktien 0,00 EUR 0,00 EUR 0,00 EUR
+Verlustverrechnungstopf Allgemein 0,00 EUR 0,00 EUR 0,00 EUR
+Freistellungsauftrag 0,00 EUR 0,00 EUR 0,00 EUR
+Quellensteuertopf 0,00 EUR 0,00 EUR 0,00 EUR
+Trade Republic Bank GmbH www.traderepublic.com Sitz der Gesellschaft: Berlin Geschäftsführer
+Brunnenstraße 19-21 AG Charlottenburg HRB 244347 B Andreas Torner
+10119 Berlin Umsatzsteuer-ID DE307510626 Gernot Mittendorfer
+Christian Hecker
+Thomas Pischke

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/traderepublic/TradeRepublicPDFExtractorTest.java
@@ -9102,7 +9102,6 @@ public class TradeRepublicPDFExtractorTest
 
         var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende30.txt"), errors);
 
-        errors.forEach(Exception::printStackTrace);
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
         assertThat(countBuySell(results), is(0L));
@@ -9145,7 +9144,6 @@ public class TradeRepublicPDFExtractorTest
 
         var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende30.txt"), errors);
 
-        errors.forEach(Exception::printStackTrace);
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
@@ -9175,7 +9173,6 @@ public class TradeRepublicPDFExtractorTest
 
         var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende31.txt"), errors);
 
-        errors.forEach(Exception::printStackTrace);
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
         assertThat(countBuySell(results), is(0L));
@@ -9218,7 +9215,6 @@ public class TradeRepublicPDFExtractorTest
 
         var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende31.txt"), errors);
 
-        errors.forEach(Exception::printStackTrace);
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(0L));
         assertThat(countBuySell(results), is(0L));
@@ -9237,6 +9233,77 @@ public class TradeRepublicPDFExtractorTest
                         hasNote(null), //
                         hasAmount("EUR", 0.90), hasGrossValue("EUR", 1.21), //
                         hasTaxes("EUR", 0.31), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testBarausschuettung01()
+    {
+        var extractor = new TradeRepublicPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Barausschüttung01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US5949728530"), hasWkn(null), hasTicker(null), //
+                        hasName("Strategy"), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-06-30"), hasExDate("2026-06-15"), //
+                        hasShares(60), //
+                        hasSource("Barausschüttung01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 37.11), hasGrossValue("EUR", 50.41), //
+                        hasForexGrossValue("USD", 57.50), //
+                        hasTaxes("EUR", 12.61 + 0.69), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testBarausschuettung01WithSecurityInEUR()
+    {
+        var security = new Security("Strategy", "EUR");
+        security.setIsin("US5949728530");
+
+        var client = new Client();
+        client.addSecurity(security);
+
+        var extractor = new TradeRepublicPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Barausschüttung01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "EUR");
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-06-30"), hasExDate("2026-06-15"), //
+                        hasShares(60), //
+                        hasSource("Barausschüttung01.txt"), //
+                        hasNote(null), //
+                        hasAmount("EUR", 37.11), hasGrossValue("EUR", 50.41), //
+                        hasTaxes("EUR", 12.61 + 0.69), hasFees("EUR", 0.00))));
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TradeRepublicPDFExtractor.java
@@ -1267,7 +1267,7 @@ public class TradeRepublicPDFExtractor extends AbstractPDFExtractor
 
     private void addDividendTransaction()
     {
-        final var type = new DocumentType("(?im)^(AUSSCH.TTUNG" //
+        final var type = new DocumentType("(?im)^((BAR)?AUSSCH.TTUNG" //
                         + "|(STORNIERUNG DER )?DIVIDENDE( EN ESP.CES)?" //
                         + "|REINVESTIERUNG" //
                         + "|STORNO DIVIDENDE" //


### PR DESCRIPTION
Adjusted the regex to recognize "Barausschüttungen" as dividend. PDF was provided [by the forum](https://forum.portfolio-performance.info/t/pdf-import-von-trade-republic/5107/890?u=kimmerin).