### PR TITLE
PDF: SGKB - support additional currencies and transaction types

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Dividende03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Dividende03.txt
@@ -1,0 +1,37 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.85.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+VVFsFvT wX Vermögensverwaltungskonto USD
+Depot-Nr. 9999.2345.6789 / GyVnmCB QcuwBiJw
+IBAN CH75 4423 1222 3877 4167 5
+St.Galler Kantonalbank AG
+St. Leonhardstrasse 25
+9001 St. Gallen
+www.sgkb.ch
+BIC KBSGCH22
+Ihr Kontakt: xPBHs jOilPL LYrRMj uLlneHc bp
+Telefon +41 71 227 38 75
+YAUCuZe 3762
+xPBHs.LYrRMj@sgkb.ch
+1505 YN XK
+St. Gallen, 8. Juli 2026
+Referenznummer 0345051361
+Barausschüttung
+Ihr Depotbestand per Ex-Datum 1. Juni 2026:
+750 N-Akt Nike Inc -B- Namenaktien
+Valoren-Nr.: 957150, ISIN: US6541061031
+Wir teilen Ihnen mit, dass wir die folgenden Erträgnisse unter Eingangsvorbehalt abgerechnet haben:
+Ausschüttung: USD 0.41
+Ertragsart: Ordentliche Dividende
+Betrag USD 307.50
+Quellensteuer 15% USD 46.13
+Zusätzlicher Steuerrückbehalt(CHF -36.03) USD 46.13
+Total USD 215.24 Zu Ihren Gunsten
+Valuta 01.07.2026 USD 215.24
+Rückforderbarer Steuerrückbehalt USA: 15 % von USD 307.50 = USD 46.13 = CHF 36.03 (Devisenkurs: 0.781100)
+Pauschale Steueranrechnung in der Schweiz: 15 % von USD 307.50 = USD 46.13 = CHF 36.03 (Devisenkurs: 0.781100)
+Die Abrechnung dient der Geltendmachung von Verrechnungs- und Rückforderungsansprüchen.
+Freundliche Grüsse
+St.Galler Kantonalbank AG
+PrintPreview 4119066 229616451 BP00000000 Seite 1 von 1

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Dividende04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Dividende04.txt
@@ -1,0 +1,36 @@
+Hediek HG
+Vermögensverwaltungskonto USD
+Depot-Nr. 5136.8157.5484 / PRIVATE WACHSTUM
+IBAN CH56 4818 7915 8432 2145 9
+St.Galler Kantonalbank AG
+St. Leonhardstrasse 25
+9001 St. Gallen
+www.sgkb.ch
+BIC KBSGCH22
+Ihr Kontakt:
+Muster Herzog Müller Hediek HG
+Telefon +41 71 227 97 79 Ktdiowdfas 125c
+muster.mueller@sgkb.ch 6636 Ujdfownf
+ 
+St. Gallen, 14. August 2026
+Referenznummer 1820855466
+Barausschüttung
+Ihr Depotbestand per Ex-Datum 10. August 2026:
+250 N-Akt Apple Inc USD 0.00001 nom
+Namenaktien Valoren-Nr.: 908440, ISIN: US0378331005
+Wir teilen Ihnen mit, dass wir die folgenden Erträgnisse unter Eingangsvorbehalt abgerechnet haben:
+Ausschüttung: USD 0.27
+Ertragsart: Ordentliche Dividende
+Betrag USD 67.50
+Quellensteuer 15% USD 10.13
+Zusätzlicher Steuerrückbehalt(CHF -8.18) USD 10.13
+Total USD 47.24
+Zu Ihren Gunsten Valuta 13.08.2026 USD 47.24
+Rückforderbarer Steuerrückbehalt USA:
+15 % von USD 67.50 = USD 10.13 = CHF 8.18 (Devisenkurs: 0.807500)
+Pauschale Steueranrechnung in der Schweiz:
+15 % von USD 67.50 = USD 10.13 = CHF 8.18 (Devisenkurs: 0.807500)
+Die Abrechnung dient der Geltendmachung von Verrechnungs- und Rückforderungsansprüchen.
+Freundliche Grüsse
+St.Galler Kantonalbank AG
+PrintPreview 4144837 230915148 BP00000000

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Dividende05.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Dividende05.txt
@@ -1,0 +1,29 @@
+Hediek HG
+Vermögensverwaltungskonto USD
+Depot-Nr. 5136.8157.5484 / PRIVATE WACHSTUM
+IBAN CH56 4818 7915 8432 2145 9
+St.Galler Kantonalbank AG
+St. Leonhardstrasse 25
+9001 St. Gallen
+www.sgkb.ch
+BIC KBSGCH22
+Ihr Kontakt:
+Muster Herzog Müller Hediek HG
+Telefon +41 71 227 97 79 Ktdiowdfas 125c
+muster.mueller@sgkb.ch 6636 Ujdfownf
+ 
+St. Gallen, 8. Juli 2026
+Referenznummer 1798034814
+Barausschüttung
+Ihr Depotbestand per Ex-Datum 4. Juni 2026:
+100 N-Akt Linde PLC EUR 0.001 nom
+Namenaktien Valoren-Nr.: 124625792, ISIN: IE000S9YS762
+Wir teilen Ihnen mit, dass wir die folgenden Erträgnisse unter Eingangsvorbehalt abgerechnet haben:
+Ausschüttung: USD 1.60
+Ertragsart: Ordentliche Dividende
+Betrag USD 160.00
+Total USD 160.00
+Zu Ihren Gunsten Valuta 18.06.2026 USD 160.00
+Freundliche Grüsse
+St.Galler Kantonalbank AG
+PrintPreview 4119064 229616453 BP00000000

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Kauf02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Kauf02.txt
@@ -1,0 +1,43 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.85.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+VVFsFvT wX Vermögensverwaltungskonto CHF
+Depot-Nr. 8563.5863.3467 / NkYDmDU CZpfRDnl
+IBAN CH56 7637 3751 4833 2247 2
+St.Galler Kantonalbank AG
+St. Leonhardstrasse 25
+9001 St. Gallen
+www.sgkb.ch
+BIC KBSGCH22
+Ihr Kontakt: ZYoEd VFysae vXkksX ihoEjmz Eu
+Telefon +41 71 227 18 40
+xmYVHKt 6150
+ZYoEd.vXkksX@sgkb.ch
+6447 du Qb
+St. Gallen, 8. Juli 2026
+Referenznummer 2327228781
+Abrechnung: Ihr Kauf
+Wir haben für Sie am 28. Mai 2026 gekauft (Details siehe Folgeseite):
+500 N-Akt Nestle AG CHF 0.1 nom
+Valoren-Nr. 3886335
+ISIN CH0038863350
+Währung Betrag
+Kurs CHF 79.39
+CHF 39'695.00
+Eidg. Stempelsteuer CHF 29.77
+Ausführungsgebühr SSX CHF 4.08
+Total CHF 39'728.85 Zu Ihren Lasten
+Valuta 01.06.2026 CHF 39'728.85
+Die Titel wurden in Ihr Depot eingebucht.
+Wir danken für Ihren Auftrag.
+Freundliche Grüsse
+St.Galler Kantonalbank AG
+PrintPreview 4118853 229614434 BP00000000 Seite 1 von 2
+wNbbDKA tQ Vermögensverwaltungskonto CHF
+IBAN CH56 7637 3751 4833 2247 2
+Ausführungsdetails
+Die Abrechnung setzt sich wie folgt zusammen:
+Menge Ausführungszeitpunkt Börsenplatz Währung Kurs
+500 28.05.2026 14:04:36 SIX Swiss Exchange - EBBO Book CHF 79.39
+PrintPreview 4118853 229614434 BP00000000 Seite 2 von 2

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Kauf03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Kauf03.txt
@@ -1,0 +1,47 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.87.1.202608231105
+System: win32 | x86_64 | 21.0.12.1+1-LTS | Eclipse Adoptium
+-----------------------------------------
+VVFsFvT wX
+Vermögensverwaltungskonto CHF
+Depot-Nr. 1234.5678.9012 / SAMPLE PORTFOLIO
+IBAN CH00 0000 0000 0000 0000 0
+St.Galler Kantonalbank AG
+St. Leonhardstrasse 25
+9001 St. Gallen
+www.sgkb.ch
+BIC KBSGCH22
+Ihr Kontakt:
+Anna Muster Elektronisch versandt
+Telefon +41 71 000 00 00 VVFsFvT wX
+anna.muster@sgkb.ch Musterweg 1
+ 9000 St. Gallen
+St. Gallen, 16. Juli 2026
+Referenznummer 1234567890
+Abrechnung: Ihr Kauf
+Wir haben für Sie am 16. Juli 2026 gekauft (Details siehe Folgeseite):
+500 N-Akt Georg Fischer AG CHF 0.05 nom Valoren-Nr. 116915100
+ISIN CH1169151003
+Währung Betrag
+Kurs CHF 45.52164 CHF 22'760.82
+Eidg. Stempelsteuer CHF 17.07
+Ausführungsgebühr SSX CHF 2.98
+Total CHF 22'780.87
+Zu Ihren Lasten Valuta 20.07.2026 CHF 22'780.87
+Die Titel wurden in Ihr Depot eingebucht. Wir danken für Ihren Auftrag.
+Freundliche Grüsse
+St.Galler Kantonalbank AG
+244681 229793318 1234567890 Seite 1 von 2
+VVFsFvT wX
+Vermögensverwaltungskonto CHF
+IBAN CH00 0000 0000 0000 0000 0
+Ausführungsdetails
+Die Abrechnung setzt sich wie folgt zusammen:
+Menge Ausführungszeitpunkt Börsenplatz Währung Kurs
+26 16.07.2026 10:04:49 SIX Swiss Exchange CHF 45.52
+65 16.07.2026 10:04:49 SIX Swiss Exchange CHF 45.52
+120 16.07.2026 10:04:49 SIX Swiss Exchange CHF 45.52
+50 16.07.2026 10:04:49 SIX Swiss Exchange CHF 45.52
+198 16.07.2026 10:04:49 SIX Swiss Exchange - EBBO Book CHF 45.52
+41 16.07.2026 10:04:49 SIX Swiss Exchange CHF 45.54
+244681 229793318 1234567890 Seite 2 von 2

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Kauf04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Kauf04.txt
@@ -1,0 +1,44 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.87.1.202608241030
+System: win32 | x86_64 | 21.0.12.1+1-LTS | Eclipse Adoptium
+-----------------------------------------
+VVFsFvT wX
+Vermögensverwaltungskonto CHF
+Depot-Nr. 1234.5678.9012 / SAMPLE PORTFOLIO
+IBAN CH00 0000 0000 0000 0000 0
+St.Galler Kantonalbank AG
+St. Leonhardstrasse 25
+9001 St. Gallen
+www.sgkb.ch
+BIC KBSGCH22
+Ihr Kontakt:
+Anna Muster VVFsFvT wX
+Telefon +41 71 000 00 00 Musterweg 1
+anna.muster@sgkb.ch 9000 St. Gallen
+
+St. Gallen, 8. Juli 2026
+Referenznummer 1111111111
+Abrechnung: Ihr Kauf
+Wir haben für Sie am 2. Juni 2026 gekauft (Details siehe Folgeseite):
+30 N-Akt Partners Group Holding AG CHF Valoren-Nr. 2460882
+0.01 nom ISIN CH0024608827
+Währung Betrag
+Kurs CHF 820.40 CHF 24'612.00
+Eidg. Stempelsteuer CHF 18.46
+Ausführungsgebühr SSX CHF 3.10
+Total CHF 24'633.56
+Zu Ihren Lasten Valuta 04.06.2026 CHF 24'633.56
+Die Titel wurden in Ihr Depot eingebucht. Wir danken für Ihren Auftrag.
+Freundliche Grüsse
+St.Galler Kantonalbank AG
+PrintPreview 4118838 229614449 BP00000000 Seite 1 von 2
+VVFsFvT wX
+Vermögensverwaltungskonto CHF
+IBAN CH00 0000 0000 0000 0000 0
+Ausführungsdetails
+Die Abrechnung setzt sich wie folgt zusammen:
+Menge Ausführungszeitpunkt Börsenplatz Währung Kurs
+11 02.06.2026 16:57:26 SIX Swiss Exchange CHF 820.40
+15 02.06.2026 16:57:26 SIX Swiss Exchange CHF 820.40
+4 02.06.2026 16:57:26 SIX Swiss Exchange - EBBO Book CHF 820.40
+PrintPreview 4118838 229614449 BP00000000 Seite 2 von 2

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Kauf05.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Kauf05.txt
@@ -1,0 +1,42 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.87.1.202608241030
+System: win32 | x86_64 | 21.0.12.1+1-LTS | Eclipse Adoptium
+-----------------------------------------
+VVFsFvT wX
+Vermögensverwaltungskonto CHF
+Depot-Nr. 1234.5678.9012 / SAMPLE PORTFOLIO
+IBAN CH00 0000 0000 0000 0000 0
+St.Galler Kantonalbank AG
+St. Leonhardstrasse 25
+9001 St. Gallen
+www.sgkb.ch
+BIC KBSGCH22
+Ihr Kontakt:
+Anna Muster VVFsFvT wX
+Telefon +41 71 000 00 00 Musterweg 1
+anna.muster@sgkb.ch 9000 St. Gallen
+
+St. Gallen, 8. Juli 2026
+Referenznummer 2222222222
+Abrechnung: Ihr Kauf
+Wir haben für Sie am 23. Juni 2026 gekauft (Details siehe Folgeseite):
+250 N-Akt Compagnie Financiere Richemont SA Valoren-Nr. 21048333
+CHF 1 nom ISIN CH0210483332
+Währung Betrag
+Kurs CHF 178.75 CHF 44'687.50
+Eidg. Stempelsteuer CHF 33.52
+Ausführungsgebühr SSX CHF 4.40
+Total CHF 44'725.42
+Zu Ihren Lasten Valuta 25.06.2026 CHF 44'725.42
+Die Titel wurden in Ihr Depot eingebucht. Wir danken für Ihren Auftrag.
+Freundliche Grüsse
+St.Galler Kantonalbank AG
+PrintPreview 4118862 229614463 BP00000000 Seite 1 von 2
+VVFsFvT wX
+Vermögensverwaltungskonto CHF
+IBAN CH00 0000 0000 0000 0000 0
+Ausführungsdetails
+Die Abrechnung setzt sich wie folgt zusammen:
+Menge Ausführungszeitpunkt Börsenplatz Währung Kurs
+250 23.06.2026 15:29:12 SIX Swiss Exchange, SwissAtMid CHF 178.75
+PrintPreview 4118862 229614463 BP00000000 Seite 2 von 2

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Kauf06.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Kauf06.txt
@@ -1,0 +1,39 @@
+Hediek HG
+Vermögensverwaltungskonto USD
+Depot-Nr. 5136.8157.5484 / PRIVATE WACHSTUM
+IBAN CH56 4818 7915 8432 2145 9
+St.Galler Kantonalbank AG
+St. Leonhardstrasse 25
+9001 St. Gallen
+www.sgkb.ch
+BIC KBSGCH22
+Ihr Kontakt:
+Muster Herzog Müller Hediek HG
+Telefon +41 71 227 97 79 Ktdiowdfas 125c
+muster.mueller@sgkb.ch 6636 Ujdfownf
+ 
+St. Gallen, 8. Juli 2026
+Referenznummer 1798350508
+Abrechnung: Ihr Kauf
+Wir haben für Sie am 18. Juni 2026 gekauft (Details siehe Folgeseite):
+75 N-Akt Broadcom Inc USD 0.001 nom Valoren-Nr. 41112361
+ISIN US11135F1012
+Währung Betrag
+Kurs USD 409.30027 USD 30'697.52
+Eidg. Stempelsteuer(CHF -36.52) USD 46.04
+Fremde Courtage USD 0.45
+Total USD 30'744.01
+Zu Ihren Lasten Valuta 22.06.2026 USD 30'744.01
+Die Titel wurden in Ihr Depot eingebucht. Wir danken für Ihren Auftrag.
+Freundliche Grüsse
+St.Galler Kantonalbank AG
+PrintPreview 4119061 229616456 BP00000000 Seite 1 von 2
+Hediek HG
+Vermögensverwaltungskonto USD
+IBAN CH56 4818 7915 8432 2145 9
+Ausführungsdetails
+Diese Transaktion war Teil eines Sammelauftrages für mehrere Kundenbeziehungen. Zusammenlegungen von
+Kundenaufträgen erfolgen durch die SGKB gemäss den gesetzlichen Anforderungen und ihren Ausführungsgrundsätzen
+(www.sgkb.ch/ausführungsgrundsätze) oder im Auftrag von externen Vermögensverwaltern. Für detaillierte Informationen
+stehen wir Ihnen gerne zur Verfügung.
+PrintPreview 4119061 229616456 BP00000000 Seite 2 von 2

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Kauf07.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Kauf07.txt
@@ -1,0 +1,42 @@
+Hediek HG
+Vermögensverwaltungskonto USD
+Depot-Nr. 5136.8157.5484 / PRIVATE WACHSTUM
+IBAN CH56 4818 7915 8432 2145 9
+St.Galler Kantonalbank AG
+St. Leonhardstrasse 25
+9001 St. Gallen
+www.sgkb.ch
+BIC KBSGCH22
+Ihr Kontakt:
+Muster Herzog Müller Elektronisch versandt
+Telefon +41 71 227 97 79 Hediek HG
+muster.mueller@sgkb.ch Ktdiowdfas 125c
+ 6636 Ujdfownf
+St. Gallen, 13. Juli 2026
+Referenznummer 1809761290
+Abrechnung: Ihr Kauf (Emission)
+Wir haben für Sie am 13. Juli 2026 gekauft (Details siehe Folgeseite):
+Ausführungsplatz zum Net Asset Value
+Letzter Ausführungsplatz zum Net Asset Value
+Zeitpunkt letzte Ausführung 13.07.2026 18:30
+3'000 Uts Schroder Emerging Markets Valoren-Nr. 1034591
+-C-Acc-USD ISIN LU0106252546
+Währung Betrag
+Kurs USD 35.5616 USD 106'684.80
+Eidg. Stempelsteuer(CHF -129.09) USD 160.03
+Auftragsausführung Anlagefonds USD 2.46
+Total USD 106'847.29
+Zu Ihren Lasten Valuta 16.07.2026 USD 106'847.29
+Die Titel wurden in Ihr Depot eingebucht. Wir danken für Ihren Auftrag.
+Freundliche Grüsse
+St.Galler Kantonalbank AG
+244570 229717627 1809761290 Seite 1 von 2
+Hediek HG
+Vermögensverwaltungskonto USD
+IBAN CH56 4818 7915 8432 2145 9
+Ausführungsdetails
+Diese Transaktion war Teil eines Sammelauftrages für mehrere Kundenbeziehungen. Zusammenlegungen von
+Kundenaufträgen erfolgen durch die SGKB gemäss den gesetzlichen Anforderungen und ihren Ausführungsgrundsätzen
+(www.sgkb.ch/ausführungsgrundsätze) oder im Auftrag von externen Vermögensverwaltern. Für detaillierte Informationen
+stehen wir Ihnen gerne zur Verfügung.
+244570 229717627 1809761290 Seite 2 von 2

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/StGallerKantonalbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/StGallerKantonalbankPDFExtractorTest.java
@@ -582,7 +582,7 @@ public class StGallerKantonalbankPDFExtractorTest
         assertThat(results, hasItem(security( //
                         hasIsin("IE000S9YS762"), hasWkn("124625792"), hasTicker(null), //
                         hasName("N-Akt Linde PLC EUR 0.001 nom"), //
-                        hasCurrencyCode("USD"))));
+                        hasCurrencyCode("EUR"))));
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/StGallerKantonalbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/StGallerKantonalbankPDFExtractorTest.java
@@ -184,4 +184,413 @@ public class StGallerKantonalbankPDFExtractorTest
                         hasTaxes("EUR", 1058.17), //
                         hasFees("EUR", 0.00))));
     }
+
+    @Test
+    public void testWertpapierKauf02()
+    {
+        // Valoren-Nr. on its own line, Kurs line only carries the unit price
+        // (no second currency/amount pair), and the "Zu Ihren Lasten" prefix
+        // sits on the "Total" line instead of on the "Valuta" line.
+        var extractor = new StGallerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("CH0038863350"), hasWkn("3886335"), hasTicker(null), //
+                        hasName("N-Akt Nestle AG CHF 0.1 nom"), //
+                        hasCurrencyCode("CHF"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-05-28T14:04:36"), hasShares(500), //
+                        hasSource("Kauf02.txt"), //
+                        hasNote("Referenznummer 2327228781"), //
+                        hasAmount("CHF", 39728.85), hasGrossValue("CHF", 39695.00), //
+                        hasTaxes("CHF", 29.77), hasFees("CHF", 4.08))));
+    }
+
+    @Test
+    public void testWertpapierKauf03()
+    {
+        // Short security name: Valoren-Nr. inline on the shares/name line,
+        // multi-lot execution table with several rows sharing the same
+        // execution timestamp.
+        var extractor = new StGallerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("CH1169151003"), hasWkn("116915100"), hasTicker(null), //
+                        hasName("N-Akt Georg Fischer AG CHF 0.05 nom"), //
+                        hasCurrencyCode("CHF"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-07-16T10:04:49"), hasShares(500), //
+                        hasSource("Kauf03.txt"), //
+                        hasNote("Referenznummer 1234567890"), //
+                        hasAmount("CHF", 22780.87), hasGrossValue("CHF", 22760.82), //
+                        hasTaxes("CHF", 17.07), hasFees("CHF", 2.98))));
+    }
+
+    @Test
+    public void testWertpapierKauf04()
+    {
+        // The nominal-value continuation ("0.01 nom") pushes ISIN off the
+        // start of its line: "0.01 nom ISIN CH0024608827".
+        var extractor = new StGallerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf04.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("CH0024608827"), hasWkn("2460882"), hasTicker(null), //
+                        hasName("N-Akt Partners Group Holding AG CHF"), //
+                        hasCurrencyCode("CHF"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-02T16:57:26"), hasShares(30), //
+                        hasSource("Kauf04.txt"), //
+                        hasNote("Referenznummer 1111111111"), //
+                        hasAmount("CHF", 24633.56), hasGrossValue("CHF", 24612.00), //
+                        hasTaxes("CHF", 18.46), hasFees("CHF", 3.10))));
+    }
+
+    @Test
+    public void testWertpapierKauf05()
+    {
+        // Same "nom" continuation pattern, this time with "CHF 1 nom" before ISIN.
+        var extractor = new StGallerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf05.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "CHF");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("CH0210483332"), hasWkn("21048333"), hasTicker(null), //
+                        hasName("N-Akt Compagnie Financiere Richemont SA"), //
+                        hasCurrencyCode("CHF"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-23T15:29:12"), hasShares(250), //
+                        hasSource("Kauf05.txt"), //
+                        hasNote("Referenznummer 2222222222"), //
+                        hasAmount("CHF", 44725.42), hasGrossValue("CHF", 44687.50), //
+                        hasTaxes("CHF", 33.52), hasFees("CHF", 4.40))));
+    }
+
+    @Test
+    public void testWertpapierKauf06()
+    {
+        // Bugfix: collective order ("Sammelauftrag") with neither a per-lot
+        // execution table nor a "Zeitpunkt letzte Ausführung" line on the
+        // document - the trade date must fall back to "Wir haben für Sie am
+        // ... gekauft" on the first page instead of failing the import.
+        var extractor = new StGallerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf06.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "USD");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US11135F1012"), hasWkn("41112361"), hasTicker(null), //
+                        hasName("N-Akt Broadcom Inc USD 0.001 nom"), //
+                        hasCurrencyCode("USD"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-18"), hasShares(75), //
+                        hasSource("Kauf06.txt"), //
+                        hasNote("Referenznummer 1798350508"), //
+                        hasAmount("USD", 30744.01), hasGrossValue("USD", 30697.52), //
+                        hasTaxes("USD", 46.04), hasFees("USD", 0.45))));
+    }
+
+    @Test
+    public void testWertpapierKauf07()
+    {
+        // Bugfix: "Abrechnung: Ihr Kauf (Emission)" collective order for a
+        // fund, no per-lot execution table but "Zeitpunkt letzte Ausführung"
+        // is present and preferred over the day-only fallback. Also covers
+        // the "Auftragsausführung Anlagefonds" fee.
+        var extractor = new StGallerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf07.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "USD");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("LU0106252546"), hasWkn("1034591"), hasTicker(null), //
+                        hasName("Uts Schroder Emerging Markets"), //
+                        hasCurrencyCode("USD"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-07-13T18:30"), hasShares(3000), //
+                        hasSource("Kauf07.txt"), //
+                        hasNote("Referenznummer 1809761290"), //
+                        hasAmount("USD", 106847.29), hasGrossValue("USD", 106684.80), //
+                        hasTaxes("USD", 160.03), hasFees("USD", 2.46))));
+    }
+
+    @Test
+    public void testWertpapierVerkauf02()
+    {
+        // Valoren-Nr. on its own line followed by a nameContinued line,
+        // multi-lot execution table, Kurs line with only the unit price.
+        var extractor = new StGallerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00BKSCBX74"), hasWkn("110951056"), hasTicker(null), //
+                        hasName("Ant UBS (Irl) ETF plc - UBS MSCI World Small Cap SR UCITS ETF Accum Shs USD"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-05-28T13:48:08"), hasShares(5500), //
+                        hasSource("Verkauf02.txt"), //
+                        hasNote("Referenznummer 0987763798"), //
+                        hasAmount("EUR", 59403.62), hasGrossValue("EUR", 59504.78), //
+                        hasTaxes("EUR", 89.26), hasFees("EUR", 11.90))));
+    }
+
+    @Test
+    public void testWertpapierVerkauf03()
+    {
+        // Bugfix: collective order ("Sammelauftrag") sale, date falls back to
+        // "Zeitpunkt letzte Ausführung". Also covers the "SEC Börsengebühr" fee.
+        var extractor = new StGallerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "USD");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US0231351067"), hasWkn("645156"), hasTicker(null), //
+                        hasName("N-Akt Amazon.com Inc USD 0.01 nom"), //
+                        hasCurrencyCode("USD"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-08-05T16:49"), hasShares(220), //
+                        hasSource("Verkauf03.txt"), //
+                        hasNote("Referenznummer 1818805876"), //
+                        hasAmount("USD", 60929.95), hasGrossValue("USD", 61024.06), //
+                        hasTaxes("USD", 91.53), hasFees("USD", 1.26 + 1.32))));
+    }
+
+    @Test
+    public void testDividende03()
+    {
+        // Split "Total ... Zu Ihren Gunsten" / "Valuta ..." layout (no prefix
+        // on the Valuta line itself), plus the "Zusätzlicher Steuerrückbehalt"
+        // additional US withholding tax.
+        var extractor = new StGallerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "USD");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US6541061031"), hasWkn("957150"), hasTicker(null), //
+                        hasName("N-Akt Nike Inc -B- Namenaktien"), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-07-01"), hasExDate("2026-06-01"), //
+                        hasShares(750), //
+                        hasSource("Dividende03.txt"), //
+                        hasNote("Referenznummer 0345051361"), //
+                        hasAmount("USD", 215.24), hasGrossValue("USD", 307.50), //
+                        hasTaxes("USD", 46.13 + 46.13), hasFees("USD", 0.00))));
+    }
+
+    @Test
+    public void testDividende04()
+    {
+        // Bugfix: the security's WKN/ISIN line has a "Namenaktien" prefix
+        // before "Valoren-Nr.:" instead of standing on its own - this must not
+        // be mistaken for a separate nameContinued line. Also covers the
+        // "Zusätzlicher Steuerrückbehalt" additional US withholding tax on the
+        // single-line "Zu Ihren Gunsten Valuta ..." layout.
+        var extractor = new StGallerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende04.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "USD");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US0378331005"), hasWkn("908440"), hasTicker(null), //
+                        hasName("N-Akt Apple Inc USD 0.00001 nom"), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-08-13"), hasExDate("2026-08-10"), //
+                        hasShares(250), //
+                        hasSource("Dividende04.txt"), //
+                        hasNote("Referenznummer 1820855466"), //
+                        hasAmount("USD", 47.24), hasGrossValue("USD", 67.50), //
+                        hasTaxes("USD", 10.13 + 10.13), hasFees("USD", 0.00))));
+    }
+
+    @Test
+    public void testDividende05()
+    {
+        // Same "Namenaktien Valoren-Nr.:" prefix as Dividende04, but without
+        // any withholding tax at all - the security is EUR-denominated while
+        // the distribution itself is paid in USD.
+        var extractor = new StGallerKantonalbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende05.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "USD");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE000S9YS762"), hasWkn("124625792"), hasTicker(null), //
+                        hasName("N-Akt Linde PLC EUR 0.001 nom"), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-06-18"), hasExDate("2026-06-04"), //
+                        hasShares(100), //
+                        hasSource("Dividende05.txt"), //
+                        hasNote("Referenznummer 1798034814"), //
+                        hasAmount("USD", 160.00), hasGrossValue("USD", 160.00), //
+                        hasTaxes("USD", 0.00), hasFees("USD", 0.00))));
+    }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Verkauf02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Verkauf02.txt
@@ -1,0 +1,46 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.85.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+NkZZevp bS Vermögensverwaltungskonto EUR
+Depot-Nr. 9999.2345.6789 / GyVnmCB QcuwBiJw
+IBAN CH75 4423 1222 3877 4167 5
+St.Galler Kantonalbank AG
+St. Leonhardstrasse 25
+9001 St. Gallen
+www.sgkb.ch
+BIC KBSGCH22
+Ihr Kontakt: xPBHs jOilPL LYrRMj uLlneHc bp
+Telefon +41 71 227 38 75
+YAUCuZe 3762
+xPBHs.LYrRMj@sgkb.ch
+1505 YN XK
+St. Gallen, 8. Juli 2026
+Referenznummer 0987763798
+Abrechnung: Ihr Verkauf
+Wir haben für Sie am 28. Mai 2026 verkauft (Details siehe Folgeseite):
+5'500 Ant UBS (Irl) ETF plc - UBS MSCI World
+Valoren-Nr. 110951056
+Small Cap SR UCITS ETF Accum Shs USD
+ISIN IE00BKSCBX74
+Währung Betrag
+Kurs EUR 10.81905
+EUR 59'504.78
+Eidg. Stempelsteuer(CHF -81.66) EUR 89.26
+Fremde Courtage EUR 11.90
+Total EUR 59'403.62 Zu Ihren Gunsten
+Valuta 01.06.2026 EUR 59'403.62
+Die Titel wurden Ihrem Depot entnommen.
+Wir danken für Ihren Auftrag.
+Freundliche Grüsse
+St.Galler Kantonalbank AG
+PrintPreview 4119018 229616414 BP00000000 Seite 1 von 2
+JSpRjmF vk Vermögensverwaltungskonto EUR
+IBAN CH75 4423 1222 3877 4167 5
+Ausführungsdetails
+Die Abrechnung setzt sich wie folgt zusammen:
+Menge Ausführungszeitpunkt Börsenplatz Währung Kurs
+1'516 28.05.2026 13:48:08 Xetra ETFs & ETPs EUR 10.822
+1'922 28.05.2026 13:48:08 Xetra ETFs & ETPs EUR 10.82
+2'062 28.05.2026 13:48:08 Xetra ETFs & ETPs EUR 10.816
+PrintPreview 4119018 229616414 BP00000000 Seite 2 von 2

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Verkauf03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/stgallerkantonalbank/Verkauf03.txt
@@ -1,0 +1,43 @@
+Hediek HG
+Vermögensverwaltungskonto USD
+Depot-Nr. 5136.8157.5484 / PRIVATE WACHSTUM
+IBAN CH56 4818 7915 8432 2145 9
+St.Galler Kantonalbank AG
+St. Leonhardstrasse 25
+9001 St. Gallen
+www.sgkb.ch
+BIC KBSGCH22
+Ihr Kontakt:
+Muster Herzog Müller Elektronisch versandt
+Telefon +41 71 227 97 79 Hediek HG
+muster.mueller@sgkb.ch Ktdiowdfas 125c
+ 6636 Ujdfownf
+St. Gallen, 5. August 2026
+Referenznummer 1818805876
+Abrechnung: Ihr Verkauf
+Wir haben für Sie am 5. August 2026 verkauft (Details siehe Folgeseite):
+Ausführungsplatz Multi Execution
+Letzter Ausführungsplatz BARCLAYS ATS
+Zeitpunkt letzte Ausführung 05.08.2026 16:49
+220 N-Akt Amazon.com Inc USD 0.01 nom Valoren-Nr. 645156
+ISIN US0231351067
+Währung Betrag
+Kurs USD 277.382113 USD 61'024.06
+Eidg. Stempelsteuer(CHF -74.09) USD 91.53
+SEC Börsengebühr USD 1.26
+Fremde Courtage USD 1.32
+Total USD 60'929.95
+Zu Ihren Gunsten Valuta 06.08.2026 USD 60'929.95
+Die Titel wurden Ihrem Depot entnommen. Wir danken für Ihren Auftrag.
+Freundliche Grüsse
+St.Galler Kantonalbank AG
+245523 230678118 1818805876 Seite 1 von 2
+Hediek HG
+Vermögensverwaltungskonto USD
+IBAN CH56 4818 7915 8432 2145 9
+Ausführungsdetails
+Diese Transaktion war Teil eines Sammelauftrages für mehrere Kundenbeziehungen. Zusammenlegungen von
+Kundenaufträgen erfolgen durch die SGKB gemäss den gesetzlichen Anforderungen und ihren Ausführungsgrundsätzen
+(www.sgkb.ch/ausführungsgrundsätze) oder im Auftrag von externen Vermögensverwaltern. Für detaillierte Informationen
+stehen wir Ihnen gerne zur Verfügung.
+245523 230678118 1818805876 Seite 2 von 2

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/StGallerKantonalbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/StGallerKantonalbankPDFExtractor.java
@@ -4,6 +4,9 @@ import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGros
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
@@ -206,6 +209,32 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
         addFeesSectionsTransaction(pdfTransaction, type);
     }
 
+    // @formatter:off
+    // Matches the nominal-value suffix embedded in a security name, e.g.
+    // "N-Akt Linde PLC EUR 0.001 nom" or "N-Akt Apple Inc USD 0.00001 nom".
+    // This denotes the security's own (home) currency and can differ from
+    // the currency a particular dividend happens to be paid in (e.g. a
+    // EUR-denominated stock paying a USD distribution).
+    // @formatter:on
+    private static final Pattern NOMINAL_CURRENCY_PATTERN = Pattern.compile("\\b([A-Z]{3})\\s+[\\.'\\d]+\\s+nom\\b");
+
+    /**
+     * If the security name carries an explicit nominal-value currency (see
+     * {@link #NOMINAL_CURRENCY_PATTERN}), it takes precedence over the
+     * currency inferred from the distribution/payment amount, since the
+     * latter need not match the security's own trading currency.
+     */
+    private Map<String, String> overrideWithNominalCurrency(Map<String, String> v, String name, String nameContinued)
+    {
+        var combined = nameContinued != null ? name + " " + nameContinued : name;
+
+        Matcher m = NOMINAL_CURRENCY_PATTERN.matcher(combined);
+        if (m.find())
+            v.put("currency", asCurrencyCode(m.group(1)));
+
+        return v;
+    }
+
     private void addDividendeTransaction()
     {
         final var type = new DocumentType("Baraussch.ttung");
@@ -236,7 +265,7 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
                                                         .match("^(?<nameContinued>.*)$") //
                                                         .match("^(.*\\s)?Valoren\\-Nr\\.: (?<wkn>[A-Z0-9]{5,9}), ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
                                                         .match("^Aussch.ttung: (?<currency>[A-Z]{3}) [\\.'\\d]+$") //
-                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))) //
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(overrideWithNominalCurrency(v, v.get("name"), v.get("nameContinued"))))) //
                                         , //
                                         // @formatter:off
                                         // 10'000 N-Akt TUI AG Aus Konversion
@@ -251,8 +280,19 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
                                         // Valoren-Nr.: 957150, ISIN: US6541061031
                                         // Ausschüttung: USD 0.41
                                         //
+                                        // 100 N-Akt Linde PLC EUR 0.001 nom
+                                        // Namenaktien Valoren-Nr.: 124625792, ISIN: IE000S9YS762
+                                        // Ausschüttung: USD 1.60
+                                        //
                                         // The "Valoren-Nr.:" line may or may not have prefix text (e.g. a share
                                         // class continuation like "Namenaktien") before it.
+                                        //
+                                        // The security's home/nominal currency (embedded in the name as
+                                        // "<currency> <nominal value> nom", e.g. "EUR 0.001 nom") does not always
+                                        // match the currency the distribution is paid in - e.g. a EUR-denominated
+                                        // stock (Linde PLC) can pay a USD dividend. In that case the security must
+                                        // keep its own EUR currency rather than being tainted by the USD payment
+                                        // currency picked up from the "Ausschüttung:" line.
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "wkn", "isin", "currency") //
@@ -260,7 +300,7 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
                                                         .match("^[\\.'\\d]+ (?<name>.*)$") //
                                                         .match("^(.*\\s)?Valoren\\-Nr\\.: (?<wkn>[A-Z0-9]{5,9}), ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
                                                         .match("^Aussch.ttung: (?<currency>[A-Z]{3}) [\\.'\\d]+$") //
-                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))) //
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(overrideWithNominalCurrency(v, v.get("name"), null)))) //
                         )
 
                         // @formatter:off

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/StGallerKantonalbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/StGallerKantonalbankPDFExtractor.java
@@ -17,9 +17,21 @@ import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 
 /**
- * St.Galler Kantonalbank AG
+ * @formatter:off
+ * @implNote St.Galler Kantonalbank AG
  *
- * @implSpec The VALOR number is the WKN number with 5 to 9 digits/characters.
+ * @implSpec The Valoren-Nr. is the WKN and, in all observed documents, is 5 to 9 digits/characters.
+ *
+ *           The trade date is preferably taken from the per-lot execution table on the second page
+ *           ("Menge Ausführungszeitpunkt Börsenplatz Währung Kurs"), which provides the most precise
+ *           timestamp (including seconds). For collective orders ("Sammelaufträge" - an order bundled
+ *           together with orders from other clients), this table is not always present on the second
+ *           page. In that case, the extractor falls back to "Zeitpunkt letzte Ausführung" on the first
+ *           page (minute precision) and, if that is missing too, to the date in "Wir haben für Sie am
+ *           ... (gekauft|verkauft)" on the first page, which is always present but only has day
+ *           precision. The trade date must never be required from the second page alone, since it is
+ *           not always available for collective orders.
+ * @formatter:on
  */
 
 @SuppressWarnings("nls")
@@ -30,6 +42,7 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
         super(client);
 
         addBankIdentifier("St.Galler Kantonalbank AG");
+        addBankIdentifier("St. Galler Kantonalbank");
 
         addBuySellTransaction();
         addDividendeTransaction();
@@ -58,35 +71,81 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
 
                         // Is type --> "Verkauf" change from BUY to SELL
                         .section("type").optional() //
-                        .match("^Abrechnung: Ihr (?<type>(Kauf|Verkauf))$") //
+                        .match("^Abrechnung: Ihr (?<type>(Kauf|Verkauf)).*$") //
                         .assign((t, v) -> {
                             if ("Verkauf".equals(v.get("type")))
                                 t.setType(PortfolioTransaction.Type.SELL);
                         })
 
-                        // @formatter:off
-                        // 10'000 N-Akt TUI AG Aus Konversion Valoren-Nr. 125205291
-                        // ISIN DE000TUAG505
-                        // Währung Betrag
-                        // Kurs EUR 6.822613 EUR 68'226.13
-                        // @formatter:on
-                        .section("name", "wkn", "isin", "currency") //
-                        .match("^[\\.'\\d]+ (?<name>.*) Valoren\\-Nr\\. (?<wkn>[A-Z0-9]{5,9})$") //
-                        .match("^ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
-                        .match("^Kurs (?<currency>[A-Z]{3}) [\\.'\\d]+ [A-Z]{3} [\\.'\\d]+$") //
-                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
-
-                        // @formatter:off
-                        // 10'000 N-Akt TUI AG Aus Konversion Valoren-Nr. 125205291
-                        // @formatter:on
-                        .section("shares") //
-                        .match("^(?<shares>[\\.'\\d]+) .* Valoren\\-Nr\\. [A-Z0-9]{5,9}$") //
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+                        .oneOf( //
+                                        // @formatter:off
+                                        // Wir haben für Sie am 16. Juli 2026 gekauft (Details siehe Folgeseite):
+                                        // 500 N-Akt Georg Fischer AG CHF 0.05 nom Valoren-Nr. 116915100
+                                        // ISIN CH1169151003
+                                        // Währung Betrag
+                                        // Kurs CHF 45.52164 CHF 22'760.82
+                                        //
+                                        // Short security names have the Valoren-Nr. inline on the same line as
+                                        // shares/name instead of on its own line.
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares", "name", "wkn", "isin", "currency") //
+                                                        .find("Wir haben f.r Sie am .* (gekauft|verkauft).*") //
+                                                        .match("^(?<shares>[\\.'\\d]+) (?<name>.*?) Valoren\\-Nr\\. (?<wkn>[A-Z0-9]{5,9})$") //
+                                                        .match("^.*ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                                                        .match("^W.hrung Betrag$") //
+                                                        .match("^Kurs (?<currency>[A-Z]{3}) [\\.'\\d]+( [A-Z]{3} [\\.'\\d]+)?$") //
+                                                        .assign((t, v) -> {
+                                                            t.setSecurity(getOrCreateSecurity(v));
+                                                            t.setShares(asShares(v.get("shares")));
+                                                        }),
+                                        // @formatter:off
+                                        // Wir haben für Sie am 28. Mai 2026 verkauft (Details siehe Folgeseite):
+                                        // 5'500 Ant UBS (Irl) ETF plc - UBS MSCI World
+                                        // Valoren-Nr. 110951056
+                                        // Small Cap SR UCITS ETF Accum Shs USD
+                                        // ISIN IE00BKSCBX74
+                                        // Währung Betrag
+                                        // Kurs EUR 10.81905
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares", "name", "wkn", "nameContinued", "isin", "currency") //
+                                                        .find("Wir haben f.r Sie am .* (gekauft|verkauft).*") //
+                                                        .match("^(?<shares>[\\.'\\d]+) (?<name>.*)$") //
+                                                        .match("^Valoren\\-Nr\\. (?<wkn>[A-Z0-9]{5,9})$") //
+                                                        .match("^(?<nameContinued>.*)$") //
+                                                        .match("^.*ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                                                        .match("^W.hrung Betrag$") //
+                                                        .match("^Kurs (?<currency>[A-Z]{3}) [\\.'\\d]+( [A-Z]{3} [\\.'\\d]+)?$") //
+                                                        .assign((t, v) -> {
+                                                            t.setSecurity(getOrCreateSecurity(v));
+                                                            t.setShares(asShares(v.get("shares")));
+                                                        }),
+                                        // @formatter:off
+                                        // Wir haben für Sie am 28. Mai 2026 gekauft (Details siehe Folgeseite):
+                                        // 500 N-Akt Nestle AG CHF 0.1 nom
+                                        // Valoren-Nr. 3886335
+                                        // ISIN CH0038863350
+                                        // Währung Betrag
+                                        // Kurs CHF 79.39
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares", "name", "wkn", "isin", "currency") //
+                                                        .find("Wir haben f.r Sie am .* (gekauft|verkauft).*") //
+                                                        .match("^(?<shares>[\\.'\\d]+) (?<name>.*)$") //
+                                                        .match("^Valoren\\-Nr\\. (?<wkn>[A-Z0-9]{5,9})$") //
+                                                        .match("^.*ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                                                        .match("^W.hrung Betrag$") //
+                                                        .match("^Kurs (?<currency>[A-Z]{3}) [\\.'\\d]+( [A-Z]{3} [\\.'\\d]+)?$") //
+                                                        .assign((t, v) -> {
+                                                            t.setSecurity(getOrCreateSecurity(v));
+                                                            t.setShares(asShares(v.get("shares")));
+                                                        }))
 
                         .oneOf( //
                                         // @formatter:off
                                         // Menge Ausführungszeitpunkt Börsenplatz Währung Kurs
-                                        // 10'000 20.02.2025 09:00:13 Xetra EUR 6.702
+                                        // 500 28.05.2026 14:04:36 SIX Swiss Exchange - EBBO Book CHF 79.39
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date", "time") //
@@ -94,8 +153,23 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
                                                         .match("^[\\.'\\d]+ (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}\\:[\\d]{2}\\:[\\d]{2}) .*$") //
                                                         .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time")))),
                                         // @formatter:off
+                                        // Diese Transaktion war Teil eines Sammelauftrages für mehrere Kundenbeziehungen.
+                                        // In this case, the per-lot execution table above is not present. If the order was
+                                        // executed as a single fill, "Zeitpunkt letzte Ausführung" gives the exact time instead.
+                                        //
+                                        // Zeitpunkt letzte Ausführung 13.07.2026 18:30
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date", "time") //
+                                                        .match("^Zeitpunkt letzte Ausf.hrung (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}\\:[\\d]{2})$") //
+                                                        .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time")))),
+                                        // @formatter:off
                                         // Wir haben für Sie am 24. Februar 2025 gekauft (Details siehe Folgeseite):
-                                        // Wir haben für Sie am 20. Februar 2025 verkauft (Details siehe Folgeseite):
+                                        // Wir haben für Sie am 18. Juni 2026 gekauft (Details siehe Folgeseite):
+                                        //
+                                        // Fallback for collective orders ("Sammelaufträge") where neither the per-lot
+                                        // execution table nor "Zeitpunkt letzte Ausführung" is present on the document.
+                                        // This line is always present, but only provides day precision.
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("date") //
@@ -103,11 +177,17 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> t.setDate(asDate(v.get("date")))))
 
                         // @formatter:off
-                        // Zu Ihren Lasten Valuta 26.02.2025 EUR 69'297.29
-                        // Zu Ihren Gunsten Valuta 24.02.2025 EUR 65'967.79
+                        // Total CHF 39'728.85 Zu Ihren Lasten
+                        // Valuta 01.06.2026 CHF 39'728.85
+                        //
+                        // Total EUR 59'403.62 Zu Ihren Gunsten
+                        // Valuta 01.06.2026 EUR 59'403.62
+                        //
+                        // Total CHF 22'780.87
+                        // Zu Ihren Lasten Valuta 20.07.2026 CHF 22'780.87
                         // @formatter:on
                         .section("currency", "amount") //
-                        .match("^Zu Ihren (Lasten|Gunsten) Valuta [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<currency>[A-Z]{3}) (?<amount>[\\.'\\d]+)$") //
+                        .match("^(Zu Ihren (Lasten|Gunsten) )?Valuta [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<currency>[A-Z]{3}) (?<amount>[\\.'\\d]+)$") //
                         .assign((t, v) -> {
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -154,7 +234,7 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
                                                         .find("Ihr Depotbestand per Ex\\-Datum .*") //
                                                         .match("^[\\.'\\d]+ (?<name>.*)$") //
                                                         .match("^(?<nameContinued>.*)$") //
-                                                        .match("^.* Valoren\\-Nr\\.: (?<wkn>[A-Z0-9]{5,9}), ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                                                        .match("^(.*\\s)?Valoren\\-Nr\\.: (?<wkn>[A-Z0-9]{5,9}), ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
                                                         .match("^Aussch.ttung: (?<currency>[A-Z]{3}) [\\.'\\d]+$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))) //
                                         , //
@@ -162,12 +242,23 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
                                         // 10'000 N-Akt TUI AG Aus Konversion
                                         // Namenaktien Valoren-Nr.: 125205291, ISIN: DE000TUAG505
                                         // Ausschüttung: EUR 0.10
+                                        //
+                                        // 250 N-Akt Apple Inc USD 0.00001 nom
+                                        // Namenaktien Valoren-Nr.: 908440, ISIN: US0378331005
+                                        // Ausschüttung: USD 0.27
+                                        //
+                                        // 750 N-Akt Nike Inc -B- Namenaktien
+                                        // Valoren-Nr.: 957150, ISIN: US6541061031
+                                        // Ausschüttung: USD 0.41
+                                        //
+                                        // The "Valoren-Nr.:" line may or may not have prefix text (e.g. a share
+                                        // class continuation like "Namenaktien") before it.
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("name", "wkn", "isin", "currency") //
                                                         .find("Ihr Depotbestand per Ex\\-Datum .*") //
                                                         .match("^[\\.'\\d]+ (?<name>.*)$") //
-                                                        .match("^.* Valoren\\-Nr\\.: (?<wkn>[A-Z0-9]{5,9}), ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                                                        .match("^(.*\\s)?Valoren\\-Nr\\.: (?<wkn>[A-Z0-9]{5,9}), ISIN: (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
                                                         .match("^Aussch.ttung: (?<currency>[A-Z]{3}) [\\.'\\d]+$") //
                                                         .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))) //
                         )
@@ -188,17 +279,23 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> t.setExDate(asDate(v.get("exDate"))))
 
                         // @formatter:off
-                        // Zu Ihren Gunsten Valuta 13.02.2026 EUR 736.25
+                        // Total USD 215.24 Zu Ihren Gunsten
+                        // Valuta 01.07.2026 USD 215.24
+                        //
+                        // Zu Ihren Gunsten Valuta 13.08.2026 USD 47.24
                         // @formatter:on
                         .section("date") //
-                        .match("^Zu Ihren Gunsten Valuta (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) [A-Z]{3} [\\.'\\d]+$") //
+                        .match("^(Zu Ihren Gunsten )?Valuta (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) [A-Z]{3} [\\.'\\d]+$") //
                         .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
                         // @formatter:off
-                        // Zu Ihren Gunsten Valuta 13.02.2026 EUR 736.25
+                        // Total USD 215.24 Zu Ihren Gunsten
+                        // Valuta 01.07.2026 USD 215.24
+                        //
+                        // Zu Ihren Gunsten Valuta 13.08.2026 USD 47.24
                         // @formatter:on
                         .section("currency", "amount") //
-                        .match("^Zu Ihren Gunsten Valuta [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<currency>[A-Z]{3}) (?<amount>[\\.'\\d]+)$") //
+                        .match("^(Zu Ihren Gunsten )?Valuta [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<currency>[A-Z]{3}) (?<amount>[\\.'\\d]+)$") //
                         .assign((t, v) -> {
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                             t.setAmount(asAmount(v.get("amount")));
@@ -244,6 +341,16 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
                         .match("^Eidg\\. Stempelsteuer ?(\\(.*\\))? (?<currency>[A-Z]{3}) (\\-)?(?<tax>[\\.'\\d]+)$") //
                         .assign((t, v) -> processTaxEntries(t, v, type))
 
+                        // @formatter:off
+                        // Zusätzlicher Steuerrückbehalt(CHF -36.03) USD 46.13
+                        //
+                        // Additional US withholding tax retained on top of the ordinary "Quellensteuer"
+                        // (e.g. under the Swiss/US relief-at-source mechanism) - only seen on USD dividends.
+                        // @formatter:on
+                        .section("currency", "tax").optional() //
+                        .match("^Zus.tzlicher Steuerr.ckbehalt\\(.*\\) (?<currency>[A-Z]{3}) (?<tax>[\\.'\\d]+)$") //
+                        .assign((t, v) -> processTaxEntries(t, v, type))
+
                         .optionalOneOf( //
                                         // @formatter:off
                                         // Quellensteuer 20% USD 1'243.77
@@ -262,6 +369,7 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
                                         ,
                                         // @formatter:off
                                         // Quellensteuer 26.375% EUR 263.75
+                                        // Quellensteuer 15% USD 10.13
                                         // @formatter:on
                                         section -> section //
                                                         .attributes("withHoldingTax", "currency") //
@@ -277,6 +385,13 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
         transaction //
 
                         // @formatter:off
+                        // Ausführungsgebühr SSX CHF 4.08
+                        // @formatter:on
+                        .section("currency", "fee").optional() //
+                        .match("^Ausf.hrungsgeb.hr( [A-Za-z0-9]+)? (?<currency>[A-Z]{3}) (\\-)?(?<fee>[\\.'\\d]+)$") //
+                        .assign((t, v) -> processFeeEntries(t, v, type))
+
+                        // @formatter:off
                         // Courtage EUR 955.17
                         // @formatter:on
                         .section("fee", "currency").optional() //
@@ -284,10 +399,24 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
-                        // Fremde Courtage EUR 13.65
+                        // Fremde Courtage EUR 11.90
                         // @formatter:on
-                        .section("fee", "currency").optional() //
+                        .section("currency", "fee").optional() //
                         .match("^Fremde Courtage (?<currency>[A-Z]{3}) (\\-)?(?<fee>[\\.'\\d]+)$") //
+                        .assign((t, v) -> processFeeEntries(t, v, type))
+
+                        // @formatter:off
+                        // Auftragsausführung Anlagefonds USD 2.46
+                        // @formatter:on
+                        .section("currency", "fee").optional() //
+                        .match("^Auftragsausf.hrung Anlagefonds (?<currency>[A-Z]{3}) (\\-)?(?<fee>[\\.'\\d]+)$") //
+                        .assign((t, v) -> processFeeEntries(t, v, type))
+
+                        // @formatter:off
+                        // SEC Börsengebühr USD 1.26
+                        // @formatter:on
+                        .section("currency", "fee").optional() //
+                        .match("^SEC B.rsengeb.hr (?<currency>[A-Z]{3}) (\\-)?(?<fee>[\\.'\\d]+)$") //
                         .assign((t, v) -> processFeeEntries(t, v, type));
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/StGallerKantonalbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/StGallerKantonalbankPDFExtractor.java
@@ -5,7 +5,6 @@ import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
 import java.util.Map;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
@@ -228,7 +227,7 @@ public class StGallerKantonalbankPDFExtractor extends AbstractPDFExtractor
     {
         var combined = nameContinued != null ? name + " " + nameContinued : name;
 
-        Matcher m = NOMINAL_CURRENCY_PATTERN.matcher(combined);
+        var m = NOMINAL_CURRENCY_PATTERN.matcher(combined);
         if (m.find())
             v.put("currency", asCurrencyCode(m.group(1)));
 


### PR DESCRIPTION
### Summary
Extends the PDF extractor for **St.Galler Kantonalbank (SGKB)** to support additional currencies and transaction types.

### Key Changes
- **Currencies:** Added parsing for additional currencies in SGKB PDF documents.
- **Transaction Types:** Added extraction logic for additional transaction types.
- **Unit Tests:** Added unit test cases with anonymised PDF text samples for the new document variants.