### PR TITLE
Nitpick PR for Consors PDF importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/AnleiheVerkauf01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/AnleiheVerkauf01.txt
@@ -1,0 +1,67 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.87.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Consorsbank • 90318 Nürnberg
+Depotnummer: 0123 456 789
+1504753979/00
+Vermerk der Bank: 2000
+2
+Vorname Nachname
+Adress Str. 1 Datum: 14.12.2020
+01234 Stadt Seite: 1 von 2
+Ordernummer 183797558.001
+Orderdatum 14.12.2020
+ORDERABRECHNUNG
+VERKAUF AM 14.12.2020 UM 16:06:51 INL.AUSSERBOERSLICH NR. 183797558.001
+Bezeichnung WKN ISIN
+3,65 % GRIECHENLAND 12-29 7 24.FEB A1G1UG GR0133007204
+Einheit Umsatz Fälligkeit
+EUR 160,00000 Letzte Fälligkeit 24.02.2029
+Preis pro Anteil 124,963000 % FRANCO COURTAGE
+Kurswert 199,94 EUR
+Stückzins Zinsvaluta 15.12.2020 296 Tage 4,72 EUR
+abzgl. Provision 5,00 EUR
+abzgl. Grundgebühr 4,95 EUR
+abzgl. Kapitalertragssteuer 25,00% 128,99 EUR 32,25 EUR
+abzgl. Solidaritätszuschlag 5,50% 32,25 EUR 1,77 EUR
+zugunsten Konto-Nr. 8291948001 160,69 EUR
+Bestand zulasten Girosammelverwahrung
+CBF 2126
+JAHRESSTEUERBESCHEINIGUNG FOLGT
+Limitkurs 124,963000 %
+Beratungsfreies Geschäft
+Hinweis für Orderabrechnungen und Depotbuchungsanzeigen:
+Einwendungen wegen Unrichtigkeit oder Unvollständigkeit dieser Mitteilung müssen unverzüglich erhoben werden, vgl. Nummer B. Ziffer I. 11 (4) und (5) der
+Allgemeinen Geschäftsbedingungen (AGB Banken).
+Machen Sie Ihre Einwendungen in Textform geltend, genügt die Absendung innerhalb der Sechs-Wochen-Frist an die Consorsbank oder per Fax oder Mail an die
+unten angegebenen Adressen. Das Unterlassen rechtzeitiger Einwendungen gilt als Genehmigung.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland (AG nach franz. Recht).
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+Depotnummer: 0123 456 789
+1504753979/00
+Vermerk der Bank: 2000
+2
+Datum: 14.12.2020
+Seite: 2 von 2
+Ordernummer 183797558.001
+Orderdatum 14.12.2020
+Informationen bei Gewinn Aktien / Wertpapiere ungleich Aktien
+Veräusserungsgewinn nach Differenzmethode 124,27 EUR
+Erhaltene Kapst-pflichtige Stückzinsen 4,72 EUR
+Bemessungsgrundlage für Kapitalertragsteuer 128,99 EUR
+Stand Ihrer Töpfe und Freibeträge nach dem Geschäft
+Sparerpauschbetrag nach dem Geschäft 0,00 EUR
+Verrechnungstopf Aktien nach dem Geschäft 123,70 EUR
+Verrechnungstopf Allg. nach dem Geschäft 0,00 EUR
+Verrechnungstopf QUST nach dem Geschäft 0,00 EUR
+Es wurde keine Kirchensteuer einbehalten.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland (AG nach franz. Recht).
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/AnleiheVerkauf02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/AnleiheVerkauf02.txt
@@ -1,0 +1,65 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.87.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Consorsbank • 90318 Nürnberg
+Depotnummer 0123456789
+1504753979/00
+Vorname Nachname
+Adress Str. 1
+01234 Stadt Vermerk der Bank 2000
+02
+ORDERABRECHNUNG
+VERKAUF AM 25.11.2020  UM 10:55:28 INL.AUSSERBOERSLICH NR. 182034228.001
+Bezeichnung WKN ISIN
+3,65 % GRIECHENLAND 12-32 10       24.FEB A1G1UK GR0133010232
+Einheit Umsatz Fälligkeit
+EUR 160,00000 Letzte Fälligkeit 24.02.2032
+Kurs 130,791000  % FRANCO COURTAGE  
+Kurswert EUR 209,27
+Stückzins    Zinsvaluta    26.11.2020    277    Tage EUR 4,42
+Provision EUR 5,00
+Grundgebühr EUR 4,95
+KAPST 25,00% EUR 34,51
+SOLZ 5,50% EUR 1,89
+Wert 27.11.2020 EUR 167,34
+zugunsten Konto-Nr. 8291948001
+Bestand zulasten Girosammelverwahrung 
+CBF 2126
+JAHRESSTEUERBESCHEINIGUNG FOLGT
+Limitkurs  130,791000 %
+Beratungsfreies Geschäft
+Hinweis für Orderabrechnungen und Depotbuchungsanzeigen:
+Einwendungen wegen Unrichtigkeit oder Unvollständigkeit dieser Mitteilung müssen unverzüglich erhoben werden, vgl. Nummer B. Ziffer I. 11 (4) und (5) der
+Allgemeinen Geschäftsbedingungen (AGB Banken).
+Machen Sie Ihre Einwendungen in Textform geltend, genügt die Absendung innerhalb der Sechs-Wochen-Frist an die Consorsbank oder per Fax oder Mail an die
+unten angegebenen Adressen. Das Unterlassen rechtzeitiger Einwendungen gilt als Genehmigung.
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland (AG nach franz. Recht).
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+Seite 2 zu Orderabrechnung Nr. 182034228.001 vom 25.11.2020 Depotnummer 0123456789
+Infos bei Gewinn Aktien/ Wertpapiere ungleich Aktien
+Veräusserungsgewinn nach Differenzmethode EUR 133,60
+Erhaltene Kapst-pflichtige Stückzinsen EUR 4,42
+Summe ergibt
+KAPST-pflichtige Kapitalerträge EUR 138,02
+Mit Sparerpauschbetrag verrechnet EUR 0,00
+Bemessungsgrundlage für KAPST vor QUST EUR 138,02
+An Kapitalertrag anrechenbare. ausl. QUST 0,00*4 EUR 0,00
+Bemessungsgrundlage für KAPST EUR 138,02
+Bemessungsgrundlage für KAPST anteilig 100,00% EUR 138,02
+Salden nach dem Geschäft
+Verrechnungstopf Aktien nach dem Geschäft EUR 123,42
+Verrechnungstopf Allg. nach dem Geschäft EUR 0,00
+Verrechnungstopf QUST nach dem Geschäft EUR 0,00
+Sparerpauschbetrag nach dem Geschäft EUR 0,00
+Es wurde keine Kirchensteuer einbehalten.
+ 
+Consorsbank ist eine eingetragene Marke der BNP Paribas S.A. Niederlassung Deutschland (AG nach franz. Recht).
+Standort Nürnberg: Bahnhofstraße 55, 90402 Nürnberg, HRB Nürnberg 31129, USt-IdNr. DE191528929
+Fon +49 (0) 911 / 369-30 00, Fax +49 (0) 911 / 369-10 00, info@consorsbank.de, www.consorsbank.de
+Sitz der BNP Paribas S.A.: 16, boulevard des Italiens, 75009 Paris, Frankreich, Registergericht: R.C.S. Paris 662 042 449
+Président du Conseil d‘Administration (Präsident des Verwaltungsrates): Jean Lemierre, Directeur Général (Generaldirektor): Jean-Laurent Bonnafé
+

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/consorsbank/ConsorsbankPDFExtractorTest.java
@@ -118,7 +118,7 @@ public class ConsorsbankPDFExtractorTest
         assertThat(results, hasItem(purchase( //
                         hasDate("2015-09-21T12:45:38"), hasShares(250.00), //
                         hasSource("Kauf02.txt"), //
-                        hasNote("92612045.001 | Limitkurs  5,500000 EUR"), //
+                        hasNote("92612045.001 | Limitkurs 5,500000 EUR"), //
                         hasAmount("EUR", 1387.85), hasGrossValue("EUR", 1370.00), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 2.95 + 3.00 + 5.00 + 4.95 + 1.95))));
     }
@@ -186,7 +186,7 @@ public class ConsorsbankPDFExtractorTest
         assertThat(results, hasItem(purchase( //
                         hasDate("2020-01-15T12:00:56"), hasShares(210.00), //
                         hasSource("Kauf04.txt"), //
-                        hasNote("123456.001 | Limitkurs  46,200000 EUR"), //
+                        hasNote("123456.001 | Limitkurs 46,200000 EUR"), //
                         hasAmount("EUR", 9745.25), hasGrossValue("EUR", 9702.00), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 2.50 + 11.54 + 24.26 + 4.95))));
     }
@@ -912,7 +912,7 @@ public class ConsorsbankPDFExtractorTest
         assertThat(results, hasItem(purchase( //
                         hasDate("2019-09-06T13:43:10"), hasShares(300.00), //
                         hasSource("Kauf20.txt"), //
-                        hasNote("148553598.001 | Limitkurs  11,300000 EUR"), //
+                        hasNote("148553598.001 | Limitkurs 11,300000 EUR"), //
                         hasAmount("EUR", 3408.64), hasGrossValue("EUR", 3390.00), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 2.50 + 2.71 + 8.48 + 4.95))));
     }
@@ -946,7 +946,7 @@ public class ConsorsbankPDFExtractorTest
         assertThat(results, hasItem(purchase( //
                         hasDate("2020-03-27T20:13:13"), hasShares(37.00), //
                         hasSource("Kauf21.txt"), //
-                        hasNote("161127520.001 | Limitkurs  27,700000 EUR"), //
+                        hasNote("161127520.001 | Limitkurs 27,700000 EUR"), //
                         hasAmount("EUR", 1026.34), hasGrossValue("EUR", 1016.39), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 5.00 + 4.95))));
     }
@@ -1360,7 +1360,7 @@ public class ConsorsbankPDFExtractorTest
         assertThat(results, hasItem(purchase( //
                         hasDate("2017-12-19T17:00:34"), hasShares(4000), //
                         hasSource("AnleiheKauf01.txt"), //
-                        hasNote("120321388.001 | Limitkurs  0,550000 %"), //
+                        hasNote("120321388.001 | Limitkurs 0,550000 %"), //
                         hasAmount("EUR", 2210.45), hasGrossValue("EUR", 2200.00), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 5.50 + 4.95))));
     }
@@ -1462,7 +1462,7 @@ public class ConsorsbankPDFExtractorTest
         assertThat(results, hasItem(sale( //
                         hasDate("2015-02-18T12:10:30"), hasShares(140.00), //
                         hasSource("Verkauf01.txt"), //
-                        hasNote("12345678.001 | Limitkurs  42,850000 EUR"), //
+                        hasNote("12345678.001 | Limitkurs 42,850000 EUR"), //
                         hasAmount("EUR", 5794.56), hasGrossValue("EUR", 6048.00), //
                         hasTaxes("EUR", 198.08 + 17.82 + 10.89), hasFees("EUR", 2.95 + 3.63 + 15.12 + 4.95))));
     }
@@ -1941,6 +1941,74 @@ public class ConsorsbankPDFExtractorTest
                         hasNote("15681369.001"), //
                         hasAmount("EUR", 211.30), hasGrossValue("EUR", 222.20), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.95 + 5.00 + 4.95))));
+    }
+
+    @Test
+    public void testAnleiheVerkauf01()
+    {
+        var extractor = new ConsorsbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "AnleiheVerkauf01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("GR0133007204"), hasWkn("A1G1UG"), hasTicker(null), //
+                        hasName("3,65 % GRIECHENLAND 12-29 7 24.FEB"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2020-12-14T16:06:51"), hasShares(1.6), //
+                        hasSource("AnleiheVerkauf01.txt"), //
+                        hasNote("183797558.001 | Limitkurs 124,963000 % | Stückzins 296 Tage 4,72 EUR"), //
+                        hasAmount("EUR", 160.69), hasGrossValue("EUR", 204.66), //
+                        hasTaxes("EUR", 32.25 + 1.77), hasFees("EUR", 5.00 + 4.95))));
+    }
+
+    @Test
+    public void testAnleiheVerkauf02()
+    {
+        var extractor = new ConsorsbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "AnleiheVerkauf02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("GR0133010232"), hasWkn("A1G1UK"), hasTicker(null), //
+                        hasName("3,65 % GRIECHENLAND 12-32 10       24.FEB"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2020-11-25T10:55:28"), hasShares(1.6), //
+                        hasSource("AnleiheVerkauf02.txt"), //
+                        hasNote("182034228.001 | Limitkurs 130,791000 % | Stückzins 277 Tage EUR 4,42"), //
+                        hasAmount("EUR", 167.34), hasGrossValue("EUR", 213.69), //
+                        hasTaxes("EUR", 34.51 + 1.89), hasFees("EUR", 5.00 + 4.95))));
     }
 
     @Test

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -397,7 +397,7 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         // Stückzins    Zinsvaluta    26.11.2020    277    Tage EUR 4,42
                         // @formatter:on
                         .section("note1", "note2").optional() //
-                        .match("^(Hallo)?(?<note1>St.ckzins) .* (?<note2>[\\d]+\\s+Tag(e)?\\s+([\\.,\\d]+ [A-Z]{3}|[A-Z]{3} [\\.,\\d]+))$") //
+                        .match("^(?<note1>St.ckzins) .* (?<note2>[\\d]+\\s+Tag(e)?\\s+([\\.,\\d]+ [A-Z]{3}|[A-Z]{3} [\\.,\\d]+))$") //
                         .assign((t, v) -> {
                             t.setNote(concatenate(t.getNote(), v.get("note1"), " | "));
                             t.setNote(concatenate(t.getNote(), replaceMultipleBlanks(v.get("note2")), " "));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/ConsorsbankPDFExtractor.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
 import static name.abuchen.portfolio.util.TextUtil.concatenate;
+import static name.abuchen.portfolio.util.TextUtil.replaceMultipleBlanks;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
@@ -381,7 +382,8 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("note").optional() //
                         .match("^(?<note>Limitkurs .*)") //
-                        .assign((t, v) -> t.setNote(concatenate(t.getNote(), v.get("note"), " | ")))
+                        .assign((t, v) -> t
+                                        .setNote(concatenate(t.getNote(), replaceMultipleBlanks(v.get("note")), " | ")))
 
                         // @formatter:off
                         // Ursprungs-WKN 549532
@@ -392,12 +394,13 @@ public class ConsorsbankPDFExtractor extends AbstractPDFExtractor
 
                         // @formatter:off
                         // Stückzins Zinsvaluta 10.07.2023 356 Tage 25,60 EUR
+                        // Stückzins    Zinsvaluta    26.11.2020    277    Tage EUR 4,42
                         // @formatter:on
                         .section("note1", "note2").optional() //
-                        .match("^(?<note1>St.ckzins) .* (?<note2>[\\d]+ Tag(e)? [\\.,\\d]+ [A-Z]{3})$") //
+                        .match("^(Hallo)?(?<note1>St.ckzins) .* (?<note2>[\\d]+\\s+Tag(e)?\\s+([\\.,\\d]+ [A-Z]{3}|[A-Z]{3} [\\.,\\d]+))$") //
                         .assign((t, v) -> {
                             t.setNote(concatenate(t.getNote(), v.get("note1"), " | "));
-                            t.setNote(concatenate(t.getNote(), v.get("note2"), " "));
+                            t.setNote(concatenate(t.getNote(), replaceMultipleBlanks(v.get("note2")), " "));
                         })
 
                         .optionalOneOf( //


### PR DESCRIPTION
Sometime between November and December 2020 Consors changed their PDF format leading to the info about interests paid/received when buying/selling bonds not being recognized if an older version is attempted to be imported. This PR fixes that.

At the moment this has only a cosmetic effect on the note but with an upcoming bond-support this might change.

While at it; I've changed the note-adding to remove multiple blanks, because sometimes the limit price appeared as `Limitpreis 12,34` and sometimes as `Limitpreis   12,34`. This had an effect on existing tests where this effect also occurred and was ignored.