### PR TITLE
Make the width of the chart lines configurable

### DIFF
--- a/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/util/chart/ChartLineWidthTest.java
+++ b/name.abuchen.portfolio.ui.tests/src/name/abuchen/portfolio/ui/util/chart/ChartLineWidthTest.java
@@ -1,0 +1,47 @@
+package name.abuchen.portfolio.ui.util.chart;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.After;
+import org.junit.Test;
+
+@SuppressWarnings("nls")
+public class ChartLineWidthTest
+{
+    @After
+    public void resetToDefault()
+    {
+        ChartLineWidth.set(ChartLineWidth.DEFAULT_WIDTH);
+    }
+
+    @Test
+    public void testDefaultWidthIsUsedInitially()
+    {
+        assertThat(ChartLineWidth.get(), is(ChartLineWidth.DEFAULT_WIDTH));
+    }
+
+    @Test
+    public void testSupportedWidthsAreApplied()
+    {
+        for (int width = ChartLineWidth.MIN_WIDTH; width <= ChartLineWidth.MAX_WIDTH; width++)
+        {
+            ChartLineWidth.set(width);
+            assertThat(ChartLineWidth.get(), is(width));
+        }
+    }
+
+    @Test
+    public void testWidthsOutsideTheRangeFallBackToDefault()
+    {
+        // the preference can be edited manually and the injected value is 0 if
+        // it cannot be read as a number
+
+        for (int width : new int[] { 0, -1, ChartLineWidth.MAX_WIDTH + 1, 99 })
+        {
+            ChartLineWidth.set(width);
+            assertThat("width " + width + " must fall back to the default", ChartLineWidth.get(),
+                            is(ChartLineWidth.DEFAULT_WIDTH));
+        }
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/UIConstants.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/UIConstants.java
@@ -44,6 +44,7 @@ public interface UIConstants
         {
             String DISCREET_MODE = "global/discreet-mode"; //$NON-NLS-1$
             String VALUE_COLOR_SCHEME_CHANGED = "global/value-color-scheme-changed"; //$NON-NLS-1$
+            String CHART_LINE_WIDTH_CHANGED = "global/chart-line-width-changed"; //$NON-NLS-1$
         }
     }
 
@@ -220,6 +221,13 @@ public interface UIConstants
         String ENABLE_SURVEY_REMINDER = "ENABLE_SURVEY_REMINDER"; //$NON-NLS-1$ //NOSONAR
 
         String ENABLE_SWTCHART_PIECHARTS = "ENABLE_SWTCHART_PIECHARTS"; //$NON-NLS-1$
+
+        /**
+         * Preference key for the width (in pixel) of the lines painted by those
+         * charts and dashboard widget series that do not offer a line width per
+         * data series.
+         */
+        String CHART_LINE_WIDTH = "CHART_LINE_WIDTH"; //$NON-NLS-1$
 
         /**
          * Preference key whether to activate in-place editing with a double

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/addons/Preference2EnvAddon.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/addons/Preference2EnvAddon.java
@@ -25,6 +25,7 @@ import name.abuchen.portfolio.online.impl.TwelveDataSearchProvider;
 import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.dialogs.transactions.PresetValues;
 import name.abuchen.portfolio.ui.util.ValueColorScheme;
+import name.abuchen.portfolio.ui.util.chart.ChartLineWidth;
 import name.abuchen.portfolio.util.FormatHelper;
 import name.abuchen.portfolio.util.TradeCalendarManager;
 
@@ -42,6 +43,17 @@ public class Preference2EnvAddon
 
         if (broker != null && !Objects.equals(currentScheme, ValueColorScheme.current().getIdentifier()))
             broker.post(UIConstants.Event.Global.VALUE_COLOR_SCHEME_CHANGED, scheme);
+    }
+
+    @Inject
+    @Optional
+    public void setChartLineWidth(@Preference(value = UIConstants.Preferences.CHART_LINE_WIDTH) int lineWidth)
+    {
+        int currentWidth = ChartLineWidth.get();
+        ChartLineWidth.set(lineWidth);
+
+        if (broker != null && currentWidth != ChartLineWidth.get())
+            broker.post(UIConstants.Event.Global.CHART_LINE_WIDTH_CHANGED, ChartLineWidth.get());
     }
 
     @Inject

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/AbstractFinanceView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/AbstractFinanceView.java
@@ -120,6 +120,14 @@ public abstract class AbstractFinanceView
         onRecalculationNeeded();
     }
 
+    @Inject
+    @org.eclipse.e4.core.di.annotations.Optional
+    public void onChartLineWidthChanged(
+                    @UIEventTopic(UIConstants.Event.Global.CHART_LINE_WIDTH_CHANGED) Object ignored)
+    {
+        onRecalculationNeeded();
+    }
+
     /** called when some other view modifies the model */
     public void notifyModelUpdated()
     {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/PreferencesInitializer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/preferences/PreferencesInitializer.java
@@ -10,6 +10,7 @@ import name.abuchen.portfolio.ui.UIConstants;
 import name.abuchen.portfolio.ui.dialogs.transactions.PresetValues;
 import name.abuchen.portfolio.ui.editor.ClientInput;
 import name.abuchen.portfolio.ui.util.ValueColorScheme;
+import name.abuchen.portfolio.ui.util.chart.ChartLineWidth;
 
 public class PreferencesInitializer extends AbstractPreferenceInitializer
 {
@@ -34,6 +35,7 @@ public class PreferencesInitializer extends AbstractPreferenceInitializer
                         Platform.getOS().equals(Platform.OS_LINUX) || (Platform.getOS().equals(Platform.OS_MACOSX)
                                         && Platform.getOSArch().equals(Platform.ARCH_X86_64)
                                         && compareOSVersion("13.0") >= 0)); //$NON-NLS-1$
+        store.setDefault(UIConstants.Preferences.CHART_LINE_WIDTH, ChartLineWidth.DEFAULT_WIDTH);
         store.setDefault(UIConstants.Preferences.ALPHAVANTAGE_CALL_FREQUENCY_LIMIT, 5);
         store.setDefault(UIConstants.Preferences.CALENDAR, "default"); //$NON-NLS-1$
         store.setDefault(UIConstants.Preferences.PRESET_VALUE_TIME, PresetValues.TimePreset.MIDNIGHT.name());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartContextMenu.java
@@ -28,6 +28,13 @@ import name.abuchen.portfolio.util.TextUtil;
     private Chart chart;
     private Menu contextMenu;
 
+    /**
+     * Whether to offer the line width of the chart. Charts painting lines of a
+     * configurable width switch it on; charts with configurable data series
+     * switch it off again because the user picks a line width per data series.
+     */
+    private boolean lineWidthConfigurable = false;
+
     private static int lastUsedFileExtension = DEFAULT_FILE_EXTENSION;
 
     public ChartContextMenu(Chart chart)
@@ -76,8 +83,19 @@ import name.abuchen.portfolio.util.TextUtil;
         manager.add(new Separator());
         addMoveActions(manager);
 
+        if (lineWidthConfigurable)
+        {
+            manager.add(new Separator());
+            ChartLineWidth.addMenu(manager);
+        }
+
         manager.add(new Separator());
         exportMenuAboutToShow(manager, chart.getTitle().getText());
+    }
+
+    /* package */ void setLineWidthConfigurable(boolean configurable)
+    {
+        this.lineWidthConfigurable = configurable;
     }
 
     private void addZoomActions(IMenuManager manager)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartLineWidth.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/ChartLineWidth.java
@@ -1,0 +1,66 @@
+package name.abuchen.portfolio.ui.util.chart;
+
+import java.util.stream.IntStream;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IMenuManager;
+import org.eclipse.jface.action.MenuManager;
+
+import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.PortfolioPlugin;
+import name.abuchen.portfolio.ui.UIConstants;
+import name.abuchen.portfolio.ui.util.SimpleAction;
+
+/**
+ * The width (in pixel) of the lines painted by those charts that do not offer a
+ * line width per data series. The value is configured per installation - not
+ * per file - because it compensates for how the monitor scales the lines.
+ * <p/>
+ * Charts driven by configurable data series (Statement of Assets, Performance)
+ * are not affected: they let the user pick a line width per series. Dashboard
+ * widgets are affected if their data series do not offer a per-series line
+ * width.
+ */
+public final class ChartLineWidth
+{
+    public static final int MIN_WIDTH = 1;
+    public static final int MAX_WIDTH = 3;
+    public static final int DEFAULT_WIDTH = 2;
+
+    private static int current = DEFAULT_WIDTH;
+
+    private ChartLineWidth()
+    {
+    }
+
+    public static int get()
+    {
+        return current;
+    }
+
+    /**
+     * Sets the current line width. Values outside the supported range are
+     * silently replaced by the default, for example because the preference has
+     * been edited manually.
+     */
+    public static void set(int width)
+    {
+        current = width < MIN_WIDTH || width > MAX_WIDTH ? DEFAULT_WIDTH : width;
+    }
+
+    /**
+     * Adds the sub-menu to pick the line width. Picking a width updates the
+     * preference which in turn updates all charts.
+     */
+    public static void addMenu(IMenuManager manager)
+    {
+        MenuManager lineWidth = new MenuManager(Messages.ChartSeriesPickerLineWidth);
+        IntStream.rangeClosed(MIN_WIDTH, MAX_WIDTH).forEach(width -> {
+            Action action = new SimpleAction(width + " px", a -> PortfolioPlugin.getDefault().getPreferenceStore() //$NON-NLS-1$
+                            .setValue(UIConstants.Preferences.CHART_LINE_WIDTH, width));
+            action.setChecked(width == get());
+            lineWidth.add(action);
+        });
+        manager.add(lineWidth);
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedTimelineChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/StackedTimelineChart.java
@@ -86,6 +86,17 @@ public class StackedTimelineChart extends Chart // NOSONAR
         });
 
         this.contextMenu = new ChartContextMenu(this);
+        this.contextMenu.setLineWidthConfigurable(true);
+    }
+
+    /**
+     * Offers the line width in the context menu. Offered by default; charts
+     * with configurable data series switch it off because the user picks a line
+     * width per data series there.
+     */
+    public void setLineWidthConfigurable(boolean configurable)
+    {
+        contextMenu.setLineWidthConfigurable(configurable);
     }
 
     public void setDates(List<LocalDate> dates)
@@ -105,7 +116,7 @@ public class StackedTimelineChart extends Chart // NOSONAR
         series.setDescription(label);
         series.setYSeries(values);
 
-        series.setLineWidth(2);
+        series.setLineWidth(ChartLineWidth.get());
         series.setSymbolType(PlotSymbolType.NONE);
         series.setAntialias(SWT.ON);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/chart/TimelineChart.java
@@ -134,6 +134,17 @@ public class TimelineChart extends Chart // NOSONAR
         getPlotArea().getControl().addTraverseListener(event -> event.doit = true);
 
         this.contextMenu = new ChartContextMenu(this);
+        this.contextMenu.setLineWidthConfigurable(true);
+    }
+
+    /**
+     * Offers the line width in the context menu. Offered by default; charts
+     * with configurable data series switch it off because the user picks a line
+     * width per data series there.
+     */
+    public void setLineWidthConfigurable(boolean configurable)
+    {
+        contextMenu.setLineWidthConfigurable(configurable);
     }
 
     public void addMarkerLine(LocalDate date, Color color, String label)
@@ -204,7 +215,7 @@ public class TimelineChart extends Chart // NOSONAR
         lineSeries.setDescription(label);
         lineSeries.setDataModel(new TimelineSeriesModel(dates, values));
         lineSeries.enableArea(showArea);
-        lineSeries.setLineWidth(2);
+        lineSeries.setLineWidth(ChartLineWidth.get());
         lineSeries.setSymbolType(PlotSymbolType.NONE);
         lineSeries.setLineColor(color);
         lineSeries.setAntialias(SWT.ON);
@@ -266,7 +277,7 @@ public class TimelineChart extends Chart // NOSONAR
 
             e.gc.setLineStyle(SWT.LINE_SOLID);
             e.gc.setForeground(marker.color);
-            e.gc.setLineWidth(2);
+            e.gc.setLineWidth(ChartLineWidth.get());
             e.gc.drawLine(x, 0, x, e.height);
 
             if (marker.label != null)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PerformanceChartView.java
@@ -113,6 +113,7 @@ public class PerformanceChartView extends AbstractHistoricView
         composite.setBackground(Colors.theme().defaultBackground());
 
         chart = new TimelineChart(composite);
+        chart.setLineWidthConfigurable(false);
         chart.getTitle().setText(getTitle());
         chart.getTitle().setVisible(false);
         chart.getAxisSet().getYAxis(0).getTick().setFormat(new AxisTickPercentNumberFormat("0.#%")); //$NON-NLS-1$

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioBalanceChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/PortfolioBalanceChart.java
@@ -45,6 +45,7 @@ import name.abuchen.portfolio.ui.util.ClientFilterMenu;
 import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.SimpleAction;
+import name.abuchen.portfolio.ui.util.chart.ChartLineWidth;
 import name.abuchen.portfolio.ui.util.chart.TimelineChart;
 import name.abuchen.portfolio.ui.util.chart.TimelineChartCSVExporter;
 import name.abuchen.portfolio.ui.util.chart.TimelineChartToolTip;
@@ -329,6 +330,9 @@ public class PortfolioBalanceChart
         manager.add(addMenuAction(ChartDetails.ABSOLUTE_DELTA));
         manager.add(addMenuAction(ChartDetails.TAXES_ACCUMULATED));
         manager.add(addMenuAction(ChartDetails.FEES_ACCUMULATED));
+
+        manager.add(new Separator());
+        ChartLineWidth.addMenu(manager);
     }
 
     private Action addMenuAction(ChartDetails detail)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesChart.java
@@ -75,6 +75,7 @@ import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.DropDown;
 import name.abuchen.portfolio.ui.util.SimpleAction;
 import name.abuchen.portfolio.ui.util.chart.ChartColorWheel;
+import name.abuchen.portfolio.ui.util.chart.ChartLineWidth;
 import name.abuchen.portfolio.ui.util.chart.TimelineChartToolTip;
 import name.abuchen.portfolio.ui.util.chart.TimelineSeriesModel;
 import name.abuchen.portfolio.ui.util.format.AxisTickPercentNumberFormat;
@@ -885,6 +886,8 @@ public class SecuritiesChart
         subMenuChartSettings.add(addMenuAction(ChartDetails.SHOW_PERCENTAGE_AXIS));
         subMenuChartSettings.add(addMenuAction(ChartDetails.SHOW_MAIN_HORIZONTAL_LINES));
         subMenuChartSettings.add(addMenuAction(ChartDetails.SHOW_PERCENTAGE_HORIZONTAL_LINES));
+        subMenuChartSettings.add(new Separator());
+        ChartLineWidth.addMenu(subMenuChartSettings);
         manager.add(subMenuChartScaling);
         manager.add(subMenuChartDevelopment);
         manager.add(subMenuChartMarker);
@@ -1163,8 +1166,8 @@ public class SecuritiesChart
                 lineSeries.setSymbolType(PlotSymbolType.NONE);
                 Color color = isSingleSecurityMode ? colorQuote : new Color(colorWheel.getRGB(security));
                 boolean enableArea = !showAreaRelativeToFirstQuote && isSingleSecurityMode;
-                configureSeriesPainter(lineSeries, dates, values, color, 2, LineStyle.SOLID, enableArea,
-                                !isSingleSecurityMode);
+                configureSeriesPainter(lineSeries, dates, values, color, ChartLineWidth.get(), LineStyle.SOLID,
+                                enableArea, !isSingleSecurityMode);
 
                 chart.adjustRange();
 
@@ -1365,7 +1368,7 @@ public class SecuritiesChart
             ILineSeries<Integer> lineSeriesLimit = (ILineSeries<Integer>) chart.getSeriesSet()
                             .createSeries(SeriesType.LINE, lineID);
             lineSeriesLimit.setDataModel(new TimelineSeriesModel(dates, values));
-            lineSeriesLimit.setLineWidth(2);
+            lineSeriesLimit.setLineWidth(ChartLineWidth.get());
             lineSeriesLimit.setLineStyle(LineStyle.DASH);
             lineSeriesLimit.enableArea(false);
             lineSeriesLimit.setSymbolType(PlotSymbolType.NONE);
@@ -1390,7 +1393,7 @@ public class SecuritiesChart
                         lineID);
         lineSeriesSMA.setDataModel(new TimelineSeriesModel(smaLines.getDates(), smaLines.getValues()));
 
-        lineSeriesSMA.setLineWidth(2);
+        lineSeriesSMA.setLineWidth(ChartLineWidth.get());
         lineSeriesSMA.enableArea(false);
         lineSeriesSMA.setSymbolType(PlotSymbolType.NONE);
         lineSeriesSMA.setAntialias(swtAntialias);
@@ -1412,7 +1415,7 @@ public class SecuritiesChart
         ILineSeries<Integer> lineSeriesEMA = (ILineSeries<Integer>) chart.getSeriesSet().createSeries(SeriesType.LINE,
                         lineID);
         lineSeriesEMA.setDataModel(new TimelineSeriesModel(emaLines.getDates(), emaLines.getValues()));
-        lineSeriesEMA.setLineWidth(2);
+        lineSeriesEMA.setLineWidth(ChartLineWidth.get());
         lineSeriesEMA.enableArea(false);
         lineSeriesEMA.setSymbolType(PlotSymbolType.NONE);
         lineSeriesEMA.setAntialias(swtAntialias);
@@ -1785,7 +1788,7 @@ public class SecuritiesChart
                         .setDataModel(new TimelineSeriesModel(lowerBand.getDates(), lowerBand.getValues()));
 
         lineSeriesBollingerBandsLowerBand.setLineStyle(LineStyle.SOLID);
-        lineSeriesBollingerBandsLowerBand.setLineWidth(2);
+        lineSeriesBollingerBandsLowerBand.setLineWidth(ChartLineWidth.get());
         lineSeriesBollingerBandsLowerBand.setSymbolType(PlotSymbolType.NONE);
         lineSeriesBollingerBandsLowerBand.setAntialias(swtAntialias);
         lineSeriesBollingerBandsLowerBand.setLineColor(colorBollingerBands);
@@ -1800,7 +1803,7 @@ public class SecuritiesChart
         lineSeriesBollingerBandsMiddleBand
                         .setDataModel(new TimelineSeriesModel(middleBand.getDates(), middleBand.getValues()));
 
-        lineSeriesBollingerBandsMiddleBand.setLineWidth(2);
+        lineSeriesBollingerBandsMiddleBand.setLineWidth(ChartLineWidth.get());
         lineSeriesBollingerBandsMiddleBand.setLineStyle(LineStyle.DOT);
         lineSeriesBollingerBandsMiddleBand.setSymbolType(PlotSymbolType.NONE);
         lineSeriesBollingerBandsMiddleBand.setAntialias(swtAntialias);
@@ -1816,7 +1819,7 @@ public class SecuritiesChart
         lineSeriesBollingerBandsUpperBand
                         .setDataModel(new TimelineSeriesModel(upperBand.getDates(), upperBand.getValues()));
 
-        lineSeriesBollingerBandsUpperBand.setLineWidth(2);
+        lineSeriesBollingerBandsUpperBand.setLineWidth(ChartLineWidth.get());
         lineSeriesBollingerBandsUpperBand.setLineStyle(LineStyle.SOLID);
         lineSeriesBollingerBandsUpperBand.setSymbolType(PlotSymbolType.NONE);
         lineSeriesBollingerBandsUpperBand.setAntialias(swtAntialias);
@@ -1859,7 +1862,7 @@ public class SecuritiesChart
                             new TimelineSeriesModel(macdLines.get().getDates(), macdLines.get().getValues()));
 
             lineSeriesMacd.setLineStyle(LineStyle.SOLID);
-            lineSeriesMacd.setLineWidth(2);
+            lineSeriesMacd.setLineWidth(ChartLineWidth.get());
             lineSeriesMacd.enableArea(false);
             lineSeriesMacd.setSymbolType(PlotSymbolType.NONE);
             lineSeriesMacd.setAntialias(swtAntialias);
@@ -1878,7 +1881,7 @@ public class SecuritiesChart
                             new TimelineSeriesModel(signalLines.get().getDates(), signalLines.get().getValues()));
 
             lineSeriesSignal.setLineStyle(LineStyle.DOT);
-            lineSeriesSignal.setLineWidth(2);
+            lineSeriesSignal.setLineWidth(ChartLineWidth.get());
             lineSeriesSignal.enableArea(false);
             lineSeriesSignal.setSymbolType(PlotSymbolType.NONE);
             lineSeriesSignal.setAntialias(swtAntialias);
@@ -1993,8 +1996,8 @@ public class SecuritiesChart
         series.setYAxisId(0);
         series.enableStep(true);
 
-        configureSeriesPainter(series, dates.toArray(new LocalDate[0]), Doubles.toArray(values), color, 2,
-                        LineStyle.SOLID, false, seriesCounter == 0);
+        configureSeriesPainter(series, dates.toArray(new LocalDate[0]), Doubles.toArray(values), color,
+                        ChartLineWidth.get(), LineStyle.SOLID, false, seriesCounter == 0);
 
         setupTooltipDisplayCalculatedQuote(label);
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsHistoryView.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsHistoryView.java
@@ -120,6 +120,7 @@ public class StatementOfAssetsHistoryView extends AbstractHistoricView
         composite.setBackground(Colors.theme().defaultBackground());
 
         chart = new TimelineChart(composite);
+        chart.setLineWidthConfigurable(false);
         chart.getTitle().setVisible(false);
 
         chart.getToolTip().reverseLabels(true);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/currency/ExchangeRatesListTab.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/currency/ExchangeRatesListTab.java
@@ -66,6 +66,18 @@ public class ExchangeRatesListTab implements AbstractTabbedView.Tab
         indeces.refresh();
     }
 
+    @Inject
+    @org.eclipse.e4.core.di.annotations.Optional
+    public void onChartLineWidthChanged(
+                    @UIEventTopic(UIConstants.Event.Global.CHART_LINE_WIDTH_CHANGED) Object obj)
+    {
+        // the view is not rebuilt by the line width change because the tab
+        // creates the chart itself and is not an information pane
+
+        if (chart != null && !chart.isDisposed())
+            refreshChart((ExchangeRateTimeSeries) indeces.getStructuredSelection().getFirstElement());
+    }
+
     @Override
     public Composite createTab(Composite parent)
     {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ChartWidget.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/ChartWidget.java
@@ -211,6 +211,7 @@ public class ChartWidget extends WidgetDelegate<Object>
         GridDataFactory.fillDefaults().grab(true, false).applyTo(title);
 
         chart = new TimelineChart(container);
+        chart.setLineWidthConfigurable(false);
         chart.getTitle().setVisible(false);
         chart.getTitle().setText(title.getText());
         chart.getAxisSet().getYAxis(0).getTick().setVisible(get(ChartShowYAxisConfig.class).getIsShowYAxis());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsAccumulatedChartBuilder.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/payments/PaymentsAccumulatedChartBuilder.java
@@ -16,6 +16,7 @@ import org.eclipse.swtchart.ISeries.SeriesType;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.util.TabularDataSource;
+import name.abuchen.portfolio.ui.util.chart.ChartLineWidth;
 import name.abuchen.portfolio.ui.util.chart.TimelineChartToolTip;
 import name.abuchen.portfolio.ui.util.format.AmountNumberFormat;
 import name.abuchen.portfolio.ui.util.format.ThousandsNumberFormat;
@@ -75,7 +76,7 @@ public class PaymentsAccumulatedChartBuilder implements PaymentsChartBuilder
             lineSeries.setYSeries(series);
 
             lineSeries.setLineColor(PaymentsColors.getColor(year));
-            lineSeries.setLineWidth(2);
+            lineSeries.setLineWidth(ChartLineWidth.get());
             lineSeries.setSymbolType(PlotSymbolType.NONE);
             lineSeries.setAntialias(SWT.ON);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/securitychart/SharesHeldChartSeries.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/securitychart/SharesHeldChartSeries.java
@@ -20,6 +20,7 @@ import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Transaction;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.ui.Messages;
+import name.abuchen.portfolio.ui.util.chart.ChartLineWidth;
 import name.abuchen.portfolio.ui.util.chart.TimelineChart;
 import name.abuchen.portfolio.ui.util.chart.TimelineSeriesModel;
 import name.abuchen.portfolio.ui.views.SecuritiesChart;
@@ -113,7 +114,7 @@ public class SharesHeldChartSeries
             series.setYAxisId(axis.getId());
             series.enableStep(true);
 
-            series.setLineWidth(2);
+            series.setLineWidth(ChartLineWidth.get());
             series.setLineStyle(LineStyle.SOLID);
             series.enableArea(false);
             series.setAntialias(chart.getAntialias());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractStackedChartViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/taxonomy/AbstractStackedChartViewer.java
@@ -35,6 +35,7 @@ import name.abuchen.portfolio.ui.editor.PortfolioPart;
 import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.ReportingPeriodDropDown.ReportingPeriodListener;
 import name.abuchen.portfolio.ui.util.SimpleAction;
+import name.abuchen.portfolio.ui.util.chart.ChartLineWidth;
 import name.abuchen.portfolio.ui.util.chart.StackedChartCSVExporter;
 import name.abuchen.portfolio.ui.util.chart.StackedTimelineChart;
 import name.abuchen.portfolio.util.Interval;
@@ -149,6 +150,9 @@ public abstract class AbstractStackedChartViewer extends AbstractChartPage imple
         });
         action.setChecked(getModel().isOrderByTaxonomyInStackChart());
         manager.add(action);
+
+        manager.add(new Separator());
+        ChartLineWidth.addMenu(manager);
     }
 
     @Override


### PR DESCRIPTION
Charts that paint data series let the user pick a line width per series. The other charts painted their lines with a hard-coded width of 2 pixel, which since the monitor-specific scaling of Eclipse 2026-06 is scaled up to 3 pixel and more.

Add a "Line width" menu offering 1, 2 and 3 pixel. The value is stored per installation - not per file - because it compensates for how the monitor scales the lines: the same file opened on a notebook and on a 4K screen needs different values. Changing it updates all open charts.

The menu is offered by the chart context menu and, if the chart has one, by the configuration menu of the chart. Charts painting data series do not offer it as the user picks a line width per series there.

Closes #5944