### PR TITLE
Support for older PDFs of Barclays Bank (Ireland) PLC

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/barclaysbankirelandplc/BarclaysBankIrelandPLCPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/barclaysbankirelandplc/BarclaysBankIrelandPLCPDFExtractorTest.java
@@ -4,10 +4,12 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interest;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.interestCharge;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
@@ -21,7 +23,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.Test;
 
@@ -38,7 +39,7 @@ public class BarclaysBankIrelandPLCPDFExtractorTest
     {
         var extractor = new BarclaysBankIrelandPLCPDFExtractor(new Client());
 
-        List<Exception> errors = new ArrayList<>();
+        var errors = new ArrayList<Exception>();
 
         var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "KreditKontoauszug01.txt"), errors);
 
@@ -86,7 +87,7 @@ public class BarclaysBankIrelandPLCPDFExtractorTest
     {
         var extractor = new BarclaysBankIrelandPLCPDFExtractor(new Client());
 
-        List<Exception> errors = new ArrayList<>();
+        var errors = new ArrayList<Exception>();
 
         var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "KreditKontoauszug02.txt"), errors);
 
@@ -146,7 +147,7 @@ public class BarclaysBankIrelandPLCPDFExtractorTest
     {
         var extractor = new BarclaysBankIrelandPLCPDFExtractor(new Client());
 
-        List<Exception> errors = new ArrayList<>();
+        var errors = new ArrayList<Exception>();
 
         var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "KreditKontoauszug03.txt"), errors);
 
@@ -161,27 +162,230 @@ public class BarclaysBankIrelandPLCPDFExtractorTest
         new AssertImportActions().check(results, "EUR");
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2023-12-31"), hasAmount("EUR", 3.54), //
+        assertThat(results, hasItem(interest( //
+                        hasDate("2023-12-31"), //
                         hasSource("KreditKontoauszug03.txt"), //
-                        hasNote(null), //
+                        hasNote("Habenzinsen"), //
+                        hasAmount("EUR", 3.54), hasGrossValue("EUR", 4.80), //
                         hasTaxes("EUR", 1.20 + 0.06), hasFees("EUR", 0.00))));
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2023-12-31"), hasAmount("EUR", 14.47), //
+        assertThat(results, hasItem(interest( //
+                        hasDate("2023-12-31"), //
                         hasSource("KreditKontoauszug03.txt"), //
-                        hasNote(null), //
+                        hasNote("Habenzinsen"), //
+                        hasAmount("EUR", 14.47), hasGrossValue("EUR", 19.65), //
                         hasTaxes("EUR", 4.91 + 0.27), hasFees("EUR", 0.00))));
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2023-12-31"), hasAmount("EUR", 16.41), //
+        assertThat(results, hasItem(interest( //
+                        hasDate("2023-12-31"), //
                         hasSource("KreditKontoauszug03.txt"), //
-                        hasNote(null), //
+                        hasNote("Habenzinsen"), //
+                        hasAmount("EUR", 16.41), hasGrossValue("EUR", 22.28), //
                         hasTaxes("EUR", 5.57 + 0.30), hasFees("EUR", 0.00))));
 
         // assert transaction
-        assertThat(results, hasItem(interest(hasDate("2023-12-31"), hasAmount("EUR", 103.38), //
+        assertThat(results, hasItem(interest( //
+                        hasDate("2023-12-31"), //
                         hasSource("KreditKontoauszug03.txt"), //
-                        hasNote(null), //
+                        hasNote("Habenzinsen"), //
+                        hasAmount("EUR", 103.38), hasGrossValue("EUR", 140.41), //
                         hasTaxes("EUR", 35.10 + 1.93), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testKreditKontoauszug04()
+    {
+        var extractor = new BarclaysBankIrelandPLCPDFExtractor(new Client());
+
+        var errors = new ArrayList<Exception>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "KreditKontoauszug04.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(26L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(26));
+        new AssertImportActions().check(results, "EUR");
+
+        // assert transactions
+        assertThat(results, hasItem(removal(hasDate("2020-07-20"), hasAmount("EUR", 89.94), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Onlineshop Umsatz 123-456-7890"))));
+        assertThat(results, hasItem(removal(hasDate("2020-07-20"), hasAmount("EUR", 45.00), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("LADEN1 MUENCHEN"))));
+        assertThat(results, hasItem(deposit(hasDate("2020-07-20"), hasAmount("EUR", 187.04), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Onlineshop3 Umsatz Luxembourg"))));
+        assertThat(results, hasItem(removal(hasDate("2020-07-20"), hasAmount("EUR", 38.80), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Onlineshop2 Umsatz EXAMPLE.COM"))));
+        assertThat(results, hasItem(removal(hasDate("2020-07-21"), hasAmount("EUR", 40.89), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Onlineshop2 Umsatz EXAMPLE.COM"))));
+        assertThat(results, hasItem(removal(hasDate("2020-07-22"), hasAmount("EUR", 58.99), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Onlineshop Umsatz 123-456-7890"))));
+        assertThat(results, hasItem(removal(hasDate("2020-07-23"), hasAmount("EUR", 7.61), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("LADEN2 MÜNCHEN"))));
+        assertThat(results, hasItem(removal(hasDate("2020-07-24"), hasAmount("EUR", 50.77), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Onlineshop Umsatz 123-456-7890"))));
+        assertThat(results, hasItem(removal(hasDate("2020-07-25"), hasAmount("EUR", 32.75), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Onlineshop Umsatz 123-456-7890"))));
+        assertThat(results, hasItem(removal(hasDate("2020-07-25"), hasAmount("EUR", 18.69), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("LADEN2 MÜNCHEN"))));
+        assertThat(results, hasItem(removal(hasDate("2020-07-27"), hasAmount("EUR", 17.40), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("LADEN3 MUENCHEN"))));
+        assertThat(results, hasItem(removal(hasDate("2020-07-27"), hasAmount("EUR", 18.61), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("LADEN2 MÜNCHEN"))));
+        assertThat(results, hasItem(removal(hasDate("2020-07-31"), hasAmount("EUR", 96.45), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("LADEN 3 weitweg Eching"))));
+        assertThat(results, hasItem(removal(hasDate("2020-07-31"), hasAmount("EUR", 50.95), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Laden 4 ECHING"))));
+        assertThat(results, hasItem(removal(hasDate("2020-08-03"), hasAmount("EUR", 19.49), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Laden 5 Muenchen"))));
+        assertThat(results, hasItem(removal(hasDate("2020-08-03"), hasAmount("EUR", 9.80), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("LADEN2 MÜNCHEN"))));
+        assertThat(results, hasItem(removal(hasDate("2020-08-05"), hasAmount("EUR", 38.98), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Onlineshop2 Umsatz EXAMPLE.COM"))));
+        assertThat(results, hasItem(removal(hasDate("2020-08-05"), hasAmount("EUR", 12.42), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Onlineshop2 Umsatz EXAMPLE.COM"))));
+        assertThat(results, hasItem(removal(hasDate("2020-08-07"), hasAmount("EUR", 38.70), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Onlineshop Umsatz 123-456-7890"))));
+        assertThat(results, hasItem(removal(hasDate("2020-08-10"), hasAmount("EUR", 13.21), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Laden 6 MUENCHEN"))));
+        assertThat(results, hasItem(removal(hasDate("2020-08-10"), hasAmount("EUR", 22.91), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Laden 4 ECHING"))));
+        assertThat(results, hasItem(removal(hasDate("2020-08-10"), hasAmount("EUR", 73.77), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Onlineshop2 Umsatz EXAMPLE.COM"))));
+        assertThat(results, hasItem(removal(hasDate("2020-08-10"), hasAmount("EUR", 24.49), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("LADEN2 MÜNCHEN"))));
+        assertThat(results, hasItem(removal(hasDate("2020-08-12"), hasAmount("EUR", 19.99), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Onlineshop Umsatz 123-456-7890"))));
+        assertThat(results, hasItem(deposit(hasDate("2020-08-12"), hasAmount("EUR", 19.98), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Onlineshop Umsatz 123-456-7890"))));
+        assertThat(results, hasItem(removal(hasDate("2020-08-18"), hasAmount("EUR", 119.22), //
+                        hasSource("KreditKontoauszug04.txt"), //
+                        hasNote("Onlineshop2 Umsatz EXAMPLE.COM"))));
+    }
+
+    @Test
+    public void testKreditKontoauszug05()
+    {
+        var extractor = new BarclaysBankIrelandPLCPDFExtractor(new Client());
+
+        var errors = new ArrayList<Exception>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "KreditKontoauszug05.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(10L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(10));
+        new AssertImportActions().check(results, "EUR");
+
+        // assert transactions
+        assertThat(results, hasItem(removal(hasDate("2015-06-27"), hasAmount("EUR", 95.91), //
+                        hasSource("KreditKontoauszug05.txt"), //
+                        hasNote("Shell 7730 Muenchen"))));
+        assertThat(results, hasItem(removal(hasDate("2015-06-27"), hasAmount("EUR", 454.39), //
+                        hasSource("KreditKontoauszug05.txt"), //
+                        hasNote("HOTELRES123123456789 11234567895"))));
+        assertThat(results, hasItem(removal(hasDate("2015-07-01"), hasAmount("EUR", 18.00), //
+                        hasSource("KreditKontoauszug05.txt"), //
+                        hasNote("ASFINAG.AT VIDEOMAUT WIEN"))));
+        assertThat(results, hasItem(removal(hasDate("2015-07-02"), hasAmount("EUR", 56.60), //
+                        hasSource("KreditKontoauszug05.txt"), //
+                        hasNote("AUTOST BRENNERO/FROSIN TOLL WAY"))));
+        assertThat(results, hasItem(removal(hasDate("2015-07-14"), hasAmount("EUR", 18.99), //
+                        hasSource("KreditKontoauszug05.txt"), //
+                        hasNote("Amazon EU AMAZON.DE"))));
+        assertThat(results, hasItem(removal(hasDate("2015-07-15"), hasAmount("EUR", 5.00), //
+                        hasSource("KreditKontoauszug05.txt"), //
+                        hasNote("PARCHEGGI FIUMICINO AD FIUMICINO"))));
+        assertThat(results, hasItem(removal(hasDate("2015-07-17"), hasAmount("EUR", 26.49), //
+                        hasSource("KreditKontoauszug05.txt"), //
+                        hasNote("Amazon EU AMAZON.DE"))));
+        assertThat(results, hasItem(removal(hasDate("2015-07-18"), hasAmount("EUR", 56.60), //
+                        hasSource("KreditKontoauszug05.txt"), //
+                        hasNote("A 22 BRENNERO BARRIERA VIPITENO"))));
+        assertThat(results, hasItem(removal(hasDate("2015-07-19"), hasAmount("EUR", 31.00), //
+                        hasSource("KreditKontoauszug05.txt"), //
+                        hasNote("Reiseversicherung jährlicher Abschluss"))));
+        assertThat(results, hasItem(deposit(hasDate("2015-07-08"), hasAmount("EUR", 2000.00), //
+                        hasSource("KreditKontoauszug05.txt"), //
+                        hasNote("Vorname Nachname"))));
+    }
+
+    @Test
+    public void testKreditKontoauszug06()
+    {
+        var extractor = new BarclaysBankIrelandPLCPDFExtractor(new Client());
+
+        var errors = new ArrayList<Exception>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "KreditKontoauszug06.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(6L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(6));
+        new AssertImportActions().check(results, "EUR");
+
+        // assert transactions
+        assertThat(results, hasItem(removal(hasDate("2021-02-19"), hasAmount("EUR", 10.16), //
+                        hasSource("KreditKontoauszug06.txt"), //
+                        hasNote("Laden 1 Filiale Muenchen"))));
+        assertThat(results, hasItem(removal(hasDate("2021-02-19"), hasAmount("EUR", 25.90), //
+                        hasSource("KreditKontoauszug06.txt"), //
+                        hasNote("Laden 1 Filiale Muenchen"))));
+        assertThat(results, hasItem(removal(hasDate("2021-03-15"), hasAmount("EUR", 33.91), //
+                        hasSource("KreditKontoauszug06.txt"), //
+                        hasNote("Laden 2 Filiale Muenchen"))));
+        assertThat(results, hasItem(removal(hasDate("2021-03-17"), hasAmount("EUR", 39.45), //
+                        hasSource("KreditKontoauszug06.txt"), //
+                        hasNote("Laden 3 Filiale ECHING"))));
+        assertThat(results, hasItem(removal(hasDate("2021-03-18"), hasAmount("EUR", 14.92), //
+                        hasSource("KreditKontoauszug06.txt"), //
+                        hasNote("Laden 4 Filiale POECKING"))));
+        assertThat(results, hasItem(interestCharge( //
+                        hasDate("2021-03-18"), //
+                        hasSource("KreditKontoauszug06.txt"), //
+                        hasNote("Monatl. Zinsen für Einkäufe/Überweisungen"), //
+                        hasAmount("EUR", 1.68), hasGrossValue("EUR", 1.68), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/barclaysbankirelandplc/KreditKontoauszug04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/barclaysbankirelandplc/KreditKontoauszug04.txt
@@ -1,0 +1,113 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.2.qualifier
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Barclays Bank Ireland PLC
+Hamburg Branch
+Gasstraße 4c
+22761 Hamburg
+Herrn
+Vorname Nachname Kundenservice
+Adress Str. 1 Tel: (0 40) 8 90 99-866
+01234 STADT Mo.-Fr. 8 - 20 Uhr
+Fax: (0 40) 8 90 99 - 298
+E-Mail: service@barclaycard.de
+Bei Kartenverlust
+Tel: (0 40) 8 90 99 - 877
+Produkt ID: 1234567890
+Kontoübersicht vom 18. August 2020
+Abrechnungszeitraum: 20.07.2020 - 18.08.2020 Alter Saldo: EUR           364,81+
+Barclaycard Kontonr.: 1234567890 Neuer Saldo: EUR           388,00 -
+IBAN: DE12 3456 7800 1234 5678 90 Kreditrahmen: EUR         2.800,00
+BIC: BARCDEHAXXX Offener Verfügungsrahmen: EUR         2.412,00
+Schon gewusst: Wir bieten auch Ratenkredite an
+Unser Ratenkredit gibt Ihnen Spielraum für Ihre Ideen. Und ist für Sie als Barclaycard Kunde besonders einfach und
+schnell. Gern erstellen wir Ihnen ein kostenloses und unverbindliches Angebot.
+Alle Informationen finden Sie mit einem Klick auf barclaycard.de/kredit
+Konto-Saldo und Rückzahlung
+Bezeichnung/Individueller Verwendungszweck Neuer Saldo Zahlungsmodalität Nächste Zahlung
+(EUR) (EUR)
+Allgemeine Umsätze    388,00- 2,0% (mind. EUR 15,00)      15,00
+Gesamt (EUR)    388,00-      15,00
+Überweisen Sie bitte mindestens EUR 15,00 auf Ihr Konto mit der IBAN DE12 3456 7800 1234 5678 90 und dem
+BIC BARCDEHAXXX. Bitte berücksichtigen Sie, dass der Betrag bis spätestens 15.09.2020 auf Ihrem
+Barclaycard-Konto verbucht sein muss.
+Ihre aktuelle Zahlungsmodalität können Sie jederzeit im Online-Banking oder telefonisch ändern.
+Tipp: Begleichen Sie Ihre allgemeinen Umsätze von EUR 388,00 in 12 Monatsraten à EUR 33,21 zu einem Sollzins
+von 4,99% p.a. Richten Sie Ihren Barclaycard Ratenkauf bis zum 10.09.2020 im Barclaycard Online-Banking ein.
+Weitere Informationen finden Sie auf barclaycard.de/ratenkauf
+         Seite 1 von 3 Bitte wenden
+Umsatzübersicht
+Beleg- Buchungs-/ Beschreibung Karte Betrag (EUR)
+datum Valutadatum
+Alter Saldo vom 19. Juli 2020            364,81+
+Hauptkarte/n, Vorname Nachname
+19.07.2020 20.07.2020 Onlineshop Umsatz      123-456-7890  LU Visa             89,94-
+18.07.2020 20.07.2020 LADEN1                 MUENCHEN      DE Visa A             45,00-
+19.07.2020 20.07.2020 Onlineshop3 Umsatz     Luxembourg    LU Visa            187,04+
+ORIGINAL UMSATZ USD         214,09
+WECHSELKURS 1 EUR =         1,144 USD
+18.07.2020 20.07.2020 Onlineshop2 Umsatz     EXAMPLE.COM   LU Visa             38,80-
+20.07.2020 21.07.2020 Onlineshop2 Umsatz     EXAMPLE.COM   LU Visa             40,89-
+21.07.2020 22.07.2020 Onlineshop Umsatz      123-456-7890  LU Visa             58,99-
+22.07.2020 23.07.2020 LADEN2                 MÜNCHEN       DE Visa A              7,61-
+23.07.2020 24.07.2020 Onlineshop Umsatz      123-456-7890  LU Visa             50,77-
+24.07.2020 25.07.2020 Onlineshop Umsatz      123-456-7890  LU Visa             32,75-
+24.07.2020 25.07.2020 LADEN2                 MÜNCHEN       DE Visa A             18,69-
+25.07.2020 27.07.2020 LADEN3                 MUENCHEN      DE Visa             17,40-
+25.07.2020 27.07.2020 LADEN2                 MÜNCHEN       DE Visa A             18,61-
+30.07.2020 31.07.2020 LADEN 3 weitweg        Eching        DE Visa             96,45-
+30.07.2020 31.07.2020 Laden 4                ECHING        DE Visa A             50,95-
+01.08.2020 03.08.2020 Laden 5                Muenchen      DE Visa A             19,49-
+01.08.2020 03.08.2020 LADEN2                 MÜNCHEN       DE Visa A              9,80-
+04.08.2020 05.08.2020 Onlineshop2 Umsatz     EXAMPLE.COM   LU Visa             38,98-
+04.08.2020 05.08.2020 Onlineshop2 Umsatz     EXAMPLE.COM   LU Visa             12,42-
+06.08.2020 07.08.2020 Onlineshop Umsatz      123-456-7890  LU Visa             38,70-
+08.08.2020 10.08.2020 Laden 6                MUENCHEN      DE Visa A             13,21-
+08.08.2020 10.08.2020 Laden 4                ECHING        DE Visa A             22,91-
+08.08.2020 10.08.2020 Onlineshop2 Umsatz     EXAMPLE.COM   LU Visa             73,77-
+08.08.2020 10.08.2020 LADEN2                 MÜNCHEN       DE Visa A             24,49-
+11.08.2020 12.08.2020 Onlineshop Umsatz      123-456-7890  LU Visa             19,99-
+11.08.2020 12.08.2020 Onlineshop Umsatz      123-456-7890  LU Visa             19,98+
+17.08.2020 18.08.2020 Onlineshop2 Umsatz     EXAMPLE.COM   LU Visa            119,22-
+Neuer Saldo am 18. August 2020            388,00-
+Hauptkarte/n, Vorname Nachname
+Umsätze Visa Karten-Nr. 491234XXXXXX7890  EUR           752,81
+         Seite 2 von 3 Bitte wenden
+Zinssätze
+Allgemeine Umsätze
+Allgemeine Umsätze sind alle Umsätze, für deren Rückzahlung Sie keinen Ratenkauf eingerichtet haben. Für diese
+allgemeinen Umsätze gelten folgende Sollzinssätze:
+Sollzinsen bei Einkäufen und Überweisungen (einschl. möglicher Gebühren) 15,23 % p.a.
+Sollzinsen bei Barabhebungen (einschl. möglicher Gebühren) 16,94 % p.a.
+Sofern Sie alle allgemeinen Umsätze bis zum 15.09.2020 vollständig zurückgezahlt haben, fallen die oben
+genannten Zinsen nicht an. Bei Teilzahlung werden Zinsen taggenau ab dem Buchungs-/Valutadatum berechnet.
+Barclaycard Ratenkauf-Optionen
+Für größere Umsätze können wir Ihnen einen Ratenkauf gemäß unseren AGB anbieten. Diesen können Sie einfach
+im Online-Banking einrichten. Voraussetzung ist, dass Ihr Barclaycard Kreditkarten-Konto zum Zeitpunkt der
+Einrichtung ordnungsgemäß geführt ist, das heißt insbesondere: Es darf nicht im Verzug sein. Weitere
+Informationen sowie Bedingungen können Sie jederzeit auf barclaycard.de/ratenkauf einsehen.
+Für folgende Umsätze aus dieser Kontoübersicht können Sie einen Ratenkauf einrichten:
+Belegdatum Beschreibung Betrag (EUR) Einrichtung
+möglich bis
+30.07.2020 LADEN 3 weitweg        Eching        DE             96,45- 10.09.2020
+17.08.2020 EXAMPLE.COM            EXAMPLE.COM   LU            119,22- 10.09.2020
+Für Umsätze in den unten genannten Monaten können Sie Ratenkäufe mit folgenden Konditionen einrichten:
+Belegdatum Umsatzart/Händler Laufzeit Sollzins p.a.
+im (betragsabhängig)
+August Gesamte Kontoübersicht ab 95 Euro 6 - 24 Monate  4,99%
+September Gesamte Kontoübersicht ab 95 Euro 6 - 24 Monate  4,99%
+August Einzelne Umsätze und Überweisungen ab 95 Euro 6 - 24 Monate  4,99%
+September Einzelne Umsätze und Überweisungen ab 95 Euro 6 - 24 Monate  4,99%
+Wichtige Hinweise
+Bitte überprüfen Sie Ihre Kontoübersicht. Eventuelle Beanstandungen können Sie uns schnell und sicher über die
+Nachrichtfunktion des Online-Banking oder in sonstiger Textform mitteilen, z.B. per Post oder Fax an die Nummer
+040 89099-285. Bitte nennen Sie den Reklamationsgrund und erheben Sie Ihre Einwendung innerhalb von 6
+Wochen nach Zugang der Kontoübersicht. Es genügt die Absendung innerhalb der Frist. Das Unterlassen
+rechtzeitiger Einwendungen gilt als Genehmigung.
+Guthaben auf Ihrem Konto sind als Einlagen nach Maßgabe des Einlagensicherungsgesetzes
+entschädigungsfähig. Nähere Informationen finden Sie im "Informationsbogen für Einleger" auf barclaycard.de
+unter "AGB & Dokumente".
+Vielen Dank, dass Sie Ihre Barclaycard Kreditkarten eingesetzt haben!
+         Seite 3 von 3
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/barclaysbankirelandplc/KreditKontoauszug05.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/barclaysbankirelandplc/KreditKontoauszug05.txt
@@ -1,0 +1,56 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.2.qualifier
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Barclaycard
+Barclays Bank PLC
+Gasstraße 4c
+22761 Hamburg
+Herrn
+Vorname Nachname Kundenservice
+Adress Str. 1 Tel: (0 40) 8 90 99-866
+81241 STADT Mo.-So. 8 - 20 Uhr
+Fax: (0 40) 8 90 99 - 298
+E-Mail: service@barclaycard.de
+Bei Kartenverlust
+Tel: (0 40) 8 90 99 - 877
+Ihre Kontoübersicht vom 19. Juli 2015
+Abrechnungszeitraum: 19.06.2015 - 19.07.2015 Kreditrahmen: EUR         2.800,00
+Freistellungsbetrag, erteilt: EUR             0,00
+IBAN: DE12345678001234567890 Alter Saldo: EUR           609,54 -
+BIC: BARCDEHAXXX Konto: 1234567890 Neuer Saldo: EUR           159,11+
+Beleg- Buchung/
+Beschreibung Karte Betrag in Euro
+datum Valuta
+Alter Saldo vom 18. Juni 2015            609,54-
+Hauptkarte/n, Vorname Nachname
+25.06.2015 27.06.2015 Shell 7730             Muenchen      DE Visa             95,91-
+26.06.2015 27.06.2015 HOTELRES123123456789   11234567895   ES Visa            454,39-
+28.06.2015 01.07.2015 ASFINAG.AT VIDEOMAUT   WIEN          AT Visa             18,00-
+30.06.2015 02.07.2015 AUTOST BRENNERO/FROSIN TOLL WAY      IT Visa             56,60-
+13.07.2015 14.07.2015 Amazon EU              AMAZON.DE     LU Visa             18,99-
+14.07.2015 15.07.2015 PARCHEGGI FIUMICINO AD FIUMICINO     IT Visa              5,00-
+         Seite 1 von 2 Bitte wenden
+Beleg- Buchung/
+Beschreibung Karte Betrag in Euro
+datum Valuta
+16.07.2015 17.07.2015 Amazon EU              AMAZON.DE     LU Visa             26,49-
+16.07.2015 18.07.2015 A 22 BRENNERO BARRIERA VIPITENO      IT Visa             56,60-
+Weitere Kontotransaktionen
+19.07.2015 19.07.2015 Reiseversicherung jährlicher Abschluss /             31,00-
+08.07.2015 08.07.2015 Vorname Nachname /          2.000,00+
+Vorname Nachname
+Neuer Saldo am 19. Juli 2015            159,11+
+Hauptkarte/n, Vorname Nachname
+Umsätze Visa, Karten-Nr. 4912345678909876 : EUR      1.200,35
+Sollzinsen bei Einkäufen und Überweisungen 15,48 % p.a.
+Sollzinsen bei Barabhebungen (einschl. möglicher Gebühren) 17,19 % p.a.
+Guthaben auf Ihrem Konto sind als Einlagen nach Maßgabe des Einlagensicherungsgesetzes
+entschädigungsfähig. Nähere Informationen können dem "Informationsbogen für den Einleger" entnommen
+werden, den Sie auf unserer Homepage im Infocenter abrufen können.
+Bitte überprüfen Sie Ihre Kontoübersicht. Eventuelle Beanstandungen teilen Sie uns bitte schriftlich (per Fax:
+(0 40) 8 90 99 - 285) zusammen mit einer Kopie des unterschriebenen Einkaufsbelegs und dem Reklamations-
+grund innerhalb von 6 Wochen nach Erstellungsdatum der Kontoübersicht mit. Das Unterlassen rechtzeitiger
+Einwendungen gilt als Genehmigung.
+Vielen Dank, dass Sie Ihre Barclaycard Kreditkarten eingesetzt haben!
+         Seite 2 von 2

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/barclaysbankirelandplc/KreditKontoauszug06.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/barclaysbankirelandplc/KreditKontoauszug06.txt
@@ -1,0 +1,124 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.2.qualifier
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Barclays Bank Ireland PLC
+Hamburg Branch
+Gasstraße 4c
+22761 Hamburg
+Barclaycard | 22792 Hamburg
+Herrn Produkt ID: 1234567890
+Vorname Nachname
+Adress Str. 1
+01234 STADT
+Kontoauszug vom 18. März 2021
+Abrechnungszeitraum: 19.02.2021 - 18.03.2021 Alter Saldo: EUR           132,19 -
+Barclaycard Kontonr.: 1234567890 Neuer Saldo: EUR           256,53 -
+IBAN: DE12 3456 7890 1234 5678 12 Kreditrahmen: EUR        12.800,00
+BIC: BARCDEHAXXX Offener Verfügungsrahmen: EUR         1.828,17
+Konto-Saldo und Rückzahlung
+Bezeichnung/Individueller Verwendungszweck Neuer Saldo Rückzahlungsoptionen Nächste Zahlung
+(EUR) (EUR)
+Allgemeine Umsätze    971,83- s. Hinweis oben      34,14
+Gesamt (EUR)    971,83-      34,14
+BBarclays Bank Ireland PLC Hamburg Branch, Gasstraße 4c, 22761 Hamburg
+barclaycard.de
+Handelregister Hamburg HRB: 153530 | USt-IdNr.: DE 319 453 063 | Finanzdienstleistungen sind nach § 4 Nr. 8 UStG steuerfrei / Financial Services are VAT exempt |
+BIC BARCDEHAXXX | Hauptsitz: One Molesworth Street Dublin 2 D02 RF29 | Reg. Ireland: 396330 | Ständiger Vertreter: Tobias Grieß | Vorstand der Barclays Bank Ireland PLC:
+Francesco Ceccato und Keith Smithson. Eine Liste mit den Namen sowie weiteren persönlichen Informationen zu den Vorständen der Gesellschaft kann am Geschäftssitz der
+Gesellschaft eingesehen werden.
+         Seite 1 von 4 Bitte wenden
+Umsatzübersicht
+Beleg- Buchungs-/ Beschreibung Karte Betrag (EUR)
+datum Valutadatum
+Alter Saldo vom 18. Februar 2021            132,19-
+Hauptkarte/n, Vorname Nachname
+18.02.2021 19.02.2021 Laden 1 Filiale        Muenchen      DE Visa A             10,16-
+18.02.2021 19.02.2021 Laden 1 Filiale        Muenchen      DE Visa A             25,90-
+13.03.2021 15.03.2021 Laden 2 Filiale        Muenchen      DE Visa A             33,91-
+16.03.2021 17.03.2021 Laden 3 Filiale        ECHING        DE Visa A             39,45-
+Barclays Bank Ireland PLC Hamburg Branch, Gasstraße 4c, 22761 Hamburg
+barclaycard.de
+Handelregister Hamburg HRB: 153530 | USt-IdNr.: DE 319 453 063 | Finanzdienstleistungen sind nach § 4 Nr. 8 UStG steuerfrei / Financial Services are VAT exempt |
+BIC BARCDEHAXXX | Hauptsitz: One Molesworth Street Dublin 2 D02 RF29 | Reg. Ireland: 396330 | Ständiger Vertreter: Tobias Grieß | Vorstand der Barclays Bank Ireland PLC:
+Francesco Ceccato und Keith Smithson. Eine Liste mit den Namen sowie weiteren persönlichen Informationen zu den Vorständen der Gesellschaft kann am Geschäftssitz der
+Gesellschaft eingesehen werden.
+         Seite 2 von 4 Bitte wenden
+Umsatzübersicht
+Beleg- Buchungs-/ Beschreibung Karte Betrag (EUR)
+datum Valutadatum
+17.03.2021 18.03.2021 Laden 4 Filiale        POECKING      DE Visa A             14,92-
+Sonstige Umsätze
+18.03.2021 18.03.2021 Monatl. Zinsen für Einkäufe/Überweisungen              1,68-
+Neuer Saldo am 18. März 2021            256,53-
+Hauptkarte/n, Vorname Nachname
+Umsätze Visa Karten-Nr. 491234XXXXXX9876  EUR           124,34
+Zinssätze
+Allgemeine Umsätze
+Allgemeine Umsätze sind alle Umsätze, für deren Rückzahlung Sie keinen Ratenkauf eingerichtet haben. Für diese
+allgemeinen Umsätze gelten folgende Sollzinssätze:
+Sollzinsen bei Einkäufen und Überweisungen (einschl. möglicher Gebühren) 15,23 % p.a.
+Sollzinsen bei Barabhebungen (einschl. möglicher Gebühren) 16,94 % p.a.
+Sofern Sie alle allgemeinen Umsätze bis zum 15.04.2021 vollständig zurückgezahlt haben, fallen die oben
+genannten Zinsen nicht an. Bei Teilzahlung werden Zinsen taggenau ab dem Buchungs-/Valutadatum berechnet.
+Der Barclaycard Ratenkauf
+Für einzelne Umsätze ab 95 Euro bieten wir Ihnen auch den Barclaycard Ratenkauf an. Diesen richten Sie ganz
+einfach per App oder im Online-Banking zu einem vergünstigten Sollzinssatz ein. Die Gesamtkosten werden Ihnen
+vor der Aktivierung transparent ausgewiesen. Bitte beachten Sie, dass Ihr Barclaycard Konto für die Nutzung
+eines Barclaycard Ratenkaufs nicht im Zahlungsverzug sein darf. Mehr Infos unter barclaycard.de/ratenkauf.
+Für folgende Umsätze aus diesem Kontoauszug können Sie einen Barclaycard Ratenkauf einrichten:
+Belegdatum Beschreibung Betrag (EUR) Einrichtung
+möglich bis
+06.03.2021 GoFndMe* Bricks4theKid Dublin        IE            107,00- 12.04.2021
+Wichtige Hinweise
+Bitte überprüfen Sie Ihren Kontoauszug. Eventuelle Beanstandungen können Sie uns schnell und sicher über die
+Nachrichtfunktion des Online-Banking oder in sonstiger Textform mitteilen, z.B. per Post oder Fax an die Nummer
+040 89099-285. Bitte nennen Sie den Reklamationsgrund und erheben Sie Ihre Einwendung innerhalb von 6
+Wochen nach Zugang des Kontoauszuges. Es genügt die Absendung innerhalb der Frist. Das Unterlassen
+rechtzeitiger Einwendungen gilt als Genehmigung.
+Guthaben auf Ihrem Konto sind als Einlagen nach Maßgabe des Einlagensicherungsgesetzes
+entschädigungsfähig. Nähere Informationen finden Sie im "Informationsbogen für Einleger" auf barclaycard.de
+unter "AGB & Dokumente".
+Barclays Bank Ireland PLC Hamburg Branch, Gasstraße 4c, 22761 Hamburg
+barclaycard.de
+Handelregister Hamburg HRB: 153530 | USt-IdNr.: DE 319 453 063 | Finanzdienstleistungen sind nach § 4 Nr. 8 UStG steuerfrei / Financial Services are VAT exempt |
+BIC BARCDEHAXXX | Hauptsitz: One Molesworth Street Dublin 2 D02 RF29 | Reg. Ireland: 396330 | Ständiger Vertreter: Tobias Grieß | Vorstand der Barclays Bank Ireland PLC:
+Francesco Ceccato und Keith Smithson. Eine Liste mit den Namen sowie weiteren persönlichen Informationen zu den Vorständen der Gesellschaft kann am Geschäftssitz der
+Gesellschaft eingesehen werden.
+         Seite 3 von 4 Bitte wenden
+Vielen Dank, dass Sie Ihre Barclaycard Kreditkarten eingesetzt haben!
+Schon gewusst: Wir bieten auch Ratenkredite an
+Unser Ratenkredit gibt Ihnen Spielraum für Ihre Ideen. Und ist für Sie als Barclaycard Kunde besonders einfach und
+schnell. Gern erstellen wir Ihnen ein kostenloses und unverbindliches Angebot.
+Alle Informationen finden Sie mit einem Klick auf barclaycard.de/kredit
+Sie haben sie: Deutschlands erste Sofortkaufen- & Späterzahlen-Karte
+Bezahlen Sie einfach, wie noch nie:  Online und im Laden (kontaktlos, mobil, weltweit), per Überweisung und
+Rechnungsscan.
+Zahlen Sie flexibel zurück, wie noch nie:  Machen Sie einzelne Ausgaben per App zu Raten und begleichen Sie Ihre
+Monatsrechnung in festen Raten, in flexiblen Teilbeträgen oder voll.
+Haben Sie alles unter Kontrolle, wie noch nie:  Per App und mit frei wählbaren Benachrichtigungen mit dem
+Smartphone alle Ausgaben in Echtzeit im Blick behalten.
+Neue Konditionen: Ab jetzt bieten wir den Ratenkauf zu 0% an
+Mit dem Barclaycard Ratenkauf machen Sie Ausgaben ab 95 Euro zu Raten. So bleiben Sie stets finanziell flexibel. Der
+Sollzins von 0,00% p.a. gilt für Ratenkäufe unter 500 Euro mit einer Laufzeit von drei Monaten. Längere Laufzeiten
+und höhere Ratenkäufe sind möglich. Details zu Konditionen im Online-Banking.
+Einfach gleich ausprobieren in unserer App oder im Online Banking.
+Hinweis: Die Einrichtung dieser Rückzahlungsoption setzt eine ordnungsgemäße Führung des Barclaycard Kontos
+voraus. Barclaycard behält sich vor, die Konditionen zu ändern.
+Alles unter Kontrolle mit der Barclaycard App
+Mit unserer App haben Sie jederzeit alle Umsätze im Blick und managen Ihre Rückzahlungen einfach per Fingertipp.
+Per Push-Nachricht gibt's auf Wunsch automatisch alle wichtigen Details zu Ihrem Konto. Sie können unsere App im
+App Store oder Google Play Store downloaden.
+Ein kleiner Schritt zu mehr Sicherheit
+Online zu bezahlen wird immer beliebter. Damit das auch besonders sicher ist, setzen wir einen neuen
+EU-Sicherheitsstandard um - die starke Kundenauthentifizierung. Deshalb werden Sie zukünftig häufiger gebeten, Ihre
+Online-Zahlungen freizugeben. Hierzu benötigen Sie die Barclaycard App oder das Online-Banking. Dieses Verfahren
+ersetzt ab September schrittweise das bisherige mTan-Verfahren. Mehr Infos finden Sie hier:
+www.barclaycard.de/sicher-online-einkaufen
+Barclays Bank Ireland PLC Hamburg Branch, Gasstraße 4c, 22761 Hamburg
+barclaycard.de
+Handelregister Hamburg HRB: 153530 | USt-IdNr.: DE 319 453 063 | Finanzdienstleistungen sind nach § 4 Nr. 8 UStG steuerfrei / Financial Services are VAT exempt |
+BIC BARCDEHAXXX | Hauptsitz: One Molesworth Street Dublin 2 D02 RF29 | Reg. Ireland: 396330 | Ständiger Vertreter: Tobias Grieß | Vorstand der Barclays Bank Ireland PLC:
+Francesco Ceccato und Keith Smithson. Eine Liste mit den Namen sowie weiteren persönlichen Informationen zu den Vorständen der Gesellschaft kann am Geschäftssitz der
+Gesellschaft eingesehen werden.
+         Seite 4 von 4

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BarclaysBankIrelandPLCPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BarclaysBankIrelandPLCPDFExtractor.java
@@ -5,6 +5,7 @@ import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
+import name.abuchen.portfolio.datatransfer.pdf.PDFParser.ParsedData;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.Client;
@@ -19,6 +20,7 @@ public class BarclaysBankIrelandPLCPDFExtractor extends AbstractPDFExtractor
         super(client);
 
         addBankIdentifier("Barclays Bank Ireland PLC");
+        addBankIdentifier("Barclays Bank PLC");
 
         addCreditcardStatementTransaction();
     }
@@ -31,51 +33,72 @@ public class BarclaysBankIrelandPLCPDFExtractor extends AbstractPDFExtractor
 
     private void addCreditcardStatementTransaction()
     {
-        final var type = new DocumentType("Kontoauszug", //
+        final var type = new DocumentType("(?:Kontoauszug|Konto.bersicht)", //
                         documentContext -> documentContext //
-                                        // @formatter:off
-                                        // Beleg- Buchungs-/ Beschreibung Karte Betrag (EUR)
-                                        // Gebucht am Wertstellung am Verwendungszweck Betrag (EUR)
-                                        // @formatter:on
-                                        .section("currency") //
-                                        .match("^.* \\((?<currency>[A-Z]{3})\\)$") //
-                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency")))));
+                                        .oneOf( //
+                                                        // @formatter:off
+                                                        // Beleg- Buchungs-/ Beschreibung Karte Betrag (EUR)
+                                                        // Gebucht am Wertstellung am Verwendungszweck Betrag (EUR)
+                                                        // @formatter:on
+                                                        section -> section //
+                                                                        .attributes("currency") //
+                                                                        .match("^.* \\((?<currency>[A-Z]{3})\\)$") //
+                                                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency")))),
+                                                        // @formatter:off
+                                                        // Abrechnungszeitraum: 19.06.2015 - 19.07.2015 Kreditrahmen: EUR         2.800,00
+                                                        // IBAN: DE12 3456 7890 1234 5678 12 Kreditrahmen: EUR        12.800,00
+                                                        // @formatter:on
+                                                        section -> section //
+                                                                        .attributes("currency") //
+                                                                        .match("^.*Kreditrahmen: (?<currency>[A-Z]{3}).*$") //
+                                                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency"))))));
 
         this.addDocumentTyp(type);
 
-        // @formatter:off
-        // 23.12.2023 25.12.2023 Lidl sagt Danke        Ort           DE Visa B A             60,78-
-        // 23.12.2023 28.12.2023 Lidl sagt Danke        Ort           DE Visa B A             60,78+
-        // @formatter:on
         var depositRemovalBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} " //
-                        + "(?!(Abgeltungsteuer|Solidarit.tszuschlag)).* [\\.,\\d]+[\\-|\\+]$");
+                        + "(?!(?:Monatl\\. Zinsen|Abgeltungsteuer|Solidarit.tszuschlag)).* [\\.,\\d]+[\\-\\+]$");
         type.addBlock(depositRemovalBlock);
         depositRemovalBlock.set(new Transaction<AccountTransaction>()
 
                         .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
-                        .section("date", "note", "amount", "type") //
-                        .documentContext("currency") //
-                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} " //
-                                        + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) " //
-                                        + "(?<note>.{1,36})" //
-                                        + ".* " //
-                                        + "(?<amount>[\\.,\\d]+)" //
-                                        + "(?<type>[\\-|\\+])$") //
-                        .assign((t, v) -> {
-                            // Is type --> "-" change from DEPOSIT to REMOVAL
-                            if ("-".equals(v.get("type")))
-                                t.setType(AccountTransaction.Type.REMOVAL);
+                        .oneOf( //
+                                        // @formatter:off
+                                        // Weitere Kontotransaktionen
+                                        // 19.07.2015 19.07.2015 Reiseversicherung jährlicher Abschluss /             31,00-
+                                        // 08.07.2015 08.07.2015 Vorname Nachname /          2.000,00+
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date", "note", "amount", "type") //
+                                                        .documentContext("currency") //
+                                                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} " //
+                                                                        + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) " //
+                                                                        + "(?<note>.*?)" //
+                                                                        + "\\s\\/\\s+" //
+                                                                        + "(?<amount>[\\.,\\d]+)" //
+                                                                        + "(?<type>[\\-\\+])$") //
+                                                        .assign(this::assignDepositRemoval),
 
-                            t.setDateTime(asDate(v.get("date")));
-                            t.setAmount(asAmount(v.get("amount")));
-                            t.setCurrencyCode(v.get("currency"));
-                            t.setNote(trim(replaceMultipleBlanks(v.get("note"))));
-                        })
+                                        // @formatter:off
+                                        // 23.12.2023 25.12.2023 Lidl sagt Danke        Ort           DE Visa B A             60,78-
+                                        // 23.12.2023 28.12.2023 Lidl sagt Danke        Ort           DE Visa B A             60,78+
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date", "note", "amount", "type") //
+                                                        .documentContext("currency") //
+                                                        .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} " //
+                                                                        + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) " //
+                                                                        + "(?<note>.{1,36})" //
+                                                                        + ".* " //
+                                                                        + "(?<amount>[\\.,\\d]+)" //
+                                                                        + "(?<type>[\\-\\+])$") //
+                                                        .assign(this::assignDepositRemoval) //
+                        )
 
                         .wrap(TransactionItem::new));
 
-        var interestBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} Habenzinsen [\\.,\\d]+$");
+        var interestBlock = new Block("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} " //
+                        + "(?:Monatl\\. Zinsen.*|Habenzinsen) [\\.,\\d]+\\-?$");
         type.addBlock(interestBlock);
         interestBlock.setMaxSize(4);
         interestBlock.set(new Transaction<AccountTransaction>()
@@ -84,17 +107,23 @@ public class BarclaysBankIrelandPLCPDFExtractor extends AbstractPDFExtractor
 
                         // @formatter:off
                         // 31.12.2023 31.12.2023 Habenzinsen 4,80
+                        // 18.03.2021 18.03.2021 Monatl. Zinsen für Einkäufe/Überweisungen              1,68-
                         // @formatter:on
-                        .section("date", "amount") //
+                        .section("date", "note", "amount", "negative") //
                         .documentContext("currency") //
                         .match("^[\\d]{2}\\.[\\d]{2}\\.[\\d]{4} " //
                                         + "(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) " //
-                                        + "Habenzinsen " //
-                                        + "(?<amount>[\\.,\\d]+)$") //
+                                        + "(?<note>Monatl\\. Zinsen.*|Habenzinsen) " //
+                                        + "(?<amount>[\\.,\\d]+)(?<negative>\\-?)$") //
                         .assign((t, v) -> {
+                            // Is negative --> "-" change from INTEREST to INTEREST_CHARGE
+                            if ("-".equals(v.get("negative")))
+                                t.setType(AccountTransaction.Type.INTEREST_CHARGE);
+
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(v.get("currency"));
+                            t.setNote(trim(v.get("note")));
                         })
 
                         // @formatter:off
@@ -124,5 +153,17 @@ public class BarclaysBankIrelandPLCPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .wrap(TransactionItem::new));
+    }
+
+    private void assignDepositRemoval(AccountTransaction t, ParsedData v)
+    {
+        // Is type --> "-" change from DEPOSIT to REMOVAL
+        if ("-".equals(v.get("type")))
+            t.setType(AccountTransaction.Type.REMOVAL);
+
+        t.setDateTime(asDate(v.get("date")));
+        t.setAmount(asAmount(v.get("amount")));
+        t.setCurrencyCode(v.get("currency"));
+        t.setNote(trim(replaceMultipleBlanks(v.get("note"))));
     }
 }


### PR DESCRIPTION
While the Barclay's PDFs are quite stable some of the identifying elements have changed over time with the effect that older PDFs can't be parsed. This PR fixes that.