### PR TITLE
Baader Bank PDF Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/BaaderBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/BaaderBankPDFExtractorTest.java
@@ -1875,6 +1875,40 @@ public class BaaderBankPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierKauf38()
+    {
+        var extractor = new BaaderBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf38.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("IE00BF4RFH31"), hasWkn("A2DWBY"), hasTicker(null), //
+                        hasName("iShsIII-MSCI Wld Sm.Ca.UCI.ETF Registered Shares USD(Acc)o.N."), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-03-02T14:09:43"), hasShares(20.00), //
+                        hasSource("Kauf38.txt"), //
+                        hasNote("Vorgangs-Nr.: 453010440"), //
+                        hasAmount("EUR", 168.60), hasGrossValue("EUR", 167.60), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", (0.50 - 0.40) + 0.90))));
+    }
+
+    @Test
     public void testWertpapierVerkauf01()
     {
         var extractor = new BaaderBankPDFExtractor(new Client());
@@ -2918,6 +2952,40 @@ public class BaaderBankPDFExtractorTest
                         hasNote("Vorgangs-Nr.: 442024039"), //
                         hasAmount("EUR", 5576.69), hasGrossValue("EUR", 5828.13), //
                         hasTaxes("EUR", 219.61 + 19.76 + 12.07), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testWertpapierVerkauf22()
+    {
+        var extractor = new BaaderBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Verkauf22.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US9224751084"), hasWkn("A1W5SA"), hasTicker(null), //
+                        hasName("Veeva System Inc. Registered Shares A DL -,00001"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2026-08-14T15:00:55"), hasShares(0.222), //
+                        hasSource("Verkauf22.txt"), //
+                        hasNote("Vorgangs-Nr.: 219895934"), //
+                        hasAmount("EUR", 45.57), hasGrossValue("EUR", 48.22), //
+                        hasTaxes("EUR", 1.57 + 0.08), hasFees("EUR", 1.00))));
     }
 
     @Test

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/Kauf38.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/Kauf38.txt
@@ -1,0 +1,65 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.5
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Baader Bank AG   Weihenstephaner Straße 4   85716 Unterschleißheim Gartenstraße 67
+T  00800 00 586336*   F  +49 89 5150 2442    service@baaderbank.de 76135 Karlsruhe
+www.finanzen.net/zero
++49 89 5455 8188
+Seite 1/2
+Herrn Karlsruhe
+02.03.2026
+BLLnRss VbXjl
+XXXXX-XXXX-XXX. X yXCbSeB mVcZD
+13013 pBCUQchPlGW Stamm-Nr.: 0886101    Portfolio: 1
+Depot-Nr.: 0062639585
+Vorgangs-Nr.: 453010440
+Referenz-Nr.: 495116874
+Wertpapierabrechnung: Kauf
+Auftragsdatum: 02.03.2026 Ausführungsplatz: GETTEX - MM Munich
+Auftragszeit: 14:09:43:00
+Nominale ISIN: IE00BF4RFH31 WKN: A2DWBY Kurs 
+STK 20 iShsIII-MSCI Wld Sm.Ca.UCI.ETF EUR 8,38
+Registered Shares USD(Acc)o.N.
+Auftraggeber: Depotinhaber
+Art der Auftragserteilung: Orderroutingssystem
+Kurswert EUR 167,60
+Finanzkommission Baader EUR 0,50
+Handelsplatzabhängige Gutschrift Baader EUR 0,40 -
+Vermittlungsentgelt Finanzen EUR 0,90
+Zu Lasten Konto 4376051208 Valuta: 04.03.2026 EUR 168,60
+Die Wertpapiere buchen wir zu Gunsten Ihres Depots.
+Details zur Ausführung: Handels- Handels- 
+Nominale Kurs Ausführungsplatz datum uhrzeit 
+STK   20 EUR 8,38 GETTEX - MM Munich 02.03.2026 14:09:43:976
+Verwahrart: Wertpapierrechnung Zeitzone der Handelsuhrzeit: MEZ/MESZ
+Lagerstelle: 1419 MIC des Ausführungsplatzes: MUNC
+Lagerland: Luxemburg
+Für die Ausführung dieses Auftrags gelten die Usancen des jeweiligen Ausführungsplatzes.
+Diese Auftragsbestätigung/Abrechnung wurde von der Baader Bank AG erstellt. Bitte prüfen Sie diese auf Richtigkeit und Vollständigkeit. Etwaige 
+Einwendungen gegen diese Auftragsbestätigung/Abrechnung müssen nach Zugang unverzüglich bei der Baader Bank AG erhoben werden. 
+Dieser Auftrag erfolgte ohne Empfehlung der Bank. Es wurde keine Anlageberatung und keine individuelle Aufklärung durch die Bank erbracht.
+Sofern keine Umsatzsteuer ausgewiesen ist, handelt es sich um eine umsatzsteuerbefreite Finanzdienstleistung.
+finanzen.net zero GmbH, Gartenstraße 67, 76135 Karlsruhe • Impressum unter: www.finanzen.net/zero/impressum
+finanzen.net zero GmbH erbringt Anlagevermittlung als gebundener Vermittler der DonauCapital Wertpapier GmbH 
+ 
+Herausgeberin und verantwortlich für den Inhalt ist die Baader Bank Aktiengesellschaft • Weihenstephaner Straße 4 • 85716 Unterschleißheim • Deutschland
+Vorstand: Nico Baader (Vorsitzender), Oliver Riedel (stv. Vorsitzender), Martin Zoller • Vorsitzender des Aufsichtsrates: Dr. Louis Hagen • Amtsgericht München HRB 121537 • 
+Sitz der Gesellschaft: Unterschleißheim • StNr. 143/107/04009 • USt-IdNr. DE114123893 • LEI: 529900JFOPPEDUR61H13 • T 00800 00 586336* • service@baaderbank.de
+ 
+* Kostenfreie Telefonnummer aus dem (inter-) nationalen Festnetz. Für Anrufe aus anderen Netzen können Gebühren anfallen. WPABRECHNUNG-060.114
+Wertpapierabrechnung: Kauf
+Fortsetzung: Seite 2/2
+Die Aushändigung des Fondsprospektes/Offering Memorandum sowie des aktuellen Rechenschaftsberichtes durch die Bank ist im Rahmen der 
+Kooperation der Bank mit Ihrem Finanzdienstleister nicht erforderlich bzw. wird von diesem übernommen. Sofern Sie einen Fondsprospekt 
+wünschen, wenden Sie sich daher bitte direkt an den Finanzdienstleister.
+Einkünfte aus Kapitalvermögen im Sinne von § 20 EStG sind einkommensteuerpflichtig.
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+finanzen.net zero GmbH, Gartenstraße 67, 76135 Karlsruhe • Impressum unter: www.finanzen.net/zero/impressum
+finanzen.net zero GmbH erbringt Anlagevermittlung als gebundener Vermittler der DonauCapital Wertpapier GmbH 
+ 
+Herausgeberin und verantwortlich für den Inhalt ist die Baader Bank Aktiengesellschaft • Weihenstephaner Straße 4 • 85716 Unterschleißheim • Deutschland
+Vorstand: Nico Baader (Vorsitzender), Oliver Riedel (stv. Vorsitzender), Martin Zoller • Vorsitzender des Aufsichtsrates: Dr. Louis Hagen • Amtsgericht München HRB 121537 • 
+Sitz der Gesellschaft: Unterschleißheim • StNr. 143/107/04009 • USt-IdNr. DE114123893 • LEI: 529900JFOPPEDUR61H13 • T 00800 00 586336* • service@baaderbank.de
+ 
+* Kostenfreie Telefonnummer aus dem (inter-) nationalen Festnetz. Für Anrufe aus anderen Netzen können Gebühren anfallen. WPABRECHNUNG-060.114

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/Verkauf22.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/baaderbank/Verkauf22.txt
@@ -1,0 +1,76 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.87.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Baader Bank AG   Weihenstephaner Straße 4   85716 Unterschleißheim Gartenstraße 67
+T  00800 00 586336*   F  +49 89 5150 2442    service@baaderbank.de 76135 Karlsruhe
+www.finanzen.net/zero
++49 89 5455 8188
+Seite 1/2
+Herrn Karlsruhe
+14.08.2026
+XQVUmOv xeOQi
+xxx lgxNScZ MLLyv
+10413 VQHzGQiqYjv Stamm-Nr.: 8925854    Portfolio: 1
+Depot-Nr.: 2273402440
+Vorgangs-Nr.: 219895934
+Referenz-Nr.: 6643499838
+Wertpapierabrechnung: Verkauf
+Auftragsdatum: 14.08.2026 Ausführungsplatz: GETTEX - MM Munich
+Auftragszeit: 15:00:55:00
+Nominale ISIN: US9224751084 WKN: A1W5SA Kurs 
+STK 0,222 Veeva System Inc. EUR 217,20
+Registered Shares A DL -,00001
+Auftraggeber: Depotinhaber
+Art der Auftragserteilung: Orderroutingsystem
+Kurswert EUR 48,22
+Kapitalertragsteuer EUR 1,57 -
+Solidaritätszuschlag EUR 0,08 -
+Mindermengenzuschlag EUR 1,00 -
+Zu Gunsten Konto 1699699844 Valuta: 18.08.2026 EUR 45,57
+Die Wertpapiere buchen wir zu Lasten Ihres Depots.
+Details zur Ausführung:
+Handelsdatum Handelsuhrzeit 
+14.08.2026 15:00:55:46
+Verwahrart: Girosammelverwahrung Zeitzone der Handelsuhrzeit: MEZ/MESZ
+Lagerstelle: 100 MIC des Ausführungsplatzes: MUNC
+Lagerland: Deutschland
+Für die Ausführung dieses Auftrags gelten die Usancen des jeweiligen Ausführungsplatzes.
+Diese Auftragsbestätigung/Abrechnung wurde von der Baader Bank AG erstellt. Bitte prüfen Sie diese auf Richtigkeit und Vollständigkeit. Etwaige 
+Einwendungen gegen diese Auftragsbestätigung/Abrechnung müssen nach Zugang unverzüglich bei der Baader Bank AG erhoben werden. 
+Dieser Auftrag erfolgte ohne Empfehlung der Bank. Es wurde keine Anlageberatung und keine individuelle Aufklärung durch die Bank erbracht.
+Sofern keine Umsatzsteuer ausgewiesen ist, handelt es sich um eine umsatzsteuerbefreite Finanzdienstleistung.
+GBRdf052062deca4f249936fcfd6c18051f
+Einkünfte aus Kapitalvermögen im Sinne von § 20 EStG sind einkommensteuerpflichtig.
+Dieses Dokument wurde maschinell erstellt und wird nicht unterschrieben.
+finanzen.net zero GmbH, Gartenstraße 67, 76135 Karlsruhe • Impressum unter: www.finanzen.net/zero/impressum
+finanzen.net zero GmbH erbringt Anlagevermittlung als gebundener Vermittler der DonauCapital Wertpapier GmbH 
+ 
+Herausgeberin und verantwortlich für den Inhalt ist die Baader Bank Aktiengesellschaft • Weihenstephaner Straße 4 • 85716 Unterschleißheim • Deutschland
+Vorstand: Oliver Riedel (Vorsitzender), Kai Göhring, Martin Zoller • Vorsitzender des Aufsichtsrates: Dr. Louis Hagen • Amtsgericht München HRB 121537 • Sitz der 
+Gesellschaft: Unterschleißheim • StNr. 143/107/04009 • USt-IdNr. DE114123893 • LEI: 529900JFOPPEDUR61H13 • T 00800 00 586336* • service@baaderbank.de
+ 
+* Kostenfreie Telefonnummer aus dem (inter-) nationalen Festnetz. Für Anrufe aus anderen Netzen können Gebühren anfallen. WPABRECHNUNG-063.115
+Wertpapierabrechnung: Verkauf
+Fortsetzung: Seite 2/2
+Darstellung der steuerlichen Berechnungsgrundlagen:
+Merkposten / Steuertöpfe vorher Erhöhung/Reduktion nachher
+Kapitalertragsteuer Aktiengewinne EUR 130,97 EUR 1,57 EUR 132,54
+Bemessungsgrundlagen Steuerpflicht brutto Steuerpflicht netto
+Gewinn / Verlust aus Aktienveräußerungen EUR 6,26 EUR 6,26
+Bemessungsgrundlage zur KESt (Aktiengewinne) EUR 6,26 EUR 6,26
+Steuerbeträge
+Kapitalertragsteuer Aktiengewinne 25,00 % EUR 1,57 - EUR 1,57 -
+Solidaritätszuschlag Aktiengewinne 5,50 % EUR 0,08 - EUR 0,08 -
+Berücksichtigte Anschaffungsgeschäfte (alle ermittelten Beträge in EUR)
+Geschäfts-
+Geschäft Nr. Datum Whg./St. Nominal/Stück Anschaff.-kosten ant. Veräußer.-erlös ant. Ergebnis
+WP Kauf 385367588 22.04.2025 STK 0,222 40,96 47,22 6,26
+finanzen.net zero GmbH, Gartenstraße 67, 76135 Karlsruhe • Impressum unter: www.finanzen.net/zero/impressum
+finanzen.net zero GmbH erbringt Anlagevermittlung als gebundener Vermittler der DonauCapital Wertpapier GmbH 
+ 
+Herausgeberin und verantwortlich für den Inhalt ist die Baader Bank Aktiengesellschaft • Weihenstephaner Straße 4 • 85716 Unterschleißheim • Deutschland
+Vorstand: Oliver Riedel (Vorsitzender), Kai Göhring, Martin Zoller • Vorsitzender des Aufsichtsrates: Dr. Louis Hagen • Amtsgericht München HRB 121537 • Sitz der 
+Gesellschaft: Unterschleißheim • StNr. 143/107/04009 • USt-IdNr. DE114123893 • LEI: 529900JFOPPEDUR61H13 • T 00800 00 586336* • service@baaderbank.de
+ 
+* Kostenfreie Telefonnummer aus dem (inter-) nationalen Festnetz. Für Anrufe aus anderen Netzen können Gebühren anfallen. WPABRECHNUNG-063.115

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/BaaderBankPDFExtractor.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetFee;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetGrossUnit;
 import static name.abuchen.portfolio.util.TextUtil.concatenate;
 import static name.abuchen.portfolio.util.TextUtil.trim;
@@ -1530,10 +1531,48 @@ public class BaaderBankPDFExtractor extends AbstractPDFExtractor
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off
-                        // Mindermengenzuschlag Finanzen.net EUR 1,00
+                        // Finanzkommission Baader EUR 0,50
+                        // Handelsplatzabhängige Gutschrift Baader EUR 0,40 -
+                        // @formatter:on
+                        .section("currency", "fee", "discountCurrency", "discount").optional() //
+                        .match("^Finanzkommission .* (?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)( \\-)?$") //
+                        .match("^Handelsplatzabh.ngige Gutschrift .* (?<discountCurrency>[A-Z]{3}) (?<discount>[\\.,\\d]+) \\-$") //
+                        .assign((t, v) -> {
+                            var fee = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("fee")));
+                            var discount = Money.of(asCurrencyCode(v.get("discountCurrency")), asAmount(v.get("discount")));
+
+                            if (fee.subtract(discount).isPositive())
+                            {
+                                fee = fee.subtract(discount);
+                                checkAndSetFee(fee, t, type.getCurrentContext());
+                            }
+
+                            type.getCurrentContext().putBoolean("noFinanzkommission", true);
+                        })
+
+                        // @formatter:off
+                        // Finanzkommission Baader EUR 0,50
                         // @formatter:on
                         .section("currency", "fee").optional() //
-                        .match("^Mindermengenzuschlag .* (?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)( \\-)?$") //
+                        .match("^Finanzkommission .* (?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)( \\-)?$") //
+                        .assign((t, v) -> {
+                            if (!type.getCurrentContext().getBoolean("noFinanzkommission"))
+                                processFeeEntries(t, v, type);
+                        })
+
+                        // @formatter:off
+                        // Mindermengenzuschlag Finanzen.net EUR 1,00
+                        // Mindermengenzuschlag EUR 1,00 -
+                        // @formatter:on
+                        .section("currency", "fee").optional() //
+                        .match("^Mindermengenzuschlag( .*)? (?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)( \\-)?$") //
+                        .assign((t, v) -> processFeeEntries(t, v, type))
+
+                        // @formatter:off
+                        // Vermittlungsentgelt Finanzen EUR 0,90
+                        // @formatter:on
+                        .section("currency", "fee").optional() //
+                        .match("^Vermittlungsentgelt .* (?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)( \\-)?$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off


### PR DESCRIPTION
The "Mindermengenzuschlag" section required a text between the keyword and the currency, so the newer variant without it ("Mindermengenzuschlag EUR 1,00 -") was not recognized. Both variants are now covered by one section.

Additionally, the fees of finanzen.net zero statements are supported: "Finanzkommission", "Vermittlungsentgelt" and the "Handelsplatzabhängige Gutschrift" that is deducted from the commission.