### PR TITLE
Fix IB Flex dividend reversal sign

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
@@ -3530,6 +3530,38 @@ public class IBFlexStatementExtractorTest
         assertThat(cashDelta, is(0L));
     }
 
+    /// A withholding tax lands on the dividend the user can actually import.
+    @Test
+    public void testDividendReversalDoesNotConsumeTheWithholdingTax() throws IOException
+    {
+        var extractor = new IBFlexStatementExtractor(new Client());
+        var activityStatement = getClass().getResourceAsStream("testIBFlexStatementFile31.xml");
+        var tempFile = createTempFile(activityStatement);
+        var errors = new ArrayList<Exception>();
+
+        var results = extractor.extract(Collections.singletonList(tempFile), errors);
+
+        assertThat(errors, empty());
+
+        // postProcessing pairs a tax with one dividend per date and security,
+        // and removes the tax item. The reversal and the replacement share both,
+        // so whichever is matched first takes the tax. It has to be the
+        // replacement: the reversal is flagged and never reaches the portfolio,
+        // which would drop the tax entirely.
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-06-16"), hasShares(9), //
+                        hasSecurity(hasTicker("TEST")), //
+                        hasAmount("USD", 0.65), hasGrossValue("USD", 0.76), //
+                        hasTaxes("USD", 0.11), hasFees("USD", 0.00))));
+
+        // The reversal keeps the amount IB reported and stays flagged.
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorCashDividendCorrectionUnmatched, //
+                        dividend( //
+                                        hasDate("2026-06-16"), hasShares(-8), //
+                                        hasAmount("USD", -0.70)))));
+    }
+
     @Test
     public void testIBFlexStatementFile27() throws IOException
     {

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
@@ -19,6 +19,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.inboundCash;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.outboundCash;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.withFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
@@ -3491,7 +3492,7 @@ public class IBFlexStatementExtractorTest
     }
 
     @Test
-    public void testDividendReversalKeepsNegativeAmount() throws IOException
+    public void testDividendReversalIsFlaggedAsFailedItem() throws IOException
     {
         var extractor = new IBFlexStatementExtractor(new Client());
         var activityStatement = getClass().getResourceAsStream("testIBFlexStatementFile30.xml");
@@ -3502,15 +3503,27 @@ public class IBFlexStatementExtractorTest
 
         assertThat(errors, empty());
         assertThat(countAccountTransactions(results), is(3L));
-        assertThat(results, hasItem(dividend( //
-                        hasDate("2026-06-16"), hasShares(-8), //
-                        hasSecurity(hasTicker("TEST")), //
-                        hasAmount("USD", -0.70))));
+        new AssertImportActions().check(results, CurrencyUnit.USD);
+
+        // The reversal keeps the negative amount that IB reports and is flagged
+        // as a failure, because the correction cannot be applied to the
+        // original dividend. The user has to remove that one by hand.
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorCashDividendCorrectionUnmatched, //
+                        dividend( //
+                                        hasDate("2026-06-16"), hasShares(-8), //
+                                        hasSecurity(hasTicker("TEST")), //
+                                        hasAmount("USD", -0.70)))));
+
+        // The replacement dividend is imported as usual.
         assertThat(results, hasItem(dividend( //
                         hasDate("2026-06-16"), hasShares(9), //
                         hasSecurity(hasTicker("TEST")), //
                         hasAmount("USD", 0.76))));
 
+        // Signed cash across all three rows nets to zero, which is the
+        // arithmetic the report asks for. Reading the reversal as income
+        // instead overstates the account by 1.40 USD.
         var cashDelta = results.stream().filter(TransactionItem.class::isInstance).map(TransactionItem.class::cast)
                         .map(TransactionItem::getSubject).map(AccountTransaction.class::cast)
                         .mapToLong(t -> t.getType().isDebit() ? -t.getAmount() : t.getAmount()).sum();

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractorTest.java
@@ -3491,6 +3491,33 @@ public class IBFlexStatementExtractorTest
     }
 
     @Test
+    public void testDividendReversalKeepsNegativeAmount() throws IOException
+    {
+        var extractor = new IBFlexStatementExtractor(new Client());
+        var activityStatement = getClass().getResourceAsStream("testIBFlexStatementFile30.xml");
+        var tempFile = createTempFile(activityStatement);
+        var errors = new ArrayList<Exception>();
+
+        var results = extractor.extract(Collections.singletonList(tempFile), errors);
+
+        assertThat(errors, empty());
+        assertThat(countAccountTransactions(results), is(3L));
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-06-16"), hasShares(-8), //
+                        hasSecurity(hasTicker("TEST")), //
+                        hasAmount("USD", -0.70))));
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-06-16"), hasShares(9), //
+                        hasSecurity(hasTicker("TEST")), //
+                        hasAmount("USD", 0.76))));
+
+        var cashDelta = results.stream().filter(TransactionItem.class::isInstance).map(TransactionItem.class::cast)
+                        .map(TransactionItem::getSubject).map(AccountTransaction.class::cast)
+                        .mapToLong(t -> t.getType().isDebit() ? -t.getAmount() : t.getAmount()).sum();
+        assertThat(cashDelta, is(0L));
+    }
+
+    @Test
     public void testIBFlexStatementFile27() throws IOException
     {
         // Test minor unit currency handling: IBKR provides GBP, security is GBX

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/testIBFlexStatementFile30.xml
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/testIBFlexStatementFile30.xml
@@ -1,0 +1,12 @@
+<FlexQueryResponse queryName="DividendReversal" type="AF">
+  <FlexStatements count="1">
+    <FlexStatement accountId="U1234567" fromDate="20260616" toDate="20260616" period="LastMonth" whenGenerated="20260617;120000">
+      <AccountInformation accountId="U1234567" currency="USD" />
+      <CashTransactions>
+        <CashTransaction accountId="U1234567" currency="USD" fxRateToBase="1" assetCategory="STK" symbol="TEST" description="TEST(US0000000001) CASH DIVIDEND USD 0.0875 PER SHARE (Reversal)" conid="1" securityID="US0000000001" securityIDType="ISIN" isin="US0000000001" listingExchange="NYSE" multiplier="1" dateTime="20260616;120000" settleDate="20260616" amount="-0.70" type="Dividends" transactionID="reversal" reportDate="20260616" levelOfDetail="DETAIL" />
+        <CashTransaction accountId="U1234567" currency="USD" fxRateToBase="1" assetCategory="STK" symbol="TEST" description="TEST(US0000000001) CASH DIVIDEND USD 0.0844444444 PER SHARE (Ordinary Dividend)" conid="1" securityID="US0000000001" securityIDType="ISIN" isin="US0000000001" listingExchange="NYSE" multiplier="1" dateTime="20260616;120100" settleDate="20260616" amount="0.76" type="Dividends" transactionID="replacement" reportDate="20260616" levelOfDetail="DETAIL" />
+        <CashTransaction accountId="U1234567" currency="USD" fxRateToBase="1" assetCategory="CASH" symbol="" description="Dividend cash adjustment" dateTime="20260616;120200" amount="-0.06" type="Deposits/Withdrawals" transactionID="adjustment" reportDate="20260616" levelOfDetail="DETAIL" />
+      </CashTransactions>
+    </FlexStatement>
+  </FlexStatements>
+</FlexQueryResponse>

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/testIBFlexStatementFile31.xml
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/ibflex/testIBFlexStatementFile31.xml
@@ -1,0 +1,13 @@
+<FlexQueryResponse queryName="DividendReversalWithTax" type="AF">
+  <FlexStatements count="1">
+    <FlexStatement accountId="U1234567" fromDate="20260616" toDate="20260616" period="LastMonth" whenGenerated="20260617;120000">
+      <AccountInformation accountId="U1234567" currency="USD" />
+      <CashTransactions>
+        <CashTransaction accountId="U1234567" currency="USD" fxRateToBase="1" assetCategory="STK" symbol="TEST" description="TEST(US0000000001) CASH DIVIDEND USD 0.0875 PER SHARE (Reversal)" conid="1" securityID="US0000000001" securityIDType="ISIN" isin="US0000000001" listingExchange="NYSE" multiplier="1" dateTime="20260616;120000" settleDate="20260616" amount="-0.70" type="Dividends" transactionID="reversal" reportDate="20260616" levelOfDetail="DETAIL" />
+        <CashTransaction accountId="U1234567" currency="USD" fxRateToBase="1" assetCategory="STK" symbol="TEST" description="TEST(US0000000001) CASH DIVIDEND USD 0.0844444444 PER SHARE (Ordinary Dividend)" conid="1" securityID="US0000000001" securityIDType="ISIN" isin="US0000000001" listingExchange="NYSE" multiplier="1" dateTime="20260616;120100" settleDate="20260616" amount="0.76" type="Dividends" transactionID="replacement" reportDate="20260616" levelOfDetail="DETAIL" />
+        <CashTransaction accountId="U1234567" currency="USD" fxRateToBase="1" assetCategory="STK" symbol="TEST" description="TEST(US0000000001) CASH DIVIDEND USD 0.0844444444 PER SHARE - US TAX" conid="1" securityID="US0000000001" securityIDType="ISIN" isin="US0000000001" listingExchange="NYSE" multiplier="1" dateTime="20260616;120130" settleDate="20260616" amount="-0.11" type="Withholding Tax" transactionID="tax" reportDate="20260616" levelOfDetail="DETAIL" />
+        <CashTransaction accountId="U1234567" currency="USD" fxRateToBase="1" assetCategory="CASH" symbol="" description="Dividend cash adjustment" dateTime="20260616;120200" amount="-0.06" type="Deposits/Withdrawals" transactionID="adjustment" reportDate="20260616" levelOfDetail="DETAIL" />
+      </CashTransactions>
+    </FlexStatement>
+  </FlexStatements>
+</FlexQueryResponse>

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractor.java
@@ -459,6 +459,11 @@ public class IBFlexStatementExtractor implements Extractor
                     break;
                 case "Dividends":
                 case "Payment In Lieu Of Dividends":
+                    // Dividend reversals are reported as negative cash transactions.
+                    // Keep that sign instead of turning the correction into income.
+                    if (asDecimal(element.getAttribute("amount")).signum() < 0)
+                        amount = Money.of(amount.getCurrencyCode(), -amount.getAmount());
+
                     // Set the Symbol
                     if (element.getAttribute("symbol").length() > 0)
                         accountTransaction.setSecurity(this.getOrCreateSecurity(element, true));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractor.java
@@ -1473,8 +1473,14 @@ public class IBFlexStatementExtractor implements Extractor
                         .toList();
 
         // Filter transactions by dividend transactions
+        //
+        // Failed items are left out: matchTransactionPair keeps one dividend
+        // per date and security and then deletes the tax item, so a flagged
+        // dividend correction sharing both with its replacement would take the
+        // tax and carry it out of the import.
         List<Item> dividendTransactionList = items.stream() //
                         .filter(TransactionItem.class::isInstance) //
+                        .filter(i -> !i.isFailure()) //
                         .filter(i -> i.getSubject() instanceof AccountTransaction) //
                         .filter(i -> AccountTransaction.Type.DIVIDENDS //
                                         .equals((((AccountTransaction) i.getSubject()).getType()))) //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ibflex/IBFlexStatementExtractor.java
@@ -437,6 +437,7 @@ public class IBFlexStatementExtractor implements Extractor
          */
         private Consumer<Element> buildAccountTransaction = element -> {
             AccountTransaction accountTransaction = new AccountTransaction();
+            boolean isDividendCorrection = false;
 
             accountTransaction.setDateTime(extractDate(element));
 
@@ -459,10 +460,17 @@ public class IBFlexStatementExtractor implements Extractor
                     break;
                 case "Dividends":
                 case "Payment In Lieu Of Dividends":
-                    // Dividend reversals are reported as negative cash transactions.
-                    // Keep that sign instead of turning the correction into income.
+                    // A dividend reversal is reported as a negative cash
+                    // transaction. Keep that sign, which asAmount strips, so
+                    // the correction is not presented as income. Portfolio
+                    // Performance cannot apply a correction to the original
+                    // dividend, so the item is flagged as a failure below and
+                    // the user is asked to fix the original by hand.
                     if (asDecimal(element.getAttribute("amount")).signum() < 0)
+                    {
                         amount = Money.of(amount.getCurrencyCode(), -amount.getAmount());
+                        isDividendCorrection = true;
+                    }
 
                     // Set the Symbol
                     if (element.getAttribute("symbol").length() > 0)
@@ -522,7 +530,12 @@ public class IBFlexStatementExtractor implements Extractor
 
             // Transactions without an account-id will not be imported.
             if (!"-".equals(element.getAttribute("accountId")))
-                addItem(accountTransaction);
+            {
+                TransactionItem item = addItem(accountTransaction);
+
+                if (isDividendCorrection)
+                    item.setFailureMessage(Messages.MsgErrorCashDividendCorrectionUnmatched);
+            }
         };
 
         /**


### PR DESCRIPTION
Fixes #5930.

IB Flex dividend reversals carry a negative `amount`, but the shared amount parser normalizes all amounts with `abs()`. The dividend share calculation retains the original sign, which explains the reported combination of negative shares and a positive cash amount.

This change restores the negative sign only for dividend and payment-in-lieu reversals. It also adds a regression fixture for the full reported reconciliation: `-0.70 + 0.76 - 0.06 = 0.00 USD`.

Verification:

```text
mvn -o -f portfolio-app/pom.xml verify \
  -pl :portfolio-target-definition,:name.abuchen.portfolio.pdfbox1,:name.abuchen.portfolio.pdfbox3,:name.abuchen.portfolio,:name.abuchen.portfolio.junit,:name.abuchen.portfolio.tests \
  -am -amd \
  -Dtest=name.abuchen.portfolio.datatransfer.ibflex.IBFlexStatementExtractorTest
```

Result: 31 tests passed; checkstyle clean.
