### PR TITLE
Tiger Broker PDF Importer

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/tigerbrokerspteltd/AccountStatement12.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/tigerbrokerspteltd/AccountStatement12.txt
@@ -1,0 +1,179 @@
+PDFBox Version: 3.0.5 != 1.8.17
+Portfolio Performance Version: 0.80.2
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Tiger Brokers (Singapore) PTE.LTD.
+Activity Statement : 2025.01.01 - 2025.10.12
+kSxdKN iHSKroec
+Account Information
+Account Address Account Category Base Currency
+50385408 OBFBTDW-ojGkxtjBd GRKERIEJEKSHR. 339 / xCAmW 2 kc MkbYeY jwhEcy 64785 Cash USD
+Account Overview
+Cash Stock Bond Option Future Funds in Transit Interest Accruals Dividend Accruals Total
+Beginning Of The Period 109.66 49,535.23 0.00 0.00 0.00 0.00 0.00 38.31 49,683.20
+End Of The Period 302.21 56,712.43 0.00 0.00 0.00 0.00 0.00 31.85 57,046.49
+Cash Report
+Currency: USD
+Total Securities Futures
+Starting Cash 109.66 109.66 0.00
+Commissions -0.99 -0.99 0
+Platform Fees -1 -1 0
+Dividends 354.1 354.1 0
+Net Trades (Purchase) -106.43 -106.43 0
+Withholding Tax -53.13 -53.13 0
+Ending Cash 302.21 302.21 0.00
+Address: 1 Raffles Place, #35-61 One Raffles Place Tower 2, Singapore 048616. 1/6
+Tiger Brokers (Singapore) PTE.LTD.
+Activity Statement : 2025.01.01 - 2025.10.12
+Total Securities Futures
+Ending Settled Cash 302.21 302.21 0.00
+Notes:
+1. Net Trades:
+Sales: Cash received from selling securities
+Purchases: Cash paid for buying securities
+2. Other Fees: Including IPO fees, withdraw fees, bond custody fees and other expenses.
+3. Futures are traded on margin; therefore, changes in futures positions are not shown in this module.
+4. Withholding Tax: This refers to the tax automatically deducted from the cash dividends you receive from stocks or funds, in accordance with applicable tax rates.
+Trades
+Stock
+Activity Trade Accrued Interest in Realized P Settle 
+Symbol Market Exchange Quantity Amount Comm/Fee GST Notes Trade Time Currency
+Type Price Trade /L Date
+Vanguard Total World Stock Commission: 2025-04-08
+ETF US ARCA Open 1 106.43000 106.43 0.00 -0.99 2025-
+Platform Fee: 0.00 0.00 11:28:50, US USD
+04-09
+(VT) -1.00 /Eastern
+Total VT 1 106.43 0.00 -1.99 0.00 0.00 USD
+Total 106.43 0.00 -1.99 0.00 0.00 USD
+Note: We calculate realized P&L using the FIFO (First In, First Out) method. This means that when you sell a position, we assume you’re selling the earliest (oldest) shares you bought first.
+Holdings
+Stock
+Symbol Quantity Multiplier Cost Price Close Price Value Unrealized P/L Initial Margin Maint Margin Currency
+Invesco QQQ
+54 1.0 334.8934944 589.50000 31,833.00 13,748.75 0.00 0.00 USD
+(QQQ)
+Vanguard S&P 500 ETF
+25 1.0 391.4812000 600.51000 15,012.75 5,225.72 0.00 0.00 USD
+(VOO)
+Vanguard Total World Stock ETF
+73 1.0 97.9023123 135.16000 9,866.68 2,719.81 0.00 0.00 USD
+(VT)
+Address: 1 Raffles Place, #35-61 One Raffles Place Tower 2, Singapore 048616. 2/6
+Tiger Brokers (Singapore) PTE.LTD.
+Activity Statement : 2025.01.01 - 2025.10.12
+Symbol Quantity Multiplier Cost Price Close Price Value Unrealized P/L Initial Margin Maint Margin Currency
+Total(In Base) 152 56,712.43 21,694.28 0.00 0.00 USD
+Note: The multiplier represents the fixed number used to calculate the total contract value by multiplying it with the price of the underlying asset in equity options or futures trading.
+Dividends
+Dividend Reinvestment Cash Net Cash 
+Date Product Symbol Quantity/Gross Rate Phase Shares Fees & Tax Currency
+Plan Dividends Value
+Quantity: 54
+2025-01- Invesco QQQ Dividend tax: 
+Stock Gross Rate: 0.834660 Paid 45.07 0 38.31 USD
+02 (QQQ) 6.76
+/Share
+Vanguard Total World Stock Quantity: 72
+2025-03- Dividend tax: 
+Stock ETF Gross Rate: 0.385200 Paid 27.73 0 23.57 USD
+25 4.16
+(VT) /Share
+Quantity: 54
+2025-05- Invesco QQQ Dividend tax: 
+Stock Gross Rate: 0.715710 Paid 38.65 0 32.85 USD
+01 (QQQ) 5.80
+/Share
+Quantity: 25
+2025-03- Vanguard S&P 500 ETF Dividend tax: 
+Stock Gross Rate: 1.812100 Paid 45.30 0 38.50 USD
+31 (VOO) 6.80
+/Share
+Vanguard Total World Stock Quantity: 73
+2025-06- Dividend tax: 
+Stock ETF Gross Rate: 0.594700 Paid 43.41 0 36.90 USD
+24 6.51
+(VT) /Share
+Quantity: 54
+2025-07- Invesco QQQ Dividend tax: 
+Stock Gross Rate: 0.591110 Paid 31.92 0 27.13 USD
+31 (QQQ) 4.79
+/Share
+Quantity: 25
+2025-07- Vanguard S&P 500 ETF Dividend tax: 
+Stock Gross Rate: 1.744700 Paid 43.62 0 37.08 USD
+03 (VOO) 6.54
+/Share
+Vanguard Total World Stock Quantity: 73
+2025-09- Dividend tax: 
+Stock ETF Gross Rate: 0.478100 Paid 34.90 0 29.66 USD
+23 5.24
+(VT) /Share
+Quantity: 54
+2025-09- Invesco QQQ Dividend Accruals Dividend tax: 
+Stock Gross Rate: 0.693950 37.47 0 31.85 USD
+22 (QQQ) Cash Increase 5.62
+/Share
+Address: 1 Raffles Place, #35-61 One Raffles Place Tower 2, Singapore 048616. 3/6
+Tiger Brokers (Singapore) PTE.LTD.
+Activity Statement : 2025.01.01 - 2025.10.12
+Dividend Reinvestment Cash Net Cash 
+Date Product Symbol Quantity/Gross Rate Phase Shares Fees & Tax Currency
+Plan Dividends Value
+Quantity: 25
+2025-10- Vanguard S&P 500 ETF Dividend tax: 
+Stock Gross Rate: 1.740000 Paid 43.50 0 36.97 USD
+01 (VOO) 6.53
+/Share
+Total(In Base) Accruals/Paid 31.85/300.97 USD
+Notes: Accrued Dividends refers to the expected amount of cash or number of shares you will receive after a company announces a dividend. Before the payment is made, the amount or shares will appear as “accrued.” Once the 
+dividend is officially distributed, the cash will be credited to your account balance, or the shares will be added to your holdings.
+Financial Instrument Information
+Stock
+Symbol Issuer Description Multiplier Expiry Strike Right
+QQQ Invesco QQQ 1
+VOO Vanguard S&P 500 ETF 1
+VT Vanguard Total World Stock ETF 1
+Base Currency Exchange Rate
+Date 2025-10-12
+USD 1
+AUD 0.64750
+CAD 0.71334
+CHF 1.25082
+CNH 0.14037
+EUR 1.16210
+GBP 1.33600
+HKD 0.12848
+Address: 1 Raffles Place, #35-61 One Raffles Place Tower 2, Singapore 048616. 4/6
+Tiger Brokers (Singapore) PTE.LTD.
+Activity Statement : 2025.01.01 - 2025.10.12
+Date 2025-10-12
+IDR 0.00006
+JPY 0.00661
+MXN 0.05378
+MYR 0.23669
+NOK 0.09878
+NZD 0.57220
+PLN 0.27288
+SEK 0.10515
+SGD 0.77048
+TRY 0.02397
+Note: You can refer to the USD index table to view the exchange rate information as of the report cutoff date, with USD as the quote currency.
+Notes:
+1. Please examine the details in the monthly statement and promptly report any inaccuracy or discrepancy found to service@tigerbrokers.com.sg within 14 calendar days from the date of the statement. All the above details shall be 
+deemed correct and conclusive if no written notice of objection is received by us within 14 days from the date of the monthly statement.
+2. Tiger Brokers (Singapore) Pte Ltd is a member of Financial Institutions Dispute Resolution Centre (FIDReC), which is an independent and impartial institution specialising in the resolution of disputes between financial institutions 
+and consumers. Unresolved issues can also be brought up to FIDReC at www.fidrec.com.sg for mediation.
+3. Information on our fees can be found at https://www.tigerbrokers.com.sg/commissions/fees
+4. Information regarding your account can be found in the Terms and Conditions at https://www.tigerbrokers.com.sg/info/terms-n-conditions
+5. Customer money and assets are deposited in trust and held in custody, respectively in accordance with the Securities and Futures (Licensing and Conduct of Business) Regulations, governing the protection of client money and 
+assets.;
+[1] TIGER BROKERS (HK) GLOBAL LIMITED AS THE PRINCIPAL
+TIGER BROKERS (SINGAPORE) PTE. LTD.
++65 6331 2277
+WhatsApp +65 6331 2277
+Address: 1 Raffles Place, #35-61 One Raffles Place Tower 2, Singapore 048616. 5/6
+Tiger Brokers (Singapore) PTE.LTD.
+Activity Statement : 2025.01.01 - 2025.10.12
+service@tigerbrokers.com.sg
+Address: 1 Raffles Place, #35-61 One Raffles Place Tower 2, Singapore 048616. 6/6

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/tigerbrokerspteltd/AccountStatement13.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/tigerbrokerspteltd/AccountStatement13.txt
@@ -1,0 +1,834 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.87.0
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+Tiger Brokers (Singapore) PTE.LTD.
+Address:1 Raffles Place, #35-61 One Raffles Place Tower 2, Singapore 048616.
+GST registration number:201810449W
+SSSSSSSS Statement Issuance Date:2025-12-31
+Statement Period:2025-08-06 - 2025-12-31
+Account Information
+Account Address Account Category Base Currency
+9999  TOKYO Cash USD
+Account Overview
+Cash Stock Fund Funds in Transit Interest Accruals Dividend Accruals Total
+Beginning Of The Period 0.00 0.00 0.00 0.00 0.00 0.00 0.00
+End Of The Period 21,121.02 186,615.88 0.00 0.00 0.00 1,037.14 208,774.05
+Short Stock Collateral(Base Currency): 0.00 USD
+Short Stock Margin(Base Currency): 0.00 USD
+Option Margin(Base Currency): 0.00 USD
+Note: 
+1. The cash column shows the balance excluding funds in the futures segment and reflects only other cash balances.
+2. Futures column = Total futures equity (incl. cash).
+Cash Report
+Currency: Base Currency Summary
+This statement also serves as a Tax Invoice for GST purpose. 1/20
+Tiger Brokers (Singapore) PTE.LTD.
+Total Securities Fund
+Starting Cash 0.00 0.00 0.00
+Commissions -52.86 -52.86 0
+Platform Fees -53.14 -53.14 0
+Deposits 160,148.39 160,148.39 0
+Withdrawals -7.78 -7.78 0
+Dividends 1,813.91 1,813.91 0
+Net Trades (Sales) 56,092.32 56,092.32 0
+Net Trades (Purchase) -196,960.49 -196,960.49 0
+Settlement Fees -10.92 -10.92 0
+Consolidated Audit Trail Fee -0.08 -0.08 0
+Trading Activity Fees -0.15 -0.15 0
+Exchange Fees -23.06 -23.06 0
+Withholding Tax -118.85 -118.85 0
+Allowance 293.72 293.72 0
+Ending Cash 21,121.02 21,121.02 0.00
+Ending Settled Cash 9,022.30 9,022.30 0.00
+Currency: USD
+Total Securities Fund
+Starting Cash 0.00 0.00 0.00
+Commissions -23.8 -23.8 0
+This statement also serves as a Tax Invoice for GST purpose. 2/20
+Tiger Brokers (Singapore) PTE.LTD.
+Total Securities Fund
+Platform Fees -23.88 -23.88 0
+Deposits 94,674.24 94,674.24 0
+Dividends 1,188.39 1,188.39 0
+Net Trades (Sales) 48,657.01 48,657.01 0
+Net Trades (Purchase) -131,184.55 -131,184.55 0
+Settlement Fees -10.92 -10.92 0
+Consolidated Audit Trail Fee -0.08 -0.08 0
+Trading Activity Fees -0.15 -0.15 0
+Withholding Tax -118.85 -118.85 0
+Allowance 60.35 60.35 0
+Ending Cash 13,217.76 13,217.76 0.00
+Ending Settled Cash 1,119.04 1,119.04 0.00
+Currency: SGD
+Total Securities Fund
+Starting Cash 0.00 0.00 0.00
+Commissions -37.36 -37.36 0
+Platform Fees -37.61 -37.61 0
+Deposits 84,167.83 84,167.83 0
+Withdrawals -10 -10 0
+Dividends 804.12 804.12 0
+Net Trades (Sales) 9,558.18 9,558.18 0
+This statement also serves as a Tax Invoice for GST purpose. 3/20
+Tiger Brokers (Singapore) PTE.LTD.
+Total Securities Fund
+Net Trades (Purchase) -84,555.78 -84,555.78 0
+Exchange Fees -29.64 -29.64 0
+Allowance 300 300 0
+Ending Cash 10,159.74 10,159.74 0.00
+Ending Settled Cash 10,159.74 10,159.74 0.00
+Notes:
+1. Net Trades:
+Sales: Cash received from selling securities
+Purchases: Cash paid for buying securities
+2. Other Fees: Including IPO fees, withdraw fees, bond custody fees and other expenses.
+3. Futures are traded on margin; therefore, changes in futures positions are not shown in this module.
+4. Withholding Tax: This refers to the tax automatically deducted from the cash dividends you receive from stocks or funds, in accordance with applicable tax rates.
+Transfer
+Product Symbol Date Transfer Method Source Account Destination Account Transfer Qty Fee Qty Cost Price Market Value Currency
+DBS
+Stock 2025-09-01, 15:38:02, GMT+8 EXTERNAL IN 9999 200 0 34.2100 10,040.00 SGD
+(D05.SI)
+Total DBS (D05.SI) 200 0 10,040.00 SGD
+OCBC Bank
+Stock 2025-09-01, 15:38:02, GMT+8 EXTERNAL IN 9999 1300 0 16.1500 21,775.00 SGD
+(O39.SI)
+Total OCBC Bank (O39.SI) 1300 0 21,775.00 SGD
+UOB
+Stock 2025-09-01, 15:38:02, GMT+8 EXTERNAL IN 9999 700 0 34.6000 24,668.00 SGD
+(U11.SI)
+Total UOB (U11.SI) 700 0 24,668.00 SGD
+SGX
+Stock 2025-08-22, 15:12:00, GMT+8 EXTERNAL IN 9999 100 0 11.8200 1,652.00 SGD
+(S68.SI)
+This statement also serves as a Tax Invoice for GST purpose. 4/20
+Tiger Brokers (Singapore) PTE.LTD.
+Product Symbol Date Transfer Method Source Account Destination Account Transfer Qty Fee Qty Cost Price Market Value Currency
+Total SGX (S68.SI) 100 0 1,652.00 SGD
+Total 58,135.00 SGD
+Total(In Base) 45,223.22 USD
+Trades
+Forex
+Symbol(Base.Quote) Activity Type Quantity(Base) Trade Price Amount(Quote) Notes Trade Time Settle Date Currency
+2025-09-09
+USD.SGD Buy 3,885.3600 1.28688 -5,000.00 2025-09-10 SGD
+13:52:45, US/Eastern
+2025-09-17
+USD.SGD Buy 92.1000 1.28118 -118.00 2025-09-17 SGD
+02:55:15, US/Eastern
+2025-10-10
+USD.SGD Buy 5,476.0300 1.30154 -7,127.28 2025-10-14 SGD
+04:17:42, US/Eastern
+2025-10-16
+USD.SGD Sell -5000 1.29103 6,455.15 2025-10-16 SGD
+01:14:03, US/Eastern
+2025-10-16
+USD.SGD Sell -1000 1.29103 1,291.03 2025-10-16 SGD
+01:18:32, US/Eastern
+Total USD.SGD 3,453.4900 -4,499.10 SGD
+Total -4,499.10 SGD
+Total(In Base) -3,499.85 USD
+Stock
+Activity Trade Accrued Interest Realized Settle 
+Symbol Market Exchange Quantity Amount Comm/Fee GST Notes Trade Time Currency
+Type Price in Trade P/L Date
+2025-08-07
+Exchange Fee: -0.11
+This statement also serves as a Tax Invoice for GST purpose. 5/20
+Tiger Brokers (Singapore) PTE.LTD.
+Activity Trade Accrued Interest Realized Settle 
+Symbol Market Exchange Quantity Amount Comm/Fee GST Notes Trade Time Currency
+Type Price in Trade P/L Date
+CapLand Ascendas REIT SG SGX Open 100 2.73000 273.00 0.00 Commission: -0.99 0.00 0.00 12:58:58, 2025- SGD
+(A17U.SI) Platform Fee: -1.00 GMT+8 08-11
+2025-08-07
+CapLand Ascendas REIT Exchange Fee: -0.33 2025-
+SG SGX Open 300 2.74000 822.00 0.00 51, SGD
+(A17U.SI) Commission: -0.99 0.00 0.00 14:24:
+Platform Fee: -1.00 08-11
+GMT+8
+-07
+CapLand Ascendas REIT Exchange Fee: -0.76 2025-08
+2025-
+SG SGX Open 700 2.74000 1,918.00 0.00
+(A17U.SI) Commission: -0.99 0.00 0.00 14:54:22, SGD
+Platform Fee: -1.00 08-11
+GMT+8
+08-08
+CapLand Ascendas REIT Exchange Fee: -1.19 2025-
+2025-
+SG SGX Open 1100 2.72000 2,992.00 0.00
+(A17U.SI) Commission: -0.99 0.00 0.00 14:10:30, SGD
+Platform Fee: -1.00 08-12
+GMT+8
+25-08-25
+CapLand Ascendas REIT Exchange Fee: -0.65 20
+2025-
+SG SGX Open 600 2.72000 1,632.00 0.00
+(A17U.SI) Commission: -0.99 0.00 0.00 14:44:30, SGD
+Platform Fee: -1.00 08-27
+GMT+8
+CapLand Ascendas REIT Exchange Fee: -1.98 2025-09-03
+2025-
+SG SGX Open 1800 2.75000 4,950.00 0.00 6:06:34, SGD
+(A17U.SI) Commission: -1.49 0.00 0.00 1
+Platform Fee: -1.49 09-05
+GMT+8
+Total A17U.SI 4600 12,587.00 0.00 -17.95 0.00 0.00 SGD
+Keppel DC Reit Exchange Fee: -1.78 2025-12-15
+2025-
+SG SGX Open 2000 2.23000 4,460.00 0.00
+(AJBU.SI) Commission: -1.34 0.00 0.00 16:32:07, SGD
+Platform Fee: -1.34 12-17
+GMT+8
+Total AJBU.SI 2000 4,460.00 0.00 -4.46 0.00 0.00 SGD
+2025-08-07
+Frasers L&C Tr Exchange Fee: -0.35 2025-
+SG SGX Open 1000 0.87500 875.00 0.00 .00 0.00 12:58:58, SGD
+(BUOU.SI) Commission: -0.99 0
+Platform Fee: -1.00 08-11
+GMT+8
+2025-08-07
+Frasers L&C Tr Exchange Fee: -0.07 2025-
+SG SGX Open 200 0.88000 176.00 0.00
+(BUOU.SI) Commission: -0.99 0.00 0.00 14:27:11, SGD
+Platform Fee: -1.00 08-11
+GMT+8
+Frasers L&C Tr Exchange Fee: -0.46 2025-08-08
+2025-
+SG SGX Open 1300 0.88500 1,150.50 0.00
+(BUOU.SI) Commission: -0.99 0.00 0.00 16:47:49, SGD
+Platform Fee: -1.00 08-12
+GMT+8
+2025-10-06
+16:49:35, 
+This statement also serves as a Tax Invoice for GST purpose. 6/20
+Tiger Brokers (Singapore) PTE.LTD.
+Activity Trade Accrued Interest Realized Settle 
+Symbol Market Exchange Quantity Amount Comm/Fee GST Notes Trade Time Currency
+Type Price in Trade P/L Date
+Frasers L&C Tr SG SGX Open 5200 0.96500 5,018.00 0.00 Exchange Fee: -2.01 0.00 0.00 GMT+8 2025- SGD
+(BUOU.SI) Commission: -1.51
+Platform Fee: -1.51 10-08
+2025-11-06
+Frasers L&C Tr Exchange Fee: -1.51 2025-
+SG SGX Open 4000 0.94500 3,780.00 0.00 :10, SGD
+(BUOU.SI) Commission: -1.13 0.00 0.00 10:18
+Platform Fee: -1.13 11-10
+GMT+8
+Total BUOU.SI 11700 10,999.50 0.00 -15.65 0.00 0.00 SGD
+ParkwayLife Reit Exchange Fee: -0.32 2025-11-04
+2025-
+SG SGX Open 200 4.03000 806.00 0.00
+(C2PU.SI) Commission: -0.99 0.00 0.00 16:43:23, SGD
+Platform Fee: -1.00 11-06
+GMT+8
+ParkwayLife Reit Exchange Fee: -1.61 2025-11-06
+2025-
+SG SGX Open 1000 4.04000 4,040.00 0.00
+(C2PU.SI) Commission: -1.20 0.00 0.00 10:33:41, SGD
+Platform Fee: -1.20 11-10
+GMT+8
+25-12-05
+ParkwayLife Reit Exchange Fee: -0.80 20
+2025-
+SG SGX Open 500 4.03000 2,015.00 0.00 SGD
+(C2PU.SI) Commission: -0.99 0.00 0.00 13:00:01, 
+Platform Fee: -1.00 12-09
+GMT+8
+Total C2PU.SI 1700 6,861.00 0.00 -9.11 0.00 0.00 SGD
+Frasers Cpt Tr Exchange Fee: -0.27 2025-08-07
+2025-
+SG SGX Open 300 2.22000 666.00 0.00
+(J69U.SI) Commission: -0.99 0.00 0.00 08:58:18, SGD
+Platform Fee: -1.00 08-11
+GMT+8
+Frasers Cpt Tr Exchange Fee: -0.17 2025-08-07
+2025-
+SG SGX Open 200 2.23000 446.00 0.00
+(J69U.SI) Commission: -0.99 0.00 0.00 14:30:15, SGD
+Platform Fee: -1.00 08-11
+GMT+8
+Frasers Cpt Tr Exchange Fee: -1.07 2025-08-07
+2025-
+SG SGX Open 1200 2.23000 2,676.00 0.00  SGD
+(J69U.SI) Commission: -0.99 0.00 0.00 14:53:49,
+Platform Fee: -1.00 08-11
+GMT+8
+2025-08-08
+Frasers Cpt Tr Exchange Fee: -1.17 2025-
+SG SGX Open 1300 2.24000 2,912.00 0.00 0.00 0.00 16:43:59, SGD
+(J69U.SI) Commission: -0.99
+Platform Fee: -1.00 08-12
+GMT+8
+2025-11-06
+Frasers Cpt Tr Exchange Fee: -1.37 2025-
+SG SGX Open 1500 2.27000 3,405.00 0.00
+(J69U.SI) Commission: -1.02 0.00 0.00 10:06:27, SGD
+Platform Fee: -1.02 11-10
+GMT+8
+2025-11-06
+10:30:34, 
+This statement also serves as a Tax Invoice for GST purpose. 7/20
+Tiger Brokers (Singapore) PTE.LTD.
+Activity Trade Accrued Interest Realized Settle 
+Symbol Market Exchange Quantity Amount Comm/Fee GST Notes Trade Time Currency
+Type Price in Trade P/L Date
+Frasers Cpt Tr SG SGX Open 2000 2.26000 4,520.00 0.00 Exchange Fee: -1.81 0.00 0.00 GMT+8 2025- SGD
+(J69U.SI) Commission: -1.36
+Platform Fee: -1.36 11-10
+2025-12-04
+Frasers Cpt Tr Exchange Fee: -0.91 2025-
+SG SGX Open 1000 2.27000 2,270.00 0.00 :19, SGD
+(J69U.SI) Commission: -0.99 0.00 0.00 16:51
+Platform Fee: -1.00 12-08
+GMT+8
+Total J69U.SI 7500 16,895.00 0.00 -21.48 0.00 0.00 SGD
+Mapletree Ind Tr Exchange Fee: -0.25 2025-08-07
+2025-
+SG SGX Open 300 2.00000 600.00 0.00
+(ME8U.SI) Commission: -0.99 0.00 0.00 11:30:49, SGD
+Platform Fee: -1.00 08-11
+GMT+8
+025-08-07
+Mapletree Ind Tr Exchange Fee: -0.16 2
+2025-
+SG SGX Open 200 2.01000 402.00 0.00
+(ME8U.SI) Commission: -0.99 0.00 0.00 14:32:45, SGD
+Platform Fee: -1.00 08-11
+GMT+8
+2025-08-11
+Mapletree Ind Tr Exchange Fee: -0.39 2025-
+SG SGX Open 500 1.99000 995.00 0.00 SGD
+(ME8U.SI) Commission: -0.99 0.00 0.00 09:16:23, 
+Platform Fee: -1.00 08-13
+GMT+8
+2025-08-27
+Mapletree Ind Tr Exchange Fee: -0.09 2025-
+SG SGX Open 100 2.05000 205.00 0.00 .00 0.00 16:33:19, SGD
+(ME8U.SI) Commission: -0.99 0
+Platform Fee: -1.00 08-29
+GMT+8
+2025-10-06
+Mapletree Ind Tr Exchange Fee: -1.98 2025-
+SG SGX Open 2300 2.15000 4,945.00 0.00
+(ME8U.SI) Commission: -1.48 0.00 0.00 16:50:47, SGD
+Platform Fee: -1.48 10-08
+GMT+8
+Mapletree Ind Tr Exchange Fee: -1.23 2025-11-06
+2025-
+SG SGX Open 1500 2.05000 3,075.00 0.00
+(ME8U.SI) Commission: -0.99 0.00 0.00 15:49:54, SGD
+Platform Fee: -1.00 11-10
+GMT+8
+Mapletree Ind Tr Exchange Fee: -0.49 2025-11-06
+2025-
+SG SGX Open 600 2.04000 1,224.00 0.00 SGD
+(ME8U.SI) Commission: -0.99 0.00 0.00 16:33:04, 
+Platform Fee: -1.00 11-10
+GMT+8
+25-12-01
+Mapletree Ind Tr Exchange Fee: -0.81 20
+2025-
+SG SGX Open 1000 2.03000 2,030.00 0.00 16:59:08, SGD
+(ME8U.SI) Commission: -0.99 0.00 0.00
+Platform Fee: -1.00 12-03
+GMT+8
+Total ME8U.SI 6500 13,476.00 0.00 -22.29 0.00 0.00 SGD
+Mapletree PanAsia Com 2025-08-06
+Tr 15:27:55, 
+This statement also serves as a Tax Invoice for GST purpose. 8/20
+Tiger Brokers (Singapore) PTE.LTD.
+Activity Trade Accrued Interest Realized Settle 
+Symbol Market Exchange Quantity Amount Comm/Fee GST Notes Trade Time Currency
+Type Price in Trade P/L Date
+(N2IU.SI) SG SGX Open 100 1.32000 132.00 0.00 Exchange Fee: -0.05 0.00 0.00 GMT+8 2025- SGD
+Commission: -0.99
+Platform Fee: -1.00 08-08
+Mapletree PanAsia Com Exchange Fee: -0.05 2025-08-07
+2025-
+Tr SG SGX Close -100 1.34000 -134.00 0.00 Commission: -0.99 0.00 -2.08 16:21:34, SGD
+08-11
+(N2IU.SI) Platform Fee: -1.00 GMT+8
+Total N2IU.SI 0 -2.00 0.00 -4.08 0.00 -2.08 SGD
+SGX Exchange Fee: -0.68 2025-08-25
+2025-
+SG SGX Close -100 16.78000 -1,678.00 0.00 4:42:32, SGD
+(S68.SI) Commission: -0.99 0.00 493.33 1
+Platform Fee: -1.00 08-27
+GMT+8
+Total S68.SI -100 -1,678.00 0.00 -2.67 0.00 493.33 SGD
+UOB Exchange Fee: -1.38 2025-10-16
+2025-
+SG SGX Open 100 34.50000 3,450.00 0.00 SGD
+(U11.SI) Commission: -1.04 0.00 0.00 13:16:02, 
+Platform Fee: -1.04 10-21
+GMT+8
+UOB Exchange Fee: -1.38 2025-10-16
+2025-
+SG SGX Open 100 34.50000 3,450.00 0.00 8:50, SGD
+(U11.SI) Commission: -1.04 0.00 0.00 14:5
+Platform Fee: -1.04 10-21
+GMT+8
+Total U11.SI 200 6,900.00 0.00 -6.92 0.00 0.00 SGD
+Total 70,498.50 0.00 -104.61 0.00 491.25 SGD
+Alexandria Real Estate Settlement Fee: -0.60
+Commission: -1.00 2025-10-29
+2025-
+Equities US NYSE Open 200 60.40230 12,080.46 0.00 Platform Fee: -1.00 0.00 0.00 11:51:25, US USD
+(ARE) Consolidated Audit Trail 10-30
+/Eastern
+Fee: -0.01
+Alexandria Real Estate Settlement Fee: -0.15 2025-10-30
+2025-
+Equities US NYSE Open 50 57.67000 2,883.50 0.00 Commission: -0.99 0.00 0.00 08:46:23, US USD
+(ARE) Platform Fee: -1.00 10-31
+/Eastern
+Alexandria Real Estate Settlement Fee: -0.40
+Trading Activity Fee: 2025-12-30
+2026-
+Equities US NYSE Close -133 48.42647 -6,440.72 0.00 -0.05 0.00 -1,596.96 22:02:07, US USD
+01-02
+(ARE) Commission: -0.99 /Eastern
+Platform Fee: -1.00
+Alexandria Real Estate Settlement Fee: -0.35
+Trading Activity Fee: 2025-12-30
+2026-
+Equities US NYSE Close -117 48.40000 -5,662.80 0.00 -0.02 0.00 -1,273.03 23:18:29, US USD
+(ARE) Commission: -0.99 01-02
+/Eastern
+Platform Fee: -1.00
+This statement also serves as a Tax Invoice for GST purpose. 9/20
+Tiger Brokers (Singapore) PTE.LTD.
+Activity Trade Accrued Interest Realized Settle 
+Symbol Market Exchange Quantity Amount Comm/Fee GST Notes Trade Time Currency
+Type Price in Trade P/L Date
+Total ARE 0 2,860.44 0.00 -9.55 0.00 -2,869.99 USD
+Blackstone Secured Settlement Fee: -1.09 2025-09-29
+2025-
+Lending Fund US NYSE Open 367 27.19272 9,979.73 0.00 Commission: -1.84 0.00 0.00 05:24:34, US USD
+Platform Fee: -1.84 09-30
+(BXSL) /Eastern
+Blackstone Secured Settlement Fee: -1.35
+Commission: -2.26 2025-10-06
+2025-
+Lending Fund US NYSE Open 451 26.24000 11,834.24 0.00 Platform Fee: -2.26 0.00 0.00 19:28:15, US USD
+(BXSL) Consolidated Audit Trail 10-07
+/Eastern
+Fee: -0.02
+Blackstone Secured Settlement Fee: -0.64 2025-10-10
+2025-
+Lending Fund US NYSE Open 215 25.38628 5,458.05 0.00 Commission: -1.08 0.00 0.00 04:22:05, US USD
+(BXSL) Platform Fee: -1.08 10-14
+/Eastern
+Total BXSL 1033 27,272.02 0.00 -13.46 0.00 0.00 USD
+Settlement Fee: -2.70
+Realty Income Commission: -4.51 2025-10-16
+2025-
+US NYSE Open 900 59.45946 53,513.51 0.00
+(O) Platform Fee: -4.51 0.00 0.00 08:25:56, US USD
+Consolidated Audit Trail 10-17
+/Eastern
+Fee: -0.03
+Settlement Fee: -0.75
+Trading Activity Fee: 
+-0.04 2025-10-23
+Realty Income 2025-
+US NYSE Close -250 60.00000 -15,000.00 0.00
+(O) Commission: -1.25 0.00 127.78 10:21:30, US USD
+Platform Fee: -1.25 10-24
+/Eastern
+Consolidated Audit Trail 
+Fee: -0.01
+Settlement Fee: -0.60
+Realty Income Trading Activity Fee: 2025-10-24
+2025-
+US NYSE Close -200 60.50000 -12,100.00 0.00 0.00 203.10 08:30:56, US USD
+(O) -0.04
+Commission: -1.00 10-27
+/Eastern
+Platform Fee: -1.00
+Settlement Fee: -0.60
+Realty Income Commission: -1.00 2025-10-29
+2025-
+US NYSE Open 200 58.90000 11,780.00 0.00
+(O) Platform Fee: -1.00 0.00 0.00 11:48:10, US USD
+Consolidated Audit Trail 10-30
+/Eastern
+Fee: -0.01
+Realty Income Settlement Fee: -0.01 2025-11-17
+Trade 2025-
+US NYSE Open 2.73213 56.96000 155.62 0.00
+(O) Commission: -0.99 0.00 0.00 13:30:02, US USD
+Platform Fee: -1.00 Allocation 11-18
+/Eastern
+Realty Income Settlement Fee: -0.01 2025-12-16
+Trade 2025-
+US NYSE Open 2.70965 57.68000 156.29 0.00
+(O) Commission: -0.99 0.00 0.00 13:30:02, US USD
+Platform Fee: -1.00 Allocation 12-17
+/Eastern
+Total O 655.44178 38,505.42 0.00 -24.30 0.00 330.88 USD
+This statement also serves as a Tax Invoice for GST purpose. 10/20
+Tiger Brokers (Singapore) PTE.LTD.
+Activity Trade Accrued Interest Realized Settle 
+Symbol Market Exchange Quantity Amount Comm/Fee GST Notes Trade Time Currency
+Type Price in Trade P/L Date
+-09
+Putnam Bdc Income ETF Settlement Fee: -0.35 2025-09
+2025-
+US ARCA Open 115 33.66000 3,870.90 0.00 0.00 0.00 13:53:58, US USD
+(PBDC) Commission: -0.99
+Platform Fee: -1.00 09-10
+/Eastern
+2025-09-17
+Putnam Bdc Income ETF Settlement Fee: -0.01 2025-
+US ARCA Open 3 33.19000 99.57 0.00 0.00 0.00 03:53:28, US USD
+(PBDC) Commission: -0.99
+Platform Fee: -1.00 09-18
+/Eastern
+Putnam Bdc Income ETF Settlement Fee: -1.16 2025-10-07
+2025-
+US ARCA Open 387 30.64000 11,857.68 0.00
+(PBDC) Commission: -1.94 0.00 0.00 04:00:43, US USD
+Platform Fee: -1.94 10-08
+/Eastern
+Putnam Bdc Income ETF Settlement Fee: -0.15 2025-10-16
+2025-
+US ARCA Open 50 30.30000 1,515.00 0.00
+(PBDC) Commission: -0.99 0.00 0.00 11:45:13, US USD
+Platform Fee: -1.00 10-17
+/Eastern
+Total PBDC 555 17,343.15 0.00 -11.52 0.00 0.00 USD
+Total 85,981.03 0.00 -58.83 0.00 -2,539.11 USD
+Total(In Base) 140,821.81 0.00 -140.21 0.00 -2,156.96 USD
+Note: 
+1. We calculate realized P&L using the FIFO (First In, First Out) method. This means that when you sell a position, we assume you're selling the earliest (oldest) shares you bought first.
+2. Trades and fees for futures options (including Hong Kong index futures options) are shown together with other futures transactions in the "Transaction Details — Futures" module.
+Deposits & Withdrawals
+Date Description Amount Currency
+2025-08-06 Deposit 432.18 SGD
+2025-08-06 Deposit 8,660.11 SGD
+2025-08-07 Withdrawal -10.00 SGD
+2025-08-08 Deposit 8,010.00 SGD
+2025-08-26 Deposit 65.54 SGD
+This statement also serves as a Tax Invoice for GST purpose. 11/20
+Tiger Brokers (Singapore) PTE.LTD.
+Date Description Amount Currency
+2025-09-01 Deposit 10,000.00 SGD
+2025-10-01 Deposit 17,000.00 SGD
+2025-11-05 Deposit 20,000.00 SGD
+2025-12-01 Deposit 20,000.00 SGD
+Total 84,157.83 SGD
+2025-09-29 Deposit 9,990.00 USD
+2025-10-06 Deposit 23,690.00 USD
+2025-10-15 Deposit 60,994.24 USD
+Total 94,674.24 USD
+Total(In Base) 160,140.62 USD
+Holdings
+Stock
+Symbol Quantity Multiplier Cost Price Close Price Value Unrealized P/L Initial Margin Maint Margin Currency
+CapLand Ascendas REIT
+4600 1.0 2.7402065 2.83000 13,018.00 413.05 0.00 0.00 SGD
+(A17U.SI)
+Keppel DC Reit
+2000 1.0 2.2322300 2.25000 4,500.00 35.54 0.00 0.00 SGD
+(AJBU.SI)
+Frasers L&C Tr
+11700 1.0 0.9414658 0.99500 11,641.50 626.35 0.00 0.00 SGD
+(BUOU.SI)
+ParkwayLife Reit
+1700 1.0 4.0412412 4.08000 6,936.00 65.89 0.00 0.00 SGD
+(C2PU.SI)
+DBS
+200 1.0 34.2100000 56.36000 11,272.00 4,430.00 0.00 0.00 SGD
+(D05.SI)
+This statement also serves as a Tax Invoice for GST purpose. 12/20
+Tiger Brokers (Singapore) PTE.LTD.
+Symbol Quantity Multiplier Cost Price Close Price Value Unrealized P/L Initial Margin Maint Margin Currency
+Frasers Cpt Tr
+7500 1.0 2.2555307 2.33000 17,475.00 558.52 0.00 0.00 SGD
+(J69U.SI)
+Mapletree Ind Tr
+6500 1.0 2.0766600 2.08000 13,520.00 21.71 0.00 0.00 SGD
+(ME8U.SI)
+OCBC Bank
+1300 1.0 16.1500000 19.76000 25,688.00 4,693.00 0.00 0.00 SGD
+(O39.SI)
+UOB
+900 1.0 34.5854667 35.06000 31,554.00 427.08 0.00 0.00 SGD
+(U11.SI)
+Total 36400 135,604.50 11,271.14 0.00 0.00 SGD
+Blackstone Secured Lending Fund
+1033 1.0 26.4138238 26.33000 27,198.89 -86.59 0.00 0.00 USD
+(BXSL)
+Realty Income
+655.44178 1.0 59.2891811 56.37000 36,947.25 -1,913.35 0.00 0.00 USD
+(O)
+Putnam Bdc Income ETF
+555 1.0 31.2696757 30.60000 16,983.00 -371.67 0.00 0.00 USD
+(PBDC)
+Total 2243.44178 81,129.14 -2,371.61 0.00 0.00 USD
+Total(In Base) 38643.44178 186,615.88 6,396.21 0.00 0.00 USD
+Note:
+1. The multiplier represents the fixed number used to calculate the total contract value by multiplying it with the price of the underlying asset in equity options or futures trading.
+2. For certain private funds, the end-of-period market value includes estimated adjustments for Equalization to smooth the calculation of performance fees or allocations.
+Dividends
+Dividend Reinvestment Cash 
+Date Product Symbol Quantity/Gross Rate Phase Shares Fees & Tax Net Cash Value Currency
+Plan Dividends
+Quantity: 2200
+2025-09- CapLand Ascendas REIT
+Stock Gross Rate: 0.000930 Paid 2.05 0 2.05 SGD
+04 (A17U.SI) Reinvestment
+/Share
+Quantity: 2200
+2025-09- CapLand Ascendas REIT
+This statement also serves as a Tax Invoice for GST purpose. 13/20
+Tiger Brokers (Singapore) PTE.LTD.
+Dividend Reinvestment Cash 
+Date Product Symbol Quantity/Gross Rate Phase Shares Fees & Tax Net Cash Value Currency
+Plan Dividends
+04 Stock (A17U.SI) Reinvestment Gross Rate: 0.009050 Paid 19.91 0 19.91 SGD
+/Share
+Quantity: 3000
+2025-11- Frasers Cpt Tr
+Stock Gross Rate: 0.002080 Paid 6.24 0 6.24 SGD
+28 (J69U.SI) Reinvestment
+/Share
+Quantity: 3000
+2025-11- Frasers Cpt Tr
+Stock Gross Rate: 0.001700 Paid 5.10 0 5.10 SGD
+28 (J69U.SI) Reinvestment
+/Share
+Quantity: 3000
+2025-10- Frasers Cpt Tr Dividend Accruals 
+Stock Gross Rate: 0.055850 167.55 0 167.55 SGD
+31 (J69U.SI) Reinvestment Increase
+/Share
+Quantity: 3000
+2025-11- Frasers Cpt Tr Dividend Accruals 
+Stock Gross Rate: 0.055850 -167.55 0 -167.55 SGD
+07 (J69U.SI) Reinvestment Reduction
+/Share
+Quantity: 3400
+2025-11- Mapletree Ind Tr Dividend Accruals 
+Stock Gross Rate: 0.023400 79.56 0 79.56 SGD
+05 (ME8U.SI) Reinvestment Increase
+/Share
+Quantity: 3400
+2025-11- Mapletree Ind Tr Dividend Accruals 
+Stock Gross Rate: 0.023400 -79.56 0 -79.56 SGD
+07 (ME8U.SI) Reinvestment Reduction
+/Share
+Quantity: 3000
+2025-11- Frasers Cpt Tr
+Stock Gross Rate: 0.055850 Paid 167.55 0 167.55 SGD
+28 (J69U.SI) Reinvestment
+/Share
+Quantity: 3400
+2025-12- Mapletree Ind Tr
+Stock Gross Rate: 0.023400 Paid 79.56 0 79.56 SGD
+10 (ME8U.SI)
+/Share
+Quantity: 3400
+2025-12- Mapletree Ind Tr
+Stock Gross Rate: 0.002300 Paid 7.82 0 7.82 SGD
+10 (ME8U.SI)
+/Share
+Quantity: 3400
+2025-12- Mapletree Ind Tr
+Stock Gross Rate: 0.006100 Paid 20.74 0 20.74 SGD
+10 (ME8U.SI)
+/Share
+Quantity: 200
+Gross Rate: 0.600000
+This statement also serves as a Tax Invoice for GST purpose. 14/20
+Tiger Brokers (Singapore) PTE.LTD.
+Dividend Reinvestment Cash 
+Date Product Symbol Quantity/Gross Rate Phase Shares Fees & Tax Net Cash Value Currency
+Plan Dividends
+2025-11- Stock DBS /Share Paid 120.00 0 120.00 SGD
+24 (D05.SI) Reinvestment
+Quantity: 200
+2025-11- DBS
+Stock Gross Rate: 0.150000 Paid 30.00 0 30.00 SGD
+24 (D05.SI) Reinvestment
+/Share
+Quantity: 11700
+2025-11- Frasers L&C Tr Dividend Accruals 
+Stock Gross Rate: 0.002400 28.08 0 28.08 SGD
+18 (BUOU.SI) Reinvestment Increase
+/Share
+Quantity: 11700
+2025-11- Frasers L&C Tr Dividend Accruals 
+Stock Gross Rate: 0.002400 -28.08 0 -28.08 SGD
+19 (BUOU.SI) Reinvestment Reduction
+/Share
+Quantity: 11700
+2025-12- Frasers L&C Tr
+Stock Gross Rate: 0.003400 Paid 39.78 0 39.78 SGD
+23 (BUOU.SI)
+/Share
+Quantity: 11700
+2025-12- Frasers L&C Tr
+Stock Gross Rate: 0.002600 Paid 30.42 0 30.42 SGD
+23 (BUOU.SI)
+/Share
+Quantity: 11700
+2025-12- Frasers L&C Tr
+Stock Gross Rate: 0.002400 Paid 28.08 0 28.08 SGD
+23 (BUOU.SI)
+/Share
+Quantity: 11700
+2025-12- Frasers L&C Tr
+Stock Gross Rate: 0.021100 Paid 246.87 0 246.87 SGD
+23 (BUOU.SI)
+/Share
+Total Accruals/Paid 0.00/804.12 SGD
+Blackstone Secured Lending Quantity: 367
+2025-10- Dividend tax: 
+Stock Fund Gross Rate: 0.770000 Paid 282.59 0 254.33 USD
+24 Reinvestment 28.26
+(BXSL) /Share
+Quantity: 118
+2025-10- Putnam Bdc Income ETF Dividend tax: 
+Stock Gross Rate: 0.820460 Paid 96.81 0 87.13 USD
+17 (PBDC) Reinvestment 9.68
+/Share
+Quantity: 650
+2025-11- Realty Income Dividend tax: 
+Stock Gross Rate: 0.269500 Paid 175.17 0 157.65 USD
+14 (O) Reinvestment 17.52
+/Share
+This statement also serves as a Tax Invoice for GST purpose. 15/20
+Tiger Brokers (Singapore) PTE.LTD.
+Dividend Reinvestment Cash 
+Date Product Symbol Quantity/Gross Rate Phase Shares Fees & Tax Net Cash Value Currency
+Plan Dividends
+Quantity: 652.7321
+2025-12- Realty Income Dividend tax: 
+Stock Gross Rate: 0.269500 Paid 175.91 0 158.31 USD
+15 (O) 17.60
+/Share
+Quantity: 555
+2025-12- Putnam Bdc Income ETF Dividend tax: 
+Stock Gross Rate: 0.825070 Paid 457.91 0 412.12 USD
+31 (PBDC) 45.79
+/Share
+Blackstone Secured Lending Quantity: 1033
+2025-12- Dividend Accruals Dividend tax: 
+Stock Fund Gross Rate: 0.770000 795.41 0 715.87 USD
+31 Increase 79.54
+(BXSL) /Share
+Quantity: 250
+2025-12- Alexandria Real Estate Equities Dividend Accruals Dividend tax: 
+Stock Gross Rate: 0.720000 180.00 0 162.00 USD
+31 (ARE) Cash Increase 18.00
+/Share
+Quantity: 655.4418
+2025-12- Realty Income Dividend Accruals Dividend tax: 
+Stock Gross Rate: 0.270000 176.97 0 159.27 USD
+31 (O) Cash Increase 17.70
+/Share
+1,037.14/1,
+Total Accruals/Paid USD
+069.54
+1,037.14/1,
+Total(In Base) Accruals/Paid USD
+695.06
+Notes: Accrued Dividends refers to the expected amount of cash or number of shares you will receive after a company announces a dividend. Before the payment is made, the amount or shares will appear as “accrued.” Once the 
+dividend is officially distributed, the cash will be credited to your account balance, or the shares will be added to your holdings.
+Allowance
+Date Description Amount Currency
+2025-10-06 Order Rebate 50.00 SGD
+2025-10-06 Order Rebate 50.00 SGD
+2025-10-16 Order Rebate 50.00 SGD
+2025-12-04 Order Rebate 50.00 SGD
+This statement also serves as a Tax Invoice for GST purpose. 16/20
+Tiger Brokers (Singapore) PTE.LTD.
+Date Description Amount Currency
+2025-12-05 Order Rebate 50.00 SGD
+2025-12-15 Order Rebate 50.00 SGD
+Total 300.00 SGD
+2025-09-09 Coupon Rebate 0.99 USD
+2025-09-17 Coupon Rebate 0.99 USD
+2025-09-29 Coupon Rebate 1.84 USD
+2025-10-06 Coupon Rebate 2.26 USD
+2025-10-07 Coupon Rebate 1.94 USD
+2025-10-10 Order Rebate 38.53 USD
+2025-10-10 Coupon Rebate 1.08 USD
+2025-10-16 Coupon Rebate 0.99 USD
+2025-10-16 Coupon Rebate 4.51 USD
+2025-10-23 Coupon Rebate 1.25 USD
+2025-10-24 Coupon Rebate 1.00 USD
+2025-10-29 Coupon Rebate 1.00 USD
+2025-10-29 Coupon Rebate 1.00 USD
+2025-10-30 Coupon Rebate 0.99 USD
+2025-12-31 Coupon Rebate 0.99 USD
+2025-12-31 Coupon Rebate 0.99 USD
+Total 60.35 USD
+Total(In Base) 293.72 USD
+Financial Instrument Information
+This statement also serves as a Tax Invoice for GST purpose. 17/20
+Tiger Brokers (Singapore) PTE.LTD.
+Forex
+Symbol Issuer Description Multiplier Expiry Strike Right
+USD.SGD USD.SGD 1
+Stock
+Symbol Issuer Description Multiplier Expiry Strike Right
+A17U.SI CapLand Ascendas REIT 1
+AJBU.SI Keppel DC Reit 1
+ARE Alexandria Real Estate Equities 1
+BUOU.SI Frasers L&C Tr 1
+BXSL Blackstone Secured Lending Fund 1
+C2PU.SI ParkwayLife Reit 1
+D05.SI DBS 1
+J69U.SI Frasers Cpt Tr 1
+ME8U.SI Mapletree Ind Tr 1
+N2IU.SI Mapletree PanAsia Com Tr 1
+O Realty Income 1
+O39.SI OCBC Bank 1
+PBDC Putnam Bdc Income ETF 1
+S68.SI SGX 1
+U11.SI UOB 1
+Base Currency Exchange Rate
+This statement also serves as a Tax Invoice for GST purpose. 18/20
+Tiger Brokers (Singapore) PTE.LTD.
+Date 2025-12-31
+USD 1
+AUD 0.66740
+CAD 0.72854
+CHF 1.26231
+CNH 0.14334
+EUR 1.17530
+GBP 1.34800
+HKD 0.12849
+IDR 0.00006
+JPY 0.00638
+MXN 0.05551
+MYR 0.24643
+NOK 0.09913
+NZD 0.57570
+PLN 0.27806
+SEK 0.10862
+SGD 0.77790
+TRY 0.02328
+Note: You can refer to the USD index table to view the exchange rate information as of the report cutoff date, with USD as the quote currency.
+Notes:
+This statement also serves as a Tax Invoice for GST purpose. 19/20
+Tiger Brokers (Singapore) PTE.LTD.
+1. Please examine the details in the monthly statement and promptly report any inaccuracy or discrepancy found to service@tigerbrokers.com.sg within 14 calendar days from the date of the statement. All the above details shall be 
+deemed correct and conclusive if no written notice of objection is received by us within 14 days from the date of the monthly statement.
+2. Tiger Brokers (Singapore) Pte Ltd is a member of Financial Institutions Dispute Resolution Centre (FIDReC), which is an independent and impartial institution specialising in the resolution of disputes between financial institutions 
+and consumers. Unresolved issues can also be brought up to FIDReC at www.fidrec.com.sg for mediation.
+3. Information on our fees can be found at https://www.tigerbrokers.com.sg/commissions/fees
+4. Information regarding your account can be found in the Terms and Conditions at https://www.tigerbrokers.com.sg/info/terms-n-conditions
+5. Customer money and assets are deposited in trust and held in custody, respectively in accordance with the Securities and Futures (Licensing and Conduct of Business) Regulations, governing the protection of client money and 
+assets.;
+[1] TIGER BROKERS (HK) GLOBAL LIMITED AS THE PRINCIPAL
+TIGER BROKERS (SINGAPORE) PTE. LTD.
++65 6331 2277
+WhatsApp +65 6331 2277
+service@tigerbrokers.com.sg
+This statement also serves as a Tax Invoice for GST purpose. 20/20

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/tigerbrokerspteltd/TigerBrokersPteLtdPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/tigerbrokerspteltd/TigerBrokersPteLtdPDFExtractorTest.java
@@ -4,6 +4,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasExDate;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasIsin;
@@ -15,7 +16,15 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.inboundDelivery;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.feeRefund;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.inboundCash;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.outboundCash;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.skippedItem;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxRefund;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransactions;
 import static name.abuchen.portfolio.datatransfer.ExtractorTestUtilities.countAccountTransfers;
@@ -35,6 +44,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.datatransfer.Extractor.BuySellEntryItem;
 import name.abuchen.portfolio.datatransfer.Extractor.SecurityItem;
 import name.abuchen.portfolio.datatransfer.Extractor.TransactionItem;
@@ -953,13 +963,13 @@ public class TigerBrokersPteLtdPDFExtractorTest
         var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "AccountStatement09_late24.txt"), errors);
 
         assertThat(errors, empty());
-        assertThat(countSecurities(results), is(2L));
+        assertThat(countSecurities(results), is(3L));
         assertThat(countBuySell(results), is(1L));
         assertThat(countAccountTransactions(results), is(2L));
         assertThat(countAccountTransfers(results), is(0L));
         assertThat(countItemsWithFailureMessage(results), is(0L));
-        assertThat(countSkippedItems(results), is(0L));
-        assertThat(results.size(), is(5));
+        assertThat(countSkippedItems(results), is(5L));
+        assertThat(results.size(), is(11));
         new AssertImportActions().check(results, "USD");
 
         // check securities
@@ -993,6 +1003,61 @@ public class TigerBrokersPteLtdPDFExtractorTest
                         hasSource("AccountStatement09_late24.txt"), hasNote(null), //
                         hasAmount("USD", 36.94), hasGrossValue("USD", 43.46), //
                         hasTaxes("USD", 6.52), hasFees("USD", 0.00))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2024-12-20"), hasExDate(null), //
+                                        hasShares(72.00), //
+                                        hasSource("AccountStatement09_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 53.69), hasGrossValue("USD", 63.17), //
+                                        hasTaxes("USD", 9.48), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2024-12-26"), hasExDate(null), //
+                                        hasShares(72.00), //
+                                        hasSource("AccountStatement09_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 53.69), hasGrossValue("USD", 53.69), //
+                                        hasTaxes("USD", 0.00), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2024-12-23"), hasExDate(null), //
+                                        hasShares(25.00), //
+                                        hasSource("AccountStatement09_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 36.94), hasGrossValue("USD", 43.46), //
+                                        hasTaxes("USD", 6.52), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2024-12-30"), hasExDate(null), //
+                                        hasShares(25.00), //
+                                        hasSource("AccountStatement09_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 36.94), hasGrossValue("USD", 36.94), //
+                                        hasTaxes("USD", 0.00), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2024-12-23"), hasExDate(null), //
+                                        hasShares(54.00), //
+                                        hasSource("AccountStatement09_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 38.31), hasGrossValue("USD", 45.07), //
+                                        hasTaxes("USD", 6.76), hasFees("USD", 0.00)))));
     }
 
     @Test
@@ -1042,8 +1107,8 @@ public class TigerBrokersPteLtdPDFExtractorTest
         assertThat(countAccountTransactions(results), is(8L));
         assertThat(countAccountTransfers(results), is(0L));
         assertThat(countItemsWithFailureMessage(results), is(0L));
-        assertThat(countSkippedItems(results), is(0L));
-        assertThat(results.size(), is(12));
+        assertThat(countSkippedItems(results), is(13L));
+        assertThat(results.size(), is(25));
         new AssertImportActions().check(results, "USD");
 
         assertThat(results, hasItem(purchase( //
@@ -1064,5 +1129,385 @@ public class TigerBrokersPteLtdPDFExtractorTest
                         hasAmount("USD", 37.08), hasGrossValue("USD", 43.62), //
                         hasTaxes("USD", 6.54), hasFees("USD", 0.00))));
 
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2024-12-20"), hasExDate(null), //
+                                        hasShares(72.00), //
+                                        hasSource("AccountStatement11_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 53.69), hasGrossValue("USD", 63.17), //
+                                        hasTaxes("USD", 9.48), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2024-12-26"), hasExDate(null), //
+                                        hasShares(72.00), //
+                                        hasSource("AccountStatement11_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 53.69), hasGrossValue("USD", 53.69), //
+                                        hasTaxes("USD", 0.00), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2024-12-23"), hasExDate(null), //
+                                        hasShares(25.00), //
+                                        hasSource("AccountStatement11_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 36.94), hasGrossValue("USD", 43.46), //
+                                        hasTaxes("USD", 6.52), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2024-12-30"), hasExDate(null), //
+                                        hasShares(25.00), //
+                                        hasSource("AccountStatement11_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 36.94), hasGrossValue("USD", 36.94), //
+                                        hasTaxes("USD", 0.00), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2025-01-02"), hasExDate(null), //
+                                        hasShares(54.00), //
+                                        hasSource("AccountStatement11_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 38.31), hasGrossValue("USD", 38.31), //
+                                        hasTaxes("USD", 0.00), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2025-03-21"), hasExDate(null), //
+                                        hasShares(72.00), //
+                                        hasSource("AccountStatement11_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 23.57), hasGrossValue("USD", 27.73), //
+                                        hasTaxes("USD", 4.16), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2025-03-25"), hasExDate(null), //
+                                        hasShares(72.00), //
+                                        hasSource("AccountStatement11_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 23.57), hasGrossValue("USD", 23.57), //
+                                        hasTaxes("USD", 0.00), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2025-03-24"), hasExDate(null), //
+                                        hasShares(54.00), //
+                                        hasSource("AccountStatement11_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 32.85), hasGrossValue("USD", 38.65), //
+                                        hasTaxes("USD", 5.80), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2025-05-01"), hasExDate(null), //
+                                        hasShares(54.00), //
+                                        hasSource("AccountStatement11_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 32.85), hasGrossValue("USD", 32.85), //
+                                        hasTaxes("USD", 0.00), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2025-03-27"), hasExDate(null), //
+                                        hasShares(25.00), //
+                                        hasSource("AccountStatement11_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 38.50), hasGrossValue("USD", 45.30), //
+                                        hasTaxes("USD", 6.80), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2025-03-31"), hasExDate(null), //
+                                        hasShares(25.00), //
+                                        hasSource("AccountStatement11_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 38.50), hasGrossValue("USD", 38.50), //
+                                        hasTaxes("USD", 0.00), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2025-06-24"), hasExDate(null), //
+                                        hasShares(73.00), //
+                                        hasSource("AccountStatement11_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 36.90), hasGrossValue("USD", 36.90), //
+                                        hasTaxes("USD", 0.00), hasFees("USD", 0.00)))));
+
+        // check skipped item
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2025-07-03"), hasExDate(null), //
+                                        hasShares(25.00), //
+                                        hasSource("AccountStatement11_late24.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 37.08), hasGrossValue("USD", 37.08), //
+                                        hasTaxes("USD", 0.00), hasFees("USD", 0.00)))));
+    }
+
+    @Test
+    public void testAccountStatement12()
+    {
+        var extractor = new TigerBrokersPteLtdPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "AccountStatement12.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(3L));
+        assertThat(countBuySell(results), is(1L));
+        assertThat(countAccountTransactions(results), is(9L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(1L));
+        assertThat(results.size(), is(14));
+        new AssertImportActions().check(results, "USD");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin(null), hasWkn(null), hasTicker("QQQ"), //
+                        hasName("Invesco QQQ"), //
+                        hasCurrencyCode("USD"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin(null), hasWkn(null), hasTicker("VOO"), //
+                        hasName("Vanguard S&P 500 ETF"), //
+                        hasCurrencyCode("USD"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin(null), hasWkn(null), hasTicker("VT"), //
+                        hasName("Vanguard Total World Stock ETF"), //
+                        hasCurrencyCode("USD"))));
+
+        // check purchase transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2025-04-08T11:28:50"), hasShares(1), //
+                        hasSource("AccountStatement12.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 108.42), hasGrossValue("USD", 106.43), //
+                        hasTaxes("USD", 0.00), hasFees("USD", (0.99 + 1.00)))));
+
+        // check dividend transactions
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-01-02"), hasExDate(null), //
+                        hasShares(54), //
+                        hasSource("AccountStatement12.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 38.31), hasGrossValue("USD", 45.07), //
+                        hasTaxes("USD", 6.76), hasFees("USD", 0.00))));
+
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-03-25"), hasExDate(null), //
+                        hasShares(72), //
+                        hasSource("AccountStatement12.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 23.57), hasGrossValue("USD", 27.73), //
+                        hasTaxes("USD", 4.16), hasFees("USD", 0.00))));
+
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-03-31"), hasExDate(null), //
+                        hasShares(25), //
+                        hasSource("AccountStatement12.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 38.50), hasGrossValue("USD", 45.30), //
+                        hasTaxes("USD", 6.80), hasFees("USD", 0.00))));
+
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-05-01"), hasExDate(null), //
+                        hasShares(54), //
+                        hasSource("AccountStatement12.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 32.85), hasGrossValue("USD", 38.65), //
+                        hasTaxes("USD", 5.80), hasFees("USD", 0.00))));
+
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-06-24"), hasExDate(null), //
+                        hasShares(73), //
+                        hasSource("AccountStatement12.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 36.90), hasGrossValue("USD", 43.41), //
+                        hasTaxes("USD", 6.51), hasFees("USD", 0.00))));
+
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-07-03"), hasExDate(null), //
+                        hasShares(25), //
+                        hasSource("AccountStatement12.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 37.08), hasGrossValue("USD", 43.62), //
+                        hasTaxes("USD", 6.54), hasFees("USD", 0.00))));
+
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-07-31"), hasExDate(null), //
+                        hasShares(54), //
+                        hasSource("AccountStatement12.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 27.13), hasGrossValue("USD", 31.92), //
+                        hasTaxes("USD", 4.79), hasFees("USD", 0.00))));
+
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-09-23"), hasExDate(null), //
+                        hasShares(73), //
+                        hasSource("AccountStatement12.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 29.66), hasGrossValue("USD", 34.90), //
+                        hasTaxes("USD", 5.24), hasFees("USD", 0.00))));
+
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-10-01"), hasExDate(null), //
+                        hasShares(25), //
+                        hasSource("AccountStatement12.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 36.97), hasGrossValue("USD", 43.50), //
+                        hasTaxes("USD", 6.53), hasFees("USD", 0.00))));
+
+        // check skipped item
+        // "Dividend Accruals" are not paid out yet, there is no cash flow
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2025-09-22"), hasExDate(null), //
+                                        hasShares(54), //
+                                        hasSource("AccountStatement12.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("USD", 31.85), hasGrossValue("USD", 37.47), //
+                                        hasTaxes("USD", 5.62), hasFees("USD", 0.00)))));
+    }
+
+    @Test
+    public void testAccountStatement13()
+    {
+        var extractor = new TigerBrokersPteLtdPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "AccountStatement13.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(15L));
+        assertThat(countBuySell(results), is(52L));
+        assertThat(countAccountTransactions(results), is(57L));
+        assertThat(countAccountTransfers(results), is(5L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(9L));
+        assertThat(results.size(), is(138));
+        new AssertImportActions().check(results, "SGD", "USD");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin(null), hasWkn(null), hasTicker("U11.SI"), //
+                        hasName("UOB"), //
+                        hasCurrencyCode("SGD"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin(null), hasWkn(null), hasTicker("O"), //
+                        hasName("Realty Income"), //
+                        hasCurrencyCode("USD"))));
+
+        assertThat(results, hasItem(security( //
+                        hasIsin(null), hasWkn(null), hasTicker("D05.SI"), //
+                        hasName("DBS"), //
+                        hasCurrencyCode("SGD"))));
+
+        // check purchase transaction
+        assertThat(results, hasItem(purchase( //
+                        hasDate("2025-10-16T13:16:02"), hasShares(100.00), //
+                        hasSource("AccountStatement13.txt"), //
+                        hasNote(null), //
+                        hasAmount("SGD", 3453.46), hasGrossValue("SGD", 3450.00), //
+                        hasTaxes("SGD", 0.00), hasFees("SGD", (1.38 + 1.04 + 1.04)))));
+
+        // check sale transaction
+        assertThat(results, hasItem(sale( //
+                        hasDate("2025-08-25T14:42:32"), hasShares(100.00), //
+                        hasSource("AccountStatement13.txt"), //
+                        hasNote(null), //
+                        hasAmount("SGD", 1675.33), hasGrossValue("SGD", 1678.00), //
+                        hasTaxes("SGD", 0.00), hasFees("SGD", (0.68 + 0.99 + 1.00)))));
+
+        // check deposit and removal transaction
+        assertThat(results, hasItem(deposit(hasDate("2025-08-06"), hasAmount("SGD", 432.18), //
+                        hasSource("AccountStatement13.txt"), hasNote(null))));
+
+        assertThat(results, hasItem(removal(hasDate("2025-08-07"), hasAmount("SGD", 10.00), //
+                        hasSource("AccountStatement13.txt"), hasNote(null))));
+
+        assertThat(results, hasItem(deposit(hasDate("2025-11-05"), hasAmount("SGD", 20000.00), //
+                        hasSource("AccountStatement13.txt"), hasNote(null))));
+
+        // check dividend transaction without withholding tax
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-09-04"), hasExDate(null), //
+                        hasShares(2200.00), //
+                        hasSource("AccountStatement13.txt"), //
+                        hasNote(null), //
+                        hasAmount("SGD", 2.05), hasGrossValue("SGD", 2.05), //
+                        hasTaxes("SGD", 0.00), hasFees("SGD", 0.00))));
+
+        // check dividend transaction with withholding tax
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2025-12-15"), hasExDate(null), //
+                        hasShares(652.7321), //
+                        hasSource("AccountStatement13.txt"), //
+                        hasNote(null), //
+                        hasAmount("USD", 158.31), hasGrossValue("USD", 175.91), //
+                        hasTaxes("USD", 17.60), hasFees("USD", 0.00))));
+
+        // check fee refund transaction
+        assertThat(results, hasItem(feeRefund( //
+                        hasDate("2025-10-16"), //
+                        hasSource("AccountStatement13.txt"), //
+                        hasNote("Coupon Rebate"), //
+                        hasAmount("USD", 0.99), hasGrossValue("USD", 0.99), //
+                        hasTaxes("USD", 0.00), hasFees("USD", 0.00))));
+
+        // check inbound delivery transaction
+        assertThat(results, hasItem(inboundDelivery( //
+                        hasDate("2025-09-01T15:38:02"), hasShares(200.00), //
+                        hasSource("AccountStatement13.txt"), //
+                        hasNote("EXTERNAL IN"), //
+                        hasAmount("SGD", 6842.00), hasGrossValue("SGD", 6842.00), //
+                        hasTaxes("SGD", 0.00), hasFees("SGD", 0.00))));
+
+        // check skipped item
+        // "Dividend Accruals" are announced but not paid out yet
+        assertThat(results, hasItem(skippedItem( //
+                        Messages.MsgErrorTransactionTypeNotSupportedOrRequired, //
+                        dividend( //
+                                        hasDate("2025-10-31"), hasExDate(null), //
+                                        hasShares(3000.00), //
+                                        hasSource("AccountStatement13.txt"), //
+                                        hasNote("Dividend Accruals"), //
+                                        hasAmount("SGD", 167.55), hasGrossValue("SGD", 167.55), //
+                                        hasTaxes("SGD", 0.00), hasFees("SGD", 0.00)))));
     }
 }

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/tigerbrokerspteltd/TigerBrokersPteLtdPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/tigerbrokerspteltd/TigerBrokersPteLtdPDFExtractorTest.java
@@ -1,6 +1,8 @@
 package name.abuchen.portfolio.datatransfer.pdf.tigerbrokerspteltd;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.feeRefund;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
@@ -15,14 +17,10 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.inboundDelivery;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.deposit;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.inboundDelivery;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.feeRefund;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.inboundCash;
-import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.outboundCash;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.security;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.skippedItem;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.taxRefund;

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/tigerbrokerspteltd/TigerBrokersPteLtdPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/tigerbrokerspteltd/TigerBrokersPteLtdPDFExtractorTest.java
@@ -17,7 +17,9 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasSource;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTaxes;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasTicker;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasWkn;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.inboundCash;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.inboundDelivery;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.outboundCash;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.purchase;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.removal;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.sale;
@@ -1487,6 +1489,33 @@ public class TigerBrokersPteLtdPDFExtractorTest
                         hasNote("Coupon Rebate"), //
                         hasAmount("USD", 0.99), hasGrossValue("USD", 0.99), //
                         hasTaxes("USD", 0.00), hasFees("USD", 0.00))));
+
+        // check currency transfer transaction
+        // "Buy USD.SGD" --> SGD is sold, USD is bought
+        assertThat(results, hasItem(outboundCash( //
+                        hasDate("2025-09-09T13:52:45"), //
+                        hasSource("AccountStatement13.txt"), //
+                        hasNote("USD/SGD 1.28688"), //
+                        hasAmount("SGD", 5000.00))));
+
+        assertThat(results, hasItem(inboundCash( //
+                        hasDate("2025-09-09T13:52:45"), //
+                        hasSource("AccountStatement13.txt"), //
+                        hasNote("USD/SGD 1.28688"), //
+                        hasAmount("USD", 3885.36))));
+
+        // "Sell USD.SGD" --> USD is sold, SGD is bought
+        assertThat(results, hasItem(outboundCash( //
+                        hasDate("2025-10-16T01:14:03"), //
+                        hasSource("AccountStatement13.txt"), //
+                        hasNote("USD/SGD 1.29103"), //
+                        hasAmount("USD", 5000.00))));
+
+        assertThat(results, hasItem(inboundCash( //
+                        hasDate("2025-10-16T01:14:03"), //
+                        hasSource("AccountStatement13.txt"), //
+                        hasNote("USD/SGD 1.29103"), //
+                        hasAmount("SGD", 6455.15))));
 
         // check inbound delivery transaction
         assertThat(results, hasItem(inboundDelivery( //

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TigerBrokersPteLtdPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/TigerBrokersPteLtdPDFExtractor.java
@@ -1,26 +1,32 @@
 package name.abuchen.portfolio.datatransfer.pdf;
 
+import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetFee;
 import static name.abuchen.portfolio.datatransfer.ExtractorUtils.checkAndSetTax;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import name.abuchen.portfolio.Messages;
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Block;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.DocumentType;
 import name.abuchen.portfolio.datatransfer.pdf.PDFParser.Transaction;
 import name.abuchen.portfolio.model.AccountTransaction;
+import name.abuchen.portfolio.model.AccountTransferEntry;
 import name.abuchen.portfolio.model.BuySellEntry;
 import name.abuchen.portfolio.model.Client;
 import name.abuchen.portfolio.model.PortfolioTransaction;
+import name.abuchen.portfolio.model.Transaction.Unit;
 import name.abuchen.portfolio.money.Money;
 import name.abuchen.portfolio.money.Values;
 
@@ -53,6 +59,8 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
 {
     private static final DateTimeFormatter DATEFORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
+    private static final DateTimeFormatter TIMEFORMAT = DateTimeFormatter.ofPattern("HH:mm:ss");
+
     public TigerBrokersPteLtdPDFExtractor(Client client)
     {
         super(client);
@@ -60,6 +68,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
         addBankIdentifier("Tiger Brokers (Singapore) PTE.LTD.");
 
         addAccountStatementTransaction();
+        addAccountStatementTransaction_late25();
     }
 
     @Override
@@ -72,7 +81,7 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
     {
         final var type = new DocumentType("Activity Statement", (context, lines) -> {
             var pCurrency = Pattern.compile("^.* (Base Currency :|Cash) (?<currency>[A-Z]{3})$");
-            var pSecurity = Pattern.compile("^(?<tickerSymbol>(?!(GST|Net))[A-Z0-9]{1,6}(?:\\\\.[A-Z]{1,4})?) (?<name>.*) [\\d]$");
+            var pSecurity = Pattern.compile("^(?<tickerSymbol>(?!(GST|Net))[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?) (?<name>.*) [\\d]$");
             var pSecurityCurrency = Pattern.compile("^Stock Currency: (?<securityCurrency>[A-Z]{3})$");
             var pDividendTaxes = Pattern.compile("^(?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}) (?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?) Cash Dividend .* \\-(?<tax>[\\.,\\d]+).*$");
 
@@ -131,6 +140,51 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
                     dividendTaxesTransactionListHelper.items.add(dividendTaxesTransactionItem);
                 }
             }
+
+            // @formatter:off
+            // Collect the trade dates. The trade date is located somewhere between
+            // the previous and the current trade data line and may be split into
+            // two fragments. If no complete date is present, every pair of digit
+            // fragments is combined in both directions until a valid date results.
+            // @formatter:on
+            var tradeDateListHelper = new TradeDateListHelper();
+            context.putType(tradeDateListHelper);
+
+            var pTradeData = Pattern.compile("^.*(SG|US) (SGX|NYSE|ARCA|NASDAQ) (Open|Close) "
+                            + "\\-?[\\.,\\d]+ [\\.,\\d]+ \\-?[\\.,\\d]+ [\\.,\\d]+.*$");
+            var pFullDate = Pattern.compile("^.*?(?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}).*$");
+            var pDateFragment = Pattern.compile("[\\d][\\d\\-]*");
+
+            var previousTradeLine = 0;
+
+            for (var ii = 0; ii < lines.length; ii++)
+            {
+                if (!pTradeData.matcher(lines[ii]).matches())
+                    continue;
+
+                String tradeDate = null;
+
+                for (var jj = previousTradeLine; jj <= ii && tradeDate == null; jj++)
+                {
+                    var mFullDate = pFullDate.matcher(lines[jj]);
+                    if (mFullDate.matches())
+                        tradeDate = mFullDate.group("date");
+                }
+
+                if (tradeDate == null)
+                    tradeDate = assembleDate(lines, previousTradeLine, ii, pDateFragment);
+
+                if (tradeDate != null)
+                {
+                    var tradeDateItem = new TradeDateItem();
+                    tradeDateItem.lineNo = ii;
+                    tradeDateItem.date = tradeDate;
+                    tradeDateItem.time = assembleTime(lines, previousTradeLine, ii);
+                    tradeDateListHelper.items.add(tradeDateItem);
+                }
+
+                previousTradeLine = ii + 1;
+            }
         });
         this.addDocumentTyp(type);
 
@@ -187,10 +241,13 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
                         .wrap(t -> {
                             type.getCurrentContext().removeType(SecurityItem.class);
 
-                            if (t.getPortfolioTransaction().getCurrencyCode() != null && t.getPortfolioTransaction().getAmount() != 0)
-                                return new BuySellEntryItem(t);
+                            if (t.getPortfolioTransaction().getCurrencyCode() == null)
+                                return null;
 
-                            return null;
+                            if (t.getPortfolioTransaction().getAmount() == 0)
+                                return new SkippedItem(new BuySellEntryItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                            return new BuySellEntryItem(t);
                         });
 
         addFeesSectionsTransaction(buyBlock_Format01, type);
@@ -245,10 +302,13 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
                         .wrap(t -> {
                             type.getCurrentContext().removeType(SecurityItem.class);
 
-                            if (t.getPortfolioTransaction().getCurrencyCode() != null && t.getPortfolioTransaction().getAmount() != 0)
-                                return new BuySellEntryItem(t);
+                            if (t.getPortfolioTransaction().getCurrencyCode() == null)
+                                return null;
 
-                            return null;
+                            if (t.getPortfolioTransaction().getAmount() == 0)
+                                return new SkippedItem(new BuySellEntryItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                            return new BuySellEntryItem(t);
                         });
 
         addFeesSectionsTransaction(buyBlock_Format02, type);
@@ -303,10 +363,13 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
                         .wrap(t -> {
                             type.getCurrentContext().removeType(SecurityItem.class);
 
-                            if (t.getPortfolioTransaction().getCurrencyCode() != null && t.getPortfolioTransaction().getAmount() != 0)
-                                return new BuySellEntryItem(t);
+                            if (t.getPortfolioTransaction().getCurrencyCode() == null)
+                                return null;
 
-                            return null;
+                            if (t.getPortfolioTransaction().getAmount() == 0)
+                                return new SkippedItem(new BuySellEntryItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                            return new BuySellEntryItem(t);
                         });
 
         addFeesSectionsTransaction(buyBlock_Format03, type);
@@ -404,10 +467,13 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
                         .wrap(t -> {
                             type.getCurrentContext().removeType(SecurityItem.class);
 
-                            if (t.getPortfolioTransaction().getCurrencyCode() != null && t.getPortfolioTransaction().getAmount() != 0)
-                                return new BuySellEntryItem(t);
+                            if (t.getPortfolioTransaction().getCurrencyCode() == null)
+                                return null;
 
-                            return null;
+                            if (t.getPortfolioTransaction().getAmount() == 0)
+                                return new SkippedItem(new BuySellEntryItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                            return new BuySellEntryItem(t);
                         });
 
         addFeesSectionsTransaction(buyBlock_Format04, type);
@@ -466,13 +532,92 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
                         .wrap(t -> {
                             type.getCurrentContext().removeType(SecurityItem.class);
 
-                            if (t.getPortfolioTransaction().getCurrencyCode() != null && t.getPortfolioTransaction().getAmount() != 0)
-                                return new BuySellEntryItem(t);
+                            if (t.getPortfolioTransaction().getCurrencyCode() == null)
+                                return null;
 
-                            return null;
+                            if (t.getPortfolioTransaction().getAmount() == 0)
+                                return new SkippedItem(new BuySellEntryItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                            return new BuySellEntryItem(t);
                         });
         
         addFeesSectionsTransaction(buyBlock_Format05, type);
+
+        var buyBlock_Format06 = new Transaction<BuySellEntry>();
+
+        // @formatter:off
+        // Vanguard Total World Stock Commission: 2025-04-08
+        // ETF US ARCA Open 1 106.43000 106.43 0.00 -0.99 2025-
+        // Platform Fee: 0.00 0.00 11:28:50, US USD
+        // 04-09
+        // (VT) -1.00 /Eastern
+        // @formatter:on
+        var firstRelevantLineForBuyBlock_Format06 = new Block("^.* Commission: [\\d]{4}\\-[\\d]{2}\\-[\\d]{2}$");
+        type.addBlock(firstRelevantLineForBuyBlock_Format06);
+        firstRelevantLineForBuyBlock_Format06.setMaxSize(5);
+        firstRelevantLineForBuyBlock_Format06.set(buyBlock_Format06);
+
+        buyBlock_Format06 //
+
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
+
+                        .section("date", "shares", "gross", "fee1", "time", "currency", "tickerSymbol", "fee2") //
+                        .match("^.* Commission: (?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2})$") //
+                        .match("^.* Open " //
+                                        + "(?<shares>[\\.,\\d]+) " //
+                                        + "[\\.,\\d]+ " //
+                                        + "(?<gross>[\\.,\\d]+) " //
+                                        + "[\\.,\\d]+ " //
+                                        + "\\-(?<fee1>[\\.,\\d]+) [\\d]{4}\\-$") //
+                        .match("^Platform Fee: [\\.,\\d]+ [\\.,\\d]+ (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}), .* (?<currency>[A-Z]{3})$") //
+                        .match("^\\((?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?)\\) \\-(?<fee2>[\\.,\\d]+) .*$") //
+                        .assign((t, v) -> {
+                            var context = type.getCurrentContext();
+
+                            var securityItem = context.getType(SecurityListHelper.class).get()
+                                            .findItem(v.get("tickerSymbol"));
+
+                            securityItem.ifPresent(s -> {
+                                v.put("name", s.name);
+                                v.put("tickerSymbol", s.tickerSymbol);
+                            });
+
+                            t.setSecurity(getOrCreateSecurity(v));
+
+                            t.setDate(asDate(v.get("date"), v.get("time")));
+                            t.setShares(asShares(v.get("shares")));
+
+                            // The amount is stated in gross
+                            t.setAmount(asAmount(v.get("gross")) + asAmount(v.get("fee1")) + asAmount(v.get("fee2")));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                        })
+
+                        // @formatter:off
+                        // ETF US ARCA Open 1 106.43000 106.43 0.00 -0.99 2025-
+                        // @formatter:on
+                        .section("fee").optional() //
+                        .match("^.* Open [\\.,\\d]+ [\\.,\\d]+ [\\.,\\d]+ [\\.,\\d]+ \\-(?<fee>[\\.,\\d]+) [\\d]{4}\\-$") //
+                        .assign((t, v) -> processTradeFee(t, v, type))
+
+                        // @formatter:off
+                        // (VT) -1.00 /Eastern
+                        // @formatter:on
+                        .section("fee").optional() //
+                        .match("^\\([A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?\\) \\-(?<fee>[\\.,\\d]+) .*$") //
+                        .assign((t, v) -> processTradeFee(t, v, type))
+
+                        .wrap(t -> {
+                            type.getCurrentContext().removeType(SecurityItem.class);
+
+                            if (t.getPortfolioTransaction().getCurrencyCode() == null)
+                                return null;
+
+                            if (t.getPortfolioTransaction().getAmount() == 0)
+                                return new SkippedItem(new BuySellEntryItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                            return new BuySellEntryItem(t);
+                        });
+
 
         var dividendBlock = new Transaction<AccountTransaction>();
 
@@ -696,6 +841,9 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
                                 return new TransactionItem(t);
                         });
 
+        addDividendTransaction_late25(type);
+        addDividendAccrualsTransaction_late25(type);
+
         var taxRefundBlock = new Transaction<AccountTransaction>();
 
         // @formatter:off
@@ -748,6 +896,864 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
                         })
 
                         .wrap(TransactionItem::new);
+    }
+
+
+    /**
+     * Combines two digit fragments into a valid date. Returns null if no
+     * combination yields a valid date.
+     */
+    private String assembleDate(String[] lines, int from, int to, Pattern pDateFragment)
+    {
+        List<String> fragments = new ArrayList<>();
+
+        for (var ii = from; ii <= to; ii++)
+        {
+            var m = pDateFragment.matcher(lines[ii]);
+            while (m.find())
+                fragments.add(m.group());
+        }
+
+        for (String first : fragments) // NOSONAR
+        {
+            for (String second : fragments) // NOSONAR
+            {
+                if (first.equals(second))
+                    continue;
+
+                var candidate = first + second;
+
+                if (!candidate.matches("[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}"))
+                    continue;
+
+                try
+                {
+                    LocalDate.parse(candidate, DATEFORMAT);
+                    return candidate;
+                }
+                catch (DateTimeParseException e)
+                {
+                    // no valid combination, try the next one
+                }
+            }
+        }
+
+        return null;
+    }
+
+
+
+    /**
+     * @formatter:off
+     * Re-assembles the trade time. The end of the time is always followed by a
+     * comma and a blank ("12:58:58, US/Eastern"), which distinguishes it from a
+     * thousands separator ("5,018.00"). If that part alone is not a valid time,
+     * the beginning is the last digit group of the following line, because the
+     * PDF to text conversion may split "16:06:34" into "1" and "6:06:34".
+     * @formatter:on
+     */
+    private String assembleTime(String[] lines, int from, int to)
+    {
+        var pTail = Pattern.compile("(?<![\\d:\\.])(?<time>[\\d:]+),(?=\\s|$)");
+        var pFragment = Pattern.compile("[\\d:]+");
+
+        String tail = null;
+        var tailLine = -1;
+
+        for (var ii = from; ii <= to + 1 && ii < lines.length; ii++)
+        {
+            var mTail = pTail.matcher(lines[ii]);
+            while (mTail.find())
+            {
+                tail = mTail.group("time");
+                tailLine = ii;
+            }
+        }
+
+        if (tail == null)
+            return null;
+
+        if (isValidTime(tail))
+            return tail;
+
+        if (tailLine + 1 >= lines.length)
+            return null;
+
+        String head = null;
+        var mFragment = pFragment.matcher(lines[tailLine + 1]);
+        while (mFragment.find())
+            head = mFragment.group();
+
+        if (head != null && isValidTime(head + tail))
+            return head + tail;
+
+        return null;
+    }
+
+    private boolean isValidTime(String value)
+    {
+        try
+        {
+            LocalTime.parse(value, TIMEFORMAT);
+            return true;
+        }
+        catch (DateTimeParseException e)
+        {
+            return false;
+        }
+    }
+
+    private void processTradeFee(BuySellEntry t, Map<String, String> v, DocumentType type)
+    {
+        var fee = Money.of(t.getPortfolioTransaction().getCurrencyCode(), asAmount(v.get("fee")));
+        checkAndSetFee(fee, t, type.getCurrentContext());
+    }
+
+    private void assignDividend(AccountTransaction t, Map<String, String> v, DocumentType type)
+    {
+        var context = type.getCurrentContext();
+
+        var securityItem = context.getType(SecurityListHelper.class).get().findItem(v.get("tickerSymbol"));
+
+        securityItem.ifPresent(s -> {
+            v.put("name", s.name);
+            v.put("tickerSymbol", s.tickerSymbol);
+        });
+
+        t.setSecurity(getOrCreateSecurity(v));
+
+        t.setDateTime(asDate(v.get("dateYear") + "-" + v.get("dateDay")));
+        t.setShares(asShares(v.get("shares")));
+        t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+        t.setAmount(asAmount(v.get("amount")));
+
+        // Some layouts state the withholding tax within the amount line
+        if (v.get("taxes") != null)
+        {
+            var tax = Money.of(asCurrencyCode(v.get("currency")), asAmount(v.get("taxes")));
+            checkAndSetTax(tax, t, context);
+        }
+    }
+
+    /**
+     * Dividends in the late 2025 layout. Used by both document types, the
+     * layout appears in the "Activity Statement" as well as in the
+     * "Statement Period" documents.
+     */
+    private void addDividendTransaction_late25(DocumentType type)
+    {
+        var dividendBlock_late25 = new Transaction<AccountTransaction>();
+
+        var firstRelevantLineForDividendBlock_late25 = new Block("^.*Quantity: [\\.,\\d]+$");
+        type.addBlock(firstRelevantLineForDividendBlock_late25);
+        firstRelevantLineForDividendBlock_late25.setMaxSize(9);
+        firstRelevantLineForDividendBlock_late25.set(dividendBlock_late25);
+
+        dividendBlock_late25 //
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
+
+                        .optionalOneOf( //
+                                        // @formatter:off
+                                        // Quantity: 2200
+                                        // 2025-09- CapLand Ascendas REIT
+                                        // Stock Gross Rate: 0.000930 Paid 2.05 0 2.05 SGD
+                                        // 04 (A17U.SI) Reinvestment
+                                        // /Share
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares", "dateYear", "grossAmount", "amount",
+                                                                        "currency", "dateDay", "tickerSymbol") //
+                                                        .match("^.*Quantity: (?<shares>[\\.,\\d]+)$") //
+                                                        .match("^(?<dateYear>[\\d]{4}\\-[\\d]{2})\\- .*$") //
+                                                        .match("^.* Gross Rate: [\\.,\\d]+ Paid (?<grossAmount>[\\.,\\d]+) [\\.,\\d]+ (?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                                                        .match("^(?<dateDay>[\\d]{2}) \\((?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?)\\).*$") //
+                                                        .assign((t, v) -> assignDividend(t, v, type)),
+                                        // @formatter:off
+                                        // Blackstone Secured Lending Quantity: 367
+                                        // 2025-10- Dividend tax:
+                                        // Stock Fund Gross Rate: 0.770000 Paid 282.59 0 254.33 USD
+                                        // 24 Reinvestment 28.26
+                                        // (BXSL) /Share
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares", "dateYear", "grossAmount", "amount",
+                                                                        "currency", "dateDay", "tickerSymbol") //
+                                                        .match("^.*Quantity: (?<shares>[\\.,\\d]+)$") //
+                                                        .match("^(?<dateYear>[\\d]{4}\\-[\\d]{2})\\- .*$") //
+                                                        .match("^.* Gross Rate: [\\.,\\d]+ Paid (?<grossAmount>[\\.,\\d]+) [\\.,\\d]+ (?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                                                        .match("^(?<dateDay>[\\d]{2}).*$") //
+                                                        .match("^\\((?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?)\\) \\/Share$") //
+                                                        .assign((t, v) -> assignDividend(t, v, type)),
+                                        // @formatter:off
+                                        // Quantity: 200
+                                        // Gross Rate: 0.600000
+                                        // 2025-11- Stock DBS /Share Paid 120.00 0 120.00 SGD
+                                        // 24 (D05.SI) Reinvestment
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares", "dateYear", "grossAmount", "amount",
+                                                                        "currency", "dateDay", "tickerSymbol") //
+                                                        .match("^.*Quantity: (?<shares>[\\.,\\d]+)$") //
+                                                        .match("^(?<dateYear>[\\d]{4}\\-[\\d]{2})\\- .* Paid (?<grossAmount>[\\.,\\d]+) [\\.,\\d]+ (?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                                                        .match("^(?<dateDay>[\\d]{2}) \\((?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?)\\).*$") //
+                                                        .assign((t, v) -> assignDividend(t, v, type)),
+                                        // @formatter:off
+                                        // Quantity: 2200
+                                        // 2025-09- CapLand Ascendas REIT
+                                        // 04 Stock (A17U.SI) Reinvestment Gross Rate: 0.009050 Paid 19.91 0 19.91 SGD
+                                        // /Share
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares", "dateYear", "dateDay", "tickerSymbol",
+                                                                        "grossAmount", "amount", "currency") //
+                                                        .match("^.*Quantity: (?<shares>[\\.,\\d]+)$") //
+                                                        .match("^(?<dateYear>[\\d]{4}\\-[\\d]{2})\\- .*$") //
+                                                        .match("^(?<dateDay>[\\d]{2}) .*\\((?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?)\\).* Gross Rate: [\\.,\\d]+ Paid (?<grossAmount>[\\.,\\d]+) [\\.,\\d]+ (?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                                                        .assign((t, v) -> assignDividend(t, v, type)))
+
+
+                        // @formatter:off
+                        // The withholding tax is stated at the end of the day line and is
+                        // present for USD dividends only.
+                        //
+                        // 15 (O) 17.60
+                        // 24 Reinvestment 28.26
+                        // @formatter:on
+                        .section("taxes").optional() //
+                        .match("^[\\d]{2} (.* )?(?<taxes>[\\d]+\\.[\\d]{2})$") //
+                        .assign((t, v) -> {
+                            if (t.getCurrencyCode() == null)
+                                return;
+
+                            var tax = Money.of(t.getCurrencyCode(), asAmount(v.get("taxes")));
+                            checkAndSetTax(tax, t, type.getCurrentContext());
+                        })
+
+                        .wrap(t -> {
+                            type.getCurrentContext().removeType(SecurityItem.class);
+
+                            if (t.getDateTime() == null)
+                                return null;
+
+                            return new TransactionItem(t);
+                        });
+    }
+
+    /**
+     * "Dividend Accruals" are announced but not paid out yet, there is no
+     * cash flow. They are skipped with a message instead of being dropped
+     * silently.
+     */
+    private void addDividendAccrualsTransaction_late25(DocumentType type)
+    {
+        var dividendAccrualsBlock_late25 = new Transaction<AccountTransaction>();
+
+        var firstRelevantLineForDividendAccrualsBlock_late25 = new Block("^.*Quantity: [\\.,\\d]+$");
+        type.addBlock(firstRelevantLineForDividendAccrualsBlock_late25);
+        firstRelevantLineForDividendAccrualsBlock_late25.setMaxSize(9);
+        firstRelevantLineForDividendAccrualsBlock_late25.set(dividendAccrualsBlock_late25);
+
+        dividendAccrualsBlock_late25 //
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DIVIDENDS))
+
+                        // @formatter:off
+                        // "Dividend Accruals" are announced but not paid out yet, there is
+                        // no cash flow. They are skipped with a message instead of being
+                        // dropped silently.
+                        // @formatter:on
+                        .optionalOneOf( //
+                                        // @formatter:off
+                                        // Quantity: 3000
+                                        // 2025-10- Frasers Cpt Tr Dividend Accruals
+                                        // Stock Gross Rate: 0.055850 167.55 0 167.55 SGD
+                                        // 31 (J69U.SI) Reinvestment Increase
+                                        // /Share
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares", "dateYear", "grossAmount", "amount",
+                                                                        "currency", "dateDay", "tickerSymbol") //
+                                                        .match("^.*Quantity: (?<shares>[\\.,\\d]+)$") //
+                                                        .match("^(?<dateYear>[\\d]{4}\\-[\\d]{2})\\- .*Dividend Accruals.*$") //
+                                                        .match("^.* Gross Rate: [\\.,\\d]+ (\\-)?(?<grossAmount>[\\.,\\d]+) [\\.,\\d]+ (\\-)?(?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                                                        .match("^(?<dateDay>[\\d]{2}) \\((?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?)\\).*$") //
+                                                        .assign((t, v) -> assignDividend(t, v, type)),
+                                        // @formatter:off
+                                        // Blackstone Secured Lending Quantity: 1033
+                                        // 2025-12- Dividend Accruals Dividend tax:
+                                        // Stock Fund Gross Rate: 0.770000 795.41 0 715.87 USD
+                                        // 31 Increase 79.54
+                                        // (BXSL) /Share
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares", "dateYear", "grossAmount", "amount",
+                                                                        "currency", "dateDay", "tickerSymbol") //
+                                                        .match("^.*Quantity: (?<shares>[\\.,\\d]+)$") //
+                                                        .match("^(?<dateYear>[\\d]{4}\\-[\\d]{2})\\- .*Dividend Accruals.*$") //
+                                                        .match("^.* Gross Rate: [\\.,\\d]+ (\\-)?(?<grossAmount>[\\.,\\d]+) [\\.,\\d]+ (\\-)?(?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                                                        .match("^(?<dateDay>[\\d]{2}).*$") //
+                                                        .match("^\\((?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?)\\) \\/Share$") //
+                                                        .assign((t, v) -> assignDividend(t, v, type)),
+                                        // @formatter:off
+                                        // Vanguard Total World Stock Quantity: 72
+                                        // 2024-12-
+                                        // Stock ETF Gross Rate: 0.88 Dividend Accruals Increase 63.17 0 Dividend tax: 9.48 53.69 USD
+                                        // 20
+                                        // (VT) /Share
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares", "dateYear", "grossAmount", "taxes",
+                                                                        "amount", "currency", "dateDay", "tickerSymbol") //
+                                                        .match("^.*Quantity: (?<shares>[\\.,\\d]+)$") //
+                                                        .match("^(?<dateYear>[\\d]{4}\\-[\\d]{2})\\-( .*)?$") //
+                                                        .match("^.* Gross Rate: [\\.,\\d]+ Dividend Accruals (Increase|Reduction) (\\-)?(?<grossAmount>[\\.,\\d]+) [\\.,\\d]+ Dividend tax: (?<taxes>[\\.,\\d]+) (?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                                                        .match("^(?<dateDay>[\\d]{2})$") //
+                                                        .match("^\\((?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?)\\) \\/Share$") //
+                                                        .assign((t, v) -> assignDividend(t, v, type)),
+                                        // @formatter:off
+                                        // Quantity: 25
+                                        // 2024-12- Vanguard S&P 500 ETF
+                                        // Stock Gross Rate: 1.74 Dividend Accruals Increase 43.46 0 Dividend tax: 6.52 36.94 USD
+                                        // 23 (VOO)
+                                        // /Share
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("shares", "dateYear", "grossAmount", "taxes",
+                                                                        "amount", "currency", "dateDay", "tickerSymbol") //
+                                                        .match("^.*Quantity: (?<shares>[\\.,\\d]+)$") //
+                                                        .match("^(?<dateYear>[\\d]{4}\\-[\\d]{2})\\-( .*)?$") //
+                                                        .match("^.* Gross Rate: [\\.,\\d]+ Dividend Accruals (Increase|Reduction) (\\-)?(?<grossAmount>[\\.,\\d]+) [\\.,\\d]+ Dividend tax: (?<taxes>[\\.,\\d]+) (?<amount>[\\.,\\d]+) (?<currency>[A-Z]{3})$") //
+                                                        .match("^(?<dateDay>[\\d]{2}) \\((?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?)\\)$") //
+                                                        .match("^\\/Share$") //
+                                                        .assign((t, v) -> assignDividend(t, v, type)))
+
+
+                        // @formatter:off
+                        // The withholding tax is stated at the end of the day line and is
+                        // present for USD dividends only.
+                        //
+                        // 15 (O) 17.60
+                        // 24 Reinvestment 28.26
+                        // @formatter:on
+                        .section("taxes").optional() //
+                        .match("^[\\d]{2} (.* )?(?<taxes>[\\d]+\\.[\\d]{2})$") //
+                        .assign((t, v) -> {
+                            if (t.getCurrencyCode() == null)
+                                return;
+
+                            var tax = Money.of(t.getCurrencyCode(), asAmount(v.get("taxes")));
+                            checkAndSetTax(tax, t, type.getCurrentContext());
+                        })
+
+                        // @formatter:off
+                        // Set a note so that the reason for skipping is visible in the
+                        // import dialog and in the note column.
+                        //
+                        // 2025-10- Frasers Cpt Tr Dividend Accruals
+                        // @formatter:on
+                        .section("note").optional() //
+                        .match("^.*(?<note>Dividend Accruals).*$") //
+                        .assign((t, v) -> t.setNote(trim(v.get("note"))))
+
+                        .wrap(t -> {
+                            type.getCurrentContext().removeType(SecurityItem.class);
+
+                            if (t.getDateTime() == null)
+                                return null;
+
+                            return new SkippedItem(new TransactionItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+                        });
+    }
+
+    /**
+     * @formatter:off
+     * Late 2025 layout. These documents carry "Statement Period" in the header
+     * instead of "Activity Statement" and contain bookings in more than one
+     * currency. They need their own document type because single fee lines
+     * like "Settlement Fee: -2.70" are indistinguishable from the old layout.
+     * @formatter:on
+     */
+    private void addAccountStatementTransaction_late25()
+    {
+        final var type = new DocumentType("Statement Period", (context, lines) -> {
+            var pSecurity = Pattern.compile("^(?<tickerSymbol>(?!(GST|Net))[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?) (?<name>.*) [\\d]$");
+
+            // @formatter:off
+            // Create a helper to store the list of security items found in the document.
+            //
+            // These documents do not contain a "Stock Currency:" line and hold bookings
+            // in more than one currency, therefore no currency is stored here. It is
+            // taken from the respective transaction instead.
+            // @formatter:on
+            var securityListHelper = new SecurityListHelper();
+            context.putType(securityListHelper);
+
+            for (String line : lines)
+            {
+                var mSecurity = pSecurity.matcher(line);
+                if (mSecurity.matches())
+                {
+                    var securityItem = new SecurityItem();
+                    securityItem.tickerSymbol = mSecurity.group("tickerSymbol");
+                    securityItem.name = mSecurity.group("name");
+                    securityListHelper.items.add(securityItem);
+                }
+            }
+
+            // @formatter:off
+            // Collect the trade dates. The trade date is located somewhere between
+            // the previous and the current trade data line and may be split into
+            // two fragments. If no complete date is present, every pair of digit
+            // fragments is combined in both directions until a valid date results.
+            // @formatter:on
+            var tradeDateListHelper = new TradeDateListHelper();
+            context.putType(tradeDateListHelper);
+
+            var pTradeData = Pattern.compile("^.*(SG|US) (SGX|NYSE|ARCA|NASDAQ) (Open|Close) "
+                            + "\\-?[\\.,\\d]+ [\\.,\\d]+ \\-?[\\.,\\d]+ [\\.,\\d]+.*$");
+            var pFullDate = Pattern.compile("^.*?(?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}).*$");
+            var pDateFragment = Pattern.compile("[\\d][\\d\\-]*");
+
+            var previousTradeLine = 0;
+
+            for (var ii = 0; ii < lines.length; ii++)
+            {
+                if (!pTradeData.matcher(lines[ii]).matches())
+                    continue;
+
+                String tradeDate = null;
+
+                for (var jj = previousTradeLine; jj <= ii && tradeDate == null; jj++)
+                {
+                    var mFullDate = pFullDate.matcher(lines[jj]);
+                    if (mFullDate.matches())
+                        tradeDate = mFullDate.group("date");
+                }
+
+                if (tradeDate == null)
+                    tradeDate = assembleDate(lines, previousTradeLine, ii, pDateFragment);
+
+                if (tradeDate != null)
+                {
+                    var tradeDateItem = new TradeDateItem();
+                    tradeDateItem.lineNo = ii;
+                    tradeDateItem.date = tradeDate;
+                    tradeDateItem.time = assembleTime(lines, previousTradeLine, ii);
+                    tradeDateListHelper.items.add(tradeDateItem);
+                }
+
+                previousTradeLine = ii + 1;
+            }
+        });
+        this.addDocumentTyp(type);
+
+        var buySellBlock_late25 = new Transaction<BuySellEntry>();
+
+        // @formatter:off
+        // Every trade starts with exactly one fee line, therefore this is the only
+        // reliable anchor: the trade date is torn apart by the PDF to text conversion
+        // and is taken from the TradeDateListHelper instead.
+        //
+        // CapLand Ascendas REIT Exchange Fee: -1.98 2025-09-03
+        // 2025-
+        // SG SGX Open 1800 2.75000 4,950.00 0.00 6:06:34, SGD
+        // (A17U.SI) Commission: -1.49 0.00 0.00 1
+        // Platform Fee: -1.49 09-05
+        // GMT+8
+        // @formatter:on
+        var firstRelevantLineForBuySellBlock_late25 = new Block("^.*(Exchange Fee|Settlement Fee): \\-[\\.,\\d]+.*$");
+        type.addBlock(firstRelevantLineForBuySellBlock_late25);
+        firstRelevantLineForBuySellBlock_late25.setMaxSize(10);
+        firstRelevantLineForBuySellBlock_late25.set(buySellBlock_late25);
+
+        buySellBlock_late25 //
+
+                        .subject(() -> new BuySellEntry(PortfolioTransaction.Type.BUY))
+
+                        // @formatter:off
+                        // The document contains SGD and USD bookings, therefore the
+                        // currency is parsed per transaction. It must be set before the
+                        // fee sections are processed.
+                        // @formatter:on
+                        .section("currency") //
+                        .match("^.* (?<currency>[A-Z]{3})$") //
+                        .assign((t, v) -> t.setCurrencyCode(asCurrencyCode(v.get("currency"))))
+
+                        .oneOf( //
+                                        // @formatter:off
+                                        // (N2IU.SI) SG SGX Open 100 1.32000 132.00 0.00 Exchange Fee: -0.05 0.00 0.00 GMT+8 2025- SGD
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("tickerSymbol", "type", "shares", "gross") //
+                                                        .match("^.*\\((?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?)\\).*" //
+                                                                        + "(SG|US) (SGX|NYSE|ARCA|NASDAQ) " //
+                                                                        + "(?<type>Open|Close) " //
+                                                                        + "(?<shares>\\-?[\\.,\\d]+) " //
+                                                                        + "[\\.,\\d]+ " //
+                                                                        + "\\-?(?<gross>[\\.,\\d]+) " //
+                                                                        + "[\\.,\\d]+.*$") //
+                                                        .assign((t, v) -> {
+                                                            var context = type.getCurrentContext();
+
+                                                            var securityItem = context.getType(SecurityListHelper.class).get()
+                                                                            .findItem(v.get("tickerSymbol"));
+
+                                                            securityItem.ifPresent(s -> {
+                                                                v.put("name", s.name);
+                                                                v.put("tickerSymbol", s.tickerSymbol);
+                                                            });
+
+                                                            v.put("currency", t.getPortfolioTransaction().getCurrencyCode());
+                                                            t.setSecurity(getOrCreateSecurity(v));
+
+                                                            // Is type --> "Close" change from BUY to SELL
+                                                            if ("Close".equals(v.get("type")))
+                                                                t.setType(PortfolioTransaction.Type.SELL);
+
+                                                            var tradeDate = context.getType(TradeDateListHelper.class).get()
+                                                                            .findItem(v.getStartLineNumber());
+
+                                                            if (tradeDate.isPresent())
+                                                                t.setDate(asDate(tradeDate.get().date, tradeDate.get().time));
+                                                            else
+                                                                v.skipTransaction(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                                                            t.setShares(asShares(v.get("shares")));
+
+                                                            // The amount is stated in gross, the fees are added in wrap()
+                                                            t.setAmount(asAmount(v.get("gross")));
+                                                        }),
+                                        // @formatter:off
+                                        // SG SGX Open 1800 2.75000 4,950.00 0.00 6:06:34, SGD
+                                        // (A17U.SI) Commission: -1.49 0.00 0.00 1
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("type", "shares", "gross", "tickerSymbol") //
+                                                        .match("^.*(SG|US) (SGX|NYSE|ARCA|NASDAQ) " //
+                                                                        + "(?<type>Open|Close) " //
+                                                                        + "(?<shares>\\-?[\\.,\\d]+) " //
+                                                                        + "[\\.,\\d]+ " //
+                                                                        + "\\-?(?<gross>[\\.,\\d]+) " //
+                                                                        + "[\\.,\\d]+.*$") //
+                                                        .match("^.*\\((?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?)\\).*$") //
+                                                        .assign((t, v) -> {
+                                                            var context = type.getCurrentContext();
+
+                                                            var securityItem = context.getType(SecurityListHelper.class).get()
+                                                                            .findItem(v.get("tickerSymbol"));
+
+                                                            securityItem.ifPresent(s -> {
+                                                                v.put("name", s.name);
+                                                                v.put("tickerSymbol", s.tickerSymbol);
+                                                            });
+
+                                                            v.put("currency", t.getPortfolioTransaction().getCurrencyCode());
+                                                            t.setSecurity(getOrCreateSecurity(v));
+
+                                                            // Is type --> "Close" change from BUY to SELL
+                                                            if ("Close".equals(v.get("type")))
+                                                                t.setType(PortfolioTransaction.Type.SELL);
+
+                                                            var tradeDate = context.getType(TradeDateListHelper.class).get()
+                                                                            .findItem(v.getStartLineNumber());
+
+                                                            if (tradeDate.isPresent())
+                                                                t.setDate(asDate(tradeDate.get().date, tradeDate.get().time));
+                                                            else
+                                                                v.skipTransaction(Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                                                            t.setShares(asShares(v.get("shares")));
+
+                                                            // The amount is stated in gross, the fees are added in wrap()
+                                                            t.setAmount(asAmount(v.get("gross")));
+                                                        }))
+
+                        // @formatter:off
+                        // CapLand Ascendas REIT Exchange Fee: -1.98 2025-09-03
+                        // @formatter:on
+                        .section("fee").optional() //
+                        .match("^.*Exchange Fee: \\-(?<fee>[\\.,\\d]+).*$") //
+                        .assign((t, v) -> processTradeFee(t, v, type))
+
+                        // @formatter:off
+                        // Blackstone Secured Settlement Fee: -1.09 2025-09-29
+                        // @formatter:on
+                        .section("fee").optional() //
+                        .match("^.*Settlement Fee: \\-(?<fee>[\\.,\\d]+).*$") //
+                        .assign((t, v) -> processTradeFee(t, v, type))
+
+                        // @formatter:off
+                        // (A17U.SI) Commission: -1.49 0.00 0.00 1
+                        // @formatter:on
+                        .section("fee").optional() //
+                        .match("^.*Commission: \\-(?<fee>[\\.,\\d]+).*$") //
+                        .assign((t, v) -> processTradeFee(t, v, type))
+
+                        // @formatter:off
+                        // Platform Fee: -1.49 09-05
+                        // @formatter:on
+                        .section("fee").optional() //
+                        .match("^.*Platform Fee: \\-(?<fee>[\\.,\\d]+).*$") //
+                        .assign((t, v) -> processTradeFee(t, v, type))
+
+                        // @formatter:off
+                        // (ARE) Consolidated Audit Trail 10-30
+                        // /Eastern
+                        // Fee: -0.01
+                        // @formatter:on
+                        .section("fee").optional() //
+                        .match("^.*Consolidated Audit Trail.*$") //
+                        .match("^Fee: \\-(?<fee>[\\.,\\d]+)$") //
+                        .assign((t, v) -> processTradeFee(t, v, type))
+
+                        // @formatter:off
+                        // Trading Activity Fee:
+                        // -0.04 2025-10-23
+                        // @formatter:on
+                        .section("fee").optional() //
+                        .match("^.*Trading Activity Fee:.*$") //
+                        .match("^\\-(?<fee>[\\.,\\d]+) .*$") //
+                        .assign((t, v) -> processTradeFee(t, v, type))
+
+                        // @formatter:off
+                        // Realty Income Trading Activity Fee: 2025-10-24
+                        // (O) -0.04
+                        // @formatter:on
+                        .section("fee").optional() //
+                        .match("^.*Trading Activity Fee:.*$") //
+                        .match("^\\([A-Z0-9\\.]+\\) \\-(?<fee>[\\.,\\d]+)$") //
+                        .assign((t, v) -> processTradeFee(t, v, type))
+
+                        // @formatter:off
+                        // Equities US NYSE Close -133 48.42647 -6,440.72 0.00 -0.05 0.00 -1,596.96 22:02:07, US USD
+                        // @formatter:on
+                        .section("fee").optional() //
+                        .match("^.*(Open|Close) \\-?[\\.,\\d]+ [\\.,\\d]+ \\-?[\\.,\\d]+ [\\.,\\d]+ " //
+                                        + "\\-(?<fee>[\\.,\\d]+) [\\.,\\d]+ \\-?[\\.,\\d]+ [\\d]{2}:[\\d]{2}:[\\d]{2}, .*$") //
+                        .assign((t, v) -> processTradeFee(t, v, type))
+
+                        .wrap(t -> {
+                            type.getCurrentContext().removeType(SecurityItem.class);
+
+                            var tx = t.getPortfolioTransaction();
+
+                            if (tx.getCurrencyCode() == null || tx.getDateTime() == null)
+                                return null;
+
+                            // @formatter:off
+                            // The amount is stated in gross. Add the fees for a purchase
+                            // and subtract them for a sale to get the settlement amount.
+                            // @formatter:on
+                            var fees = tx.getUnitSum(Unit.Type.FEE).getAmount();
+
+                            if (tx.getType() == PortfolioTransaction.Type.BUY)
+                                t.setAmount(tx.getAmount() + fees);
+                            else
+                                t.setAmount(tx.getAmount() - fees);
+
+                            if (tx.getAmount() == 0)
+                                return new SkippedItem(new BuySellEntryItem(t), Messages.MsgErrorTransactionTypeNotSupportedOrRequired);
+
+                            return new BuySellEntryItem(t);
+                        });
+
+        var depositRemovalBlock_late25 = new Transaction<AccountTransaction>();
+
+        // @formatter:off
+        // 2025-08-06 Deposit 432.18 SGD
+        // 2025-08-07 Withdrawal -10.00 SGD
+        // @formatter:on
+        var firstRelevantLineForDepositRemovalBlock_late25 = new Block("^[\\d]{4}\\-[\\d]{2}\\-[\\d]{2} (Deposit|Withdrawal) (\\-)?[\\.,\\d]+ [A-Z]{3}$");
+        type.addBlock(firstRelevantLineForDepositRemovalBlock_late25);
+        firstRelevantLineForDepositRemovalBlock_late25.set(depositRemovalBlock_late25);
+
+        depositRemovalBlock_late25 //
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
+
+                        .section("date", "type", "amount", "currency") //
+                        .match("^(?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}) " //
+                                        + "(?<type>Deposit|Withdrawal) " //
+                                        + "(\\-)?(?<amount>[\\.,\\d]+) " //
+                                        + "(?<currency>[A-Z]{3})$") //
+                        .assign((t, v) -> {
+                            // Is type --> "Withdrawal" change from DEPOSIT to REMOVAL
+                            if ("Withdrawal".equals(v.get("type")))
+                                t.setType(AccountTransaction.Type.REMOVAL);
+
+                            t.setDateTime(asDate(v.get("date")));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setAmount(asAmount(v.get("amount")));
+                        })
+
+                        .wrap(TransactionItem::new);
+
+        var feesRefundBlock_late25 = new Transaction<AccountTransaction>();
+
+        // @formatter:off
+        // 2025-10-06 Order Rebate 50.00 SGD
+        // 2025-09-09 Coupon Rebate 0.99 USD
+        // @formatter:on
+        var firstRelevantLineForFeesRefundBlock_late25 = new Block("^[\\d]{4}\\-[\\d]{2}\\-[\\d]{2} (Order|Coupon) Rebate [\\.,\\d]+ [A-Z]{3}$");
+        type.addBlock(firstRelevantLineForFeesRefundBlock_late25);
+        firstRelevantLineForFeesRefundBlock_late25.set(feesRefundBlock_late25);
+
+        feesRefundBlock_late25 //
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.FEES_REFUND))
+
+                        .section("date", "note", "amount", "currency") //
+                        .match("^(?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}) " //
+                                        + "(?<note>(Order|Coupon) Rebate) " //
+                                        + "(?<amount>[\\.,\\d]+) " //
+                                        + "(?<currency>[A-Z]{3})$") //
+                        .assign((t, v) -> {
+                            t.setDateTime(asDate(v.get("date")));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setAmount(asAmount(v.get("amount")));
+                            t.setNote(trim(v.get("note")));
+                        })
+
+                        .wrap(TransactionItem::new);
+
+        var accountTransferBlock_late25 = new Transaction<AccountTransferEntry>();
+
+        // @formatter:off
+        // 2025-09-09
+        // USD.SGD Buy 3,885.3600 1.28688 -5,000.00 2025-09-10 SGD
+        // 13:52:45, US/Eastern
+        // @formatter:on
+        var firstRelevantLineForAccountTransferBlock_late25 = new Block("^[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}$");
+        type.addBlock(firstRelevantLineForAccountTransferBlock_late25);
+        firstRelevantLineForAccountTransferBlock_late25.setMaxSize(3);
+        firstRelevantLineForAccountTransferBlock_late25.set(accountTransferBlock_late25);
+
+        accountTransferBlock_late25 //
+
+                        .subject(AccountTransferEntry::new)
+
+                        .section("date", "baseCurrency", "quoteCurrency", "type", "baseAmount", "exchangeRate",
+                                        "quoteAmount", "time").optional() //
+                        .match("^(?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2})$") //
+                        .match("^(?<baseCurrency>[A-Z]{3})\\.(?<quoteCurrency>[A-Z]{3}) " //
+                                        + "(?<type>Buy|Sell) " //
+                                        + "(\\-)?(?<baseAmount>[\\.,\\d]+) " //
+                                        + "(?<exchangeRate>[\\.,\\d]+) " //
+                                        + "(\\-)?(?<quoteAmount>[\\.,\\d]+) " //
+                                        + "[\\d]{4}\\-[\\d]{2}\\-[\\d]{2} [A-Z]{3}$") //
+                        .match("^(?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}), .*$") //
+                        .assign((t, v) -> {
+                            // @formatter:off
+                            // Buy  --> the quote currency is sold, the base currency is bought
+                            // Sell --> the base currency is sold, the quote currency is bought
+                            // @formatter:on
+                            var sourceCurrency = "Buy".equals(v.get("type")) ? v.get("quoteCurrency") : v.get("baseCurrency");
+                            var targetCurrency = "Buy".equals(v.get("type")) ? v.get("baseCurrency") : v.get("quoteCurrency");
+                            var sourceAmount = "Buy".equals(v.get("type")) ? v.get("quoteAmount") : v.get("baseAmount");
+                            var targetAmount = "Buy".equals(v.get("type")) ? v.get("baseAmount") : v.get("quoteAmount");
+
+                            t.setDate(asDate(v.get("date"), v.get("time")));
+
+                            t.getSourceTransaction().setCurrencyCode(asCurrencyCode(sourceCurrency));
+                            t.getSourceTransaction().setAmount(asAmount(sourceAmount));
+
+                            t.getTargetTransaction().setCurrencyCode(asCurrencyCode(targetCurrency));
+                            t.getTargetTransaction().setAmount(asAmount(targetAmount));
+
+                            var gross = Money.of(asCurrencyCode(sourceCurrency), asAmount(sourceAmount));
+                            var forex = Money.of(asCurrencyCode(targetCurrency), asAmount(targetAmount));
+                            // @formatter:off
+                            // The unit requires forex x exchangeRate == amount. Depending
+                            // on the direction that is either the printed trade price or
+                            // its reciprocal, therefore it is derived from both amounts.
+                            // @formatter:on
+                            var exchangeRate = BigDecimal.valueOf(gross.getAmount())
+                                            .divide(BigDecimal.valueOf(forex.getAmount()), 10, RoundingMode.HALF_UP);
+
+                            t.getSourceTransaction().addUnit(new Unit(Unit.Type.GROSS_VALUE, gross, forex, exchangeRate));
+
+                            t.setNote(v.get("baseCurrency") + "/" + v.get("quoteCurrency") + " " + v.get("exchangeRate"));
+                        })
+
+                        .wrap(t -> {
+                            if (t.getSourceTransaction().getCurrencyCode() == null)
+                                return null;
+
+                            return new AccountTransferItem(t, true);
+                        });
+
+        var deliveryInboundBlock_late25 = new Transaction<PortfolioTransaction>();
+
+        // @formatter:off
+        // DBS
+        // Stock 2025-09-01, 15:38:02, GMT+8 EXTERNAL IN 9999 200 0 34.2100 10,040.00 SGD
+        // (D05.SI)
+        // @formatter:on
+        var firstRelevantLineForDeliveryInboundBlock_late25 = new Block("^(Stock|Fund) [\\d]{4}\\-[\\d]{2}\\-[\\d]{2}, [\\d]{2}:[\\d]{2}:[\\d]{2}, .* EXTERNAL IN .*$");
+        type.addBlock(firstRelevantLineForDeliveryInboundBlock_late25);
+        firstRelevantLineForDeliveryInboundBlock_late25.setMaxSize(2);
+        firstRelevantLineForDeliveryInboundBlock_late25.set(deliveryInboundBlock_late25);
+
+        deliveryInboundBlock_late25 //
+
+                        .subject(() -> new PortfolioTransaction(PortfolioTransaction.Type.DELIVERY_INBOUND))
+
+                        // @formatter:off
+                        // An inbound delivery from another custodian. The book value is
+                        // the cost price times the number of shares, the market value
+                        // column states the value at transfer date instead.
+                        // @formatter:on
+                        .section("date", "time", "note", "shares", "amountPerShare", "currency", "tickerSymbol") //
+                        .match("^(Stock|Fund) (?<date>[\\d]{4}\\-[\\d]{2}\\-[\\d]{2}), (?<time>[\\d]{2}:[\\d]{2}:[\\d]{2}), " //
+                                        + "[^\\s]+ (?<note>EXTERNAL IN) [\\d]+ " //
+                                        + "(?<shares>[\\.,\\d]+) " //
+                                        + "[\\.,\\d]+ " //
+                                        + "(?<amountPerShare>[\\.,\\d]+) " //
+                                        + "[\\.,\\d]+ " //
+                                        + "(?<currency>[A-Z]{3})$") //
+                        .match("^\\((?<tickerSymbol>[A-Z0-9]{1,6}(?:\\.[A-Z]{1,4})?)\\)$") //
+                        .assign((t, v) -> {
+                            var context = type.getCurrentContext();
+
+                            var securityItem = context.getType(SecurityListHelper.class).get()
+                                            .findItem(v.get("tickerSymbol"));
+
+                            securityItem.ifPresent(s -> {
+                                v.put("name", s.name);
+                                v.put("tickerSymbol", s.tickerSymbol);
+                            });
+
+                            t.setSecurity(getOrCreateSecurity(v));
+
+                            t.setDateTime(asDate(v.get("date"), v.get("time")));
+                            t.setShares(asShares(v.get("shares")));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setNote(trim(v.get("note")));
+
+                            // @formatter:off
+                            // The market value is stated at transfer date, the book value
+                            // is the cost price times the number of shares.
+                            // @formatter:on
+                            var amountPerShare = BigDecimal.valueOf(asAmount(v.get("amountPerShare")));
+                            var shares = BigDecimal.valueOf(asShares(v.get("shares")));
+
+                            t.setAmount(amountPerShare.multiply(shares)
+                                            .divide(BigDecimal.valueOf(Values.Share.factor()), 0, RoundingMode.HALF_UP)
+                                            .longValue());
+                        })
+
+                        .wrap(t -> {
+                            type.getCurrentContext().removeType(SecurityItem.class);
+
+                            if (t.getCurrencyCode() == null)
+                                return null;
+
+                            return new TransactionItem(t);
+                        });
+
+        addDividendTransaction_late25(type);
+        addDividendAccrualsTransaction_late25(type);
     }
 
     private <T extends Transaction<?>> void addFeesSectionsTransaction(T transaction, DocumentType type)
@@ -959,6 +1965,44 @@ public class TigerBrokersPteLtdPDFExtractor extends AbstractPDFExtractor
                     continue;
 
                 return Optional.of(item);
+            }
+
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * @formatter:off
+     * Holds the trade date of every trade found in the document.
+     *
+     * In the late 2025 format the trade date is torn apart by the PDF to text
+     * conversion ("20" + "25-08-25", "2025-08" + "-07"). Re-assembling it with
+     * regular expressions is not possible, therefore the whole trades section is
+     * scanned once and the date is stored per line number of the trade data line.
+     * @formatter:on
+     */
+    private static class TradeDateItem
+    {
+        int lineNo;
+        String date;
+        String time;
+    }
+
+    private static class TradeDateListHelper
+    {
+        private final List<TradeDateItem> items = new ArrayList<>();
+
+        /**
+         * Returns the first trade at or after the given line number. Every trade
+         * starts with exactly one fee line, therefore the block start is never
+         * behind its own data line.
+         */
+        public Optional<TradeDateItem> findItem(int startLineNo)
+        {
+            for (TradeDateItem item : items) // NOSONAR
+            {
+                if (item.lineNo >= startLineNo)
+                    return Optional.of(item);
             }
 
             return Optional.empty();


### PR DESCRIPTION
Tiger Brokers (Singapore) — Importer erweitert

Neu: zweiter Dokumenttyp „Statement Period"
Die Auszüge ab Ende 2025 tragen einen anderen Kopf und enthalten Buchungen in SGD und USD gemischt. Sie bekommen einen eigenen DocumentType, weil einzelne Zeilen wie Settlement Fee: -2.70 im alten und neuen Layout identisch aussehen und sich nicht per Regex unterscheiden lassen.

Unterstützt werden dort: Käufe und Verkäufe (SGX und US), Ein- und Auszahlungen, Dividenden, Gebührenrückerstattungen (Order/Coupon Rebate), Währungsumtausch als Umbuchung zwischen zwei Konten, und Depotüberträge (EXTERNAL IN) als Einlieferung mit den ursprünglichen Anschaffungskosten.

Handelsdatum und Uhrzeit werden rekonstruiert
Die PDF-zu-Text-Wandlung zerreißt Datum und Uhrzeit (20 + 25-08-25, 1 + 6:06:34). Beides wird jetzt einmalig im Dokumentkontext zusammengesetzt und über die Zeilennummer zugeordnet, statt per Regex. Damit werden alle 52 Geschäfte des Beleges erfasst; Stückzahlen, Beträge und Gebühren stimmen je Titel exakt mit den Summenzeilen des Dokuments überein.

Übersprungene Buchungen sind jetzt sichtbar
Dividend Accruals sind angekündigte, aber nicht ausgezahlte Dividenden. Sie wurden bisher wortlos verworfen und erscheinen jetzt als übersprungene Buchung mit der Notiz Dividend Accruals. Das betrifft auch ältere Auszüge: in AccountStatement09 fünf und in AccountStatement11 dreizehn Buchungen, die vorher unsichtbar waren. Ebenso melden die Kaufblöcke eine erkannte Buchung mit Betrag 0 nun als übersprungen, statt sie stillschweigend zu verwerfen.

Fehlerbehebungen
Im Wertpapier-Pattern war ein Escaping-Fehler, durch den Ticker mit Börsenkürzel (A17U.SI) nicht eingelesen wurden — die Wertpapiernamen blieben leer. Die Gebühren im neuen Kaufformat hängen nicht mehr an der Währung aus dem Dokumentkontext, sondern nehmen sie aus der Buchung; dadurch verschwinden Importfehler bei Auszügen, in denen die Kontozeile umbricht.

Zusätzlich im „Activity Statement"
Ein weiteres Kaufformat und ein weiteres Dividendenlayout, die in Auszügen aus 2025 auftreten.

Tests
AccountStatement12.txt und AccountStatement13.txt neu, testAccountStatement09 und 11 um vollständige Prüfungen der übersprungenen Buchungen ergänzt.