### PR TITLE
Flatex Degiro AT: Support of interest charges in account statements

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FinTechGroupBankPDFExtractorTest.java
@@ -75,7 +75,7 @@ import name.abuchen.portfolio.online.impl.CoinGeckoQuoteFeed;
 @SuppressWarnings("nls")
 public class FinTechGroupBankPDFExtractorTest
 {
-    FinTechGroupBankPDFExtractor extractor = new FinTechGroupBankPDFExtractor(new Client())
+    FinTechGroupBankPDFExtractor cryptoExtractor = new FinTechGroupBankPDFExtractor(new Client())
     {
         @Override
         protected List<SecuritySearchProvider> lookupCryptoProvider()
@@ -4659,7 +4659,7 @@ public class FinTechGroupBankPDFExtractorTest
     {
         List<Exception> errors = new ArrayList<>();
 
-        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDegiroCryptoKauf01.txt"), errors);
+        var results = cryptoExtractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDegiroCryptoKauf01.txt"), errors);
 
         assertThat(errors, empty());
         assertThat(countSecurities(results), is(1L));
@@ -5105,7 +5105,7 @@ public class FinTechGroupBankPDFExtractorTest
     {
         List<Exception> errors = new ArrayList<>();
 
-        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDegiroCryptoVerkauf01.txt"),
+        var results = cryptoExtractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDegiroCryptoVerkauf01.txt"),
                         errors);
 
         assertThat(errors, empty());
@@ -5140,7 +5140,7 @@ public class FinTechGroupBankPDFExtractorTest
     {
         List<Exception> errors = new ArrayList<>();
 
-        var results = extractor.extract(
+        var results = cryptoExtractor.extract(
                         PDFInputFile.loadTestCase(getClass(), "FlatExDegiroSammelabrechnungCrypto01.txt"), errors);
 
         assertThat(errors, empty());
@@ -8516,6 +8516,30 @@ public class FinTechGroupBankPDFExtractorTest
                         hasAmount("EUR", 1319.57), hasGrossValue("EUR", 1386.40), //
                         hasForexGrossValue("USD", 1604.34), //
                         hasTaxes("EUR", 51.93 + 2.85 + 4.15), hasFees("EUR", 5.90 + 2.00))));
+    }
+
+    @Test
+    public void testFlatExDeGiroRechnungsabschluss01()
+    {
+        var extractor = new FinTechGroupBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "FlatExDegiroRechnungsabschluss01.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "EUR");
+
+        assertThat(results, hasItem(interestCharge(hasDate("2026-06-30"), hasAmount("EUR", 8.21), //
+                        hasSource("FlatExDegiroRechnungsabschluss01.txt"), hasNote(null))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatExDegiroRechnungsabschluss01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/fintechgroupbank/FlatExDegiroRechnungsabschluss01.txt
@@ -1,0 +1,37 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.86.1
+System: macosx | aarch64 | 21.0.5+11-LTS | Azul Systems, Inc.
+
+flatexDEGIRO Bank SE
+Kundenservice
+Gadollaplatz 1
+8010 Graz
+Tel.: +43 - (0)720 518 777
+Mail: info@flatex.at
+flatexDEGIRO Bank SE - Gadollaplatz 1 - A-8010 Graz
+dVuzqYjAOCJKiXvezLOcTZ
+ZdVTGlf qwQHDFhM                       Graz, 03.07.2026
+XXQwBBBhnj 1
+6407 JoHMMVOFjC Bd MtrcREDfnU
+ÖSTERREICH
+Rechnungsabschluss: 01.04.2026 - 30.06.2026
+Kontonummer: 27663626044
+dazugehörige IBAN: pk039418935266777952
+Kontenart: Kontokorrentkonto
+Kontowährung: EUR
+Saldo vor Rechnungsabschluss nFm 30.06.2026: -522,32 EUR
+Zeitraum Saldo Zinssatz Betrag
+01.04.2026 - 30.06.2026 -525,55 6,250 % -8,21 EUR
+Summe Zinsen: -8,21 EUR
+Einbehaltene Steuer: 0,00 EUR
+Rechnungsabschluss: -8,21 EUR
+Saldo nach Rechnungsabschluss zum 30.06.2026: -530,53 EUR
+Der Rechnungsabschluss gilt als genehmigt, wenn Sie nicht innerhalb von 6 Wochen nach Zugang Ihre Einwendungen
+anzeigen, vgl. Ziffer 8, Abs. 2 unserer AGB.
+flatexDEGIRO Bank SE Niederlassung Österreich | Societas Europaea | Gadollaplatz 1 | 8010 Graz | Landesgericht für Zivilrechtssachen Graz | FN 334642 x | UID ATU 65140956
+Hauptniederlassung: flatexDEGIRO Bank SE | Omniturm | Große Gallusstr. 16-18 | 60312 Frankfurt am Main (Deutschland) | Amtsgericht Frankfurt am Main | HRB 141330
+
+Vorsitzender des Aufsichtsrats: Hans-Hermann Lotter | Vorstand: Oliver Behrens (Vorsitzender), Dr. Benon Janos (stellv. Vorsitzender),
+Evgeni Kaplun, Jens Möbitz, Christiane Strubel -
+Seite 1 von 1
+2000006083770330 035112101000

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -3998,7 +3998,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                         .match("^Einbehaltene Steuer:\\D+(?<tax>[,.\\d]+).*$")
                         .match("^Saldo nach Rechnungsabschluss zum (?<date>\\d{2}\\.\\d{2}\\.\\d{4}).*$")
                         .assign((t, v) -> {
-                            String currencyCode = v.get("currency");
+                            String currencyCode = asCurrencyCode(v.get("currency"));
 
                             t.setDateTime(asDate(v.get("date")));
                             t.setAmount(asAmount(v.get("amount")));

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/FinTechGroupBankPDFExtractor.java
@@ -25,6 +25,7 @@ import name.abuchen.portfolio.model.AccountTransaction;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.model.Transaction.Unit.Type;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
@@ -58,6 +59,7 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
         addAdvanceTaxTransaction();
         addDepotServiceFeesTransaction();
         addNonImportableTransaction();
+        addAccountStatementTransaction();
     }
 
     @Override
@@ -3966,6 +3968,53 @@ public class FinTechGroupBankPDFExtractor extends AbstractPDFExtractor
                             if (!type.getCurrentContext().getBoolean("negative") && type.getCurrentContext().getBoolean("isPurchaseBonds"))
                                 processFeeEntries(t, v, type);
                         });
+    }
+
+    private void addAccountStatementTransaction()
+    {
+        final var type = new DocumentType("Rechnungsabschluss");
+
+        // @formatter:off
+        // Summe Zinsen: -8,21 EUR
+        // Einbehaltene Steuer: 0,00 EUR
+        // Rechnungsabschluss: -8,21 EUR
+        // Saldo nach Rechnungsabschluss zum 30.06.2026: -530,53 EUR
+        // @formatter:on
+        var interestBlock = new Block("^Summe Zinsen:\\s+\\-[,.\\d]+\\s+[A-Z]{3}.*$");
+        type.addBlock(interestBlock);
+
+        interestBlock.set(new Transaction<AccountTransaction>()
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.INTEREST_CHARGE))
+
+                        // @formatter:off
+                        // Summe Zinsen: -8,21 EUR
+                        // Einbehaltene Steuer: 0,00 EUR
+                        // Rechnungsabschluss: -8,21 EUR
+                        // Saldo nach Rechnungsabschluss zum 30.06.2026: -530,53 EUR
+                        // @formatter:on
+                        .section("date", "amount", "currency", "tax") //
+                        .match("^Summe Zinsen:\\s+\\-(?<amount>[,.\\d]+)\\s+(?<currency>[A-Z]{3}).*$")
+                        .match("^Einbehaltene Steuer:\\D+(?<tax>[,.\\d]+).*$")
+                        .match("^Saldo nach Rechnungsabschluss zum (?<date>\\d{2}\\.\\d{2}\\.\\d{4}).*$")
+                        .assign((t, v) -> {
+                            String currencyCode = v.get("currency");
+
+                            t.setDateTime(asDate(v.get("date")));
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setCurrencyCode(currencyCode);
+
+                            var tax = Money.of(currencyCode, asAmount(v.get("tax")));
+                            if (tax.getAmount() != 0)
+                            {
+                                Type unitType = Unit.Type.TAX;
+                                t.addUnit(new Unit(unitType, tax));
+                            }
+                        })
+
+                        .wrap(TransactionItem::new));
+
+        this.addDocumentTyp(type);
     }
 
     @Override


### PR DESCRIPTION
There is a version of PDFs for FlatexDegiro as provided in the [PP-forum](https://forum.portfolio-performance.info/t/pdf-import-von-flatex-at/10776/144?u=kimmerin) that lead to errors when parsing. This PR adds a parsing block for account statements and supprt for this particular transaction (the PDF doesn't contain anything else).