### PR TITLE
Keep source when doing buy/sell <-> inbound/outbound-delivery conversions

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/actions/ConvertBuySellToDeliveryAction.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/actions/ConvertBuySellToDeliveryAction.java
@@ -69,6 +69,7 @@ public class ConvertBuySellToDeliveryAction extends Action
             delivery.setSecurity(buySellTransaction.getSecurity());
             delivery.setNote(buySellTransaction.getNote());
             delivery.setShares(buySellTransaction.getShares());
+            delivery.setSource(buySellTransaction.getSource());
 
             buySellTransaction.getUnits().forEach(delivery::addUnit);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/actions/ConvertDeliveryToBuySellAction.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/actions/ConvertDeliveryToBuySellAction.java
@@ -85,6 +85,7 @@ public class ConvertDeliveryToBuySellAction extends Action
             entry.setSecurity(deliveryTransaction.getSecurity());
             entry.setNote(deliveryTransaction.getNote());
             entry.setShares(deliveryTransaction.getShares());
+            entry.setSource(deliveryTransaction.getSource());
 
             deliveryTransaction.getUnits().forEach(entry.getPortfolioTransaction()::addUnit);
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/actions/ConvertTransferToDepositRemovalAction.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/actions/ConvertTransferToDepositRemovalAction.java
@@ -49,6 +49,7 @@ public class ConvertTransferToDepositRemovalAction extends Action
                 tx.setNote(transaction.getNote());
                 tx.setSecurity(transaction.getSecurity());
                 tx.setShares(transaction.getShares());
+                tx.setSource(transaction.getSource());
             }
 
             // add deposit and withdrawal transactions to accounts


### PR DESCRIPTION
When converting a buy/sell transaction to an inbound/outbound transaction the source value get lost. This PR fixes that.

Same for transfer <-> inbound/outbound conversion but I'm not sure if that's something where a source value is currently set (but the field now is editable)