### PR TITLE
Targobank PDF-Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/Ausbuchung01.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/Ausbuchung01.txt
@@ -1,0 +1,37 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TARGOBANK AG
+Postfach 10 02 30
+47002 Duisburg
+TARGOBANK AG - Postfach 10 02 30 - 47002 Duisburg
+www.targobank.de
+HERR
+xxxx
+........................................................................................................................................................................................................
+Ausbuchung aus Ihrem Depot 09.12.2025
+Rechnungsnummer: TIT-2025-0223620158-000yyyy
+xxxx
+Sehr geehrter Depotkunde,
+wir teilen Ihnen mit, dass wir von Ihrem oben genannten Konto per Ausbuchung eine Übertragung mit
+den folgenden Merkmalen vorgenommen haben.
+Tag der Übertragung 09.12.2025
+Lieferung an ING-DIBA AG
+Begünstigter xxxx
+50010yyy 80023yyyy
+Stück/Nominal Produkt Verwahrart Neuer Bestand
+WKN/ISIN
+34,0000 ST MUL-AMUN ST600 BANK ETF A Girosammelverwahrung 0,0000 ST
+LYX01W / LU1834983477
+18,0000 ST ISHARES MDAX UC.ETF EOA Girosammelverwahrung 0,0000 ST
+593392 / DE0005933923
+Mit freundlichen Grüßen
+Ihre TARGOBANK
+Dieser Beleg wurde maschinell erstellt und wird nicht unterschrieben. Irrtum vorbehalten.
+Seite 1
+TARGOBANK AG | Vorstand: Isabelle Chevelard (Vorsitzende); Christophe Jéhan (stellv. Vorsitzender); Berthold Rüsing; Maria Topaler; Marco Voosen
+Vorsitzender des Aufsichtsrates:  René Dangel | Sitz der Gesellschaft: Düsseldorf
+Handelsregister Amtsgericht Düsseldorf HRB 83351 | USt-ID-Nr.: DE 811 285 485
+USt-ID-Nr. des umsatzsteuerlichen Organträgers: DE 811 623 326
+KH.20251210.020847.5002.0002.19941 X 0 R

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/Dividende09.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/Dividende09.txt
@@ -1,0 +1,36 @@
+PDFBox Version: 3.0.5
+Portfolio Performance Version: 0.80.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TARGOBANK AG & Co. KGaA
+Postfach 10 11 52
+47011 Duisburg
+www.targobank.de
+HERR
+lHRBeX eonrBlbk
+sadkjfb. 8
+29583 pMIQJvcuJ
+Ksadfj, WiiUGA 15.02.2013
+Dividendengutschrift
+Depot-Nr. 880600132508
+Konto-Nr. 5842249299
+APPLE INC. REGISTERED SHARES O.N. WKN ISIN
+865985 US0378331005
+Stück 15,0000
+Dividende pro Stück      USD         2,65000000   Zahlbar                14.02.2013
+Geschäftsjahr                       2012 / 2013   Ex-Tag                 07.02.2013
+Ursprungsland            USA
+                                                        USD                     EUR
+Bruttoertrag                                          39,75                   29,83
+15,0000 % Ausländische Quellensteuer                   5,96-                   4,47-
+Umrechnungskurs USD zu EUR        1,3324000
+Gutschrift mit Wert 18.02.2013                                                25,36
+Rechnungsnummer:        EE2-505-DC00-88560860962
+Dieser Beleg wurde maschinell erstellt und wird nicht unterschrieben. Irrtum vorbehalten.
+Persönlich haftender und geschäftsführender Gesellschafter: TARGO Management AG
+Vorstand: Franz Josef Nick (Vorsitzender); Peter Klein; Pascal Laugel; Jürgen Lieberknecht; Berthold Rüsing; Maria Topaler
+Vorsitzender des Aufsichtsrates: Eckart Thomä
+C Sitz der Gesellschaft: Düsseldorf · Handelsregister Amtsgericht Düsseldorf HRB 48380
+USt-ID-Nr.: DE 811 285 485 · USt-ID-Nr. des umsatzsteuerlichen Organträgers: DE 261 486 989
+GCB 000
+M 18 DIN A4  02  02.10

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/SteuerbehandlungVonDividende09.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/SteuerbehandlungVonDividende09.txt
@@ -1,0 +1,51 @@
+PDFBox Version: 3.0.5
+Portfolio Performance Version: 0.80.3
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TARGOBANK AG & Co. KGaA
+Postfach 10 11 52
+47011 Duisburg
+www.targobank.de
+HERR
+KZapeA zbyGVMut
+SSDVOENR. 8
+43767 mOhDWQxPr
+sdfnmler, oRVnaA 15.02.2013
+Dividendengutschrift
+Steuerbeilage Depot-Nr. 880600132508
+Konto-Nr. 5842249299
+APPLE INC. REGISTERED SHARES O.N. WKN ISIN
+865985 US0378331005
+Stück 15,0000
+Kapitalertrag- Solidaritäts-
+steuer zuschlag
+25,00 % * 5,50 %
+Steuerliche Bemessungsgrundlagen zur Ertragsgutschrift - keine Steuerbescheinigung
+Dividendenanteil Inland 0,00 EUR
+Zinsanteil Inland 0,00 EUR
+Dividendenanteil auf ausländische Dividenden, Veräußerungsgewinne, Stillhalterprämien 29,83 EUR
+und Termingeschäfte (§ 20 Abs. 2 EStG)
+Miet- und Pachterträge sowie Gewinne aus der Veräußerung von Immobilien 0,00 EUR
+Anrechenbare ausländische Quellensteuer 4,47 EUR
+Erträge / Verluste nach §20 EStG 29,83 EUR
+Auf- oder Abbau von steuerlichen Verrechnungsmöglichkeiten
+Verlustverrechnung aus Aktienhandel: 0,00 EUR
+Verlustverrechnung aus sonstigen Geschäften: 0,00 EUR
+Nutzung des Sparerpauschbetrages / Freistellungsauftrages -29,83 EUR
+Anrechnung ausländischer Quellensteuer ** 0,00 EUR
+Bemessungsgrundlage 0,00 EUR
+Kapitalertragsteuer (KESt): 0,00 EUR
+Solidaritätszuschlag auf KESt: 0,00 EUR
+Kirchensteuer auf KESt: 0,00 EUR
+Gesamtsumme Steuern 0,00 EUR
+Transaktionsreferenz  IND00009801615D00094890632
+* KESt grundsätzlich 25%. Bei Einbehalt von Kirchensteuer ändert sich der KESt-Satz entsprechend Ihres Kirchensteuersatzes.
+** Quellensteuer multipliziert mit 4 als Ertragsäquivalent
+Dieser Beleg wurde maschinell erstellt und wird nicht unterschrieben. Irrtum vorbehalten.
+Persönlich haftender und geschäftsführender Gesellschafter: TARGO Management AG
+Vorstand: Franz Josef Nick (Vorsitzender); Peter Klein; Pascal Laugel; Jürgen Lieberknecht; Berthold Rüsing; Maria Topaler
+C Vorsitzender des Aufsichtsrates: Eckart Thomä
+Sitz der Gesellschaft: Düsseldorf · Handelsregister Amtsgericht Düsseldorf HRB 48380
+USt-ID-Nr.: DE 811 285 485 · USt-ID-Nr. des umsatzsteuerlichen Organträgers: DE 261 486 989
+C240 01 © w 05.05(F1C240)
+M 18 DIN A4  02  02.10

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/SteuerbehandlungVonDividende10.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/SteuerbehandlungVonDividende10.txt
@@ -1,0 +1,51 @@
+PDFBox Version: 3.0.5
+Portfolio Performance Version: 0.80.3
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+TARGOBANK AG & Co. KGaA
+Postfach 10 11 52
+47011 Duisburg
+www.targobank.de
+HERR
+KZapeA zbyGVMut
+SSDVOENR. 8
+43767 mOhDWQxPr
+sdfnmler, oRVnaA 15.02.2013
+Dividendengutschrift
+Steuerbeilage Depot-Nr. 880600132508
+Konto-Nr. 5842249299
+APPLE INC. REGISTERED SHARES O.N. WKN ISIN
+865985 US0378331005
+Stück 15,0000
+Kapitalertrag- Solidaritäts-
+steuer zuschlag
+25,00 % * 5,50 %
+Steuerliche Bemessungsgrundlagen zur Ertragsgutschrift - keine Steuerbescheinigung
+Dividendenanteil Inland 0,00 EUR
+Zinsanteil Inland 0,00 EUR
+Dividendenanteil auf ausländische Dividenden, Veräußerungsgewinne, Stillhalterprämien 29,83 EUR
+und Termingeschäfte (§ 20 Abs. 2 EStG)
+Miet- und Pachterträge sowie Gewinne aus der Veräußerung von Immobilien 0,00 EUR
+Anrechenbare ausländische Quellensteuer 4,47 EUR
+Erträge / Verluste nach §20 EStG 29,83 EUR
+Auf- oder Abbau von steuerlichen Verrechnungsmöglichkeiten
+Verlustverrechnung aus Aktienhandel: 0,00 EUR
+Verlustverrechnung aus sonstigen Geschäften: 0,00 EUR
+Nutzung des Sparerpauschbetrages / Freistellungsauftrages -7,27 EUR
+Anrechnung ausländischer Quellensteuer ** -17,88 EUR
+Bemessungsgrundlage 4,68 EUR
+Kapitalertragsteuer (KESt): 1,17 EUR
+Solidaritätszuschlag auf KESt: 0,06 EUR
+Kirchensteuer auf KESt: 0,00 EUR
+Gesamtsumme Steuern 1,23 EUR
+Transaktionsreferenz  IND00009801615D00094890632
+* KESt grundsätzlich 25%. Bei Einbehalt von Kirchensteuer ändert sich der KESt-Satz entsprechend Ihres Kirchensteuersatzes.
+** Quellensteuer multipliziert mit 4 als Ertragsäquivalent
+Dieser Beleg wurde maschinell erstellt und wird nicht unterschrieben. Irrtum vorbehalten.
+Persönlich haftender und geschäftsführender Gesellschafter: TARGO Management AG
+Vorstand: Franz Josef Nick (Vorsitzender); Peter Klein; Pascal Laugel; Jürgen Lieberknecht; Berthold Rüsing; Maria Topaler
+C Vorsitzender des Aufsichtsrates: Eckart Thomä
+Sitz der Gesellschaft: Düsseldorf · Handelsregister Amtsgericht Düsseldorf HRB 48380
+USt-ID-Nr.: DE 811 285 485 · USt-ID-Nr. des umsatzsteuerlichen Organträgers: DE 261 486 989
+C240 01 © w 05.05(F1C240)
+M 18 DIN A4  02  02.10

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/TargobankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/targobank/TargobankPDFExtractorTest.java
@@ -5,6 +5,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasExDate;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasForexGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
@@ -16,6 +17,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.outboundDelivery;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
@@ -464,7 +466,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-06-24T00:00"), hasShares(81.00), //
+                        hasDate("2020-06-24T00:00"), hasExDate("2020-06-11"), //
+                        hasShares(81.00), //
                         hasSource("Dividende01.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0123456789-0001234"), //
                         hasAmount("EUR", 21.18), hasGrossValue("EUR", 21.18), //
@@ -500,7 +503,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-06-24T00:00"), hasShares(81.00), //
+                        hasDate("2020-06-24T00:00"), hasExDate("2020-06-11"), //
+                        hasShares(81.00), //
                         hasSource("Dividende01.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0123456789-0001234"), //
                         hasAmount("EUR", 21.18), hasGrossValue("EUR", 21.18), //
@@ -578,7 +582,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-06-24T00:00"), hasShares(81.00), //
+                        hasDate("2020-06-24T00:00"), hasExDate("2020-06-11"), //
+                        hasShares(81.00), //
                         hasSource("Dividende01.txt; SteuerbehandlungVonDividende01.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0123456789-0001234 | Tr.-Nr.: INDTBK1234567890"), //
                         hasAmount("EUR", 15.59), hasGrossValue("EUR", 21.18), //
@@ -616,7 +621,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-06-24T00:00"), hasShares(81.00), //
+                        hasDate("2020-06-24T00:00"), hasExDate("2020-06-11"), //
+                        hasShares(81.00), //
                         hasSource("Dividende01.txt; SteuerbehandlungVonDividende01.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0123456789-0001234 | Tr.-Nr.: INDTBK1234567890"), //
                         hasAmount("EUR", 15.59), hasGrossValue("EUR", 21.18), //
@@ -659,7 +665,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-06-24T00:00"), hasShares(81.00), //
+                        hasDate("2020-06-24T00:00"), hasExDate("2020-06-11"), //
+                        hasShares(81.00), //
                         hasSource("Dividende01.txt; SteuerbehandlungVonDividende01.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0123456789-0001234 | Tr.-Nr.: INDTBK1234567890"), //
                         hasAmount("EUR", 15.59), hasGrossValue("EUR", 21.18), //
@@ -696,7 +703,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-06-24T00:00"), hasShares(81.00), //
+                        hasDate("2020-06-24T00:00"), hasExDate("2020-06-11"), //
+                        hasShares(81.00), //
                         hasSource("Dividende01.txt; SteuerbehandlungVonDividende01.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0123456789-0001234 | Tr.-Nr.: INDTBK1234567890"), //
                         hasAmount("EUR", 15.59), hasGrossValue("EUR", 21.18), //
@@ -737,7 +745,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-06-24T00:00"), hasShares(61.00), //
+                        hasDate("2020-06-24T00:00"), hasExDate("2020-06-11"), //
+                        hasShares(61.00), //
                         hasSource("Dividende02.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0123456789-0001234"), //
                         hasAmount("EUR", 15.29), hasGrossValue("EUR", 15.29), //
@@ -810,7 +819,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-06-24T00:00"), hasShares(61.00), //
+                        hasDate("2020-06-24T00:00"), hasExDate("2020-06-11"), //
+                        hasShares(61.00), //
                         hasSource("Dividende02.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0123456789-0001234"), //
                         hasAmount("EUR", 15.29), hasGrossValue("EUR", 15.29), //
@@ -856,7 +866,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-06-24T00:00"), hasShares(61.00), //
+                        hasDate("2020-06-24T00:00"), hasExDate("2020-06-11"), //
+                        hasShares(61.00), //
                         hasSource("Dividende02.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0123456789-0001234"), //
                         hasAmount("EUR", 15.29), hasGrossValue("EUR", 15.29), //
@@ -900,7 +911,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-04-27T00:00"), hasShares(1700.00), //
+                        hasDate("2020-04-27T00:00"), hasExDate("2020-04-22"), //
+                        hasShares(1700.00), //
                         hasSource("Dividende03.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0223620168-0001148"), //
                         hasAmount("EUR", 279.64), hasGrossValue("EUR", 279.64), //
@@ -936,7 +948,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-04-27T00:00"), hasShares(1700.00), //
+                        hasDate("2020-04-27T00:00"), hasExDate("2020-04-22"), //
+                        hasShares(1700.00), //
                         hasSource("Dividende03.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0223620168-0001148"), //
                         hasAmount("EUR", 279.64), hasGrossValue("EUR", 279.64), //
@@ -1014,7 +1027,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-04-27T00:00"), hasShares(1700.00), //
+                        hasDate("2020-04-27T00:00"), hasExDate("2020-04-22"), //
+                        hasShares(1700.00), //
                         hasSource("Dividende03.txt; SteuerbehandlungVonDividende03.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0223620168-0001148 | Tr.-Nr.: INDTBK12120CG000130O00"), //
                         hasAmount("EUR", 228.01), hasGrossValue("EUR", 279.64), //
@@ -1052,7 +1066,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-04-27T00:00"), hasShares(1700.00), //
+                        hasDate("2020-04-27T00:00"), hasExDate("2020-04-22"), //
+                        hasShares(1700.00), //
                         hasSource("Dividende03.txt; SteuerbehandlungVonDividende03.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0223620168-0001148 | Tr.-Nr.: INDTBK12120CG000130O00"), //
                         hasAmount("EUR", 228.01), hasGrossValue("EUR", 279.64), //
@@ -1095,7 +1110,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-04-27T00:00"), hasShares(1700.00), //
+                        hasDate("2020-04-27T00:00"), hasExDate("2020-04-22"), //
+                        hasShares(1700.00), //
                         hasSource("Dividende03.txt; SteuerbehandlungVonDividende03.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0223620168-0001148 | Tr.-Nr.: INDTBK12120CG000130O00"), //
                         hasAmount("EUR", 228.01), hasGrossValue("EUR", 279.64), //
@@ -1132,7 +1148,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-04-27T00:00"), hasShares(1700.00), //
+                        hasDate("2020-04-27T00:00"), hasExDate("2020-04-22"), //
+                        hasShares(1700.00), //
                         hasSource("Dividende03.txt; SteuerbehandlungVonDividende03.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0223620168-0001148 | Tr.-Nr.: INDTBK12120CG000130O00"), //
                         hasAmount("EUR", 228.01), hasGrossValue("EUR", 279.64), //
@@ -1173,7 +1190,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-07-10T00:00"), hasShares(1790.00), //
+                        hasDate("2020-07-10T00:00"), hasExDate("2020-07-08"), //
+                        hasShares(1790.00), //
                         hasSource("Dividende04.txt"), //
                         hasNote("R.-Nr.: NUMMER"), //
                         hasAmount("EUR", 17.90), hasGrossValue("EUR", 17.90), //
@@ -1246,7 +1264,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-07-10T00:00"), hasShares(1790.00), //
+                        hasDate("2020-07-10T00:00"), hasExDate("2020-07-08"), //
+                        hasShares(1790.00), //
                         hasSource("Dividende04.txt"), //
                         hasNote("R.-Nr.: NUMMER"), //
                         hasAmount("EUR", 17.90), hasGrossValue("EUR", 17.90), //
@@ -1292,7 +1311,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-07-10T00:00"), hasShares(1790.00), //
+                        hasDate("2020-07-10T00:00"), hasExDate("2020-07-08"), //
+                        hasShares(1790.00), //
                         hasSource("Dividende04.txt"), //
                         hasNote("R.-Nr.: NUMMER"), //
                         hasAmount("EUR", 17.90), hasGrossValue("EUR", 17.90), //
@@ -1336,12 +1356,13 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-08-31T00:00"), hasShares(235.00), //
+                        hasDate("2020-08-31T00:00"), hasExDate("2020-08-21"), //
+                        hasShares(235.00), //
                         hasSource("Dividende05.txt"), //
                         hasNote("R.-Nr.: NUMMER"), //
-                        hasAmount("EUR", 20.82 + 3.67), hasGrossValue("EUR", 20.82 + 3.67), //
+                        hasAmount("EUR", 20.82), hasGrossValue("EUR", 20.82 + 3.67), //
                         hasForexGrossValue("USD", 29.41), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+                        hasTaxes("EUR", 3.67), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -1372,11 +1393,12 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-08-31T00:00"), hasShares(235.00), //
+                        hasDate("2020-08-31T00:00"), hasExDate("2020-08-21"), //
+                        hasShares(235.00), //
                         hasSource("Dividende05.txt"), //
                         hasNote("R.-Nr.: NUMMER"), //
-                        hasAmount("EUR", 20.82 + 3.67), hasGrossValue("EUR", 20.82 + 3.67), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        hasAmount("EUR", 20.82), hasGrossValue("EUR", 20.82 + 3.67), //
+                        hasTaxes("EUR", 3.67), hasFees("EUR", 0.00), //
                         check(tx -> {
                             var c = new CheckCurrenciesAction();
                             var account = new Account();
@@ -1452,12 +1474,13 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-08-31T00:00"), hasShares(235.00), //
+                        hasDate("2020-08-31T00:00"), hasExDate("2020-08-21"), //
+                        hasShares(235.00), //
                         hasSource("Dividende05.txt"), //
                         hasNote("R.-Nr.: NUMMER"), //
-                        hasAmount("EUR", 20.82 + 3.67), hasGrossValue("EUR", 20.82 + 3.67), //
+                        hasAmount("EUR", 20.82), hasGrossValue("EUR", 20.82 + 3.67), //
                         hasForexGrossValue("USD", 29.41), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+                        hasTaxes("EUR", 3.67), hasFees("EUR", 0.00))));
 
         // check cancellation transaction
         assertThat(results, hasItem(withFailureMessage( //
@@ -1500,11 +1523,12 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-08-31T00:00"), hasShares(235.00), //
+                        hasDate("2020-08-31T00:00"), hasExDate("2020-08-21"), //
+                        hasShares(235.00), //
                         hasSource("Dividende05.txt"), //
                         hasNote("R.-Nr.: NUMMER"), //
-                        hasAmount("EUR", 20.82 + 3.67), hasGrossValue("EUR", 20.82 + 3.67), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        hasAmount("EUR", 20.82), hasGrossValue("EUR", 20.82 + 3.67), //
+                        hasTaxes("EUR", 3.67), hasFees("EUR", 0.00), //
                         check(tx -> {
                             var c = new CheckCurrenciesAction();
                             var account = new Account();
@@ -1560,11 +1584,12 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-08-31T00:00"), hasShares(235.00), //
+                        hasDate("2020-08-31T00:00"), hasExDate("2020-08-21"), //
+                        hasShares(235.00), //
                         hasSource("Dividende05.txt"), //
                         hasNote("R.-Nr.: NUMMER"), //
-                        hasAmount("EUR", 20.82 + 3.67), hasGrossValue("EUR", 20.82 + 3.67), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+                        hasAmount("EUR", 20.82), hasGrossValue("EUR", 20.82 + 3.67), //
+                        hasTaxes("EUR", 3.67), hasFees("EUR", 0.00))));
 
         // check cancellation transaction
         assertThat(results, hasItem(withFailureMessage( //
@@ -1607,11 +1632,12 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-08-31T00:00"), hasShares(235.00), //
+                        hasDate("2020-08-31T00:00"), hasExDate("2020-08-21"), //
+                        hasShares(235.00), //
                         hasSource("Dividende05.txt"), //
                         hasNote("R.-Nr.: NUMMER"), //
-                        hasAmount("EUR", 20.82 + 3.67), hasGrossValue("EUR", 20.82 + 3.67), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        hasAmount("EUR", 20.82), hasGrossValue("EUR", 20.82 + 3.67), //
+                        hasTaxes("EUR", 3.67), hasFees("EUR", 0.00), //
                         check(tx -> {
                             var c = new CheckCurrenciesAction();
                             var account = new Account();
@@ -1665,7 +1691,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2022-12-15T00:00"), hasShares(1227.00), //
+                        hasDate("2022-12-15T00:00"), hasExDate("2022-12-15"), //
+                        hasShares(1227.00), //
                         hasSource("Dividende06.txt"), //
                         hasNote("R.-Nr.: CPS-2022-0223620024-0002215"), //
                         hasAmount("EUR", 217.69), hasGrossValue("EUR", 217.69), //
@@ -1736,7 +1763,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2022-12-15T00:00"), hasShares(1227.00), //
+                        hasDate("2022-12-15T00:00"), hasExDate("2022-12-15"), //
+                        hasShares(1227.00), //
                         hasSource("Dividende06.txt; SteuerbehandlungVonDividende06.txt"), //
                         hasNote("R.-Nr.: CPS-2022-0223620024-0002215 | Tr.-Nr.: INDTBK34822CG020886O00"), //
                         hasAmount("EUR", 175.04), hasGrossValue("EUR", 217.69), //
@@ -1772,7 +1800,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2022-12-15T00:00"), hasShares(1227.00), //
+                        hasDate("2022-12-15T00:00"), hasExDate("2022-12-15"), //
+                        hasShares(1227.00), //
                         hasSource("Dividende06.txt; SteuerbehandlungVonDividende06.txt"), //
                         hasNote("R.-Nr.: CPS-2022-0223620024-0002215 | Tr.-Nr.: INDTBK34822CG020886O00"), //
                         hasAmount("EUR", 175.04), hasGrossValue("EUR", 217.69), //
@@ -1806,12 +1835,13 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2024-12-18T00:00"), hasShares(4.00), //
+                        hasDate("2024-12-18T00:00"), hasExDate("2024-12-02"), //
+                        hasShares(4.00), //
                         hasSource("Dividende07.txt"), //
                         hasNote("R.-Nr.: CPS-2024-0223620171-0003969"), //
-                        hasAmount("EUR", 6.71 + 1.18), hasGrossValue("EUR", 6.71 + 1.18), //
+                        hasAmount("EUR", 6.71), hasGrossValue("EUR", 6.71 + 1.18), //
                         hasForexGrossValue("USD", 8.24), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+                        hasTaxes("EUR", 1.18), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -1842,11 +1872,12 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2024-12-18T00:00"), hasShares(4.00), //
+                        hasDate("2024-12-18T00:00"), hasExDate("2024-12-02"), //
+                        hasShares(4.00), //
                         hasSource("Dividende07.txt"), //
                         hasNote("R.-Nr.: CPS-2024-0223620171-0003969"), //
-                        hasAmount("EUR", 6.71 + 1.18), hasGrossValue("EUR", 6.71 + 1.18), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        hasAmount("EUR", 6.71), hasGrossValue("EUR", 6.71 + 1.18), //
+                        hasTaxes("EUR", 1.18), hasFees("EUR", 0.00), //
                         check(tx -> {
                             var c = new CheckCurrenciesAction();
                             var account = new Account();
@@ -1887,7 +1918,7 @@ public class TargobankPDFExtractorTest
                         hasDate("2024-12-18T00:00"), hasShares(4.00), //
                         hasSource("SteuerbehandlungVonDividende07.txt"), //
                         hasNote("Tr.-Nr.: INDTBK35424CG007898O00"), //
-                        hasAmount("EUR", 0.83 + 1.18), hasGrossValue("EUR", 0.83 + 1.18), //
+                        hasAmount("EUR", 0.83), hasGrossValue("EUR", 0.83), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
@@ -1920,7 +1951,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2024-12-18T00:00"), hasShares(4.00), //
+                        hasDate("2024-12-18T00:00"), hasExDate("2024-12-02"), //
+                        hasShares(4.00), //
                         hasSource("Dividende07.txt; SteuerbehandlungVonDividende07.txt"), //
                         hasNote("R.-Nr.: CPS-2024-0223620171-0003969 | Tr.-Nr.: INDTBK35424CG007898O00"), //
                         hasAmount("EUR", 7.06 - 1.18), hasGrossValue("EUR", 7.89), //
@@ -1958,7 +1990,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2024-12-18T00:00"), hasShares(4.00), //
+                        hasDate("2024-12-18T00:00"), hasExDate("2024-12-02"), //
+                        hasShares(4.00), //
                         hasSource("Dividende07.txt; SteuerbehandlungVonDividende07.txt"), //
                         hasNote("R.-Nr.: CPS-2024-0223620171-0003969 | Tr.-Nr.: INDTBK35424CG007898O00"), //
                         hasAmount("EUR", 7.06 - 1.18), hasGrossValue("EUR", 7.89), //
@@ -2001,7 +2034,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2024-12-18T00:00"), hasShares(4.00), //
+                        hasDate("2024-12-18T00:00"), hasExDate("2024-12-02"), //
+                        hasShares(4.00), //
                         hasSource("Dividende07.txt; SteuerbehandlungVonDividende07.txt"), //
                         hasNote("R.-Nr.: CPS-2024-0223620171-0003969 | Tr.-Nr.: INDTBK35424CG007898O00"), //
                         hasAmount("EUR", 7.06 - 1.18), hasGrossValue("EUR", 7.89), //
@@ -2038,7 +2072,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2024-12-18T00:00"), hasShares(4.00), //
+                        hasDate("2024-12-18T00:00"), hasExDate("2024-12-02"), //
+                        hasShares(4.00), //
                         hasSource("Dividende07.txt; SteuerbehandlungVonDividende07.txt"), //
                         hasNote("R.-Nr.: CPS-2024-0223620171-0003969 | Tr.-Nr.: INDTBK35424CG007898O00"), //
                         hasAmount("EUR", 7.06 - 1.18), hasGrossValue("EUR", 7.89), //
@@ -2079,12 +2114,13 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-10-01T00:00"), hasShares(127.00), //
+                        hasDate("2020-10-01T00:00"), hasExDate("2020-09-14"), //
+                        hasShares(127.00), //
                         hasSource("Dividende08.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0223111111-0001111"), //
-                        hasAmount("EUR", 37.70 + 6.65), hasGrossValue("EUR", 37.70 + 6.65), //
+                        hasAmount("EUR", 37.70), hasGrossValue("EUR", 37.70 + 6.65), //
                         hasForexGrossValue("USD", 52.07), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+                        hasTaxes("EUR", 6.65), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -2115,11 +2151,12 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-10-01T00:00"), hasShares(127.00), //
+                        hasDate("2020-10-01T00:00"), hasExDate("2020-09-14"), //
+                        hasShares(127.00), //
                         hasSource("Dividende08.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0223111111-0001111"), //
-                        hasAmount("EUR", 37.70 + 6.65), hasGrossValue("EUR", 37.70 + 6.65), //
-                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00), //
+                        hasAmount("EUR", 37.70), hasGrossValue("EUR", 37.70 + 6.65), //
+                        hasTaxes("EUR", 6.65), hasFees("EUR", 0.00), //
                         check(tx -> {
                             var c = new CheckCurrenciesAction();
                             var account = new Account();
@@ -2160,7 +2197,7 @@ public class TargobankPDFExtractorTest
                         hasDate("2020-10-01T00:00"), hasShares(127.00), //
                         hasSource("SteuerbehandlungVonDividende08.txt"), //
                         hasNote("Tr.-Nr.: INDTBK27620CG00000"), //
-                        hasAmount("EUR", 4.68 + 6.65), hasGrossValue("EUR", 4.68 + 6.65), //
+                        hasAmount("EUR", 4.68), hasGrossValue("EUR", 4.68), //
                         hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
@@ -2193,7 +2230,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-10-01T00:00"), hasShares(127.00), //
+                        hasDate("2020-10-01T00:00"), hasExDate("2020-09-14"), //
+                        hasShares(127.00), //
                         hasSource("Dividende08.txt; SteuerbehandlungVonDividende08.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0223111111-0001111 | Tr.-Nr.: INDTBK27620CG00000"), //
                         hasAmount("EUR", 33.02), hasGrossValue("EUR", 44.35), //
@@ -2231,7 +2269,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-10-01T00:00"), hasShares(127.00), //
+                        hasDate("2020-10-01T00:00"), hasExDate("2020-09-14"), //
+                        hasShares(127.00), //
                         hasSource("Dividende08.txt; SteuerbehandlungVonDividende08.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0223111111-0001111 | Tr.-Nr.: INDTBK27620CG00000"), //
                         hasAmount("EUR", 39.67 - 6.65), hasGrossValue("EUR", 44.35), //
@@ -2274,7 +2313,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-10-01T00:00"), hasShares(127.00), //
+                        hasDate("2020-10-01T00:00"), hasExDate("2020-09-14"), //
+                        hasShares(127.00), //
                         hasSource("Dividende08.txt; SteuerbehandlungVonDividende08.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0223111111-0001111 | Tr.-Nr.: INDTBK27620CG00000"), //
                         hasAmount("EUR", 39.67 - 6.65), hasGrossValue("EUR", 44.35), //
@@ -2311,7 +2351,8 @@ public class TargobankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2020-10-01T00:00"), hasShares(127.00), //
+                        hasDate("2020-10-01T00:00"), hasExDate("2020-09-14"), //
+                        hasShares(127.00), //
                         hasSource("Dividende08.txt; SteuerbehandlungVonDividende08.txt"), //
                         hasNote("R.-Nr.: CPS-2020-0223111111-0001111 | Tr.-Nr.: INDTBK27620CG00000"), //
                         hasAmount("EUR", 39.67 - 6.65), hasGrossValue("EUR", 44.35), //
@@ -2323,5 +2364,301 @@ public class TargobankPDFExtractorTest
                             var s = c.process((AccountTransaction) tx, account);
                             assertThat(s, is(Status.OK_STATUS));
                         }))));
+    }
+
+    @Test
+    public void testDividende09()
+    {
+        var extractor = new TargobankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende09.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US0378331005"), hasWkn("865985"), hasTicker(null), //
+                        hasName("APPLE INC. REGISTERED SHARES O.N."), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2013-02-14T00:00"), hasExDate("2013-02-07"), //
+                        hasShares(15.00), //
+                        hasSource("Dividende09.txt"), //
+                        hasNote("R.-Nr.: EE2-505-DC00-88560860962"), //
+                        hasAmount("EUR", 25.36), hasGrossValue("EUR", 25.36 + 4.47), //
+                        hasForexGrossValue("USD", 39.75), //
+                        hasTaxes("EUR", 4.47), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende09WithSecurityInEUR()
+    {
+        var security = new Security("APPLE INC. REGISTERED SHARES O.N.", "EUR");
+        security.setIsin("US0378331005");
+        security.setWkn("865985");
+
+        var client = new Client();
+        client.addSecurity(security);
+
+        var extractor = new TargobankPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende09.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "EUR");
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2013-02-14T00:00"), hasExDate("2013-02-07"), //
+                        hasShares(15.00), //
+                        hasSource("Dividende09.txt"), //
+                        hasNote("R.-Nr.: EE2-505-DC00-88560860962"), //
+                        hasAmount("EUR", 25.36), hasGrossValue("EUR", 25.36 + 4.47), //
+                        hasTaxes("EUR", 4.47), hasFees("EUR", 0.00), //
+                        check(tx -> {
+                            var c = new CheckCurrenciesAction();
+                            var account = new Account();
+                            account.setCurrencyCode("EUR");
+                            var s = c.process((AccountTransaction) tx, account);
+                            assertThat(s, is(Status.OK_STATUS));
+                        }))));
+    }
+
+    @Test
+    public void testSteuerbehandlungVonDividende09()
+    {
+        var extractor = new TargobankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "SteuerbehandlungVonDividende09.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(1L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US0378331005"), hasWkn("865985"), hasTicker(null), //
+                        hasName("APPLE INC. REGISTERED SHARES O.N."), //
+                        hasCurrencyCode("EUR"))));
+
+        // check cancellation transaction
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        taxes( //
+                                        hasDate("2013-02-15T00:00"), hasShares(15.00), //
+                                        hasSource("SteuerbehandlungVonDividende09.txt"), //
+                                        hasNote("Tr.-Nr.: IND00009801615D00094890632"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
+    }
+
+    @Test
+    public void testDividende09MitSteuerbehandlungVonDividende09()
+    {
+        var extractor = new TargobankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(
+                        PDFInputFile.loadTestCase(getClass(), "Dividende09.txt", "SteuerbehandlungVonDividende09.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(2L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(1L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US0378331005"), hasWkn("865985"), hasTicker(null), //
+                        hasName("APPLE INC. REGISTERED SHARES O.N."), //
+                        hasCurrencyCode("USD"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2013-02-14T00:00"), hasExDate("2013-02-07"), //
+                        hasShares(15.00), //
+                        hasSource("Dividende09.txt"), //
+                        hasNote("R.-Nr.: EE2-505-DC00-88560860962"), //
+                        hasAmount("EUR", 25.36), hasGrossValue("EUR", 25.36 + 4.47), //
+                        hasForexGrossValue("USD", 39.75), //
+                        hasTaxes("EUR", 4.47), hasFees("EUR", 0.00))));
+
+        // check cancellation transaction
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        taxes( //
+                                        hasDate("2013-02-15T00:00"), hasShares(15.00), //
+                                        hasSource("SteuerbehandlungVonDividende09.txt"), //
+                                        hasNote("Tr.-Nr.: IND00009801615D00094890632"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
+    }
+
+    @Test
+    public void testDividende09MitSteuerbehandlungVonDividende09_SourceFilesReversed()
+    {
+        var extractor = new TargobankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(
+                        PDFInputFile.loadTestCase(getClass(), "SteuerbehandlungVonDividende09.txt", "Dividende09.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(2L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(1L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US0378331005"), hasWkn("865985"), hasTicker(null), //
+                        hasName("APPLE INC. REGISTERED SHARES O.N."), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2013-02-14T00:00"), hasExDate("2013-02-07"), //
+                        hasShares(15.00), //
+                        hasSource("Dividende09.txt"), //
+                        hasNote("R.-Nr.: EE2-505-DC00-88560860962"), //
+                        hasAmount("EUR", 25.36), hasGrossValue("EUR", 25.36 + 4.47), //
+                        hasTaxes("EUR", 4.47), hasFees("EUR", 0.00))));
+
+        // check cancellation transaction
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        taxes( //
+                                        hasDate("2013-02-15T00:00"), hasShares(15.00), //
+                                        hasSource("SteuerbehandlungVonDividende09.txt"), //
+                                        hasNote("Tr.-Nr.: IND00009801615D00094890632"), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
+    }
+
+    @Test
+    public void testSteuerbehandlungVonDividende10()
+    {
+        var extractor = new TargobankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "SteuerbehandlungVonDividende10.txt"),
+                        errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US0378331005"), hasWkn("865985"), hasTicker(null), //
+                        hasName("APPLE INC. REGISTERED SHARES O.N."), //
+                        hasCurrencyCode("EUR"))));
+
+        // check taxes transaction
+        assertThat(results, hasItem(taxes( //
+                        hasDate("2013-02-15T00:00"), hasShares(15.00), //
+                        hasSource("SteuerbehandlungVonDividende10.txt"), //
+                        hasNote("Tr.-Nr.: IND00009801615D00094890632"), //
+                        hasAmount("EUR", 1.17 + 0.06), hasGrossValue("EUR", 1.17 + 0.06), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testAusbuchung01()
+    {
+        var extractor = new TargobankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Ausbuchung01.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(2L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(2L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(2L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(4));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("LU1834983477"), hasWkn("LYX01W"), hasTicker(null), //
+                        hasName("MUL-AMUN ST600 BANK ETF A"), //
+                        hasCurrencyCode("EUR"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin("DE0005933923"), hasWkn("593392"), hasTicker(null), //
+                        hasName("ISHARES MDAX UC.ETF EOA"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check unsupported transaction
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        outboundDelivery( //
+                                        hasDate("2025-12-09T00:00"), hasShares(34.00), //
+                                        hasSource("Ausbuchung01.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
+
+        assertThat(results, hasItem(withFailureMessage( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        outboundDelivery( //
+                                        hasDate("2025-12-09T00:00"), hasShares(18.00), //
+                                        hasSource("Ausbuchung01.txt"), //
+                                        hasNote(null), //
+                                        hasAmount("EUR", 0.00), hasGrossValue("EUR", 0.00), //
+                                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00)))));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/weberbank/Dividende02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/weberbank/Dividende02.txt
@@ -1,0 +1,58 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.87.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+ Seite 1
+Depotnummer
+ 8000075900
+ Kundennummer xxxxxxxxxx
+ Namexxxxxx
+Abrechnungsnr. 54861333620
+Namexxx Datum 17.02.2026
+Namexxx Ihr Berater Herr Namexxx
+Namexxx Telefon 030/xxxxx 
+Strxxx. xx
+PLZ Berlin
+ 
+  
+ 
+Dividendengutschrift
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 65 ASML HOLDING N.V. NL0010273215 (A1J4U4)
+AANDELEN OP NAAM EO -,09
+Zahlbarkeitstag 18.02.2026 Dividende pro Stück 1,60 EUR
+Bestandsstichtag 06.02.2026 Herkunftsland Niederlande
+Ex-Tag 09.02.2026 Art der Dividende Schlussdividende
+Geschäftsjahr 01.01.2025 - 31.12.2025
+Dividendengutschrift 104,00+ EUR
+Einbehaltene Quellensteuer 15 % auf 104,00 EUR 15,60- EUR
+Anrechenbare Quellensteuer 15 % auf 104,00 EUR 15,60 EUR
+Kapitalertragsteuerpflichtige Dividende 104,00 EUR
+Verrechnete anrechenbare ausländische Quellensteuer
+(Verhältnis 100/25) auf 15,60 EUR 62,40 - EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 41,60 EUR
+Kapitalertragsteuer 25 % auf 41,60 EUR 10,40- EUR
+Solidaritätszuschlag 5,5 % auf 10,40 EUR 0,57- EUR
+Ausmachender Betrag 77,43+ EUR
+Lagerstelle Clearstream Banking FFM (849000 / 40030000)
+Den Betrag buchen wir zu Gunsten des Kontos 100xxxxxxx (IBAN DE69 xxxx xxxx xxxx xxxx xx), BLZ 10120100 (BIC
+WELADED1WBB). 
+Keine Steuerbescheinigung. 
+0858.02180100.0001794ER01
+
+Seite 2
+Depotnummer xxxxxxxxxx
+Kundennummer xxxxxxxxxx
+Abrechnungsnr. 54861333620
+Datum 17.02.2026
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verrechnungstöpfe 2026 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien und Sonstige
+Pauschbetrag Quellensteuer
+Vorher 0,00 0,00 0,00 0,00 15.449,33
+Ertrag 15,60
+0,00 0,00 0,00 15,60- 41,60
+Nachher 0,00 0,00 0,00 0,00 15.490,93
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+0858.02180100.0001795ER01

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/weberbank/Dividende03.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/weberbank/Dividende03.txt
@@ -1,0 +1,62 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.87.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+ Seite 1
+Depotnummer
+ 8000075900
+ Kundennummer xxxxxxxxxx
+ Name
+Abrechnungsnr. 59465024890
+Herrn u.Frau Datum 04.04.2025
+Name Ihr Berater Herr Name
+Name Telefon 030/8 97 98-xxx 
+Str. xx
+PLZ Berlin
+ 
+  
+ 
+Dividendengutschrift
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 550 NOVO-NORDISK AS DK0062498333 (A3EU6F)
+NAVNE-AKTIER B DK 0,1
+Zahlbarkeitstag 01.04.2025 Dividende pro Stück 7,90 DKK
+Bestandsstichtag 27.03.2025 Herkunftsland Dänemark
+Ex-Tag 28.03.2025
+Geschäftsjahr 01.01.2025 - 31.12.2025
+Devisenkurs EUR / DKK 7,4820
+Devisenkursdatum 04.04.2025
+Dividendengutschrift 4.345,00 DKK 580,73+ EUR
+Umrechnung in EUR 580,73 EUR
+Einbehaltene Quellensteuer 27 % auf 4.345,00 DKK 156,80- EUR
+Anrechenbare Quellensteuer 15 % auf 580,73 EUR 87,11 EUR
+Kapitalertragsteuerpflichtige Dividende 580,73 EUR
+Verrechnete anrechenbare ausländische Quellensteuer
+(Verhältnis 100/25) auf 87,11 EUR 348,44 - EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 232,29 EUR
+Kapitalertragsteuer 25 % auf 232,29 EUR 58,07- EUR
+Solidaritätszuschlag 5,5 % auf 58,07 EUR 3,19- EUR
+Ausmachender Betrag 362,67+ EUR
+12 % rückforderbare Quellensteuer 521,40 DKK
+Lagerstelle Clearstream Banking FFM (849000 / 40030000)
+Den Betrag buchen wir zu Gunsten des Kontos xxxxxxxxxx (IBAN DE69 xxxx xxxx xxxx xxxx xx), BLZ 101 201 00 (BIC
+WELADED1WBB). 
+Keine Steuerbescheinigung. 
+0858.04050100.0001216ER01
+
+Seite 2
+Depotnummer xxxxxxxxxx
+Kundennummer xxxxxxxxxx
+Abrechnungsnr. 59465024890
+Datum 04.04.2025
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verrechnungstöpfe 2025 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien und Sonstige
+Pauschbetrag Quellensteuer
+Vorher 1.602,00 0,00 0,00 0,00 5.539,02
+Ertrag 87,11
+0,00 0,00 0,00 87,11- 232,29
+Nachher 1.602,00 0,00 0,00 0,00 5.771,31
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+0858.04050100.0001217ER01

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/weberbank/Dividende04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/weberbank/Dividende04.txt
@@ -1,0 +1,56 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.87.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+ Seite 1
+Depotnummer
+ xxxxxxxxxx
+ Kundennummer xxxxxxxxxx
+ Name Name
+Abrechnungsnr. 73164322720
+Herrn u.Frau Datum 19.08.2026
+Name Ihr Berater Herr Name
+Name Telefon 030/xxxxx 
+Str. xx
+PLZ Berlin
+ 
+  
+ 
+Zinsgutschrift
+Nominale Wertpapierbezeichnung ISIN (WKN)
+NOK 1.425.000,00 NORWEGEN, KÖNIGREICH NO0010875230 (A28TXS)
+NK-ANL. 2020(30)
+Zahlbarkeitstag 19.08.2026 Zinssatz p. a. 1,375 %
+Bestandsstichtag 17.08.2026 Laufzeit Zinsschein 360 Tag(e) 
+Kupon per 19.08.2026 Herkunftsland Norwegen
+Zinstermin Monat(e) August 
+Devisenkurs EUR / NOK 10,9341 
+Devisenkursdatum 19.08.2026
+Zinsertrag 19.593,75 NOK 1.791,99+ EUR
+Umrechnung in EUR 1.791,99 EUR
+Kapitalertragsteuerpflichtiger Ertrag 1.791,99 EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 1.791,99 EUR
+Kapitalertragsteuer 25 % auf 1.791,99 EUR 448,00- EUR
+Solidaritätszuschlag 5,5 % auf 448,00 EUR 24,64- EUR
+Ausmachender Betrag 1.319,35+ EUR
+Lagerstelle CLEARSTREAM BANKING EUROPE (849000 / 40030000)
+Den Betrag buchen wir zu Gunsten des Kontos xxxxxxxxxx (IBAN DE69 xxxx xxxx xxxx xxxx xx), BLZ 101 201 00 (BIC
+WELADED1WBB). 
+Keine Steuerbescheinigung. 
+0858.08200100.0000268ER02
+
+Seite 2
+Depotnummer xxxxxxxxxx
+Kundennummer xxxxxxxxxx
+Abrechnungsnr. 73164322720
+Datum 19.08.2026
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verrechnungstöpfe 2026 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien und Sonstige
+Pauschbetrag Quellensteuer
+Vorher 0,00 0,00 0,00 0,00 405.081,87
+Ertrag 0,00 0,00 0,00 0,00 1.791,99
+Nachher 0,00 0,00 0,00 0,00 406.873,86
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+0858.08200100.0000269ER02

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/weberbank/Kauf02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/weberbank/Kauf02.txt
@@ -1,0 +1,74 @@
+```
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.87.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+ Seite 1 von 2
+Depotnummer
+ xxxxxxxxxx
+ Kundennummer xxxxxxxxxx
+ Name
+Auftragsnummer 505279/90.00
+Herrn u.Frau Datum 02.04.2026
+Name Ihr Berater Herr Name
+Name Telefon 030/xxxx
+Str. xx Rechnungsnummer W00858-0000285362/26
+PLZ Berlin Umsatzsteuer-ID DE814386567 
+ 
+Wertpapier Abrechnung Kauf 
+Nominale Wertpapierbezeichnung ISIN (WKN)
+NOK 1.425.000,00 1,375 % NORWEGEN, KÖNIGREICH NO0010875230 (A28TXS)
+NK-ANL. 2020(30) 
+Handels-/Ausführungsplatz Gettex (gemäß Weisung)
+Börsensegment MUND
+Limit-Order
+Limit 88,50 % 
+Schlusstag/-Zeit 02.04.2026 10:48:46 Zinstermin Monat(e) 19. August
+Ausführungskurs 88,228 % Zinslauf ab 19.02.2020
+Fällig am 19.08.2030
+Auftraggeber Name
+Auftragserteilung/ -ort telefonisch
+Devisenkurs (EUR/NOK) 11,207 vom 02.04.2026
+Kurswert 112.184,26- EUR
+Stückzinsen für 232 Tage per 07.04.2026 1.111,28- EUR
+Ermittlung steuerrelevante Erträge
+Stückzinsen für 232 Tage per 07.04.2026 1.111,28- EUR
+Eingebuchte Aktienverluste 1.111,28 EUR
+Ausmachender Betrag 113.295,54- EUR
+ 
+Den Gegenwert buchen wir mit Valuta 08.04.2026 zu Lasten des Kontos 1000087112
+(IBAN DE69 xxxx xxxx xxxx xxxx xx), BLZ 10120100 (BIC WELADED1WBB).
+Die Wertpapiere schreiben wir Ihrem Depotkonto gut.
+Steuerliche Ausgleichrechnung
+Verrechnete Aktienverluste 1.111,28- EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 1.111,28 EUR
+0858.04022055.0001413OR07  
+Seite 2 von 2
+Depotnummer xxxxxxxxxx
+Kundennummer xxxxxxxxxx
+Auftragsnummer 505279/90.00
+Datum 02.04.2026
+Kapitalertragsteuer 25,00% auf 1.111,28 EUR 277,82 EUR
+Solidaritätszuschlag 5,50% auf 277,82 EUR 15,28 EUR
+Ausmachender Betrag 293,10 EUR
+ 
+Den Gegenwert buchen wir mit Valuta 02.04.2026 zu Gunsten des Kontos 1000087112
+(IBAN DE69 xxxx xxxx xxxx xxxx xx), BLZ 10120100 (BIC WELADED1WBB).
+Sofern keine Umsatzsteuer ausgewiesen ist, handelt es sich um eine umsatzsteuerbefreite Finanzdienstleistung. 
+ 
+Für das Geschäft wurde keine Anlageberatung erbracht.
+Initiator der Besprechung war der Kunde.
+ 
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verlustverrechnungstöpfe 2026 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien und Sonstige
+Pauschbetrag Quellensteuer
+Vorher 0,00 0,00 0,00 0,00 136.099,85
+Kauf 1.111,28 0,00 0,00 0,00 0,00
+Steuerausgleich 1.111,28- 0,00 0,00 0,00 1.111,28-
+Nachher 0,00 0,00 0,00 0,00 134.988,57
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+0858.04022055.0001414OR07  
+
+```

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/weberbank/Verkauf02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/weberbank/Verkauf02.txt
@@ -1,0 +1,66 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.87.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+ Seite 1 von 2
+Depotnummer
+ 80000xxxxx
+ Kundennummer xxxxxxxxxx
+ Name Name
+Auftragsnummer 673747/44.00
+Herrn u.Frau Datum 18.06.2026
+Name Ihr Berater Herr Name
+Name Telefon 030/xxxx
+Str. xx Rechnungsnummer W00858-0000502603/26
+PLZ Berlin Umsatzsteuer-ID DE814386567 
+ 
+Wertpapier Abrechnung Verkauf 
+Nominale Wertpapierbezeichnung ISIN (WKN)
+Stück 465 TYSON FOODS INC. US9024941034 (870625)
+REG. SHARES CL.A DL -,10 
+Handels-/Ausführungsplatz Tradegate (Best Execution)
+Börsensegment XGAT
+Market-Order
+Limit bestens
+Schlusstag/-Zeit 18.06.2026 17:43:22 Auftraggeber Name.
+Ausführungskurs 48,86 EUR Auftragserteilung/ -ort Persönlich im Institut
+Kurswert 22.719,90 EUR
+Ermittlung steuerrelevante Erträge
+Veräußerungsverlust 2.115,75- EUR
+Eingebuchte Aktienverluste 2.115,75 EUR
+Ausmachender Betrag 22.719,90 EUR
+ 
+Den Gegenwert buchen wir mit Valuta 22.06.2026 zu Gunsten des Kontos xxxxxxxxxx
+(IBAN DE69 xxxx xxxx xxxx xxxx xx), BLZ 10120100 (BIC WELADED1WBB).
+Die Wertpapiere entnehmen wir Ihrem Depotkonto.
+Steuerliche Ausgleichrechnung
+Verrechnete Aktienverluste 2.115,75- EUR
+Berechnungsgrundlage für die Kapitalertragsteuer 2.115,75 EUR
+0858.06182053.0002195OR07  
+Seite 2 von 2
+Depotnummer 8000075900
+Kundennummer 1064817006
+Auftragsnummer 673747/44.00
+Datum 18.06.2026
+Kapitalertragsteuer 25,00% auf 2.115,75 EUR 528,94 EUR
+Solidaritätszuschlag 5,50% auf 528,94 EUR 29,09 EUR
+Ausmachender Betrag 558,03 EUR
+ 
+Den Gegenwert buchen wir mit Valuta 18.06.2026 zu Gunsten des Kontos xxxxxxxxxx
+(IBAN DE69 DE69 xxxx xxxx xxxx xxxx xx), BLZ 10120100 (BIC WELADED1WBB).
+Sofern keine Umsatzsteuer ausgewiesen ist, handelt es sich um eine umsatzsteuerbefreite Finanzdienstleistung. 
+ 
+Für das Geschäft wurde keine Anlageberatung erbracht.
+Initiator der Besprechung war das Institut.
+ 
+Nachrichtlich die Übersicht Ihrer Verrechnungs- und Steuertopfsalden zum Zeitpunkt der Erstellung der Abrechnung.
+Verlustverrechnungstöpfe 2026 Berechnungsgrundlage
+der gezahlten Steuern
+Euro Aktien Sonstige Sparer- anrechenbare Aktien und Sonstige
+Pauschbetrag Quellensteuer
+Vorher 0,00 0,00 0,00 0,00 412.714,24
+Verkauf 2.115,75 0,00 0,00 0,00 0,00
+Steuerausgleich 2.115,75- 0,00 0,00 0,00 2.115,75-
+Nachher 0,00 0,00 0,00 0,00 410.598,49
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+0858.06182053.0002196OR07  

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/weberbank/WeberbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/weberbank/WeberbankPDFExtractorTest.java
@@ -1,39 +1,46 @@
 package name.abuchen.portfolio.datatransfer.pdf.weberbank;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasExDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasForexGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasIsin;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasName;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasNote;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasShares;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxRefund;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countBuySell;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countItemsWithFailureMessage;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSecurities;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countSkippedItems;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
-import static org.junit.Assert.assertNull;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
 
-import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
-import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
-import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
-import name.abuchen.portfolio.datatransfer.ImportAction.Status;
 import name.abuchen.portfolio.datatransfer.actions.AssertImportActions;
-import name.abuchen.portfolio.datatransfer.actions.CheckCurrenciesAction;
 import name.abuchen.portfolio.datatransfer.pdf.PDFInputFile;
 import name.abuchen.portfolio.datatransfer.pdf.WeberbankPDFExtractor;
-import name.abuchen.portfolio.model.Account;
-import name.abuchen.portfolio.model.AccountTransaction;
-import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
-import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.model.Security;
-import name.abuchen.portfolio.model.Transaction.Unit;
-import name.abuchen.portfolio.money.Money;
-import name.abuchen.portfolio.money.Values;
 
 @SuppressWarnings("nls")
 public class WeberbankPDFExtractorTest
@@ -58,34 +65,105 @@ public class WeberbankPDFExtractorTest
         new AssertImportActions().check(results, "EUR");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("NO0010081235"));
-        assertThat(security.getWkn(), is("A0B733"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("NEL ASA NAVNE-AKSJER NK -,20"));
-        assertThat(security.getCurrencyCode(), is("EUR"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("NO0010081235"), hasWkn("A0B733"), hasTicker(null), //
+                        hasName("NEL ASA NAVNE-AKSJER NK -,20"), //
+                        hasCurrencyCode("EUR"))));
 
-        // check buy sell transaction
-        var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        // check purchase transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2021-03-26T15:14:29"), hasShares(4440.00), //
+                        hasSource("Kauf01.txt"), //
+                        hasNote("Limit billigst"), //
+                        hasAmount("EUR", 9657.00), hasGrossValue("EUR", 9657.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
 
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.BUY));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.BUY));
+    @Test
+    public void testWertpapierKauf02()
+    {
+        var extractor = new WeberbankPDFExtractor(new Client());
 
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-03-26T15:14:29")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(4440)));
-        assertThat(entry.getSource(), is("Kauf01.txt"));
-        assertThat(entry.getNote(), is("Limit billigst"));
+        List<Exception> errors = new ArrayList<>();
 
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(9657.00))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(9657.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("NO0010875230"), hasWkn("A28TXS"), hasTicker(null), //
+                        hasName("1,375 % NORWEGEN, KÖNIGREICH NK-ANL. 2020(30)"), //
+                        hasCurrencyCode("NOK"))));
+
+        // check purchase transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-04-02T10:48:46"), hasShares(14250.00), //
+                        hasSource("Kauf02.txt"), //
+                        hasNote("Auftragsnummer 505279/90.00 | Limit 88,50 %"), //
+                        hasAmount("EUR", 113295.54), hasGrossValue("EUR", 112184.26), //
+                        hasForexGrossValue("NOK", 1257249.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 1111.28))));
+
+        // check tax refund transaction
+        assertThat(results, hasItem(taxRefund( //
+                        hasDate("2026-04-02T10:48:46"), hasShares(14250.00), //
+                        hasSource("Kauf02.txt"), //
+                        hasNote("Auftragsnummer 505279/90.00 | Limit 88,50 %"), //
+                        hasAmount("EUR", 293.10), hasGrossValue("EUR", 293.10), //
+                        hasForexGrossValue("NOK", 3284.77), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testWertpapierKauf02WithSecurityInEUR()
+    {
+        var security = new Security("1,375 % NORWEGEN, KÖNIGREICH NK-ANL. 2020(30)", "EUR");
+        security.setIsin("NO0010875230");
+        security.setWkn("A28TXS");
+
+        var client = new Client();
+        client.addSecurity(security);
+
+        var extractor = new WeberbankPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check purchase transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-04-02T10:48:46"), hasShares(14250.00), //
+                        hasSource("Kauf02.txt"), //
+                        hasNote("Auftragsnummer 505279/90.00 | Limit 88,50 %"), //
+                        hasAmount("EUR", 113295.54), hasGrossValue("EUR", 112184.26), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 1111.28))));
+
+        // check tax refund transaction
+        assertThat(results, hasItem(taxRefund( //
+                        hasDate("2026-04-02T10:48:46"), hasShares(14250.00), //
+                        hasSource("Kauf02.txt"), //
+                        hasNote("Auftragsnummer 505279/90.00 | Limit 88,50 %"), //
+                        hasAmount("EUR", 293.10), hasGrossValue("EUR", 293.10), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -108,42 +186,66 @@ public class WeberbankPDFExtractorTest
         new AssertImportActions().check(results, "EUR");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("US92556V1061"));
-        assertThat(security.getWkn(), is("A2QAME"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("VIATRIS INC. REGISTERED SHARES O.N."));
-        assertThat(security.getCurrencyCode(), is("EUR"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("US92556V1061"), hasWkn("A2QAME"), hasTicker(null), //
+                        hasName("VIATRIS INC. REGISTERED SHARES O.N."), //
+                        hasCurrencyCode("EUR"))));
 
-        // check buy sell transaction
-        var entry = (BuySellEntry) results.stream().filter(BuySellEntryItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        // check sale transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2021-03-26T15:12:58"), hasShares(193.00), //
+                        hasSource("Verkauf01.txt"), //
+                        hasNote("Auftragsnummer 742198/43.00 | Limit bestens"), //
+                        hasAmount("EUR", 2335.30), hasGrossValue("EUR", 2335.30), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
 
-        assertThat(entry.getPortfolioTransaction().getType(), is(PortfolioTransaction.Type.SELL));
-        assertThat(entry.getAccountTransaction().getType(), is(AccountTransaction.Type.SELL));
+    @Test
+    public void testWertpapierVerkauf02()
+    {
+        var extractor = new WeberbankPDFExtractor(new Client());
 
-        assertThat(entry.getPortfolioTransaction().getDateTime(), is(LocalDateTime.parse("2021-03-26T15:12:58")));
-        assertThat(entry.getPortfolioTransaction().getShares(), is(Values.Share.factorize(193)));
-        assertThat(entry.getSource(), is("Verkauf01.txt"));
-        assertThat(entry.getNote(), is("Limit bestens"));
+        List<Exception> errors = new ArrayList<>();
 
-        assertThat(entry.getPortfolioTransaction().getMonetaryAmount(),
-                        is(Money.of("EUR", Values.Amount.factorize(2335.30))));
-        assertThat(entry.getPortfolioTransaction().getGrossValue(),
-                        is(Money.of("EUR", Values.Amount.factorize(2335.30))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.FEE),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
-        assertThat(entry.getPortfolioTransaction().getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(3));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US9024941034"), hasWkn("870625"), hasTicker(null), //
+                        hasName("TYSON FOODS INC. REG. SHARES CL.A DL -,10"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check sale transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-06-18T17:43:22"), hasShares(465.00), //
+                        hasSource("Verkauf02.txt"), //
+                        hasNote("Auftragsnummer 673747/44.00 | Limit bestens"), //
+                        hasAmount("EUR", 22719.90), hasGrossValue("EUR", 22719.90), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+
+        // check tax refund transaction
+        assertThat(results, hasItem(taxRefund( //
+                        hasDate("2026-06-18T17:43:22"), hasShares(465.00), //
+                        hasSource("Verkauf02.txt"), //
+                        hasNote("Auftragsnummer 673747/44.00 | Limit bestens"), //
+                        hasAmount("EUR", 558.03), hasGrossValue("EUR", 558.03), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
     }
 
     @Test
     public void testDividende01()
     {
-        var client = new Client();
-
-        var extractor = new WeberbankPDFExtractor(client);
+        var extractor = new WeberbankPDFExtractor(new Client());
 
         List<Exception> errors = new ArrayList<>();
 
@@ -160,33 +262,20 @@ public class WeberbankPDFExtractorTest
         new AssertImportActions().check(results, "EUR");
 
         // check security
-        var security = results.stream().filter(SecurityItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSecurity();
-        assertThat(security.getIsin(), is("US0378331005"));
-        assertThat(security.getWkn(), is("865985"));
-        assertNull(security.getTickerSymbol());
-        assertThat(security.getName(), is("APPLE INC. REGISTERED SHARES O.N."));
-        assertThat(security.getCurrencyCode(), is("USD"));
+        assertThat(results, hasItem(security( //
+                        hasIsin("US0378331005"), hasWkn("865985"), hasTicker(null), //
+                        hasName("APPLE INC. REGISTERED SHARES O.N."), //
+                        hasCurrencyCode("USD"))));
 
         // check dividends transaction
-        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
-
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
-
-        assertThat(transaction.getShares(), is(Values.Share.factorize(107)));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-08-13T00:00")));
-        assertThat(transaction.getSource(), is("Dividende01.txt"));
-        assertThat(transaction.getNote(), is("Quartalsdividende"));
-
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(55.14))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(74.05))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(11.11 + 7.40 + 0.40))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
-
-        var grossValueUnit = transaction.getUnit(Unit.Type.GROSS_VALUE).orElseThrow(IllegalArgumentException::new);
-        assertThat(grossValueUnit.getForex(), is(Money.of("USD", Values.Amount.factorize(87.74))));
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2020-08-13T00:00"), hasExDate("2020-08-07T00:00"), //
+                        hasShares(107.00), //
+                        hasSource("Dividende01.txt"), //
+                        hasNote("Quartalsdividende"), //
+                        hasAmount("EUR", 55.14), hasGrossValue("EUR", 74.05), //
+                        hasForexGrossValue("USD", 87.74), //
+                        hasTaxes("EUR", 11.11 + 7.40 + 0.40), hasFees("EUR", 0.00))));
     }
 
     @Test
@@ -216,27 +305,191 @@ public class WeberbankPDFExtractorTest
         new AssertImportActions().check(results, "EUR");
 
         // check dividends transaction
-        var transaction = (AccountTransaction) results.stream().filter(TransactionItem.class::isInstance).findFirst()
-                        .orElseThrow(IllegalArgumentException::new).getSubject();
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2020-08-13T00:00"), hasExDate("2020-08-07T00:00"), //
+                        hasShares(107.00), //
+                        hasSource("Dividende01.txt"), //
+                        hasNote("Quartalsdividende"), //
+                        hasAmount("EUR", 55.14), hasGrossValue("EUR", 74.05), //
+                        hasTaxes("EUR", 11.11 + 7.40 + 0.40), hasFees("EUR", 0.00))));
+    }
 
-        assertThat(transaction.getType(), is(AccountTransaction.Type.DIVIDENDS));
+    @Test
+    public void testDividende02()
+    {
+        var extractor = new WeberbankPDFExtractor(new Client());
 
-        assertThat(transaction.getShares(), is(Values.Share.factorize(107)));
-        assertThat(transaction.getDateTime(), is(LocalDateTime.parse("2020-08-13T00:00")));
-        assertThat(transaction.getExDate(), is(LocalDateTime.parse("2020-08-07T00:00")));
-        assertThat(transaction.getSource(), is("Dividende01.txt"));
-        assertThat(transaction.getNote(), is("Quartalsdividende"));
+        List<Exception> errors = new ArrayList<>();
 
-        assertThat(transaction.getMonetaryAmount(), is(Money.of("EUR", Values.Amount.factorize(55.14))));
-        assertThat(transaction.getGrossValue(), is(Money.of("EUR", Values.Amount.factorize(74.05))));
-        assertThat(transaction.getUnitSum(Unit.Type.TAX),
-                        is(Money.of("EUR", Values.Amount.factorize(11.11 + 7.40 + 0.40))));
-        assertThat(transaction.getUnitSum(Unit.Type.FEE), is(Money.of("EUR", Values.Amount.factorize(0.00))));
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende02.txt"), errors);
 
-        var c = new CheckCurrenciesAction();
-        var account = new Account();
-        account.setCurrencyCode("EUR");
-        var s = c.process(transaction, account);
-        assertThat(s, is(Status.OK_STATUS));
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("NL0010273215"), hasWkn("A1J4U4"), hasTicker(null), //
+                        hasName("ASML HOLDING N.V. AANDELEN OP NAAM EO -,09"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-02-18T00:00"), hasExDate("2026-02-09T00:00"), //
+                        hasShares(65.00), //
+                        hasSource("Dividende02.txt"), //
+                        hasNote("Abrechnungsnr. 54861333620 | Schlussdividende"), //
+                        hasAmount("EUR", 77.43), hasGrossValue("EUR", 104.00), //
+                        hasTaxes("EUR", 15.60 + 10.40 + 0.57), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende03()
+    {
+        var extractor = new WeberbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("DK0062498333"), hasWkn("A3EU6F"), hasTicker(null), //
+                        hasName("NOVO-NORDISK AS NAVNE-AKTIER B DK 0,1"), //
+                        hasCurrencyCode("DKK"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-04-01T00:00"), hasExDate("2025-03-28T00:00"), //
+                        hasShares(550.00), //
+                        hasSource("Dividende03.txt"), //
+                        hasNote("Abrechnungsnr. 59465024890"), //
+                        hasAmount("EUR", 362.67), hasGrossValue("EUR", 580.73), //
+                        hasForexGrossValue("DKK", 4345.00), //
+                        hasTaxes("EUR", 156.80 + 58.07 + 3.19), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende03WithSecurityInEUR()
+    {
+        var security = new Security("NOVO-NORDISK AS NAVNE-AKTIER B DK 0,1", "EUR");
+        security.setIsin("DK0062498333");
+        security.setWkn("A3EU6F");
+
+        var client = new Client();
+        client.addSecurity(security);
+
+        var extractor = new WeberbankPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende03.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "EUR");
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-04-01T00:00"), hasExDate("2025-03-28T00:00"), //
+                        hasShares(550.00), //
+                        hasSource("Dividende03.txt"), //
+                        hasNote("Abrechnungsnr. 59465024890"), //
+                        hasAmount("EUR", 362.67), hasGrossValue("EUR", 580.73), //
+                        hasTaxes("EUR", 156.80 + 58.07 + 3.19), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende04()
+    {
+        var extractor = new WeberbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende04.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("NO0010875230"), hasWkn("A28TXS"), hasTicker(null), //
+                        hasName("NORWEGEN, KÖNIGREICH NK-ANL. 2020(30)"), //
+                        hasCurrencyCode("NOK"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-08-19T00:00"), hasExDate(null), //
+                        hasShares(14250.00), //
+                        hasSource("Dividende04.txt"), //
+                        hasNote("Abrechnungsnr. 73164322720"), //
+                        hasAmount("EUR", 1319.35), hasGrossValue("EUR", 1791.99), //
+                        hasForexGrossValue("NOK", 19593.75), //
+                        hasTaxes("EUR", 448.00 + 24.64), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testDividende04WithSecurityInEUR()
+    {
+        var security = new Security("NORWEGEN, KÖNIGREICH NK-ANL. 2020(30)", "EUR");
+        security.setIsin("NO0010875230");
+        security.setWkn("A28TXS");
+
+        var client = new Client();
+        client.addSecurity(security);
+
+        var extractor = new WeberbankPDFExtractor(client);
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende04.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(1));
+        new AssertImportActions().check(results, "EUR");
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-08-19T00:00"), hasExDate(null), //
+                        hasShares(14250.00), //
+                        hasSource("Dividende04.txt"), //
+                        hasNote("Abrechnungsnr. 73164322720"), //
+                        hasAmount("EUR", 1319.35), hasGrossValue("EUR", 1791.99), //
+                        hasTaxes("EUR", 448.00 + 24.64), hasFees("EUR", 0.00))));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TargobankPDFExtractor.java
@@ -33,9 +33,9 @@ import name.abuchen.portfolio.util.Pair;
  *           The security transaction and the taxes treatment.
  *           Both documents are provided as one PDF or as two PDFs.
  *
- *           The security transaction includes the fees, but not the correct taxes
- *           and the taxes treatment includes all taxes (including withholding tax),
- *           but not all fees.
+ *           The security transaction includes the fees and the withholding tax, but not the
+ *           correct German taxes and the taxes treatment includes the German taxes,
+ *           but not all fees and not the withholding tax.
  *
  *           Therefore, we use the documents based on their function and merge both documents, if possible, as one transaction.
  *           {@code
@@ -73,8 +73,11 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
         addBankIdentifier("TARGOBANK AG");
 
         addBuySellTransaction();
-        addDividendeTransaction();
-        addTaxesTreatmentTransaction();
+        addDividendeTransaction_Format01();
+        addDividendeTransaction_Format02();
+        addTaxesTreatmentTransaction_Format01();
+        addTaxesTreatmentTransaction_Format02();
+        addNonImportableTransaction();
     }
 
     @Override
@@ -169,7 +172,7 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
         addFeesSectionsTransaction(pdfTransaction, type);
     }
 
-    private void addDividendeTransaction()
+    private void addDividendeTransaction_Format01()
     {
         final var type = new DocumentType("(Ertragsgutschrift|Dividendengutschrift) [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}");
         this.addDocumentTyp(type);
@@ -209,7 +212,25 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
                         .match("^Zahlbar (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$") //
                         .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
+                        // @formatter:off
+                        // Ex-Tag 11.06.2020
+                        // @formatter:on
+                        .section("exDate").optional() //
+                        .match("^Ex\\-Tag (?<exDate>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$") //
+                        .assign((t, v) -> t.setExDate(asDate(v.get("exDate"))))
+
                         .oneOf( //
+                                        // @formatter:off
+                                        // Gutschrift auf Ihrem Konto mit Wertstellung zum 31. August 2020
+                                        // Konto-Nr. NUMMER 20,82 EUR
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("amount", "currency") //
+                                                        .match("^Konto\\-Nr\\. .* (?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                                                        .assign((t, v) -> {
+                                                            t.setAmount(asAmount(v.get("amount")));
+                                                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                                                        }),
                                         // @formatter:off
                                         // Bruttoertrag in EUR 24,49 EUR
                                         // @formatter:on
@@ -250,6 +271,19 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
                             checkAndSetGrossUnit(gross, fxGross, t, type.getCurrentContext());
                         })
 
+                        // The withholding tax is already deducted from the
+                        // gross income in the
+                        // dividend document. The taxes treatment only credits
+                        // it against the
+                        // German capital gains tax.
+                        //
+                        // @formatter:off
+                        // 15 % Ausländische Quellensteuer (US) 3,67 EUR
+                        // @formatter:on
+                        .section("withHoldingTax", "currency").optional() //
+                        .match("^[\\.,\\d]+ % Ausl.ndische Quellensteuer( \\(.*\\))? (?<withHoldingTax>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                        .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
+
                         // @formatter:off
                         // Rechnungsnummer: CPS-2020-0123456789-0001234
                         // @formatter:on
@@ -264,7 +298,130 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
         addFeesSectionsTransaction(pdfTransaction, type);
     }
 
-    private void addTaxesTreatmentTransaction()
+    private void addDividendeTransaction_Format02()
+    {
+        final var type = new DocumentType("Gutschrift mit Wert [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}", //
+                        documentContext -> documentContext //
+                        // @formatter:off
+                                        //                                                         USD                     EUR
+                                        // @formatter:on
+                                        .section("currency") //
+                                        .match("^[\\s]{1,}([A-Z]{3}[\\s]{1,})?(?<currency>[A-Z]{3})$") //
+                                        .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency")))));
+        this.addDocumentTyp(type);
+
+        var pdfTransaction = new Transaction<AccountTransaction>();
+
+        var firstRelevantLine = new Block("^(Ertragsgutschrift|Dividendengutschrift)$");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
+
+        pdfTransaction //
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
+
+                        // @formatter:off
+                        // APPLE INC. REGISTERED SHARES O.N. WKN ISIN
+                        // 865985 US0378331005
+                        // Dividende pro Stück      USD         2,65000000   Zahlbar                14.02.2013
+                        // @formatter:on
+                        .section("name", "wkn", "isin", "currency") //
+                        .match("^(?<name>.*) WKN ISIN$") //
+                        .match("^(?<wkn>[A-Z0-9]{6}) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                        .match("^(Aussch.ttung|Dividende) pro St.ck[\\s]{1,}(?<currency>[A-Z]{3})[\\s]{1,}[\\.,\\d]+.*$") //
+                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+
+                        // @formatter:off
+                        // Stück 15,0000
+                        // @formatter:on
+                        .section("shares") //
+                        .match("^St.ck (?<shares>[\\.,\\d]+)$") //
+                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+
+                        // @formatter:off
+                        // Dividende pro Stück      USD         2,65000000   Zahlbar                14.02.2013
+                        // @formatter:on
+                        .section("date") //
+                        .match("^(Aussch.ttung|Dividende) pro St.ck.*Zahlbar[\\s]{1,}(?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$") //
+                        .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
+
+                        // @formatter:off
+                        // Geschäftsjahr                       2012 / 2013   Ex-Tag                 07.02.2013
+                        // @formatter:on
+                        .section("exDate").optional() //
+                        .match("^Gesch.ftsjahr.*Ex\\-Tag[\\s]{1,}(?<exDate>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$") //
+                        .assign((t, v) -> t.setExDate(asDate(v.get("exDate"))))
+
+                        // @formatter:off
+                        // Gutschrift mit Wert 18.02.2013                                                25,36
+                        // @formatter:on
+                        .section("amount") //
+                        .documentContext("currency") //
+                        .match("^Gutschrift mit Wert [\\d]{2}\\.[\\d]{2}\\.[\\d]{4}[\\s]{1,}(?<amount>[\\.,\\d]+)$") //
+                        .assign((t, v) -> {
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setCurrencyCode(v.get("currency"));
+                        })
+
+                        // @formatter:off
+                        // Bruttoertrag                                          39,75                   29,83
+                        // Umrechnungskurs USD zu EUR        1,3324000
+                        // @formatter:on
+                        .section("fxGross", "termCurrency", "baseCurrency", "exchangeRate").optional() //
+                        .match("^Bruttoertrag[\\s]{1,}(?<fxGross>[\\.,\\d]+)[\\s]{1,}[\\.,\\d]+$") //
+                        .match("^Umrechnungskurs (?<termCurrency>[A-Z]{3}) zu (?<baseCurrency>[A-Z]{3})[\\s]{1,}(?<exchangeRate>[\\.,\\d]+)$") //
+                        .assign((t, v) -> {
+                            var rate = asExchangeRate(v);
+                            type.getCurrentContext().putType(rate);
+
+                            var fxGross = Money.of(rate.getTermCurrency(), asAmount(v.get("fxGross")));
+                            var gross = rate.convert(rate.getBaseCurrency(), fxGross);
+
+                            checkAndSetGrossUnit(gross, fxGross, t, type.getCurrentContext());
+                        })
+
+                        // The withholding tax is already deducted from the
+                        // gross income in the
+                        // dividend document. The taxes treatment only credits
+                        // it against the
+                        // German capital gains tax. The amount is deducted,
+                        // this is indicated
+                        // by the trailing minus sign.
+                        .optionalOneOf( //
+                        // @formatter:off
+                                        // 15,0000 % Ausländische Quellensteuer                   5,96-                   4,47-
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("withHoldingTax") //
+                                                        .documentContext("currency") //
+                                                        .match("^[\\.,\\d]+ % Ausl.ndische Quellensteuer[\\s]{1,}[\\.,\\d]+\\-[\\s]{1,}(?<withHoldingTax>[\\.,\\d]+)\\-$") //
+                                                        .assign((t, v) -> processWithHoldingTaxEntries(t, v,
+                                                                        "withHoldingTax", type)),
+                                        // @formatter:off
+                                        // 15,0000 % Ausländische Quellensteuer                   4,47-
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("withHoldingTax") //
+                                                        .documentContext("currency") //
+                                                        .match("^[\\.,\\d]+ % Ausl.ndische Quellensteuer[\\s]{1,}(?<withHoldingTax>[\\.,\\d]+)\\-$") //
+                                                        .assign((t, v) -> processWithHoldingTaxEntries(t, v,
+                                                                        "withHoldingTax", type)))
+
+                        // @formatter:off
+                        // Rechnungsnummer:        EE2-505-DC00-88560860962
+                        // @formatter:on
+                        .section("note").optional() //
+                        .match("^Rechnungsnummer: (?<note>.*)$") //
+                        .assign((t, v) -> t.setNote("R.-Nr.: " + trim(v.get("note"))))
+
+                        .conclude(ExtractorUtils.fixGrossValueA())
+
+                        .wrap(TransactionItem::new);
+
+        addFeesSectionsTransaction(pdfTransaction, type);
+    }
+
+    private void addTaxesTreatmentTransaction_Format01()
     {
         final var type = new DocumentType("\\(Steuerbeilage\\)");
         this.addDocumentTyp(type);
@@ -382,53 +539,20 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
                                                                 t.setMonetaryAmount(deductedTaxes);
                                                             }
                                                         }),
+                                        // The withholding tax is already
+                                        // deducted in the dividend document
+                                        // and is only credited against the
+                                        // capital gains tax here. Therefore
+                                        // only the total amount of taxes is
+                                        // booked.
+                                        //
                                         // @formatter:off
-                                        // 1.) No tax burden: The losses offset the income so that no withholding tax is payable.
-                                        // 2.) Offsetting only with tax liability: Withholding tax can only be offset if capital gains tax is levied in Germany.
-                                        // 3.) Loss offsetting: The offsetting reduces the tax assessment basis to zero, which also eliminates offsetting.
-                                        // 4.) Savers' lump sum/exemption order: If used, this could also reduce the tax burden to zero.
-                                        //
-                                        // See test case of taxes treatment transaction ...Dividende05 vs. ...Dividende08
-                                        // ---------------------------------------------------
-                                        // Anrechenbare ausländische Quellensteuer 3,67 EUR
-                                        // Erträge/Verluste 24,49 EUR
-                                        // Anrechnung ausländischer Quellensteuer ** 0,00 EUR
-                                        // Bemessungsgrundlage 0,00 EUR
-                                        // Gesamtsumme Steuern 0,00 EUR
-                                        //
                                         // Anrechenbare ausländische Quellensteuer 6,65 EUR
                                         // Erträge/Verluste 44,35 EUR
                                         // Anrechnung ausländischer Quellensteuer ** - 26,60 EUR
                                         // Bemessungsgrundlage 17,75 EUR
                                         // Gesamtsumme Steuern 4,68 EUR
-                                        // @formatter:on
-                                        section -> section //
-                                                        .attributes("withHoldingTaxes", "currencyWithHoldingTaxes", //
-                                                                        "grossBeforeTaxes", "currencyBeforeTaxes", //
-                                                                        "withholdingTaxesTimes4", "currencyWithholdingTaxesTimes4", //
-                                                                        "grossAssessmentBasis", "currencyAssessmentBasis", //
-                                                                        "deductedTaxes", "currencyDeductedTaxes") //
-                                                        .match("^Anrechenbare ausl.ndische Quellensteuer (?<withHoldingTaxes>[\\.,\\d]+) (?<currencyWithHoldingTaxes>[A-Z]{3})$") //
-                                                        .match("^Ertr.ge\\/Verluste (?<grossBeforeTaxes>[\\.,\\d]+) (?<currencyBeforeTaxes>[A-Z]{3})$") //
-                                                        .match("^Anrechnung ausl.ndischer Quellensteuer.* (?<withholdingTaxesTimes4>[\\.,\\d]+) (?<currencyWithholdingTaxesTimes4>[A-Z]{3})$") //
-                                                        .match("^Bemessungsgrundlage (?<grossAssessmentBasis>[\\.,\\d]+) (?<currencyAssessmentBasis>[A-Z]{3})$") //
-                                                        .match("^Gesamtsumme Steuern (?<deductedTaxes>[\\.,\\d]+) (?<currencyDeductedTaxes>[A-Z]{3})$") //
-                                                        .assign((t, v) -> {
-                                                            var withHoldingTaxes = Money.of(asCurrencyCode(v.get("currencyWithHoldingTaxes")), asAmount(v.get("withHoldingTaxes")));
-                                                            var grossBeforeTaxes = Money.of(asCurrencyCode(v.get("currencyBeforeTaxes")), asAmount(v.get("grossBeforeTaxes")));
-                                                            var withholdingTaxesTimes4 = Money.of(asCurrencyCode(v.get("currencyWithholdingTaxesTimes4")), asAmount(v.get("withholdingTaxesTimes4")));
-                                                            var grossAssessmentBasis = Money.of(asCurrencyCode(v.get("currencyAssessmentBasis")), asAmount(v.get("grossAssessmentBasis")));
-                                                            var deductedTaxes = Money.of(asCurrencyCode(v.get("currencyDeductedTaxes")), asAmount(v.get("deductedTaxes")));
-
-                                                            // Store in transaction context
-                                                            v.getTransactionContext().put(ATTRIBUTE_GROSS_TAXES_TREATMENT, grossBeforeTaxes);
-
-                                                            if (!grossAssessmentBasis.isZero() && withholdingTaxesTimes4.divide(4).equals(withHoldingTaxes))
-                                                                t.setMonetaryAmount(deductedTaxes.add(withHoldingTaxes));
-                                                            else
-                                                                t.setMonetaryAmount(deductedTaxes);
-                                                        }),
-                                        // @formatter:off
+                                        //
                                         // Erträge/Verluste 3.123,25 EUR
                                         // Bemessungsgrundlage 3.123,25 EUR
                                         // Gesamtsumme Steuern 823,76 EUR
@@ -487,46 +611,6 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
                                                         }))
 
                         // @formatter:off
-                        // Add withHolding tax and set correct gross amount
-                        // @formatter:on
-                        .optionalOneOf( //
-                                        // @formatter:off
-                                        // Bruttobetrag:                     USD               0,22
-                                        // 15,000 % Quellensteuer            USD               0,03 -
-                                        //     zum Devisenkurs: EUR/USD      1,084100                 EUR               4,65
-                                        // @formatter:on
-                                        section -> section //
-                                                        .attributes("fxCurrency", "fxGross", "currencyWithHoldingTax", "withHoldingTax", "baseCurrency", "termCurrency", "exchangeRate") //
-                                                        .match("^Bruttobetrag:[\\s]{1,}(?<fxCurrency>[A-Z]{3})[\\s]{1,}(?<fxGross>[\\.,\\d]+).*$") //
-                                                        .match("^[\\.,\\d]+ % Quellensteuer[\\s]{1,}(?<currencyWithHoldingTax>[A-Z]{3})[\\s]{1,}(?<withHoldingTax>[\\.,\\d]+) \\-.*$") //
-                                                        .match("^.*zum Devisenkurs: (?<baseCurrency>[A-Z]{3})\\/(?<termCurrency>[A-Z]{3})[\\s]{1,}(?<exchangeRate>[\\.,\\d]+).*$") //
-                                                        .assign((t, v) -> {
-                                                            var rate = asExchangeRate(v);
-                                                            type.getCurrentContext().putType(rate);
-
-                                                            var fxWithHoldingTax = Money.of(asCurrencyCode(v.get("currencyWithHoldingTax")), asAmount(v.get("withHoldingTax")));
-                                                            var withHoldingTax = rate.convert(rate.getBaseCurrency(), fxWithHoldingTax);
-
-                                                            t.setMonetaryAmount(t.getMonetaryAmount().add(withHoldingTax));
-
-                                                            var fxGross = Money.of(asCurrencyCode(v.get("fxCurrency")), asAmount(v.get("fxGross")));
-
-                                                            checkAndSetGrossUnit(t.getMonetaryAmount(), fxGross, t, type.getCurrentContext());
-                                                        }),
-                                        // @formatter:off
-                                        // 15,000 % Quellensteuer                                     EUR               XX,XX -
-                                        // @formatter:on
-                                        section -> section //
-                                                        .attributes("currency", "withHoldingTax") //
-                                                        .match("^[\\.,\\d]+ % Quellensteuer[\\s]{1,}(?<currencyWithHoldingTax>[A-Z]{3})[\\s]{1,}(?<withHoldingTax>[\\.,\\d]+) \\-.*$") //
-                                                        .assign((t, v) -> {
-                                                            var withHoldingTax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("withHoldingTax")));
-
-                                                            if (t.getMonetaryAmount().getCurrencyCode().equals(withHoldingTax.getCurrencyCode()))
-                                                                t.setMonetaryAmount(t.getMonetaryAmount().add(withHoldingTax));
-                                                        }))
-
-                        // @formatter:off
                         // Transaktionsreferenz TR TBK14720B024746O001
                         // Transaktionsreferenz INDTBK1234567890
                         // @formatter:on
@@ -545,6 +629,162 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
 
                             return item;
                         });
+    }
+
+    private void addTaxesTreatmentTransaction_Format02()
+    {
+        final var type = new DocumentType("Steuerbeilage Depot\\-Nr\\.", //
+                        documentContext -> documentContext //
+                                        // This document format does not contain
+                                        // a pay date or an ex-date,
+                                        // therefore the date of the letter is
+                                        // used. It is printed above
+                                        // the block and must be read from the
+                                        // document context.
+                                        //
+                                        // @formatter:off
+                                        // Duisburg, den 15.02.2013
+                                        // @formatter:on
+                                        .section("date") //
+                                        .match("^.*, .* (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$") //
+                                        .assign((ctx, v) -> ctx.put("date", v.get("date"))));
+        this.addDocumentTyp(type);
+
+        var block = new Block("^(Ertragsgutschrift|Dividendengutschrift)$");
+        type.addBlock(block);
+
+        var pdfTransaction = new Transaction<AccountTransaction>();
+        block.set(pdfTransaction);
+
+        pdfTransaction //
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAXES))
+
+                        // @formatter:off
+                        // APPLE INC. REGISTERED SHARES O.N. WKN ISIN
+                        // 865985 US0378331005
+                        // Gesamtsumme Steuern 0,00 EUR
+                        // @formatter:on
+                        .section("name", "wkn", "isin", "currency") //
+                        .match("^(?<name>.*) WKN ISIN$") //
+                        .match("^(?<wkn>[A-Z0-9]{6}) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                        .match("^Gesamtsumme Steuern [\\.,\\d]+ (?<currency>[A-Z]{3})$") //
+                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v)))
+
+                        // @formatter:off
+                        // Stück 15,0000
+                        // @formatter:on
+                        .section("shares") //
+                        .match("^St.ck (?<shares>[\\.,\\d]+)$") //
+                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
+
+                        // The withholding tax is already deducted in the
+                        // dividend document
+                        // and is only credited against the capital gains tax
+                        // here. Therefore
+                        // only the total amount of taxes is booked.
+                        //
+                        // @formatter:off
+                        // Erträge / Verluste nach §20 EStG 29,83 EUR
+                        // Bemessungsgrundlage 0,00 EUR
+                        // Gesamtsumme Steuern 0,00 EUR
+                        // @formatter:on
+                        .section("grossBeforeTaxes", "currencyBeforeTaxes", //
+                                        "grossAssessmentBasis", "currencyAssessmentBasis", //
+                                        "deductedTaxes", "currencyDeductedTaxes") //
+                        .documentContext("date") //
+                        .match("^Ertr.ge \\/ Verluste nach .20 EStG (?<grossBeforeTaxes>[\\.,\\d]+) (?<currencyBeforeTaxes>[A-Z]{3})$") //
+                        .match("^Bemessungsgrundlage (?<grossAssessmentBasis>[\\.,\\d]+) (?<currencyAssessmentBasis>[A-Z]{3})$") //
+                        .match("^Gesamtsumme Steuern (?<deductedTaxes>[\\.,\\d]+) (?<currencyDeductedTaxes>[A-Z]{3})$") //
+                        .assign((t, v) -> {
+                            var grossBeforeTaxes = Money.of(asCurrencyCode(v.get("currencyBeforeTaxes")),
+                                            asAmount(v.get("grossBeforeTaxes")));
+                            var grossAssessmentBasis = Money.of(asCurrencyCode(v.get("currencyAssessmentBasis")),
+                                            asAmount(v.get("grossAssessmentBasis")));
+                            var deductedTaxes = Money.of(asCurrencyCode(v.get("currencyDeductedTaxes")),
+                                            asAmount(v.get("deductedTaxes")));
+
+                            t.setDateTime(asDate(v.get("date")));
+
+                            // Calculate the taxes and store gross amount
+                            if (!grossBeforeTaxes.isZero() && grossAssessmentBasis.isGreaterThan(grossBeforeTaxes))
+                            {
+                                // Store in transaction context
+                                v.getTransactionContext().put(ATTRIBUTE_GROSS_TAXES_TREATMENT, grossAssessmentBasis);
+
+                                t.setMonetaryAmount(grossAssessmentBasis.subtract(grossBeforeTaxes).add(deductedTaxes));
+                            }
+                            else
+                            {
+                                // Store in transaction context
+                                v.getTransactionContext().put(ATTRIBUTE_GROSS_TAXES_TREATMENT, grossBeforeTaxes);
+
+                                t.setMonetaryAmount(deductedTaxes);
+                            }
+                        })
+
+                        // @formatter:off
+                        // Transaktionsreferenz  IND00009801615D00094890632
+                        // @formatter:on
+                        .section("note").optional() //
+                        .match("^Transaktionsreferenz( TR)? (?<note>.*)$") //
+                        .assign((t, v) -> t.setNote("Tr.-Nr.: " + trim(v.get("note"))))
+
+                        .wrap((t, ctx) -> {
+                            var item = new TransactionItem(t);
+
+                            // Store attribute in item data map
+                            item.setData(ATTRIBUTE_GROSS_TAXES_TREATMENT, ctx.get(ATTRIBUTE_GROSS_TAXES_TREATMENT));
+
+                            if (t.getCurrencyCode() != null && t.getAmount() == 0)
+                                ctx.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                            return item;
+                        });
+    }
+
+    private void addNonImportableTransaction()
+    {
+        final var type = new DocumentType("Ausbuchung aus Ihrem Depot", //
+                        documentContext -> documentContext //
+                        // @formatter:off
+                                        // Tag der Übertragung 09.12.2025
+                                        // @formatter:on
+                                        .section("date") //
+                                        .match("^Tag der .bertragung (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4})$") //
+                                        .assign((ctx, v) -> ctx.put("date", v.get("date"))));
+        this.addDocumentTyp(type);
+
+        var pdfTransaction = new Transaction<PortfolioTransaction>();
+
+        var firstRelevantLine = new Block("^[\\.,\\d]+ ST .* [\\.,\\d]+ ST$");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
+
+        pdfTransaction //
+
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_OUTBOUND))
+
+                        // @formatter:off
+                        // 34,0000 ST MUL-AMUN ST600 BANK ETF A Girosammelverwahrung 0,0000 ST
+                        // LYX01W / LU1834983477
+                        // @formatter:on
+                        .section("shares", "name", "wkn", "isin") //
+                        .documentContext("date") //
+                        .match("^(?<shares>[\\.,\\d]+) ST (?<name>.*) (Girosammelverwahrung|Streifbandverwahrung|Wertpapierrechnung) [\\.,\\d]+ ST$") //
+                        .match("^(?<wkn>[A-Z0-9]{6}) \\/ (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9])$") //
+                        .assign((t, v) -> {
+                            v.markAsFailure(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                            t.setDateTime(asDate(v.get("date")));
+                            t.setShares(asShares(v.get("shares")));
+                            t.setSecurity(getOrCreateSecurity(v));
+
+                            t.setCurrencyCode(asCurrencyCode(t.getSecurity().getCurrencyCode()));
+                            t.setAmount(0L);
+                        })
+
+                        .wrap(TransactionItem::new);
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
@@ -660,10 +900,10 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
         // @formatter:off
          // This loop processes a list of dividend and tax pairs, adjusting the gross amount of dividend transactions as needed.
          //
-         // For each pair, it checks if there is a corresponding tax transaction. If present, it considers the gross taxes treatment,
-         // adjusting the gross amount of the dividend transaction if necessary. If taxes amount is zero and gross taxes treatment
-         // is less than the dividend amount, it adjusts the taxes and sets the dividend amount to the gross taxes treatment.
-         // If taxes amount is not zero, it sets the dividend amount to the gross taxes treatment and fixes the gross value.
+         // For each pair, it checks if there is a corresponding tax transaction. If present, it considers the gross taxes treatment
+         // and sets the dividend amount to that gross amount, reduced by the withholding tax that has already been deducted
+         // in the dividend document. If taxes amount is zero and gross taxes treatment is less than the dividend gross value,
+         // the difference is added as an additional tax unit.
          //
          // If there is no tax transaction, it simply fixes the gross value of the dividend transaction.
          // @formatter:on
@@ -678,19 +918,23 @@ public class TargobankPDFExtractor extends AbstractPDFExtractor
 
                 if (grossTaxesTreatment != null)
                 {
-                    var dividendAmount = dividendTransaction.getMonetaryAmount();
+                    // @formatter:off
+                    // The withholding tax has already been deducted from the dividend transaction
+                    // and must not be counted twice when the gross amount of the taxes treatment
+                    // is applied.
+                    // @formatter:on
+                    var withHoldingTax = dividendTransaction.getUnitSum(Unit.Type.TAX);
+
+                    var dividendGrossValue = dividendTransaction.getGrossValue();
                     var taxesAmount = taxesTransaction.getMonetaryAmount();
 
-                    if (taxesAmount.isZero() && grossTaxesTreatment.isLessThan(dividendAmount))
+                    if (taxesAmount.isZero() && grossTaxesTreatment.isLessThan(dividendGrossValue))
                     {
-                        var adjustedTaxes = dividendAmount.subtract(grossTaxesTreatment);
+                        var adjustedTaxes = dividendGrossValue.subtract(grossTaxesTreatment);
                         dividendTransaction.addUnit(new Unit(Unit.Type.TAX, adjustedTaxes));
-                        dividendTransaction.setMonetaryAmount(grossTaxesTreatment);
                     }
-                    else
-                    {
-                        dividendTransaction.setMonetaryAmount(grossTaxesTreatment);
-                    }
+
+                    dividendTransaction.setMonetaryAmount(grossTaxesTreatment.subtract(withHoldingTax));
                 }
 
                 ExtractorUtils.fixGrossValue().accept(dividendTransaction);

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WeberbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/WeberbankPDFExtractor.java
@@ -1,8 +1,12 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
+import static name.abuchen.portfolio.util.TextUtil.concatenate;
+import static name.abuchen.portfolio.util.TextUtil.trim;
 
-import name.abuchen.portfolio.datatransfer.ExtrExchangeRate;
+import java.util.Map;
+
+import name.abuchen.portfolio.datatransfer.ExtractorUtils;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
@@ -11,6 +15,7 @@ import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
 import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.Values;
 
 @SuppressWarnings("nls")
 public class WeberbankPDFExtractor extends AbstractPDFExtractor
@@ -30,19 +35,22 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
     @Override
     public String getLabel()
     {
-        return "Weberbank AG";
+        return "Weberbank Actiengesellschaft";
     }
 
     private void addBuySellTransaction()
     {
-        DocumentType type = new DocumentType("Wertpapier Abrechnung (Kauf|Verkauf)");
+        final var type = new DocumentType("Wertpapier Abrechnung (Kauf|Verkauf)");
         this.addDocumentTyp(type);
 
-        Transaction<BuySellEntry> pdfTransaction = new Transaction<>();
-
-        Block firstRelevantLine = new Block("^Wertpapier Abrechnung (Kauf|Verkauf).*$");
+        var firstRelevantLine = new Block("^Wertpapier Abrechnung (Kauf|Verkauf).*$");
         type.addBlock(firstRelevantLine);
+
+        var pdfTransaction = new Transaction<BuySellEntry>();
         firstRelevantLine.set(pdfTransaction);
+
+        // Map for tax lost adjustment transaction
+        var context = type.getCurrentContext();
 
         pdfTransaction //
 
@@ -56,98 +64,209 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
                                 t.setType(PortfolioTransaction.Type.SELL);
                         })
 
+                        .oneOf( //
+                                        // @formatter:off
+                                        // Nominale Wertpapierbezeichnung ISIN (WKN)
+                                        // Stück 4.440 NEL ASA NO0010081235 (A0B733)
+                                        // NAVNE-AKSJER NK -,20
+                                        // Kurswert 9.657,00- EUR
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("name", "isin", "wkn", "name1", "currency") //
+                                                        .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)") //
+                                                        .match("^St.ck [\\.,\\d]+ (?<name>.*) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\((?<wkn>[A-Z0-9]{6})\\)$") //
+                                                        .match("^(?<name1>.*)$") //
+                                                        .match("^Kurswert [\\.,\\d]+(\\-)? (?<currency>[A-Z]{3})$") //
+                                                        .assign((t, v) -> {
+                                                            if (!v.get("name1").startsWith("Handels-/Ausführungsplatz"))
+                                                                v.put("name", trim(v.get("name")) + " " + trim(v.get("name1")));
+
+                                                            t.setSecurity(getOrCreateSecurity(v));
+                                                        }),
+                                        // @formatter:off
+                                        // Nominale Wertpapierbezeichnung ISIN (WKN)
+                                        // NOK 1.425.000,00 1,375 % NORWEGEN, KÖNIGREICH NO0010875230 (A28TXS)
+                                        // NK-ANL. 2020(30)
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("currency", "name", "isin", "wkn", "nameContinued") //
+                                                        .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)") //
+                                                        .match("^(?<currency>[A-Z]{3}) [\\.,\\d]+ (?<name>.*) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\((?<wkn>[A-Z0-9]{6})\\)$") //
+                                                        .match("^(?<nameContinued>.*)$") //
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
+
                         // @formatter:off
                         // Stück 4.440 NEL ASA NO0010081235 (A0B733)
-                        // NAVNE-AKSJER NK -,20
-                        // Kurswert 9.657,00- EUR
+                        // NOK 1.425.000,00 1,375 % NORWEGEN, KÖNIGREICH NO0010875230 (A28TXS)
                         // @formatter:on
-                        .section("name", "isin", "wkn", "name1", "currency") //
-                        .match("^St.ck [\\.,\\d]+ (?<name>.*) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\((?<wkn>[A-Z0-9]{6})\\)$") //
-                        .match("^(?<name1>.*)$") //
-                        .match("^Kurswert [\\.,\\d]+(\\-)? (?<currency>[\\w]{3})$") //
+                        .section("notation", "shares") //
+                        .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)") //
+                        .match("^(?<notation>(St.ck|[A-Z]{3})) (?<shares>[\\.,\\d]+).*$") //
                         .assign((t, v) -> {
-                            if (!v.get("name1").startsWith("Handels-/Ausführungsplatz"))
-                                v.put("name", v.get("name") + " " + v.get("name1"));
-
-                            t.setSecurity(getOrCreateSecurity(v));
+                            // Percentage quotation, workaround for bonds
+                            if (v.get("notation") != null && !"Stück".equalsIgnoreCase(v.get("notation")))
+                            {
+                                var shares = asBigDecimal(v.get("shares"));
+                                t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
+                            }
+                            else
+                            {
+                                t.setShares(asShares(v.get("shares")));
+                            }
                         })
-
-                        // @formatter:off
-                        // Stück 4.440 NEL ASA NO0010081235 (A0B733)
-                        // @formatter:on
-                        .section("shares") //
-                        .match("^St.ck (?<shares>[\\.,\\d]+).*$") //
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
 
                         // @formatter:off
                         // Schlusstag/-Zeit 26.03.2021 15:12:58 Auftraggeber XXXXXXXXXXXXX
                         // @formatter:on
                         .section("date", "time") //
-                        .match("^Schlusstag\\/\\-Zeit (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$") //
-                        .assign((t, v) -> t.setDate(asDate(v.get("date"), v.get("time"))))
+                        .match("^Schlusstag\\/\\-Zeit (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) (?<time>[\\d]{2}\\:[\\d]{2}\\:[\\d]{2}).*$") //
+                        .assign((t, v) -> {
+                            // @formatter:off
+                            // Handshake for tax lost adjustment transaction
+                            // @formatter:on
+                            context.put("time", v.get("time"));
+
+                            t.setDate(asDate(v.get("date"), v.get("time")));
+                        })
 
                         // @formatter:off
                         // Ausmachender Betrag 9.978,18- EUR
                         // Ausmachender Betrag 2.335,30 EUR
                         // @formatter:on
                         .section("amount", "currency") //
-                        .match("^Ausmachender Betrag (?<amount>[\\.,\\d]+)(\\-)? (?<currency>[\\w]{3})$") //
+                        .match("^Ausmachender Betrag (?<amount>[\\.,\\d]+)(\\-)? (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
                         })
 
+                        // @formatter:off
+                        // Devisenkurs (EUR/NOK) 11,207 vom 02.04.2026
+                        // Kurswert 112.184,26- EUR
+                        // @formatter:on
+                        .section("baseCurrency", "termCurrency", "exchangeRate", "gross").optional() //
+                        .match("^Devisenkurs \\((?<baseCurrency>[A-Z]{3})\\/(?<termCurrency>[A-Z]{3})\\) (?<exchangeRate>[\\.,\\d]+).*$") //
+                        .match("^Kurswert (?<gross>[\\.,\\d]+)(\\-)? [A-Z]{3}$") //
+                        .assign((t, v) -> {
+                            var rate = asExchangeRate(v);
+                            type.getCurrentContext().putType(rate);
+
+                            var gross = Money.of(rate.getBaseCurrency(), asAmount(v.get("gross")));
+                            var fxGross = rate.convert(rate.getTermCurrency(), gross);
+
+                            // @formatter:off
+                            // Handshake for tax lost adjustment transaction
+                            // @formatter:on
+                            context.put("baseCurrency", rate.getBaseCurrency());
+                            context.put("termCurrency", rate.getTermCurrency());
+                            context.put("exchangeRate", v.get("exchangeRate"));
+
+                            checkAndSetGrossUnit(gross, fxGross, t, type.getCurrentContext());
+                        })
+
+                        // @formatter:off
+                        // Auftragsnummer 742198/43.00
+                        // @formatter:on
+                        .section("note").optional() //
+                        .match("^.*(?<note>Auftragsnummer .*)$") //
+                        .assign((t, v) -> t.setNote(trim(v.get("note"))))
+
+                        // @formatter:off
                         // Limit bestens
                         // Limit billigst
+                        // @formatter:on
                         .section("note").optional() //
                         .match("^(?<note>Limit .*)$") //
-                        .assign((t, v) -> t.setNote(v.get("note")))
+                        .assign((t, v) -> t.setNote(concatenate(t.getNote(), trim(v.get("note")), " | ")))
 
-                        .wrap(BuySellEntryItem::new);
+                        .conclude(ExtractorUtils.fixGrossValueBuySell())
+
+                        .wrap((t, ctx) -> {
+                            var item = new BuySellEntryItem(t);
+
+                            // @formatter:off
+                            // Handshake for tax lost adjustment transaction
+                            // @formatter:on
+                            context.put("name", item.getSecurity().getName());
+                            context.put("isin", item.getSecurity().getIsin());
+                            context.put("wkn", item.getSecurity().getWkn());
+                            context.put("shares", Long.toString(item.getShares()));
+
+                            if (t.getNote() != null)
+                                context.put("note", t.getNote());
+
+                            return item;
+                        });
 
         addTaxesSectionsTransaction(pdfTransaction, type);
+        addFeesSectionsTransaction(pdfTransaction, type);
+        addTaxLostAdjustmentTransaction(context, type);
     }
 
     private void addDividendeTransaction()
     {
-        DocumentType type = new DocumentType("Dividendengutschrift");
+        final var type = new DocumentType("(Dividendengutschrift|Zinsgutschrift)");
         this.addDocumentTyp(type);
 
-        Transaction<AccountTransaction> pdfTransaction = new Transaction<>();
-
-        Block firstRelevantLine = new Block("^Dividendengutschrift$");
+        var firstRelevantLine = new Block("^(Dividendengutschrift|Zinsgutschrift)$");
         type.addBlock(firstRelevantLine);
+
+        var pdfTransaction = new Transaction<AccountTransaction>();
         firstRelevantLine.set(pdfTransaction);
 
         pdfTransaction //
 
                         .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
 
-                        // @formatter:off
-                        // Nominale Wertpapierbezeichnung ISIN (WKN)
-                        // Stück 107 APPLE INC. US0378331005 (865985)
-                        // Dividendengutschrift 87,74 USD 74,05+ EUR
-                        // @formatter:on
-                        .section("name", "isin", "wkn", "name1", "currency") //
-                        .match("^St.ck [\\.,\\d]+ (?<name>.*) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\((?<wkn>[A-Z0-9]{6})\\)$") //
-                        .match("(?<name1>.*)") //
-                        .match("^Dividendengutschrift [\\.,\\d]+ (?<currency>[\\w]{3}).*$") //
-                        .assign((t, v) -> {
-                            if (!v.get("name1").startsWith("Zahlbarkeitstag"))
-                                v.put("name", v.get("name") + " " + v.get("name1"));
+                        .oneOf( //
+                                        // @formatter:off
+                                        // Nominale Wertpapierbezeichnung ISIN (WKN)
+                                        // Stück 107 APPLE INC. US0378331005 (865985)
+                                        // REGISTERED SHARES O.N.
+                                        // Zahlbarkeitstag 13.08.2020 Dividende pro Stück 0,82 USD
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("name", "isin", "wkn", "nameContinued", "currency") //
+                                                        .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)") //
+                                                        .match("^St.ck [\\.,\\d]+ (?<name>.*) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\((?<wkn>[A-Z0-9]{6})\\)$") //
+                                                        .match("^(?<nameContinued>.*)$") //
+                                                        .match("^Zahlbarkeitstag .* [\\.,\\d]+ (?<currency>[A-Z]{3})$") //
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
+                                        // @formatter:off
+                                        // Nominale Wertpapierbezeichnung ISIN (WKN)
+                                        // NOK 1.425.000,00 NORWEGEN, KÖNIGREICH NO0010875230 (A28TXS)
+                                        // NK-ANL. 2020(30)
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("currency", "name", "isin", "wkn", "nameContinued") //
+                                                        .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)") //
+                                                        .match("^(?<currency>[A-Z]{3}) [\\.,\\d]+ (?<name>.*) (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]) \\((?<wkn>[A-Z0-9]{6})\\)$") //
+                                                        .match("^(?<nameContinued>.*)$") //
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
 
-                            t.setSecurity(getOrCreateSecurity(v));
+                        // @formatter:off
+                        // Stück 107 APPLE INC. US0378331005 (865985)
+                        // NOK 1.425.000,00 NORWEGEN, KÖNIGREICH NO0010875230 (A28TXS)
+                        // @formatter:on
+                        .section("notation", "shares") //
+                        .find("Nominale Wertpapierbezeichnung ISIN \\(WKN\\)") //
+                        .match("^(?<notation>(St.ck|[A-Z]{3})) (?<shares>[\\.,\\d]+) .*$") //
+                        .assign((t, v) -> {
+                            // Percentage quotation, workaround for bonds
+                            if (v.get("notation") != null && !"Stück".equalsIgnoreCase(v.get("notation")))
+                            {
+                                var shares = asBigDecimal(v.get("shares"));
+                                t.setShares(Values.Share.factorize(shares.doubleValue() / 100));
+                            }
+                            else
+                            {
+                                t.setShares(asShares(v.get("shares")));
+                            }
                         })
 
                         // @formatter:off
-                        // Stück 107 APPLE INC. US0378331005 (865985)
-                        // @formatter:on
-                        .section("shares") //
-                        .match("^St.ck (?<shares>[\\.,\\d]+).*$") //
-                        .assign((t, v) -> t.setShares(asShares(v.get("shares"))))
-
-                        // @formatter:off
                         // Zahlbarkeitstag 13.08.2020 Dividende pro Stück 0,82 USD
+                        // Zahlbarkeitstag 19.08.2026 Zinssatz p. a. 1,375 %
                         // @formatter:on
                         .section("date") //
                         .match("^Zahlbarkeitstag (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$") //
@@ -155,6 +274,7 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
 
                         // @formatter:off
                         // Ex-Tag 07.08.2020 Art der Dividende Quartalsdividende
+                        // Ex-Tag 28.03.2025
                         // @formatter:on
                         .section("exDate").optional() //
                         .match("^Ex\\-Tag (?<exDate>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}).*$") //
@@ -163,8 +283,8 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:off
                         // Ausmachender Betrag 55,14+ EUR
                         // @formatter:on
-                        .section("currency", "amount") //
-                        .match("^Ausmachender Betrag (?<amount>[\\.,\\d]+)\\+ (?<currency>[\\w]{3})") //
+                        .section("amount", "currency") //
+                        .match("^Ausmachender Betrag (?<amount>[\\.,\\d]+)\\+ (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> {
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(asCurrencyCode(v.get("currency")));
@@ -173,30 +293,102 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:off
                         // Devisenkurs EUR / USD 1,1848
                         // Dividendengutschrift 87,74 USD 74,05+ EUR
+                        //
+                        // Devisenkurs EUR / NOK 10,9341
+                        // Zinsertrag 19.593,75 NOK 1.791,99+ EUR
                         // @formatter:on
-                        .section("baseCurrency", "termCurrency", "exchangeRate", "fxGross", "gross") .optional() //
-                        .match("^Devisenkurs (?<baseCurrency>[\\w]{3}) \\/ (?<termCurrency>[\\w]{3}) (?<exchangeRate>[\\.,\\d]+)$") //
-                        .match("^Dividendengutschrift (?<fxGross>[\\.,\\d]+) [\\w]{3} (?<gross>[\\.,\\d]+)\\+ [\\w]{3}$") //
+                        .section("baseCurrency", "termCurrency", "exchangeRate", "fxGross", "gross").optional() //
+                        .match("^Devisenkurs (?<baseCurrency>[A-Z]{3}) \\/ (?<termCurrency>[A-Z]{3}) (?<exchangeRate>[\\.,\\d]+).*$") //
+                        .match("^(Dividendengutschrift|Zinsertrag) (?<fxGross>[\\.,\\d]+) [A-Z]{3} (?<gross>[\\.,\\d]+)\\+ [A-Z]{3}$") //
                         .assign((t, v) -> {
-                            ExtrExchangeRate rate = asExchangeRate(v);
+                            var rate = asExchangeRate(v);
                             type.getCurrentContext().putType(rate);
 
-                            Money gross = Money.of(rate.getBaseCurrency(), asAmount(v.get("gross")));
-                            Money fxGross = Money.of(rate.getTermCurrency(), asAmount(v.get("fxGross")));
+                            var gross = Money.of(rate.getBaseCurrency(), asAmount(v.get("gross")));
+                            var fxGross = Money.of(rate.getTermCurrency(), asAmount(v.get("fxGross")));
 
                             checkAndSetGrossUnit(gross, fxGross, t, type.getCurrentContext());
                         })
 
                         // @formatter:off
+                        // Abrechnungsnr. 54861333620
+                        // @formatter:on
+                        .section("note").optional() //
+                        .match("^.*(?<note>Abrechnungsnr\\. [\\d]+).*$") //
+                        .assign((t, v) -> t.setNote(trim(v.get("note"))))
+
+                        // @formatter:off
                         // Ex-Tag 07.08.2020 Art der Dividende Quartalsdividende
                         // @formatter:on
                         .section("note").optional() //
-                        .match("^.* Art der Dividende (?<note>.*)") //
-                        .assign((t, v) -> t.setNote(v.get("note")))
+                        .match("^.* Art der Dividende (?<note>.*)$") //
+                        .assign((t, v) -> t.setNote(concatenate(t.getNote(), trim(v.get("note")), " | ")))
+
+                        .conclude(ExtractorUtils.fixGrossValueA())
 
                         .wrap(TransactionItem::new);
 
         addTaxesSectionsTransaction(pdfTransaction, type);
+    }
+
+    private void addTaxLostAdjustmentTransaction(Map<String, String> context, DocumentType type)
+    {
+        var pdfTransaction = new Transaction<AccountTransaction>();
+
+        var firstRelevantLine = new Block("^Steuerliche Ausgleichrechnung$");
+        type.addBlock(firstRelevantLine);
+        firstRelevantLine.set(pdfTransaction);
+
+        pdfTransaction //
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.TAX_REFUND))
+
+                        // @formatter:off
+                        // Ausmachender Betrag 558,03 EUR
+                        // Den Gegenwert buchen wir mit Valuta 18.06.2026 zu Gunsten des Kontos xxxxxxxxxx
+                        // @formatter:on
+                        .section("amount", "currency", "date").optional() //
+                        .match("^Ausmachender Betrag (?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                        .match("^Den Gegenwert buchen wir mit Valuta (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) .*$") //
+                        .assign((t, v) -> {
+                            if (context.get("time") != null)
+                                t.setDateTime(asDate(v.get("date"), context.get("time")));
+                            else
+                                t.setDateTime(asDate(v.get("date")));
+
+                            t.setShares(Long.parseLong(context.get("shares")));
+                            t.setSecurity(getOrCreateSecurity(context));
+
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setAmount(asAmount(v.get("amount")));
+
+                            t.setNote(context.get("note"));
+                        })
+
+                        // @formatter:off
+                        // Ausmachender Betrag 293,10 EUR
+                        // @formatter:on
+                        .section("gross", "currency").optional() //
+                        .match("^Ausmachender Betrag (?<gross>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                        .assign((t, v) -> {
+                            if (context.get("exchangeRate") != null)
+                            {
+                                var rate = asExchangeRate(context);
+                                type.getCurrentContext().putType(rate);
+
+                                var gross = Money.of(rate.getBaseCurrency(), asAmount(v.get("gross")));
+                                var fxGross = rate.convert(rate.getTermCurrency(), gross);
+
+                                checkAndSetGrossUnit(gross, fxGross, t, type.getCurrentContext());
+                            }
+                        })
+
+                        .wrap(t -> {
+                            if (t.getCurrencyCode() != null && t.getAmount() != 0)
+                                return new TransactionItem(t);
+
+                            return null;
+                        });
     }
 
     private <T extends Transaction<?>> void addTaxesSectionsTransaction(T transaction, DocumentType type)
@@ -207,28 +399,50 @@ public class WeberbankPDFExtractor extends AbstractPDFExtractor
                         // Kapitalertragsteuer 25 % auf 29,61 EUR 7,40- EUR
                         // @formatter:on
                         .section("tax", "currency").optional() //
-                        .match("^Kapitalertrags(s)?teuer [\\.,\\d]+ % .* (?<tax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$") //
+                        .match("^Kapitalertrags(s)?teuer [\\.,\\d]+[\\s]*% auf [\\.,\\d]+ [A-Z]{3} (?<tax>[\\.,\\d]+)\\- (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> processTaxEntries(t, v, type))
 
                         // @formatter:off
                         // Solidaritätszuschlag 5,5 % auf 7,40 EUR 0,40- EUR
                         // @formatter:on
                         .section("tax", "currency").optional() //
-                        .match("^Solidarit.tszuschlag [\\.,\\d]+ % .* (?<tax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$") //
+                        .match("^Solidarit.tszuschlag [\\.,\\d]+[\\s]*% auf [\\.,\\d]+ [A-Z]{3} (?<tax>[\\.,\\d]+)\\- (?<currency>[A-Z]{3})$") //
+                        .assign((t, v) -> processTaxEntries(t, v, type))
+
+                        // @formatter:off
+                        // Kirchensteuer 9 % auf 7,40 EUR 0,66- EUR
+                        // @formatter:on
+                        .section("tax", "currency").optional() //
+                        .match("^Kirchensteuer [\\.,\\d]+[\\s]*% auf [\\.,\\d]+ [A-Z]{3} (?<tax>[\\.,\\d]+)\\- (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> processTaxEntries(t, v, type))
 
                         // @formatter:off
                         // Einbehaltene Quellensteuer 15 % auf 87,74 USD 11,11- EUR
+                        // Einbehaltene Quellensteuer 27 % auf 4.345,00 DKK 156,80- EUR
                         // @formatter:on
                         .section("withHoldingTax", "currency").optional() //
-                        .match("^Einbehaltene Quellensteuer [\\.,\\d]+ % .* (?<withHoldingTax>[\\.,\\d]+)\\- (?<currency>[\\w]{3})$") //
+                        .match("^Einbehaltene Quellensteuer [\\.,\\d]+[\\s]*% auf [\\.,\\d]+ [A-Z]{3} (?<withHoldingTax>[\\.,\\d]+)\\- (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> processWithHoldingTaxEntries(t, v, "withHoldingTax", type))
 
                         // @formatter:off
                         // Anrechenbare Quellensteuer 15 % auf 74,05 EUR 11,11 EUR
                         // @formatter:on
                         .section("creditableWithHoldingTax", "currency").optional() //
-                        .match("^Anrechenbare Quellensteuer [\\.,\\d]+ % .* (?<creditableWithHoldingTax>[\\.,\\d]+) (?<currency>[\\w]{3})$") //
+                        .match("^Anrechenbare Quellensteuer [\\.,\\d]+[\\s]*% auf [\\.,\\d]+ [A-Z]{3} (?<creditableWithHoldingTax>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> processWithHoldingTaxEntries(t, v, "creditableWithHoldingTax", type));
+    }
+
+    private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
+    {
+        transaction //
+
+                        // @formatter:off
+                        // When purchasing bonds, the accrued interest ("Stückzinsen") is treated as a fee.
+                        //
+                        // Stückzinsen für 232 Tage per 07.04.2026 1.111,28- EUR
+                        // @formatter:on
+                        .section("fee", "currency").optional() //
+                        .match("^St.ckzinsen f.r [\\d]+ Tage per [\\d]{2}\\.[\\d]{2}\\.[\\d]{4} (?<fee>[\\.,\\d]+)\\- (?<currency>[A-Z]{3})$") //
+                        .assign((t, v) -> processFeeEntries(t, v, type));
     }
 }


### PR DESCRIPTION
Quellensteuer bei Dividenden gefixt — wurde beim Einzelimport der Gutschrift komplett ignoriert
Ex-Tag wird jetzt bei allen Dividenden übernommen
Steuererstattungen werden als solche verbucht statt als Steuer Negative Beträge in der Steuerbeilage brechen den Import nicht mehr ab Ausbuchungen aus dem Depot werden als nicht unterstützt gemeldet statt stillschweigend ignoriert
Altes Beleg-Format (Dividendengutschrift und Steuerbeilage) wird unterstützt
(Steuer abgeleitet) @kimmerin 

Englisch:

Fixed withholding tax on dividends — it was ignored when importing the credit note on its own
Ex-date is now imported for all dividends
Tax refunds are booked as refunds instead of taxes Negative amounts in the tax statement no longer abort the import Securities transfers out of the depot are reported as not supported instead of being silently ignored
Added support for the older document format (dividend credit note and tax statement)