### PR TITLE
Fix AMFI India NAV parser for new 8-column format

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/AMFIIndiaQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/AMFIIndiaQuoteFeed.java
@@ -126,17 +126,17 @@ public class AMFIIndiaQuoteFeed implements QuoteFeed
         for (String line : lines)
         {
             // @formatter:off
-            // Scheme Code;ISIN Div Payout/ ISIN Growth;ISIN Div Reinvestment;Scheme Name;Net Asset Value;Date
+            // Scheme Code;ISIN Div Payout/ ISIN Growth;ISIN Div Reinvestment;Scheme Name;Plan;Option;Net Asset Value;Date
             // @formatter:on
             String[] words = line.split(";"); //$NON-NLS-1$
-            if (words.length < 6)
+            if (words.length < 8)
                 continue;
 
             String schemeCode = words[0];
             String isin1 = words[1];
             String isin2 = words[2];
-            String nav = words[4];
-            String date = words[5];
+            String nav = words[6];
+            String date = words[7];
 
             try
             {


### PR DESCRIPTION
AMFI has changed the format of its NAVAll.txt data file.

Previously, the data contained 6 fields:

Scheme Code;ISIN Div Payout/ ISIN Growth;ISIN Div Reinvestment;Scheme Name;Net Asset Value;Date

The new format contains 8 fields, with Plan and Option inserted before Net Asset Value:

Scheme Code;ISIN Div Payout/ ISIN Growth;ISIN Div Reinvestment;Scheme Name;Plan;Option;Net Asset Value;Date

AMFIIndiaQuoteFeed was still expecting the old 6-field format, so it was unable to parse the new data and the latest NAV was not being displayed.

This change updates the parser to:
- expect 8 fields
- read NAV from field 7 (index 6)
- read Date from field 8 (index 7)

The change was tested locally with the new AMFI format and successfully retrieved the latest NAV.

MFAPI was also affected by the same AMFI format change.