### PR TITLE
Saxobank PDF Impoter

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/saxobank/Dividende04.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/saxobank/Dividende04.txt
@@ -1,0 +1,46 @@
+PDFBox Version: 3.0.7
+Portfolio Performance Version: 0.87.0
+System: macosx | aarch64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+hWzQ bHMkvwAhD - 48690369
+Corporate Action Detail Report
+Reporting period: 10-Sep-2026 - 10-Sep-2026
+Generated at: 11-Sep-2026 11:17:17 11:17:17 (GMT+01)
+zbkl SAOaEEycN
+mqFvjpPE 14a 21
+13-929 WGSqNjfl
+STeapa
+Saxo Bank / Philip Heymans Alle 15 / 2900 Hellerup / Denmark qPfx lgwvkcBng Reporting period
+/ Phone No.: +45 39 77 40 00 / Fax No.: +45 39 77 42 00 / Email: info@saxobank.com Currency: EUR 10-Sep-2026 - 10-Sep-2026
+Page 1 of 3 Account(s): EUR 816245rvnL Generated at: 11-Sep-2026
+Corporate Action Detail, EUR
+Reporting period
+10-Sep-2026 to 10-Sep-2026
+Corporate Action
+Event Cash dividend Dividend per share 0.40 EUR
+VanEck Morningstar Dvlp Mkts Dvd Leaders
+Description Conversion Rate 1.000000
+UCITS ETF
+Symbol VDIV:xetr Corporate Actions - Cash Dividends 21.60 EUR
+ISIN NL0011683594 Corporate Actions - Withholding Tax -3.24 EUR
+Corporate Actions - Withholding Tax (%) 15%
+Transaction description Event Id 9593275
+Saxo Bank / Philip Heymans Alle 15 / 2900 Hellerup / Denmark wTDB JjMqIpWSi Reporting period
+/ Phone No.: +45 39 77 40 00 / Fax No.: +45 39 77 42 00 / Email: info@saxobank.com Currency: EUR 10-Sep-2026 - 10-Sep-2026
+Page 2 of 3 Account(s): EUR 811952ENzD Generated at: 11-Sep-2026
+Corporate Action Detail, EUR
+Reporting period
+10-Sep-2026 to 10-Sep-2026
+Amount Booked Amount
+Booking amount ID Ex date Record Date Posting Date Pay Date Conversion Rate
+EUR EUR
+Corporate Actions -
+59442506168 02-Sep-2026 03-Sep-2026 - 10-Sep-2026 21.60 1.000000 21.60
+Cash Dividends
+Corporate Actions -
+59442506169 02-Sep-2026 03-Sep-2026 - 10-Sep-2026 -3.24 1.000000 -3.24
+Withholding Tax
+Net Amount - - - - - 18.36 1.000000 18.36
+Saxo Bank / Philip Heymans Alle 15 / 2900 Hellerup / Denmark cOmv svqJKslkc Reporting period
+/ Phone No.: +45 39 77 40 00 / Fax No.: +45 39 77 42 00 / Email: info@saxobank.com Currency: EUR 10-Sep-2026 - 10-Sep-2026
+Page 3 of 3 Account(s): EUR 784245RifH Generated at: 11-Sep-2026

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/saxobank/Kontoauszug02.txt
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/saxobank/Kontoauszug02.txt
@@ -1,0 +1,57 @@
+PDFBox Version: 3.0.6
+Portfolio Performance Version: 0.81.5
+System: win32 | x86_64 | 21.0.5+11-LTS | Azul Systems, Inc.
+-----------------------------------------
+IJcdRZ kOAvl JuBVi ezL - 21732561
+Comptes rendus des transactions
+Période du rapport: 20-janv.-2026 - 17-févr.-2026
+Généré le: 17-févr.-2026 08:35:50 08:35:50 (W. Europe Standard Time)
+XdAbHq SjLyS cLGjf IIF Saxo Bank A/S FR Branch
+La VpJGzXTyRIEa 62 10 Rue de la Paix
+58811 Divatte-sur-zvgzk 75002 Paris
+France France
+Saxo Bank A/S FR Branch / 10 Rue de la Paix / 75002 Paris / France gWBhdj FKWva DWWKx Izw Période du rapport
+Devise: EUR 20-janv.-2026 - 17-févr.-2026
+Page 1 de 3 Compte(s): Tous les comptes Généré le: 17-févr.-2026
+Transactions, EUR
+Période du rapport
+20-janv.-2026 au 17-févr.-2026
+Type Instrument Événement Quantité Liquidités
+21-janv.-2026 -2 986,54 13,46
+Transfert d’espèces Retrait -3 000,00 -
+Deposit Type Taux de change Montant de liquidités Montant enregistré
+Retrait 1,000000 -3 000,00 EUR -3 000,00 EUR
+Transfert d’espèces Dépôts 3 000,00 -
+Deposit Type Taux de change Montant de liquidités Montant enregistré
+Dépôts 1,000000 3 000,00 EUR 3 000,00 EUR
+Opération Amundi PEA MSCI Emerging Asia UCITS EUR ETF Acheter 30 @ 31,91 EUR -957,42 -
+Commission Crédit de commission client Nombre d’actions Montant enregistré
+-2,00 EUR 2,00 EUR -957,42 EUR -957,42 EUR
+Coût total Taux de change ID d'opération ISIN
+-2,00 EUR 1,000000 6553757085 FR0013412012
+Opération Amundi PEA S&P 500 UCITS ETF Acheter 40 @ 50,73 EUR -2 029,12 -
+Nombre d’actions Montant enregistré Taux de change ID d'opération
+-2 029,12 EUR -2 029,12 EUR 1,000000 6553738910
+ISIN
+FR0011871128
+Saxo Bank A/S FR Branch / 10 Rue de la Paix / 75002 Paris / France eAFdaO fLYlR lKepV yzI Période du rapport
+Devise: EUR 20-janv.-2026 - 17-févr.-2026
+Page 2 de 3 Compte(s): Tous les comptes Généré le: 17-févr.-2026
+Transactions, EUR
+Période du rapport
+20-janv.-2026 au 17-févr.-2026
+Type Instrument Événement Quantité Liquidités
+20-janv.-2026 3 000,00 3 000,00
+Transfert d’espèces Dépôts 2 999,00 -
+IBAN Nom du détenteur de l’IBAN Deposit Type Taux de change
+Zq5254834517440942791040r15 Mlle NbQsan sbi External 1,000000
+Montant de liquidités Montant enregistré
+2 999,00 EUR 2 999,00 EUR
+Transfert d’espèces Dépôts 1,00 -
+IBAN Nom du détenteur de l’IBAN Deposit Type Taux de change
+iZ8365712471719767369757k52 Mlle xzbZng XJm External 1,000000
+Montant de liquidités Montant enregistré
+1,00 EUR 1,00 EUR
+Saxo Bank A/S FR Branch / 10 Rue de la Paix / 75002 Paris / France Melody Linda Marie Kar Période du rapport
+Devise: EUR 20-janv.-2026 - 17-févr.-2026
+Page 3 de 3 Compte(s): Tous les comptes Généré le: 17-févr.-2026

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/saxobank/SaxoBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/saxobank/SaxoBankPDFExtractorTest.java
@@ -1089,6 +1089,41 @@ public class SaxoBankPDFExtractorTest
     }
 
     @Test
+    public void testDividende04()
+    {
+        var extractor = new SaxoBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Dividende04.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(1L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(1L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(2));
+        new AssertImportActions().check(results, "EUR");
+
+        // check security
+        assertThat(results, hasItem(security( //
+                        hasIsin("NL0011683594"), hasWkn(null), hasTicker("VDIV"), //
+                        hasName("VanEck Morningstar Dvlp Mkts Dvd Leaders UCITS ETF"), //
+                        hasCurrencyCode("EUR"))));
+
+        // check dividends transaction
+        assertThat(results, hasItem(dividend( //
+                        hasDate("2026-09-10T00:00"), hasExDate("2026-09-02T00:00"), //
+                        hasShares(54.00), //
+                        hasSource("Dividende04.txt"), //
+                        hasNote("Event Id 9593275"), //
+                        hasAmount("EUR", 18.36), hasGrossValue("EUR", 21.60), //
+                        hasTaxes("EUR", 3.24), hasFees("EUR", 0.00))));
+    }
+
+    @Test
     public void testKontoauszug01()
     {
         var extractor = new SaxoBankPDFExtractor(new Client());

--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/saxobank/SaxoBankPDFExtractorTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/datatransfer/pdf/saxobank/SaxoBankPDFExtractorTest.java
@@ -5,6 +5,7 @@ import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.dividend;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasAmount;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasCurrencyCode;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasDate;
+import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasExDate;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasFees;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasForexGrossValue;
 import static name.abuchen.portfolio.datatransfer.ExtractorMatchers.hasGrossValue;
@@ -981,7 +982,8 @@ public class SaxoBankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-04-30T00:00"), hasShares(604.00), //
+                        hasDate("2025-04-30T00:00"), hasExDate("2025-04-15T00:00"), //
+                        hasShares(604.00), //
                         hasSource("Dividende01.txt"), //
                         hasNote("Event Id 9369584"), //
                         hasAmount("USD", 47.69), hasGrossValue("USD", 56.11), //
@@ -1015,7 +1017,8 @@ public class SaxoBankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-05-01T00:00"), hasShares(69.00), //
+                        hasDate("2025-05-01T00:00"), hasExDate("2025-04-11T00:00"), //
+                        hasShares(69.00), //
                         hasSource("Dividende02.txt"), //
                         hasNote("Event Id 9369517"), //
                         hasAmount("USD", 6.97), hasGrossValue("USD", 8.20), //
@@ -1049,7 +1052,8 @@ public class SaxoBankPDFExtractorTest
 
         // check dividends transaction
         assertThat(results, hasItem(dividend( //
-                        hasDate("2025-07-17T00:00"), hasShares(75.00), //
+                        hasDate("2025-07-17T00:00"), hasExDate("2025-07-15T00:00"), //
+                        hasShares(75.00), //
                         hasSource("Dividende03.txt"), //
                         hasNote("Event Id 9413396"), //
                         hasAmount("CHF", 12.67), hasGrossValue("CHF", 19.50), //
@@ -1106,5 +1110,41 @@ public class SaxoBankPDFExtractorTest
         // assert transaction
         assertThat(results, hasItem(deposit(hasDate("2024-11-26"), hasAmount("CHF", 700.00), //
                         hasSource("Kontoauszug01.txt"), hasNote(null))));
+    }
+
+    @Test
+    public void testKontoauszug02()
+    {
+        var extractor = new SaxoBankPDFExtractor(new Client());
+
+        List<Exception> errors = new ArrayList<>();
+
+        var results = extractor.extract(PDFInputFile.loadTestCase(getClass(), "Kontoauszug02.txt"), errors);
+
+        assertThat(errors, empty());
+        assertThat(countSecurities(results), is(0L));
+        assertThat(countBuySell(results), is(0L));
+        assertThat(countAccountTransactions(results), is(4L));
+        assertThat(countAccountTransfers(results), is(0L));
+        assertThat(countItemsWithFailureMessage(results), is(0L));
+        assertThat(countSkippedItems(results), is(0L));
+        assertThat(results.size(), is(4));
+        new AssertImportActions().check(results, "EUR");
+
+        // assert transaction
+        assertThat(results, hasItem(removal(hasDate("2026-01-21"), hasAmount("EUR", 3000.00), //
+                        hasSource("Kontoauszug02.txt"), hasNote(null))));
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2026-01-21"), hasAmount("EUR", 3000.00), //
+                        hasSource("Kontoauszug02.txt"), hasNote(null))));
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2026-01-20"), hasAmount("EUR", 2999.00), //
+                        hasSource("Kontoauszug02.txt"), hasNote(null))));
+
+        // assert transaction
+        assertThat(results, hasItem(deposit(hasDate("2026-01-20"), hasAmount("EUR", 1.00), //
+                        hasSource("Kontoauszug02.txt"), hasNote(null))));
     }
 }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/ExtractorUtils.java
@@ -66,6 +66,7 @@ public class ExtractorUtils
                     createFormatter("d MMM yyyy", Locale.FRENCH), //
                     createFormatter("d MMMM yyyy", Locale.FRENCH), //
                     createFormatter("d MMM. yyyy", Locale.FRENCH), //
+                    createFormatter("d-MMM-yyyy", Locale.FRENCH), //
                     };
 
     // Date formatters with case-insensitive support for the United States

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SaxoBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SaxoBankPDFExtractor.java
@@ -434,9 +434,8 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
                                                             // therefore we
                                                             // calculate the
                                                             // shares
-                                                            var amountPerShare = BigDecimal
-                                                                            .valueOf(asAmount(v.get("amountPerShare")));
-                                                            var amount = BigDecimal.valueOf(asAmount(v.get("amount")));
+                                                            var amountPerShare = asBigDecimal(v.get("amountPerShare"));
+                                                            var amount = asBigDecimal(v.get("amount"));
 
                                                             var shares = amount.divide(amountPerShare,
                                                                             Values.Share.precision(),
@@ -818,6 +817,13 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
     protected long asShares(String value)
     {
         return ExtractorUtils.convertToNumberLong(value, Values.Share,
+                        ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
+    }
+
+    @Override
+    protected BigDecimal asBigDecimal(String value)
+    {
+        return ExtractorUtils.convertToNumberBigDecimal(value, Values.Share,
                         ExtractorUtils.guessNumberLocale(value, Locale.GERMANY));
     }
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SaxoBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SaxoBankPDFExtractor.java
@@ -7,6 +7,7 @@ import static name.abuchen.portfolio.util.TextUtil.concatenate;
 import static name.abuchen.portfolio.util.TextUtil.trim;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Locale;
 
 import name.abuchen.portfolio.datatransfer.ExtractorUtils;
@@ -378,7 +379,29 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
                                                         .match("^Description (?<name>.*) Dividende pro Aktie [\\.,'\\d]+ (?<currency>[A-Z]{3})$") //
                                                         .match("^Symbol (?<tickerSymbol>[A-Z0-9\\._-]{1,10}(?:\\.[A-Z]{1,4})?):.*$") //
                                                         .match("^ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]).*$") //
-                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))))
+                                                        .assign((t, v) -> t.setSecurity(getOrCreateSecurity(v))),
+                                        // @formatter:off
+                                        // Event Cash dividend Dividend per share 0.40 EUR
+                                        // VanEck Morningstar Dvlp Mkts Dvd Leaders
+                                        // Description Conversion Rate 1.000000
+                                        // UCITS ETF
+                                        // Symbol VDIV:xetr Corporate Actions - Cash Dividends 21.60 EUR
+                                        // ISIN NL0011683594 Corporate Actions - Withholding Tax -3.24 EUR
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("currency", "name", "name1", "tickerSymbol", "isin") //
+                                                        .match("^Event .* Dividend per share [\\.,'\\d]+ (?<currency>[A-Z]{3})$") //
+                                                        .match("^(?<name>.*)$") //
+                                                        .match("^Description .*$") //
+                                                        .match("^(?<name1>.*)$") //
+                                                        .match("^Symbol (?<tickerSymbol>[A-Z0-9\\._-]{1,10}(?:\\.[A-Z]{1,4})?):.*$") //
+                                                        .match("^ISIN (?<isin>[A-Z]{2}[A-Z0-9]{9}[0-9]).*$") //
+                                                        .assign((t, v) -> {
+                                                            v.put("name", trim(v.get("name")) + " "
+                                                                            + trim(v.get("name1")));
+
+                                                            t.setSecurity(getOrCreateSecurity(v));
+                                                        }))
 
                         .oneOf( //
                                         // @formatter:off
@@ -394,7 +417,33 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
                                         section -> section //
                                                         .attributes("shares") //
                                                         .match("^.*Geeignete Menge (?<shares>[\\.,\\d]+)$") //
-                                                        .assign((t, v) -> t.setShares(asShares(v.get("shares")))))
+                                                        .assign((t, v) -> t.setShares(asShares(v.get("shares")))),
+                                        // @formatter:off
+                                        // Event Cash dividend Dividend per share 0.40 EUR
+                                        // Symbol VDIV:xetr Corporate Actions - Cash Dividends 21.60 EUR
+                                        // @formatter:on
+                                        section -> section //
+                                                        .attributes("amountPerShare", "amount") //
+                                                        .match("^Event .* Dividend per share (?<amountPerShare>[\\.,'\\d]+) [A-Z]{3}$") //
+                                                        .match("^.*Corporate Actions \\- Cash Dividends (?<amount>[\\.,'\\d]+) [A-Z]{3}$") //
+                                                        .assign((t, v) -> {
+                                                            // The eligible
+                                                            // quantity is not
+                                                            // stated in the
+                                                            // document,
+                                                            // therefore we
+                                                            // calculate the
+                                                            // shares
+                                                            var amountPerShare = BigDecimal
+                                                                            .valueOf(asAmount(v.get("amountPerShare")));
+                                                            var amount = BigDecimal.valueOf(asAmount(v.get("amount")));
+
+                                                            var shares = amount.divide(amountPerShare,
+                                                                            Values.Share.precision(),
+                                                                            RoundingMode.HALF_UP);
+                                                            t.setShares(shares.movePointRight(Values.Share.precision())
+                                                                            .longValue());
+                                                        }))
 
                         // @formatter:off
                         // 43640515029 15-Apr-2025 15-Apr-2025 02-Apr-2025 30-Apr-2025 56,11 1,000000 56,11
@@ -630,7 +679,9 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
                         .documentRange("date", "currency") //
                         .match("^Transfert d.esp.ces (?<type>(D.p.ts|Retrait)) (\\-)?(?<amount>[\\.,\\d\\s]+) \\-$") //
                         .assign((t, v) -> {
+                        // @formatter:off
                             // Is type --> "Retrait" change from DEPOSIT to REMOVAL
+                            // @formatter:on
                             if ("Retrait".equals(trim(v.get("type"))))
                                 t.setType(AccountTransaction.Type.REMOVAL);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SaxoBankPDFExtractor.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/datatransfer/pdf/SaxoBankPDFExtractor.java
@@ -403,6 +403,17 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
                         .match("^.*(?<date>[\\d]{2}\\-[\\w]+\\-[\\d]{4}) [\\.,'\\d]+ [\\.,'\\d]+ [\\.,'\\d]+$") //
                         .assign((t, v) -> t.setDateTime(asDate(v.get("date"))))
 
+                        // @formatter:off
+                        // Booking amount ID Ex date Record Date Posting Date Pay Date Conversion Rate
+                        // 43640515029 15-Apr-2025 15-Apr-2025 02-Apr-2025 30-Apr-2025 56,11 1,000000 56,11
+                        //
+                        // Buchungsbetrag-ID Ex-Tag Record Date Einstellungsdatum Zahltag Umrechnungskurs
+                        // 45865563189 15-Jul-2025 16-Jul-2025 - 17-Jul-2025 19.50 1.000000 19.50
+                        // @formatter:on
+                        .section("exDate").optional() //
+                        .match("^[\\d]+ (?<exDate>[\\d]{2}\\-[\\w]+\\-[\\d]{4}) .* [\\.,'\\d]+ [\\.,'\\d]+ [\\.,'\\d]+$") //
+                        .assign((t, v) -> t.setExDate(asDate(v.get("exDate"))))
+
                         .oneOf( //
                                         // @formatter:off
                                         // Net Amount - - - - - 47,69 1,000000 47,69
@@ -549,7 +560,7 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
 
     private void addAccountStatementTransaction()
     {
-        final var type = new DocumentType("Kontoauszugsbericht", //
+        final var type01 = new DocumentType("Kontoauszugsbericht", //
                         documentContext -> documentContext //
                                         // @formatter:off
                                         // Währung : CHF
@@ -558,14 +569,14 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
                                         .match("^W.hrung : (?<currency>[A-Z]{3}).*$") //
                                         .assign((ctx, v) -> ctx.put("currency", asCurrencyCode(v.get("currency")))));
 
-        this.addDocumentTyp(type);
+        this.addDocumentTyp(type01);
 
         // @formatter:off
         // 26-Nov-2024 26-Nov-2024 DEPOSIT (6980803089, 6083903733) 700,00 700,00
         // @formatter:on
-        var depositBlock = new Block("^[\\d]{2}\\-[\\w]+\\-[\\d]{4} [\\d]{2}\\-[\\w]+\\-[\\d]{4} (DEPOSIT) .* [\\.,'\\d]+ [\\.,'\\d]+$");
-        type.addBlock(depositBlock);
-        depositBlock.set(new Transaction<AccountTransaction>()
+        var depositBlock_Format01 = new Block("^[\\d]{2}\\-[\\w]+\\-[\\d]{4} [\\d]{2}\\-[\\w]+\\-[\\d]{4} (DEPOSIT) .* [\\.,'\\d]+ [\\.,'\\d]+$");
+        type01.addBlock(depositBlock_Format01);
+        depositBlock_Format01.set(new Transaction<AccountTransaction>()
 
                         .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
 
@@ -581,6 +592,51 @@ public class SaxoBankPDFExtractor extends AbstractPDFExtractor
                             t.setAmount(asAmount(v.get("amount")));
                             t.setCurrencyCode(v.get("currency"));
                             t.setNote(v.get("note"));
+                        })
+
+                        .wrap(TransactionItem::new));
+
+        // @formatter:off
+        // Devise: EUR 20-janv.-2026 - 17-févr.-2026
+        // @formatter:on
+        var currencyRange = new Block("^Devise: [A-Z]{3}.*$") //
+                        .asRange(section -> section //
+                                        .attributes("currency") //
+                                        .match("^Devise: (?<currency>[A-Z]{3}).*$"));
+
+        // @formatter:off
+        // 21-janv.-2026 -2 986,54 13,46
+        // 20-janv.-2026 3 000,00 3 000,00
+        // @formatter:on
+        var dateRange = new Block("^[\\d]{2}\\-[^\\-]+\\-[\\d]{4} (\\-)?[\\.,\\d\\s]+ (\\-)?[\\.,\\d\\s]+$") //
+                        .asRange(section -> section //
+                                        .attributes("date") //
+                                        .match("^(?<date>[\\d]{2}\\-[^\\-]+\\-[\\d]{4}) (\\-)?[\\.,\\d\\s]+ (\\-)?[\\.,\\d\\s]+$"));
+
+        final var type02 = new DocumentType("Comptes rendus des transactions", currencyRange, dateRange);
+        this.addDocumentTyp(type02);
+
+        // @formatter:off
+        // Transfert d’espèces Retrait -3 000,00 -
+        // Transfert d’espèces Dépôts 3 000,00 -
+        // @formatter:on
+        var depositRemovalBlock_Format02 = new Block("^Transfert d.esp.ces (D.p.ts|Retrait) (\\-)?[\\.,\\d\\s]+ \\-$");
+        type02.addBlock(depositRemovalBlock_Format02);
+        depositRemovalBlock_Format02.set(new Transaction<AccountTransaction>()
+
+                        .subject(() -> new AccountTransaction(AccountTransaction.Type.DEPOSIT))
+
+                        .section("type", "amount") //
+                        .documentRange("date", "currency") //
+                        .match("^Transfert d.esp.ces (?<type>(D.p.ts|Retrait)) (\\-)?(?<amount>[\\.,\\d\\s]+) \\-$") //
+                        .assign((t, v) -> {
+                            // Is type --> "Retrait" change from DEPOSIT to REMOVAL
+                            if ("Retrait".equals(trim(v.get("type"))))
+                                t.setType(AccountTransaction.Type.REMOVAL);
+
+                            t.setDateTime(asDate(v.get("date")));
+                            t.setCurrencyCode(asCurrencyCode(v.get("currency")));
+                            t.setAmount(asAmount(v.get("amount")));
                         })
 
                         .wrap(TransactionItem::new));


### PR DESCRIPTION
Saxo Bank — französischer Kontoauszug
Branch saxobank-fr-account-statement, Commit 6c50c3f

Neuer Dokumenttyp „Comptes rendus des transactions" (Saxo Bank A/S FR Branch) im SaxoBankPDFExtractor. Importiert werden nur die Bargeldtransfers — Dépôts → Einlage, Retrait → Auszahlung. Die im selben Dokument stehenden Wertpapiergeschäfte bleiben außen vor, da sie über die separaten „Trade details"-Dokumente bereits erfasst werden (keine Doppelbuchungen).


- neuer DocumentType in addAccountStatementTransaction(); DE-Format unverändert, nur zu _Format01 umbenannt
- eine Zeile: createFormatter("d-MMM-yyyy", Locale.FRENCH) für „21-janv.-2026"
- Ex-Date Support issues #5513
- add new Transactions fix issues #6006 