### PR TITLE
Split trades with exact apportionment

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/ApportionmentTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/math/ApportionmentTest.java
@@ -1,0 +1,176 @@
+package name.abuchen.portfolio.math;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Random;
+
+import org.junit.Test;
+
+@SuppressWarnings("nls")
+public class ApportionmentTest
+{
+    private static long sum(long[] values)
+    {
+        long answer = 0;
+        for (long value : values)
+            answer += value;
+        return answer;
+    }
+
+    @Test
+    public void testSinglePieceGetsEverything()
+    {
+        assertArrayEquals(new long[] { 100001 }, Apportionment.distribute(100001, new long[] { 7 }));
+        assertArrayEquals(new long[] { 0 }, Apportionment.distribute(0, new long[] { 7 }));
+    }
+
+    @Test
+    public void testExactDivisionNeedsNoCorrection()
+    {
+        assertArrayEquals(new long[] { 100, 100, 100 }, Apportionment.distribute(300, new long[] { 1, 1, 1 }));
+    }
+
+    @Test
+    public void testLeftoverGoesToTheLargestRemainder()
+    {
+        // 100 x 1/6, 2/6, 3/6 = 16.67, 33.33, 50.00; the flooring leaves one
+        // unit over which goes to the largest remainder (.67)
+        assertArrayEquals(new long[] { 17, 33, 50 }, Apportionment.distribute(100, new long[] { 1, 2, 3 }));
+    }
+
+    @Test
+    public void testTiesAreBrokenByLowestIndex()
+    {
+        // three equal remainders of 1/3, two units to distribute: the first two
+        // pieces get them
+        assertArrayEquals(new long[] { 334, 334, 333 }, Apportionment.distribute(1001, new long[] { 1, 1, 1 }));
+
+        // ... and one unit to distribute goes to the first piece only
+        assertArrayEquals(new long[] { 334, 333, 333 }, Apportionment.distribute(1000, new long[] { 1, 1, 1 }));
+    }
+
+    @Test
+    public void testTiesAreBrokenByLowestIndexAcrossManyPieces()
+    {
+        // with a thousand equal weights every remainder is the same, so the
+        // 999 units of the leftover go to the first 999 pieces. Ordering a
+        // large number of pieces is the case where the tie break stops being
+        // obvious - and where a sale spanning the lots of a savings plan lands
+
+        long[] weights = new long[1000];
+        Arrays.fill(weights, 100_000_000L);
+
+        long[] pieces = Apportionment.distribute(1000 * 1000L - 1, weights);
+
+        for (int ii = 0; ii < pieces.length; ii++)
+            assertThat("piece " + ii, pieces[ii], is(ii < 999 ? 1000L : 999L));
+
+        assertThat(sum(pieces), is(1000 * 1000L - 1));
+    }
+
+    @Test
+    public void testZeroWeightsGetZero()
+    {
+        assertArrayEquals(new long[] { 0, 334, 334, 0, 333 },
+                        Apportionment.distribute(1001, new long[] { 0, 1, 1, 0, 1 }));
+    }
+
+    @Test
+    public void testZeroTotalIsDistributedAsZero()
+    {
+        assertArrayEquals(new long[] { 0, 0, 0 }, Apportionment.distribute(0, new long[] { 1, 2, 3 }));
+    }
+
+    @Test
+    public void testNegativeTotal()
+    {
+        // -1001 x 1/3 = -333.67 each; flooring gives -334 three times, i.e. one
+        // unit too much, which is handed back to the largest remainder
+        assertArrayEquals(new long[] { -333, -334, -334 }, Apportionment.distribute(-1001, new long[] { 1, 1, 1 }));
+
+        // sign is the only difference: the pieces still sum up exactly
+        assertThat(sum(Apportionment.distribute(-100, new long[] { 1, 2, 3 })), is(-100L));
+    }
+
+    @Test
+    public void testEveryPieceIsWithinOneUnitOfTheExactValue()
+    {
+        long total = 1000001;
+        long[] weights = { 3, 5, 7, 11, 13 };
+
+        long[] pieces = Apportionment.distribute(total, weights);
+
+        BigInteger sumOfWeights = BigInteger.valueOf(sum(weights));
+
+        for (int ii = 0; ii < weights.length; ii++)
+        {
+            BigInteger exact = BigInteger.valueOf(total).multiply(BigInteger.valueOf(weights[ii]));
+            BigInteger scaled = BigInteger.valueOf(pieces[ii]).multiply(sumOfWeights);
+
+            assertTrue("piece " + ii + " is off by more than one unit",
+                            scaled.subtract(exact).abs().compareTo(sumOfWeights) < 0);
+        }
+    }
+
+    @Test
+    public void testSumIsAlwaysTheTotal()
+    {
+        var random = new Random(42);
+
+        for (int run = 0; run < 1000; run++)
+        {
+            long total = random.nextLong(-100_000_000L, 100_000_000L);
+
+            long[] weights = new long[1 + random.nextInt(10)];
+            long sumOfWeights = 0;
+            for (int ii = 0; ii < weights.length; ii++)
+            {
+                weights[ii] = random.nextLong(0, 1_000_000_000_000L);
+                sumOfWeights += weights[ii];
+            }
+
+            if (sumOfWeights == 0)
+                continue;
+
+            long[] pieces = Apportionment.distribute(total, weights);
+
+            assertThat(sum(pieces), is(total));
+
+            for (int ii = 0; ii < weights.length; ii++)
+            {
+                if (weights[ii] == 0)
+                    assertThat(pieces[ii], is(0L));
+            }
+        }
+    }
+
+    @Test
+    public void testProductsDoNotOverflow()
+    {
+        // Values.Share has 8 decimals, so 10,000 shares are 10^12 units. Times
+        // an amount of EUR 10 million in cents that is 10^21 - two orders of
+        // magnitude beyond a long, which is why the intermediate products are
+        // computed in BigInteger
+
+        long total = 1_000_000_001L;
+        long[] weights = { 1_000_000_000_000L, 1_000_000_000_000L, 1_000_000_000_000L };
+
+        assertArrayEquals(new long[] { 333_333_334L, 333_333_334L, 333_333_333L },
+                        Apportionment.distribute(total, weights));
+    }
+
+    @Test
+    public void testInvalidArgumentsAreRejected()
+    {
+        assertThrows(IllegalArgumentException.class, () -> Apportionment.distribute(100, new long[0]));
+        assertThrows(IllegalArgumentException.class, () -> Apportionment.distribute(100, new long[] { 1, -1 }));
+        assertThrows(IllegalArgumentException.class, () -> Apportionment.distribute(100, new long[] { 0, 0 }));
+        assertThrows(IllegalArgumentException.class, () -> Apportionment.distribute(0, new long[] { 0 }));
+    }
+}

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector7Test.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCollector7Test.java
@@ -8,7 +8,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -48,19 +47,6 @@ import name.abuchen.portfolio.util.Interval;
 @SuppressWarnings("nls")
 public class TradeCollector7Test
 {
-    /**
-     * Every piece of a split transaction is rounded independently with an error
-     * in (-0.5, 0.5] minor units, so the error of the sum of N pieces is
-     * bounded by floor(N / 2) minor units.
-     * <p>
-     * Once the exact remainder correction is implemented, this bound becomes
-     * zero and all the assertions below turn into exact equality.
-     */
-    private static long maxDrift(int pieces)
-    {
-        return pieces / 2;
-    }
-
     private static List<Trade> collect(Client client, Security security, TradeGrouping grouping)
                     throws TradeCollectorException
     {
@@ -409,43 +395,114 @@ public class TradeCollector7Test
         var trades = collect(client, security, TradeGrouping.PER_LOT);
         assertThat(trades.size(), is(3));
 
-        long bound = maxDrift(trades.size());
-
-        // shares are exact: with the weight consumedShares / closingShares,
-        // Math.round returns exactly the consumed shares. Any drift here means
-        // that the weight is computed against the wrong base
+        // shares are exact because split weights are share counts
         long shares = trades.stream().mapToLong(t -> closingOf(t).getShares()).sum();
         assertThat(shares, is(sale.getShares()));
 
+        // EUR 1,000.01 is apportioned as 333.34, 333.34 and 333.33
         long amount = trades.stream().mapToLong(t -> closingOf(t).getAmount()).sum();
-        assertTrue("amount drifted by " + (amount - sale.getAmount()), Math.abs(amount - sale.getAmount()) <= bound);
+        assertThat(amount, is(sale.getAmount()));
 
-        // units are rounded per type, so a cent moved from taxes to fees is
-        // invisible in a combined total
+        // each unit type reconciles exactly
         for (Unit.Type type : Unit.Type.values())
         {
             var original = sale.getUnitSum(type);
 
             long units = trades.stream() //
                             .mapToLong(t -> closingOf(t).getUnitSum(type).getAmount()).sum();
-            assertTrue(type + " amount drifted by " + (units - original.getAmount()),
-                            Math.abs(units - original.getAmount()) <= bound);
+            assertThat(type + " amount", units, is(original.getAmount()));
         }
 
-        // the forex amount is split independently of the amount
+        // forex is apportioned separately and also reconciles
         long forex = trades.stream() //
                         .mapToLong(t -> closingOf(t).getUnit(Unit.Type.GROSS_VALUE)
                                         .orElseThrow(IllegalArgumentException::new).getForex().getAmount())
                         .sum();
         long forexOfSale = sale.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new).getForex()
                         .getAmount();
-        assertTrue("forex drifted by " + (forex - forexOfSale), Math.abs(forex - forexOfSale) <= bound);
+        assertThat(forex, is(forexOfSale));
 
         // the exchange rate is carried over unchanged
         for (Trade trade : trades)
         {
             assertThat(closingOf(trade).getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new)
                             .getExchangeRate(), is(BigDecimal.valueOf(0.80)));
+        }
+    }
+
+    /**
+     * Purchase fixture with amounts that do not divide evenly into the later
+     * instalments.
+     */
+    private static PortfolioTransaction createPurchaseOfHundredShares(Security security)
+    {
+        var purchase = new PortfolioTransaction(LocalDateTime.parse("2021-01-01T00:00"), CurrencyUnit.EUR,
+                        amountOf(1000.01), security, sharesOf(100), PortfolioTransaction.Type.DELIVERY_INBOUND, 0, 0);
+
+        // EUR 970.01 gross value plus EUR 30.00 fees = EUR 1,000.01 paid
+        purchase.addUnit(new Unit(Unit.Type.GROSS_VALUE, //
+                        Money.of(CurrencyUnit.EUR, amountOf(970.01)), //
+                        Money.of(CurrencyUnit.USD, amountOf(1212.51)), //
+                        BigDecimal.valueOf(0.80)));
+        purchase.addUnit(new Unit(Unit.Type.FEE, Money.of(CurrencyUnit.EUR, amountOf(30))));
+
+        return purchase;
+    }
+
+    /**
+     * Asserts exact conservation of shares, amount, units and gross-value
+     * forex.
+     */
+    private static void assertConserved(PortfolioTransaction original, List<PortfolioTransaction> pieces)
+    {
+        assertThat("shares", pieces.stream().mapToLong(PortfolioTransaction::getShares).sum(),
+                        is(original.getShares()));
+        assertThat("amount", pieces.stream().mapToLong(PortfolioTransaction::getAmount).sum(),
+                        is(original.getAmount()));
+
+        for (Unit.Type type : Unit.Type.values())
+        {
+            assertThat(type + " amount", pieces.stream().mapToLong(p -> p.getUnitSum(type).getAmount()).sum(),
+                            is(original.getUnitSum(type).getAmount()));
+        }
+
+        assertThat("forex of gross value",
+                        pieces.stream().mapToLong(p -> p.getUnit(Unit.Type.GROSS_VALUE)
+                                        .orElseThrow(IllegalArgumentException::new).getForex().getAmount()).sum(),
+                        is(original.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new)
+                                        .getForex().getAmount()));
+    }
+
+    @Test
+    public void testRepeatedPartialSalesConserveTheLot() throws TradeCollectorException
+    {
+        // repeated partial sales split the synthetic remainder again, so
+        // rounding drift used to compound
+
+        var client = new Client();
+
+        var security = new SecurityBuilder(CurrencyUnit.USD).addPrice("2021-12-01", quoteOf(30)).addTo(client);
+
+        var portfolio = new PortfolioBuilder(new Account("one")) //
+                        .outbound_delivery(security, "2021-02-01", sharesOf(7), amountOf(100.01), 0, 0) //
+                        .outbound_delivery(security, "2021-03-01", sharesOf(7), amountOf(101.03), 0, 0) //
+                        .outbound_delivery(security, "2021-04-01", sharesOf(7), amountOf(102.07), 0, 0) //
+                        .outbound_delivery(security, "2021-05-01", sharesOf(7), amountOf(103.11), 0, 0) //
+                        .outbound_delivery(security, "2021-06-01", sharesOf(7), amountOf(104.13), 0, 0) //
+                        .addTo(client);
+
+        var purchase = createPurchaseOfHundredShares(security);
+        portfolio.addTransaction(purchase);
+
+        // createNewTrades runs for both groupings
+        for (TradeGrouping grouping : TradeGrouping.values())
+        {
+            var trades = collect(client, security, grouping);
+
+            // five closed trades plus the 65-share remainder
+            assertThat(grouping.name(), trades.size(), is(6));
+
+            assertConserved(purchase, trades.stream().map(TradeCollector7Test::openingOf).toList());
         }
     }
 
@@ -967,6 +1024,46 @@ public class TradeCollector7Test
             assertThat(trade.getTransactions().get(0).getOwner(), is((Object) portfolioA));
     }
 
+    @Test
+    public void testPartialTransferConservesTheLot() throws TradeCollectorException
+    {
+        // partial transfers must conserve transferred and remaining pieces
+
+        var client = new Client();
+
+        var security = new SecurityBuilder(CurrencyUnit.USD).addPrice("2021-12-01", quoteOf(30)).addTo(client);
+
+        var portfolioA = new PortfolioBuilder(new Account("one")).addTo(client);
+        var portfolioB = new PortfolioBuilder(new Account("two")).addTo(client);
+
+        var purchase = createPurchaseOfHundredShares(security);
+        portfolioA.addTransaction(purchase);
+
+        var transfer = new PortfolioTransferEntry(portfolioA, portfolioB);
+        transfer.setSecurity(security);
+        transfer.setDate(LocalDateTime.parse("2021-03-01T00:00"));
+        transfer.setShares(sharesOf(33));
+        transfer.setAmount(amountOf(330));
+        transfer.setCurrencyCode(security.getCurrencyCode());
+        transfer.insert();
+
+        var trades = collect(client, security, TradeGrouping.PER_LOT);
+        assertThat(trades.size(), is(2));
+
+        var transferred = openingOf(trades.stream().filter(t -> t.getPortfolio() == portfolioB).findAny()
+                        .orElseThrow(IllegalArgumentException::new));
+        var remaining = openingOf(trades.stream().filter(t -> t.getPortfolio() == portfolioA).findAny()
+                        .orElseThrow(IllegalArgumentException::new));
+
+        assertConserved(purchase, List.of(transferred, remaining));
+
+        // 330.0033 / 670.0067 rounds the extra cent into the larger remainder
+        assertThat(transferred.getShares(), is(sharesOf(33)));
+        assertThat(transferred.getAmount(), is(amountOf(330)));
+        assertThat(remaining.getShares(), is(sharesOf(67)));
+        assertThat(remaining.getAmount(), is(amountOf(670.01)));
+    }
+
     // -----------------------------------------------------------------------
     // relationship between the two groupings
     // -----------------------------------------------------------------------
@@ -1004,10 +1101,10 @@ public class TradeCollector7Test
     }
 
     @Test
-    public void testTotalsDriftWithinBoundIfSalesAreSplit() throws TradeCollectorException
+    public void testTotalsAreIdenticalIfSalesAreSplit() throws TradeCollectorException
     {
-        // where a sale spans several lots, each piece is rounded on its own.
-        // The totals are therefore only equal within the documented bound
+        // the fixture avoids conversion rounding, so split and combined totals
+        // match
 
         var client = createClientWithSaleSpanningThreeLots();
         var security = client.getSecurities().get(0);
@@ -1018,15 +1115,9 @@ public class TradeCollector7Test
         assertThat(combined.size(), is(1));
         assertThat(perLot.size(), is(3));
 
-        long bound = maxDrift(perLot.size());
-
         assertThat(sum(perLot, Trade::getEntryValue), is(sum(combined, Trade::getEntryValue)));
-
-        long exit = sum(perLot, Trade::getExitValue).getAmount() - sum(combined, Trade::getExitValue).getAmount();
-        assertTrue("exit value drifted by " + exit, Math.abs(exit) <= bound);
-
-        long profit = sum(perLot, Trade::getProfitLoss).getAmount() - sum(combined, Trade::getProfitLoss).getAmount();
-        assertTrue("profit/loss drifted by " + profit, Math.abs(profit) <= bound);
+        assertThat(sum(perLot, Trade::getExitValue), is(sum(combined, Trade::getExitValue)));
+        assertThat(sum(perLot, Trade::getProfitLoss), is(sum(combined, Trade::getProfitLoss)));
     }
 
     // -----------------------------------------------------------------------

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/math/Apportionment.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/math/Apportionment.java
@@ -1,0 +1,113 @@
+package name.abuchen.portfolio.math;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+/**
+ * Distributes an integer total onto weighted pieces without losing or inventing
+ * a minor unit.
+ */
+public final class Apportionment
+{
+    private Apportionment()
+    {
+    }
+
+    /**
+     * Distributes the given total proportionally to the given weights using the
+     * largest remainder method, ties broken by the lowest index.
+     * <p>
+     * The pieces sum up to the total exactly - for any sign of the total - and
+     * every piece is within one unit of the exact proportional value
+     * {@code total * weight[i] / sum(weights)}. A weight of zero always
+     * receives zero.
+     *
+     * @param total
+     *            the amount to distribute; may be negative
+     * @param weights
+     *            the weights of the pieces; at least one, none negative, and
+     *            not all zero
+     * @return one value per weight, in the same order
+     * @throws IllegalArgumentException
+     *             if no weight is given, if a weight is negative, or if all
+     *             weights are zero
+     */
+    public static long[] distribute(long total, long[] weights)
+    {
+        if (weights.length == 0)
+            throw new IllegalArgumentException("no weights given"); //$NON-NLS-1$
+
+        var sumOfWeights = BigInteger.ZERO;
+        for (long weight : weights)
+        {
+            if (weight < 0)
+                throw new IllegalArgumentException("negative weight " + weight); //$NON-NLS-1$
+            sumOfWeights = sumOfWeights.add(BigInteger.valueOf(weight));
+        }
+
+        if (sumOfWeights.signum() == 0)
+            throw new IllegalArgumentException("weights must not all be zero"); //$NON-NLS-1$
+
+        var bigTotal = BigInteger.valueOf(total);
+
+        long[] answer = new long[weights.length];
+        BigInteger[] remainders = new BigInteger[weights.length];
+
+        long distributed = 0;
+
+        for (int ii = 0; ii < weights.length; ii++)
+        {
+            BigInteger[] quotientAndRemainder = bigTotal.multiply(BigInteger.valueOf(weights[ii]))
+                            .divideAndRemainder(sumOfWeights);
+
+            var quotient = quotientAndRemainder[0];
+            var remainder = quotientAndRemainder[1];
+
+            // round towards negative infinity: with a floored quotient the
+            // remainder is in [0, sum) whatever the sign of the total, hence
+            // the leftover below is in [0, number of pieces) and needs no
+            // special casing for negative totals
+
+            if (remainder.signum() < 0)
+            {
+                quotient = quotient.subtract(BigInteger.ONE);
+                remainder = remainder.add(sumOfWeights);
+            }
+
+            answer[ii] = quotient.longValueExact();
+            remainders[ii] = remainder;
+
+            distributed += answer[ii];
+        }
+
+        // hand out the leftover one unit at a time, largest remainder first. A
+        // zero weight has a zero remainder and therefore can never absorb a
+        // unit: the leftover is always smaller than the number of pieces with
+        // a remainder greater than zero.
+        //
+        // The pieces are ordered once instead of picking the largest remainder
+        // repeatedly: the leftover grows with the number of pieces (it averages
+        // half of them), so picking would be quadratic - noticeable once a sale
+        // is matched against the hundreds of lots of a long running savings
+        // plan
+
+        long leftover = total - distributed;
+
+        if (leftover > 0)
+        {
+            Integer[] order = new Integer[weights.length];
+            for (int ii = 0; ii < order.length; ii++)
+                order[ii] = ii;
+
+            Arrays.sort(order, (a, b) -> {
+                int byRemainder = remainders[b].compareTo(remainders[a]);
+                return byRemainder != 0 ? byRemainder : Integer.compare(a, b);
+            });
+
+            for (int ii = 0; ii < leftover; ii++)
+                answer[order[ii]]++;
+        }
+
+        return answer;
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Transaction.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/model/Transaction.java
@@ -138,6 +138,11 @@ public abstract class Transaction implements Annotated, Adaptable
             return true;
         }
 
+        /**
+         * Creates one weighted, independently rounded piece. This is lossy for
+         * partitions; use Apportionment plus {@link #piece(long, long)} when
+         * pieces must reconcile.
+         */
         public Unit split(double weight)
         {
             Money newAmount = Money.of(amount.getCurrencyCode(), Math.round(amount.getAmount() * weight));
@@ -145,13 +150,27 @@ public abstract class Transaction implements Annotated, Adaptable
             if (forex == null)
                 return new Unit(type, newAmount);
 
-            // when splitting units with forex currency values, small amounts
-            // can lead to rounding errors for which the validity check in the
-            // constructor would throw an exception. We accept the rounding
-            // errors when splitting an unit, e.g. when grouping by taxonomy
-
             Money newForex = Money.of(forex.getCurrencyCode(), Math.round(forex.getAmount() * weight));
             return new Unit(type, newAmount, newForex, exchangeRate, false);
+        }
+
+        /**
+         * Creates an apportioned copy, preserving type and exchange rate. The
+         * forex amount is ignored when this unit has none.
+         */
+        public Unit piece(long newAmount, long newForexAmount)
+        {
+            Money amountOfPiece = Money.of(amount.getCurrencyCode(), newAmount);
+
+            if (forex == null)
+                return new Unit(type, amountOfPiece);
+
+            // Apportioned amount and forex can still disagree with the
+            // unchanged rate by more than the constructor tolerance for small
+            // values.
+
+            Money forexOfPiece = Money.of(forex.getCurrencyCode(), newForexAmount);
+            return new Unit(type, amountOfPiece, forexOfPiece, exchangeRate, false);
         }
 
         public Type getType()

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeCollector.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeCollector.java
@@ -3,16 +3,19 @@ package name.abuchen.portfolio.snapshot.trades;
 import java.io.Serializable;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.LongStream;
 
 import com.google.common.annotations.VisibleForTesting;
 
 import name.abuchen.portfolio.Messages;
+import name.abuchen.portfolio.math.Apportionment;
 import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
@@ -21,6 +24,7 @@ import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.PortfolioTransaction.Type;
 import name.abuchen.portfolio.model.PortfolioTransferEntry;
 import name.abuchen.portfolio.model.Security;
+import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.model.TransactionPair;
 import name.abuchen.portfolio.money.CurrencyConverter;
 import name.abuchen.portfolio.money.Values;
@@ -250,12 +254,14 @@ public class TradeCollector
             }
             else if (sharesToDistribute < candidate.getTransaction().getShares())
             {
-                consumed.add(split(candidate, (Portfolio) pair.getOwner(),
-                                sharesToDistribute / (double) candidate.getTransaction().getShares()));
-                open.set(open.indexOf(candidate),
-                                split(candidate, (Portfolio) pair.getOwner(),
-                                                (candidate.getTransaction().getShares() - sharesToDistribute)
-                                                                / (double) candidate.getTransaction().getShares()));
+                var owner = (Portfolio) pair.getOwner();
+                var lotShares = candidate.getTransaction().getShares();
+
+                var pieces = split(candidate, List.of(owner, owner),
+                                new long[] { sharesToDistribute, lotShares - sharesToDistribute });
+
+                consumed.add(pieces.get(0));
+                open.set(open.indexOf(candidate), pieces.get(1));
 
                 sharesToDistribute = 0;
             }
@@ -304,30 +310,25 @@ public class TradeCollector
     private List<Trade> createTradePerLot(TransactionPair<PortfolioTransaction> pair,
                     List<TransactionPair<PortfolioTransaction>> consumed)
     {
-        long closingShares = pair.getTransaction().getShares();
+        // Split the closing transaction by the shares contributed by each
+        // consumed lot.
+
+        List<TransactionPair<PortfolioTransaction>> closingPieces = consumed.size() == 1 ? null
+                        : split(pair, Collections.nCopies(consumed.size(), (Portfolio) pair.getOwner()),
+                                        consumed.stream().mapToLong(lot -> lot.getTransaction().getShares()).toArray());
 
         var answer = new ArrayList<Trade>();
 
-        for (TransactionPair<PortfolioTransaction> lot : consumed)
+        for (int ii = 0; ii < consumed.size(); ii++)
         {
-            // the shares of the lot are the shares it contributed to the
-            // closing transaction (the lot has been split beforehand if it has
-            // been consumed only partially)
-            long consumedShares = lot.getTransaction().getShares();
+            TransactionPair<PortfolioTransaction> lot = consumed.get(ii);
 
             var newTrade = new Trade(pair.getTransaction().getSecurity(), (Portfolio) pair.getOwner(),
-                            consumedShares);
+                            lot.getTransaction().getShares());
             newTrade.setStart(lot.getTransaction().getDateTime());
             newTrade.getTransactions().add(lot);
 
-            // if the closing transaction is matched against a single lot, the
-            // weight is 1 and the real transaction is used. Otherwise every
-            // trade gets its own split copy. Note that the weight is relative
-            // to the shares of the *closing* transaction while the other call
-            // sites of #split weight relative to the shares of the open lot
-
-            newTrade.getTransactions().add(consumed.size() == 1 ? pair
-                            : split(pair, (Portfolio) pair.getOwner(), consumedShares / (double) closingShares));
+            newTrade.getTransactions().add(closingPieces == null ? pair : closingPieces.get(ii));
 
             newTrade.setEnd(pair.getTransaction().getDateTime());
 
@@ -378,12 +379,13 @@ public class TradeCollector
             }
             else if (sharesToTransfer < candidate.getTransaction().getShares())
             {
-                long remainingShares = candidate.getTransaction().getShares() - sharesToTransfer;
+                long lotShares = candidate.getTransaction().getShares();
 
-                positions.set(positions.indexOf(candidate), split(candidate, outbound,
-                                remainingShares / (double) candidate.getTransaction().getShares()));
-                target.add(split(candidate, inbound,
-                                sharesToTransfer / (double) candidate.getTransaction().getShares()));
+                var pieces = split(candidate, List.of(inbound, outbound),
+                                new long[] { sharesToTransfer, lotShares - sharesToTransfer });
+
+                target.add(pieces.get(0));
+                positions.set(positions.indexOf(candidate), pieces.get(1));
 
                 sharesToTransfer = 0;
             }
@@ -398,18 +400,71 @@ public class TradeCollector
         }
     }
 
-    private TransactionPair<PortfolioTransaction> split(TransactionPair<PortfolioTransaction> candidate,
-                    Portfolio newOwner, double weight)
+    /**
+     * Splits a transaction by share weights. Shares are exact; amount, unit
+     * amount and unit forex amount are apportioned so all pieces reconcile.
+     *
+     * @param newOwners
+     *            one owner per piece; only copied {@link BuySellEntry}
+     *            instances use it directly
+     */
+    private List<TransactionPair<PortfolioTransaction>> split(TransactionPair<PortfolioTransaction> candidate,
+                    List<Portfolio> newOwners, long[] weights)
     {
-        if (candidate.getTransaction().getCrossEntry() instanceof BuySellEntry entry)
-            return splitBuySell(entry, newOwner, weight);
-        else if (candidate.getTransaction() instanceof PortfolioTransaction)
-            return splitPortfolioTransaction((Portfolio) candidate.getOwner(), candidate.getTransaction(), weight);
-        else
-            throw new UnsupportedOperationException();
+        PortfolioTransaction t = candidate.getTransaction();
+
+        if (newOwners.size() != weights.length)
+            throw new IllegalArgumentException("one owner required per weight"); //$NON-NLS-1$
+
+        if (LongStream.of(weights).sum() != t.getShares())
+            throw new IllegalArgumentException(
+                            MessageFormat.format("weights {0} do not add up to the {1} shares of {2}", //$NON-NLS-1$
+                                            Arrays.toString(weights), t.getShares(), t));
+
+        long[] amounts = Apportionment.distribute(t.getAmount(), weights);
+
+        // Apportion each unit object independently; do not derive GROSS_VALUE
+        // from amount, fees and taxes because imported transactions need not
+        // reconcile.
+
+        List<Unit> units = t.getUnits().toList();
+        List<long[]> unitAmounts = new ArrayList<>();
+        List<long[]> unitForexAmounts = new ArrayList<>();
+
+        for (Unit unit : units)
+        {
+            unitAmounts.add(Apportionment.distribute(unit.getAmount().getAmount(), weights));
+            unitForexAmounts.add(unit.getForex() != null
+                            ? Apportionment.distribute(unit.getForex().getAmount(), weights)
+                            : new long[weights.length]);
+        }
+
+        var answer = new ArrayList<TransactionPair<PortfolioTransaction>>();
+
+        for (int ii = 0; ii < weights.length; ii++)
+        {
+            TransactionPair<PortfolioTransaction> piece;
+
+            if (t.getCrossEntry() instanceof BuySellEntry entry)
+                piece = createBuySellPiece(entry, newOwners.get(ii), weights[ii], amounts[ii]);
+            else
+                // a transaction without a cross entry is copied with the owner
+                // of the candidate: it has no portfolio of its own to set, so
+                // the new owner is deliberately ignored here
+                piece = createPortfolioTransactionPiece((Portfolio) candidate.getOwner(), t, weights[ii], amounts[ii]);
+
+            for (int jj = 0; jj < units.size(); jj++)
+                piece.getTransaction()
+                                .addUnit(units.get(jj).piece(unitAmounts.get(jj)[ii], unitForexAmounts.get(jj)[ii]));
+
+            answer.add(piece);
+        }
+
+        return answer;
     }
 
-    private TransactionPair<PortfolioTransaction> splitBuySell(BuySellEntry entry, Portfolio portfolio, double weight)
+    private TransactionPair<PortfolioTransaction> createBuySellPiece(BuySellEntry entry, Portfolio portfolio,
+                    long shares, long amount)
     {
         PortfolioTransaction t = entry.getPortfolioTransaction();
 
@@ -423,16 +478,14 @@ public class TradeCollector
         copy.setType(t.getType());
         copy.setNote(t.getNote());
 
-        copy.setShares(Math.round(t.getShares() * weight));
-        copy.setAmount(Math.round(t.getAmount() * weight));
-
-        t.getUnits().forEach(unit -> copy.getPortfolioTransaction().addUnit(unit.split(weight)));
+        copy.setShares(shares);
+        copy.setAmount(amount);
 
         return new TransactionPair<>(entry.getPortfolio(), copy.getPortfolioTransaction());
     }
 
-    private TransactionPair<PortfolioTransaction> splitPortfolioTransaction(Portfolio portfolio,
-                    PortfolioTransaction transaction, double weight)
+    private TransactionPair<PortfolioTransaction> createPortfolioTransactionPiece(Portfolio portfolio,
+                    PortfolioTransaction transaction, long shares, long amount)
     {
         PortfolioTransaction newTransaction = new PortfolioTransaction();
         newTransaction.setType(transaction.getType());
@@ -441,10 +494,8 @@ public class TradeCollector
         newTransaction.setCurrencyCode(transaction.getCurrencyCode());
         newTransaction.setNote(transaction.getNote());
 
-        newTransaction.setShares(Math.round(transaction.getShares() * weight));
-        newTransaction.setAmount(Math.round(transaction.getAmount() * weight));
-
-        transaction.getUnits().forEach(unit -> newTransaction.addUnit(unit.split(weight)));
+        newTransaction.setShares(shares);
+        newTransaction.setAmount(amount);
 
         return new TransactionPair<>(portfolio, newTransaction);
     }


### PR DESCRIPTION
TradeCollector now splits partial lots, transfers, and per-lot closing
transactions by integer share weights instead of double percentages.
Amounts, unit amounts, and unit forex amounts are apportioned so the
synthetic pieces add back up to the original transaction exactly.

This removes rounding drift in both lot-based and combined trade
collection, including repeated partial sales where the synthetic
remainder is split again. GROSS_VALUE units are apportioned like all
other units, and forex units keep the original exchange rate with
validity checking disabled for the same small-value rounding reason as
before.

The trade tests now assert exact conservation for split sales, repeated
partial sales, and partial transfers, and the previous bounded-drift
expectations become exact equality.