### PR TITLE
Annualize the volatility used by the Sharpe ratio widget

### DIFF
--- a/name.abuchen.portfolio.tests/src/scenarios/VolatilityTestCase.java
+++ b/name.abuchen.portfolio.tests/src/scenarios/VolatilityTestCase.java
@@ -73,6 +73,50 @@ public class VolatilityTestCase
         assertThat(index.getDates()[index.getDates().length - 1], is(LocalDate.parse("2015-02-20")));
     }
 
+    /**
+     * For a reporting period of exactly one year the period-scaled standard
+     * deviation and the annualized standard deviation must be identical. This
+     * is the anchor of the annualization: everything else is derived from it.
+     */
+    @Test
+    public void testAnnualizedVolatilityEqualsStandardDeviationForOneYear() throws IOException
+    {
+        Interval report = Interval.of(LocalDate.parse("2014-01-31"), LocalDate.parse("2015-01-31"));
+        List<Exception> warnings = new ArrayList<>();
+        PerformanceIndex index = PerformanceIndex.forClient(client, converter, report, warnings);
+
+        assertThat(warnings, empty());
+        assertThat(index.getActualInterval().getDays(), is(365L));
+
+        // a one-year reporting period contributes about as many observations
+        // as a year does, so annualizing must be close to a no-op
+        double periodScaled = index.getVolatility().getStandardDeviation();
+        assertThat(index.getAnnualizedVolatility(), closeTo(periodScaled, periodScaled * 0.01));
+    }
+
+    /**
+     * For a six month reporting period the displayed volatility is scaled to
+     * those six months; annualizing it must scale it up by sqrt(365/181).
+     */
+    @Test
+    public void testAnnualizedVolatilityScalesUpShorterPeriod() throws IOException
+    {
+        Interval report = Interval.of(LocalDate.parse("2014-01-31"), LocalDate.parse("2014-07-31"));
+        List<Exception> warnings = new ArrayList<>();
+        PerformanceIndex index = PerformanceIndex.forClient(client, converter, report, warnings);
+
+        assertThat(warnings, empty());
+        assertThat(index.getActualInterval().getDays(), is(181L));
+        assertThat(index.getVolatility().getStandardDeviation(), closeTo(0.141568791460, 0.1e-10));
+
+        // six months of observations scaled up to a full year of them: the
+        // window contributes about half of the observations a year does, so
+        // the annualized figure comes out about sqrt(2) larger
+        assertThat(index.getAnnualizedVolatility(), closeTo(0.201001412964, 0.1e-10));
+        assertThat(index.getAnnualizedVolatility() / index.getVolatility().getStandardDeviation(),
+                        closeTo(Math.sqrt(2), 0.01));
+    }
+
     @Test
     public void testVolatilityIfBenchmarkHasNoQuotes() throws IOException
     {

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/dashboard/WidgetFactory.java
@@ -283,7 +283,7 @@ public enum WidgetFactory
                                         PerformanceIndex index = data.calculate(ds, period);
                                         double r = index.getPerformanceIRR();
                                         double rf = new ClientProperties(data.getClient()).getRiskFreeRateOfReturn();
-                                        double volatility = index.getVolatility().getStandardDeviation();
+                                        double volatility = index.getAnnualizedVolatility();
 
                                         // handle invalid rf value
                                         if (Double.isNaN(rf))
@@ -296,7 +296,7 @@ public enum WidgetFactory
                                         PerformanceIndex index = data.calculate(ds, period);
                                         double r = index.getPerformanceIRR();
                                         double rf = new ClientProperties(data.getClient()).getRiskFreeRateOfReturn();
-                                        double volatility = index.getVolatility().getStandardDeviation();
+                                        double volatility = index.getAnnualizedVolatility();
                                         double sharpeRatio = (r - rf) / volatility;
                                         return MessageFormat.format(Messages.TooltipSharpeRatio,
                                                         Values.Percent5.format(r), Values.Percent2.format(rf),

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
@@ -282,9 +282,9 @@ public class PerformanceIndex
      */
     public double getAnnualizedVolatility()
     {
-        IntPredicate filter = filterReturnsForVolatilityCalculation();
+        var filter = filterReturnsForVolatilityCalculation();
 
-        int observations = 0;
+        var observations = 0;
         for (int index = 0; index < delta.length; index++)
         {
             if (filter.test(index))
@@ -294,8 +294,8 @@ public class PerformanceIndex
         if (observations <= 1)
             return 0d;
 
-        LocalDate end = getActualInterval().getEnd();
-        int observationsPerYear = Dates.tradingDaysBetween(end.minusYears(1), end);
+        var end = getActualInterval().getEnd();
+        var observationsPerYear = Dates.tradingDaysBetween(end.minusYears(1), end);
 
         return getVolatility().getStandardDeviation() / Math.sqrt(observations) * Math.sqrt(observationsPerYear);
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/PerformanceIndex.java
@@ -34,6 +34,7 @@ import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.snapshot.filter.ClientClassificationFilter;
 import name.abuchen.portfolio.snapshot.filter.ClientSecurityFilter;
 import name.abuchen.portfolio.snapshot.filter.PortfolioClientFilter;
+import name.abuchen.portfolio.util.Dates;
 import name.abuchen.portfolio.util.Interval;
 import name.abuchen.portfolio.util.TradeCalendar;
 import name.abuchen.portfolio.util.TradeCalendarManager;
@@ -258,6 +259,47 @@ public class PerformanceIndex
 
         return volatility;
     }
+
+    /**
+     * Returns the standard deviation of the returns scaled to one year.
+     * <p>
+     * {@link Volatility#getStandardDeviation()} scales the standard deviation
+     * to the length of the reporting period, i.e. it matches the conventional
+     * annualized figure only if that period happens to be about one year.
+     * <p>
+     * Annualizing divides out the number of observations actually used and
+     * multiplies by the number a full year contributes. Both counts come from
+     * the trade calendar that
+     * {@link #filterReturnsForVolatilityCalculation()} already uses to drop
+     * weekends and holidays, so an instrument trading on a regular exchange
+     * scales by about sqrt(252) and one trading every calendar day by about
+     * sqrt(365), without a special case for either.
+     * <p>
+     * Note that the number of observations deliberately excludes days on which
+     * nothing was held: the result answers how volatile the investment is
+     * while it is held, rather than diluting the movement across a longer
+     * reporting period during which it was not.
+     */
+    public double getAnnualizedVolatility()
+    {
+        IntPredicate filter = filterReturnsForVolatilityCalculation();
+
+        int observations = 0;
+        for (int index = 0; index < delta.length; index++)
+        {
+            if (filter.test(index))
+                observations++;
+        }
+
+        if (observations <= 1)
+            return 0d;
+
+        LocalDate end = getActualInterval().getEnd();
+        int observationsPerYear = Dates.tradingDaysBetween(end.minusYears(1), end);
+
+        return getVolatility().getStandardDeviation() / Math.sqrt(observations) * Math.sqrt(observationsPerYear);
+    }
+
 
     /**
      * The volatility calculation must exclude returns


### PR DESCRIPTION
## Problem

The Sharpe ratio widget divides an annualized numerator by a period-scaled denominator:

- `getPerformanceIRR()` is a per annum rate — `NPVFunction` discounts with `days / 365.0`
- the configured risk-free rate is annual
- `Risk.Volatility` scales the standard deviation to the length of the reporting period

The two only cancel out when the reporting period is about one year. Same portfolio, same day, only the reporting period differs:

|  | Year to date (236 days) | Since inception (2144 days) |
|---|---|---|
| Volatility widget | 13.76% | 66.20% |
| **Sharpe ratio widget** | **6.33** | **0.21** |
| Sharpe, annualized | 5.09 | 0.50 |

A user reading this dashboard sees a factor of 30 between the two windows where a consistent calculation gives a factor of 10. Roughly two thirds of the gap comes from the length of the reporting period rather than from the portfolio, which is what makes it impossible to track risk-adjusted performance over time or to place two windows side by side.

## Change

`PerformanceIndex.getAnnualizedVolatility()` divides out the observations the volatility filter actually retained and multiplies by the number a year contributes. Both counts come from the trade calendar that `filterReturnsForVolatilityCalculation()` already uses, via `Dates.tradingDaysBetween()`, so an instrument on a regular exchange scales by about `sqrt(252)` and one trading every calendar day by about `sqrt(365)`, with no special case for either. Days on which nothing was held are excluded, so the figure is not diluted across a reporting period during which the investment was not held.

The widget then uses it. That is the whole change: two lines in `WidgetFactory`, one new method, and tests.

## Why a single annualized figure rather than a user-facing choice

An earlier revision of this PR offered `Annualized` / `Reporting period` as a widget option. I have dropped it, and the reasoning is worth recording.

A ratio built consistently on the period is well defined, but it is not scale-free: the numerator grows with `T` and the denominator with `sqrt(T)`, so the ratio grows with `sqrt(T)`. A longer window inflates it even for an unchanged portfolio. It is therefore *consistent* without being *comparable*, and it does not solve the problem it appears to solve. Offering it as an option would have presented two conventions as equally useful when only one answers the question the widget exists to answer.

Credit for that argument to Semu on the forum thread, who also pointed out that the period-scaled volatility only pairs meaningfully with a log return, whereas what PP displays alongside is the simple cumulative TTWROR.

## Please note: this changes an existing value

For a one-year reporting period the displayed value is unchanged. For shorter periods it decreases, for longer ones it increases. There is no way to fix the mismatch without changing what existing dashboards show, since the current value is in neither convention.

## Relationship to #5842 / #5846

Deliberately scoped to the Sharpe ratio; the Volatility and Semideviation widgets are untouched, so this does not overlap with @Konilo's #5846.

Following the discussion in #5842, this uses the observation count rather than the calendar-day factor an earlier revision had. When #5846 lands I will replace `getAnnualizedVolatility()` with a call to `getAnnualizedStandardDeviation()` so that there is a single implementation; I have not done so here only because that method does not exist on `master` yet.

The Return/Volatility scatter plot is affected by the same defect, arguably more visibly since that view is read as a slope. It is out of scope here and belongs with the work already under discussion in #5842.

## Tests

Two tests added to `scenarios.VolatilityTestCase`:

- **anchor**: for a reporting period of exactly one year, annualizing is close to a no-op, within 1% of the currently displayed figure
- a six-month window is scaled up by about `sqrt(2)`, checked both against the exact value and against the ratio

Full build green: 4626 tests, 0 failures, 0 errors.

No new labels, so no translation work.

Issue: https://forum.portfolio-performance.info/t/sharpe-ratio-widget-mixes-an-annualized-return-with-a-period-scaled-volatility/39696
