### PR TITLE
Postbank PDF Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/Kauf07.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/Kauf07.txt
@@ -1,0 +1,40 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.82.1
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Postbank
+Beratungsteam
+sooDtvB 24/7-Kundenservice (0228) 5500-5500
+ njZjfKCwLul 
+Ja ZSyBQWpEqw 7 
+64912 dEuXberb
+7. April 2026
+Abrechnung: Kauf von Wertpapieren 
+Depotinhaber: CasBIST sgnIyOpBKPQ
+Filialnummer Depotnummer Wertpapierbezeichnung Seite
+045 6394160 08 XTRACKERS STOXX EUROPE 600 INH.ANT.1C O.N. 1/1
+WKN DBX1A7 Nominal ST 0,6526
+ISIN LU0328475792 Kurs EUR 153,24
+Verwahrart Girosammel / Zwischenverwahrung Euroclear
+Geschäft Kommissionsgeschäft
+Börse Frankfurt a.M. - Deutsche Börse - Frankfurter Wertpapierbörse (FWB) - Xetra
+Belegnummer 9867409933 / 344685043 Schlusstag/-zeit MEZ 07.04.2026 / 08:00:50
+Ihre Referenz PBI03
+Auftragsart sonstiger Auftrag
+Abrechnung Währung Betrag
+Kurswert EUR 100,00
+Provision EUR 0,90
+Provisions-Rabatt EUR -0,90
+Belastung
+Buchung auf Kontonummer 6136110 68 mit Wertstellung 09.04.2026 EUR 100,00
+Die Wertpapiere haben wir entsprechend der Abrechnung gebucht. Unser Geschäftsverkehr mit Ihnen wird durch unsere Allgemeinen Geschäftsbedingungen 
+und die Sonderbedingungen für Wertpapiergeschäfte geregelt. Bitte überprüfen Sie diese Abrechnung schnellstmöglich und richten Sie etwaige Einwendungen 
+in den Geschäftsräumen der Bank oder schriftlich an Deutsche Bank AG, QM - Support, 04082 Leipzig. Andernfalls gilt diese Abrechnung als genehmigt. 
+Die unter § 4 Nr. 8 UStG im Inland fallenden Bank- und Finanzdienstleistungen sind von der Umsatzsteuer befreit, sofern Umsatzsteuer nicht gesondert 
+ausgewiesen ist. Soweit der Leistungsempfänger umsatzsteuerlicher Unternehmer ist und seinen Sitz in einem anderen EU-Mitgliedstaat hat und die Bank 
+und Finanzdienstleistungen nach dortigem Recht umsatzsteuerpflichtig sind, gilt die Steuerschuldnerschaft des Leistungsempfängers. Umsatzsteuer ID 
+Nr.: Deutsche Bank AG, 60262 Frankfurt DE114103379
+Postbank - eine Niederlassung der Deutsche Bank AG - Vorsitzender des Aufsichtsrats: Alexander R. Wynaendts - Vorstand: Christian Sewing (Vorsitzender),
+James von Moltke, Raja Akram, Fabrizio Campelli, Marcus Chromik, Bernd Leukert, Alexander von zur Mühlen, Laura Padovani, Claudio de Sanctis, Rebecca Short 
+Deutsche Bank Aktiengesellschaft mit Sitz in Frankfurt am Main, Amtsgericht Frankfurt am Main, HRB Nr. 30 000, Umsatzsteuer-Id.-Nr. DE114103379; www.postbank.de
+TR00000001 20260407 205_000_

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/Kauf08.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/Kauf08.txt
@@ -1,0 +1,43 @@
+PDFBox Version: 3.0.5 != 1.8.17
+Portfolio Performance Version: 0.78.1
+System: linux | x86_64 | 21.0.11+10-1-26.04.2-Ubuntu | Ubuntu
+-----------------------------------------
+Postbank
+Beratungsteam
+CufAZyQ 24/7-Kundenservice (0228) 5500-5500
+ xXkOHsJs 
+ibjlTwdaQ. 43 
+60943 QKikNLZW
+1. Juni 2026
+Abrechnung: Kauf von Wertpapieren 
+Depotinhaber: ATNzPji QlbbCRfT
+Filialnummer Depotnummer Wertpapierbezeichnung Seite
+212 7338056 00 PROCTER & GAMBLE CO., THE RG.SH. O.N. 1/1
+WKN 852062 Nominal ST 14
+ISIN US7427181091 Kurs EUR 121,42
+Verwahrart Wertpapierrechnung USA/Kanada
+Geschäft Kommissionsgeschäft
+Börse Frankfurt - Deutsche Börse - Frankfurter Wertpapierbörse
+Belegnummer 1603718970 / 128935901 Schlusstag/-zeit MEZ 01.06.2026 / 15:34:02
+Auftragsart Limitauftrag
+Abrechnung Währung Betrag
+Kurswert EUR 1.699,88
+Provision EUR 17,95
+Fremde Spesen und Auslagen EUR 3,12
+Belastung
+Buchung auf Kontonummer 6529818 00 mit Wertstellung 03.06.2026 EUR 1.720,95
+Summe der in der Abrechnung enthaltenen Provisionen und Auslagen EUR 21,07
+Zu dem abgerechneten Geschäft haben wir keine Empfehlung gegeben. Daher liegt keine entsprechende 
+Beratungsdokumentation vor.
+Die Wertpapiere haben wir entsprechend der Abrechnung gebucht. Unser Geschäftsverkehr mit Ihnen wird durch unsere Allgemeinen Geschäftsbedingungen 
+und die Sonderbedingungen für Wertpapiergeschäfte geregelt. Bitte überprüfen Sie diese Abrechnung schnellstmöglich und richten Sie etwaige Einwendungen 
+in den Geschäftsräumen der Bank oder schriftlich an Deutsche Bank AG, QM - Support, 04082 Leipzig. Andernfalls gilt diese Abrechnung als genehmigt. 
+Die unter § 4 Nr. 8 UStG im Inland fallenden Bank- und Finanzdienstleistungen sind von der Umsatzsteuer befreit, sofern Umsatzsteuer nicht gesondert 
+ausgewiesen ist. Soweit der Leistungsempfänger umsatzsteuerlicher Unternehmer ist und seinen Sitz in einem anderen EU-Mitgliedstaat hat und die Bank 
+und Finanzdienstleistungen nach dortigem Recht umsatzsteuerpflichtig sind, gilt die Steuerschuldnerschaft des Leistungsempfängers. Umsatzsteuer ID 
+Nr.: Deutsche Bank AG, 60262 Frankfurt DE114103379
+Postbank - eine Niederlassung der Deutsche Bank AG - Vorsitzender des Aufsichtsrats: Alexander R. Wynaendts - Vorstand: Christian Sewing (Vorsitzender),
+James von Moltke, Raja Akram, Fabrizio Campelli, Marcus Chromik, Marie-Jeanne Deverdun, Stefan Hoops, Bernd Leukert, Alexander von zur Mühlen,
+Laura Padovani, Claudio de Sanctis, Rebecca Short
+Deutsche Bank Aktiengesellschaft mit Sitz in Frankfurt am Main, Amtsgericht Frankfurt am Main, HRB Nr. 30 000, Umsatzsteuer-Id.-Nr. DE114103379; www.postbank.de
+TR00000001 20260601 970_000_

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/PostbankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/postbank/PostbankPDFExtractorTest.java
@@ -418,6 +418,74 @@ public class PostbankPDFExtractorTest
     }
 
     @Test
+    public void testWertpapierKauf07()
+    {
+        var extractor = new PostbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf07.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("LU0328475792"), hasWkn("DBX1A7"), hasTicker(null), //
+                        hasName("XTRACKERS STOXX EUROPE 600 INH.ANT.1C O.N."), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-04-07T08:00:50"), hasShares(0.6526), //
+                        hasSource("Kauf07.txt"), //
+                        hasNote("Belegnummer 9867409933 / 344685043"), //
+                        hasAmount("EUR", 100.00), hasGrossValue("EUR", 100.00), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 0.00))));
+    }
+
+    @Test
+    public void testWertpapierKauf08()
+    {
+        var extractor = new PostbankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kauf08.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(0L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("US7427181091"), hasWkn("852062"), hasTicker(null), //
+                        hasName("PROCTER & GAMBLE CO., THE RG.SH. O.N."), //
+                        hasCurrencyCode("EUR"))));
+
+        // check buy sell transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2026-06-01T15:34:02"), hasShares(14), //
+                        hasSource("Kauf08.txt"), //
+                        hasNote("Belegnummer 1603718970 / 128935901"), //
+                        hasAmount("EUR", 1720.95), hasGrossValue("EUR", 1699.88), //
+                        hasTaxes("EUR", 0.00), hasFees("EUR", 17.95 + 3.12))));
+    }
+
+    @Test
     public void testWertpapierVerkauf01()
     {
         var extractor = new PostbankPDFExtractor(new Client());

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostbankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/PostbankPDFExtractor.java
@@ -168,6 +168,14 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
                                                         .assign((t, v) -> t
                                                                         .setDate(asDate(v.get("date"), v.get("time")))),
                                         // @formatter:off
+                                        // Belegnummer 9867409933 / 344685043 Schlusstag/-zeit MEZ 07.04.2026 / 08:00:50
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("date", "time") //
+                                                        .match("^.*Schlusstag\\/\\-zeit ... (?<date>[\\d]{2}\\.[\\d]{2}\\.[\\d]{4}) \\/ (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}).*$") //
+                                                        .assign((t, v) -> t
+                                                                        .setDate(asDate(v.get("date"), v.get("time")))),
+                                        // @formatter:off
                                         // Den Gegenwert buchen wir mit Valuta 14.01.2020 zu Gunsten des Kontos 012345678
                                         // @formatter:on
                                         section -> section //
@@ -856,12 +864,35 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
                         .match("^Provision (?<fee>[\\.,\\d]+)\\- (?<currency>[A-Z]{3})$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
-                        // @formatter:off
-                        // Provision EUR 39,95
-                        // @formatter:on
-                        .section("currency", "fee").optional() //
-                        .match("^Provision (?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)$") //
-                        .assign((t, v) -> processFeeEntries(t, v, type))
+                        .optionalOneOf( //
+                                        // @formatter:off
+                                        // Provision EUR 0,90
+                                        // Provisions-Rabatt EUR -0,90
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("currency", "fee", "discountCurrency", "discount") //
+                                                        .match("^Provision (?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)$") //
+                                                        .match("^Provisions\\-Rabatt (?<discountCurrency>[A-Z]{3}) \\-(?<discount>[\\.,\\d]+)$") //
+                                                        .assign((t, v) -> {
+                                                            var fee = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("fee")));
+                                                            var discount = Money.of(asCurrencyCode(v.get("discountCurrency")), asAmount(v.get("discount")));
+
+                                                            // @formatter:off
+                                                            // fee = fee - discount
+                                                            // @formatter:on
+                                                            if (fee.subtract(discount).isPositive())
+                                                            {
+                                                                fee = fee.subtract(discount);
+                                                                checkAndSetFee(fee, t, type.getCurrentContext());
+                                                            }
+                                                        }),
+                                        // @formatter:off
+                                        // Provision EUR 39,95
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("currency", "fee") //
+                                                        .match("^Provision (?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)$") //
+                                                        .assign((t, v) -> processFeeEntries(t, v, type)))
 
                         // @formatter:off
                         // XETRA-Kosten EUR 0,60
@@ -896,6 +927,13 @@ public class PostbankPDFExtractor extends AbstractPDFExtractor
                         // @formatter:on
                         .section("fee", "currency").optional() //
                         .match("^Fremde Auslagen (?<fee>[\\.,\\d]+)\\- (?<currency>[A-Z]{3})$") //
+                        .assign((t, v) -> processFeeEntries(t, v, type))
+
+                        // @formatter:off
+                        // Fremde Spesen und Auslagen EUR 3,12
+                        // @formatter:on
+                        .section("currency", "fee").optional() //
+                        .match("^Fremde Spesen und Auslagen (?<currency>[A-Z]{3}) (?<fee>[\\.,\\d]+)$") //
                         .assign((t, v) -> processFeeEntries(t, v, type))
 
                         // @formatter:off


### PR DESCRIPTION
Improved PDF importer for Postbank

Added support for the newer purchase settlement format:
- Trade date/time "Schlusstag/-zeit MEZ 07.04.2026 / 08:00:50"
- Commission rebate "Provisions-Rabatt" is netted against "Provision"
- Fee "Fremde Spesen und Auslagen"

Push #5946 first, I will adjust this here again later.
